### PR TITLE
Fix src and lib directory verbiage

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -88,7 +88,7 @@ The Babel transpiler turns ES6 files into readable ES5 JavaScript with Source Ma
 ```
 
 
-Once you have added this you can start Babel with the `kb(workbench.action.tasks.build)` (Run Build Task) gesture and it will compile all files from the `src-directory` into the `lib-directory`.
+Once you have added this, you can start Babel with the `kb(workbench.action.tasks.build)` (Run Build Task) gesture and it will compile all files from the `src` directory into the `lib` directory.
 
 
 ## JavaScript Linters (ESLint, JSHint)


### PR DESCRIPTION
The explanation of the code snippet in the "Run Babel inside VS Code" section is misleading. The text makes it seem as though there's a directory named "lib-directory" and another one named "src-directory".