### PR TITLE
Fix inconsistent references to ASP.NET

### DIFF
--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -16,7 +16,7 @@ In addition, there are a number of unique features in the VS Code user interface
 ## Files, Folders & Projects
 VS Code is file and folder based - you can get started immediately by opening a file or folder in VS Code.
 
-On top of this, VS Code can read and take advantage of a variety of project files defined by different frameworks and platforms. For example, if the folder you opened in VS Code contains one or more `package.json`, `project.json`, `tsconfig.json`, or ASP .Net v5 Visual Studio solution and project files, VS Code will read these files and use them to provide additional functionality such as rich IntelliSense in the editor.
+On top of this, VS Code can read and take advantage of a variety of project files defined by different frameworks and platforms. For example, if the folder you opened in VS Code contains one or more `package.json`, `project.json`, `tsconfig.json`, or ASP.NET 5 Visual Studio solution and project files, VS Code will read these files and use them to provide additional functionality such as rich IntelliSense in the editor.
 
 
 ## Basic Layout

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -14,7 +14,7 @@ The C# support in VS Code is optimized for cross-platform .NET development (DNX)
 
 We support debugging of C# apps cross-platform via Mono (see [Mono Debugging](/Docs/editor/debugging#_mono-debugging)).
 
-Due to this focus many standard C# project types are not recognized by VS Code.  An example of a non-supported project type is an ASP .NET MVC Application.  In these cases if you simply want to have a lightweight tool to edit a file - VS Code has you covered.  If you want the best possible experience for those projects and development on Windows in general, we recommend you use [Visual Studio Community](https://www.visualstudio.com/products/visual-studio-community-vs).
+Due to this focus many standard C# project types are not recognized by VS Code.  An example of a non-supported project type is an ASP.NET MVC Application.  In these cases if you simply want to have a lightweight tool to edit a file - VS Code has you covered.  If you want the best possible experience for those projects and development on Windows in general, we recommend you use [Visual Studio Community](https://www.visualstudio.com/products/visual-studio-community-vs).
 
 
 


### PR DESCRIPTION
Minor change to make an ASP.NET 5 reference consistent with other references throughout the documentation. Changed "ASP .Net v5" to "ASP.NET 5".