### PR TITLE
Remove empty object literal from code snippet

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -167,8 +167,6 @@ Here is a example where output for the "deploy" task is always brought to front:
 		{
 			"taskName": "deploy",
 			"showOutput": "always",
-		},
-		{
 		}
 	]
 }


### PR DESCRIPTION
Removed an unnecessary, empty object literal from the code snippet provided in the Task Specific Properties section of the Editor --> Tasks page.