### PR TITLE
Remove trailing comma from code snippet

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -349,8 +349,7 @@ Below is an example of a configuration that passes the current opened file to th
 ```json
 {
 	"command": "tsc",
-
-	"args": ["${file}"],
+	"args": ["${file}"]
 }
 ```
 


### PR DESCRIPTION
Removed a trailing comma from the JSON code snippet provided in the "Variables in tasks.json" section of the Editor --> Tasks page.