### PR TITLE
Add missing semi-colons and return statement to gulpfile.js

### DIFF
--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -132,16 +132,16 @@ var gulp = require('gulp');
 var markdown = require('gulp-markdown');
 
 gulp.task('markdown', function() {
-	gulp.src('**/*.md')
+	return gulp.src('**/*.md')
 		.pipe(markdown())
 		.pipe(gulp.dest(function(f) {
 			return f.base;
-		}))
+		}));
 });
 
 gulp.task('default', function() {
 	gulp.watch('**/*.md', ['markdown']);
-})
+});
 ```
 
 What is happening here?


### PR DESCRIPTION
Added 2 missing semi-colons and a return statement. See [this PR](https://github.com/aspnet/Templates/pull/206) for more info on the return statement.