### PR TITLE
Simplify npm install command

### DIFF
--- a/docs/customization/overview.md
+++ b/docs/customization/overview.md
@@ -32,9 +32,8 @@ In the future, we'll add other options for rich customization of VS Code.
 If you have a TextMate color theme (.tmTheme) or a TextMate language specification (.tmLanguage), you can bring them into VS Code using the 'code' Yeoman generator.
 
 Install and run the code Yeoman generator as follows:
-1. `npm install -g yo`
-2. `npm install -g generator-code`
-3. `yo code`
+1. `npm install -g yo generator-code`
+2. `yo code`
 
 ![yo code](images/overview/yocode.png)
 


### PR DESCRIPTION
The "Yo Code - Adding Customizations for VS Code" section of the docs shows 2 separate `npm install` commands. This can be simplified by combining into a 1-liner.