### PR TITLE
Suggested Update Only:  yo and nodejs 5.0.0

### DIFF
--- a/docs/runtimes/ASPnet5.md
+++ b/docs/runtimes/ASPnet5.md
@@ -36,7 +36,7 @@ dnvm upgrade
 ## Getting Started
 If you don't have an existing ASP.NET DNX application, we recommend using [yeoman](http://yeoman.io/) to scaffold a new one. Presuming you have Node.js installed, simply `npm install` yeoman and supporting tools such as the asp.net generator, gulp, and bower. This can be done in one command:
 ```
-npm install -g yo generator-aspnet gulp bower
+npm install -g isarray core-util-is grouped-queue mem-fs multipipe yo generator-aspnet gulp bower
 ```
 ## Scaffolding your first Application
 From the terminal, run `yo aspnet` to start the generator. Follow the prompts and pick the `Web Application`


### PR DESCRIPTION
On Windows x64/Node JS 5, yo fails to run without isarray core-util-is grouped-queue mem-fs.

Installing these extra packages seems to fix the issue and I can run yo.  Perhaps we should update yo?  Let me know.  Without them I get something like:

Error: Cannot find module 'core-util-is'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (C:\Users\core\AppData\Roaming\npm\node_modules\yo\nod
e_modules\readable-stream\lib\_stream_readable.js:44:12)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)