### PR TITLE
Pointed issue links to the correct issue page

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -150,9 +150,9 @@ As always we fixed many issues.
 
 Here are a few of the notable ones from the public bug tracker:
 
-* [18998](/Issues/Detail/18998): newly added files not honored by tsconfig.json
-* [18692](/Issues/Detail/18692): Changes to tsconfig.json not updated immediately
-* [19239](/Issues/Detail/19239): Detaching from Unity Results in a Unity Crash
+* [18998](https://code.visualstudio.com/Issues/Detail/18998): newly added files not honored by tsconfig.json
+* [18692](https://code.visualstudio.com/Issues/Detail/18692): Changes to tsconfig.json not updated immediately
+* [19239](https://code.visualstudio.com/Issues/Detail/19239): Detaching from Unity Results in a Unity Crash
 
 Other issues we've fixed:
 


### PR DESCRIPTION
Noticed that the issue links from the email and on the GitHub repo don't
point to the correct place. This change uses an absolute link to the
VSCode site.