### PR TITLE
Update requirements.md

### DIFF
--- a/supporting/requirements.md
+++ b/supporting/requirements.md
@@ -8,8 +8,8 @@ Visual Studio Code has been tested on the following platforms.
 
 ### Additional Linux requirements
 
-* GLIBCXX version 3.4.14 or later
-* GLIBC version 2.14 or later
+* GLIBCXX version 3.4.15 or later
+* GLIBC version 2.15 or later
 
 If you find Visual Studio Code is successfully working on other platforms, email us at [vscodefeedback@microsoft.com](mailto:vscodefeedback@microsoft.com).
 


### PR DESCRIPTION
VSCode-linux-x64/Code: /lib64/libc.so.6: version `GLIBC_2.15' not found (required by VSCode-linux-x64/libgcrypt.so.11)
VSCode-linux-x64/Code: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.15' not found (required by /VSCode-linux-x64/Code)