### PR TITLE
added note about existing shortcuts

### DIFF
--- a/docs/editor/editingevolved.md
+++ b/docs/editor/editingevolved.md
@@ -23,6 +23,8 @@ Matching brackets will be highlighted as soon as the cursor is near one of them.
 
 VS Code has support for multiple cursors. You can add secondary cursors (rendered thinner) with `kbstyle(Alt+Click)`. Each cursor operates independently based on the context it sits in. The most common way to add more cursors is with `kb(editor.action.insertCursorBelow)` or `kb(editor.action.insertCursorAbove)` that insert cursors below or above.
 
+> **Note:** Your graphics card provider might overwrite these default shortcuts.
+
 ![Multi-cursor](images/editingevolved/multicursor.gif)
 
 `kb(editor.action.addSelectionToNextFindMatch)` selects the word at the cursor, or the next occurrence of the current selection.  `kb(editor.action.moveSelectionToNextFindMatch)` moves the last added cursor to next occurrence of the current selection.


### PR DESCRIPTION
On windows, the Intel driver (didn't test others) by default overwrites the multi-line shortcuts with screen rotate.