### PR TITLE
Update extension-gallery.md

### DIFF
--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -64,7 +64,7 @@ Here are a few topics you may find interesting...
 
 **Q: Can VS Code read TextMate bundles directly?**
 
-**A: No, VS Code can read some TextMate files such as .tmTheme and .tmLanguage but can not install full TextMate bundles. Also in order to use TextMate theme and syntax files, VS Code needs extra metadata for integration.  The [Yo Code](/docs/tools/yocode.md) extension generator makes it easy to package these files for use in VS Code.
+**A**: No, VS Code can read some TextMate files such as .tmTheme and .tmLanguage but can not install full TextMate bundles. Also in order to use TextMate theme and syntax files, VS Code needs extra metadata for integration.  The [Yo Code](/docs/tools/yocode.md) extension generator makes it easy to package these files for use in VS Code.
 
 **Q: Can I install Visual Studio Community extensions (shipped in .vsix) in Visual Studio Code?**
 


### PR DESCRIPTION
First answer was missing the bold "A" - showed as **A in production.