### PR TITLE
Use https wherever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Visual Studio Code Documentation
 
-You've found the GitHub repository which contains the content for the [Visual Studio Code documentation](http://code.visualstudio.com/docs).
+You've found the GitHub repository which contains the content for the [Visual Studio Code documentation](https://code.visualstudio.com/docs).
 
-Topics submitted here will be published to the [Visual Studio Code](http://code.visualstudio.com) portal.
+Topics submitted here will be published to the [Visual Studio Code](https://code.visualstudio.com) portal.
 
 ## Visual Studio Code
 
 VS Code is a lightweight but powerful development environment for building and debugging modern web and cloud applications.  It is free and available on your favorite platform - Linux, Mac OSX and Windows.
 
-If you landed here looking for other information about VS Code, head over to [our website](http://code.visualstudio.com) for additional information.
+If you landed here looking for other information about VS Code, head over to [our website](https://code.visualstudio.com) for additional information.
 
 ## Contributing documentation
 
@@ -26,7 +26,7 @@ Clone a copy of the repo:
 git clone https://github.com/Microsoft/vscode-docs.git
 ```
 
-VS Code itself is great for reviewing and editing [Markdown](http://code.visualstudio.com/docs/languages/markdown) with nice preview support.
+VS Code itself is great for reviewing and editing [Markdown](https://code.visualstudio.com/docs/languages/markdown) with nice preview support.
 
 If you want to use VS Code, simply navigate to the `vscode-docs` directory and launch VS Code from there:
 

--- a/docs/customization/colorizer.md
+++ b/docs/customization/colorizer.md
@@ -19,7 +19,7 @@ Many language colorizers have been uploaded to the VS Code [Extension Gallery](/
 
 ![filter go language](images/colorizer/filter-go.png)
 
-You can also browse the [VS Code Marketplace](http://marketplace.visualstudio.com/vscode/Languages) to find available colorizers and language support. 
+You can also browse the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode/Languages) to find available colorizers and language support. 
 
 ## Adding a New Language
 

--- a/docs/customization/themes.md
+++ b/docs/customization/themes.md
@@ -28,7 +28,7 @@ Many themes have been uploaded to the VS Code [Extension Gallery](/docs/editor/e
 
 ![filter theme](images/themes/filter-theme.png)
 
-You can also browse the [VS Code Marketplace](http://marketplace.visualstudio.com/vscode/Themes) to find available themes. 
+You can also browse the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode/Themes) to find available themes. 
 
 ## Adding a new Theme
 You can also add new TextMate theme files (.tmTheme) to your VS Code installation using the [yo code](/docs/tools/yocode.md) extension generator.  

--- a/docs/customization/userdefinedsnippets.md
+++ b/docs/customization/userdefinedsnippets.md
@@ -20,7 +20,7 @@ Many snippets have been uploaded to the VS Code [Extension Gallery](/docs/editor
 
 ![Add some snippets from the Gallery](images/userdefinedsnippets/snippetgallery.gif)
 
-You can also browse the [VS Code Marketplace](http://marketplace.visualstudio.com/vscode/Snippets) to find available snippets. 
+You can also browse the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode/Snippets) to find available snippets. 
 
 ## Creating your Own Snippets
 You can define your own snippets for specific languages.  Snippets are defined in a JSON format.

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -277,7 +277,7 @@ To write your own debugger extension, visit:
 
 **Q: Why can’t I remote debug my app?**
 
-**A:** Currently we support local debugging only. This is a known limitation. If that’s something you care about, please [let us know](http://visualstudio.uservoice.com/forums/293070-visual-studio-code/suggestions/7872216-remote-debugging)!
+**A:** Currently we support local debugging only. This is a known limitation. If that’s something you care about, please [let us know](https://visualstudio.uservoice.com/forums/293070-visual-studio-code/suggestions/7872216-remote-debugging)!
 
 **Q: I do not see any launch configurations in the debug view drop down, what is wrong?**
 

--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -17,11 +17,11 @@ You can browse and install extensions from within VS Code. Press `kb(workbench.a
 
 Pick `Extensions: Install Extension`.
 
-> **Tip:** As an alternative, press `kb(workbench.action.quickOpen)` and type `ext install ` with a trailing space. Not sure what to install? Visit [VS Code Marketplace](http://marketplace.visualstudio.com/#VSCode).
+> **Tip:** As an alternative, press `kb(workbench.action.quickOpen)` and type `ext install ` with a trailing space. Not sure what to install? Visit [VS Code Marketplace](https://marketplace.visualstudio.com/#VSCode).
 
 ![ext install](images/extension-gallery/ext-install.png)
 
-You'll see a list of extensions on the gallery along with the publisher, published date and a brief description.  You can click the `README` button to go to the extension's [VS Code Marketplace](http://marketplace.visualstudio.com/#VSCode) page where you can learn more.
+You'll see a list of extensions on the gallery along with the publisher, published date and a brief description.  You can click the `README` button to go to the extension's [VS Code Marketplace](https://marketplace.visualstudio.com/#VSCode) page where you can learn more.
 
 ## Install an Extension
 
@@ -45,7 +45,7 @@ You can quickly look for extension updates by using the `Extensions: Show Outdat
 
 ## Browse Extensions
 
-Additionally, you can browse the VS Code Extension Gallery through the [VS Code Marketplace](http://marketplace.visualstudio.com/#VSCode).
+Additionally, you can browse the VS Code Extension Gallery through the [VS Code Marketplace](https://marketplace.visualstudio.com/#VSCode).
 
 ![marketplace](images/extension-gallery/marketplace.png) 
 

--- a/docs/editor/setup.md
+++ b/docs/editor/setup.md
@@ -12,7 +12,7 @@ MetaDescription: Get Visual Studio Code up and running on Mac OS X, Linux or Win
 Getting up and running with VS Code is quick and easy.  Follow the platform specific guides below as well as the list of handy tools.
 
 ## Mac OS X
-1. [Download Visual Studio Code](http://go.microsoft.com/fwlink/?LinkID=534106) for Mac OS X.
+1. [Download Visual Studio Code](https://go.microsoft.com/fwlink/?LinkID=534106) for Mac OS X.
 2. Double-click on `VSCode-osx.zip` to expand the contents.
 3. Drag `Visual Studio Code.app` to the `Applications` folder, making it available in the `Launchpad`.
 4. Add VS Code to your Dock by right-clicking on the icon and choosing `Options`, `Keep in Dock`.
@@ -25,7 +25,7 @@ function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args $*
 Now, you can simply type `code .` in any folder to start editing files in that folder.
 
 ## Linux
-1. [Download Visual Studio Code](http://go.microsoft.com/fwlink/?LinkID=534108) for Linux.
+1. [Download Visual Studio Code](https://go.microsoft.com/fwlink/?LinkID=534108) for Linux.
 2. Make a new folder and extract `VSCode-linux-x64.zip` inside that folder.
 3. Double click on `Code` to run Visual Studio Code.
 
@@ -37,7 +37,7 @@ sudo ln -s /path/to/vscode/Code /usr/local/bin/code
 Now, you can simply type `code .` in any folder to start editing files in that folder.
 
 ## Windows
-1. [Download Visual Studio Code](http://go.microsoft.com/fwlink/?LinkID=534107) for Windows.
+1. [Download Visual Studio Code](https://go.microsoft.com/fwlink/?LinkID=534107) for Windows.
 2. Double-click on `VSCodeSetup.exe` to launch the setup process. This will only take a minute.
 
 >**Tip:** Visual Studio Code will be added to your path, so from the console you can simply type `code .` to open VS Code on that folder!
@@ -48,7 +48,7 @@ Now, you can simply type `code .` in any folder to start editing files in that f
 Visual Studio Code integrates with existing tool chains.  We think the following tools will enhance your development experiences.
 
 - [ASP.NET 5](https://github.com/aspnet/home) - a lean and composable framework for building web and cloud applications, fully open source and available on GitHub
-- [Node.js (includes NPM)](http://nodejs.org/) - a platform for easily building fast, scalable network applications
+- [Node.js (includes NPM)](https://nodejs.org/) - a platform for easily building fast, scalable network applications
 - [Git](http://git-scm.com/download) - VS Code has built-in support for source code control using Git
 - [Yeoman](http://yeoman.io/) - an application scaffolding tool, you can think of this as `File | New Project` for VS Code
 - [generator-aspnet](https://www.npmjs.com/package/generator-aspnet) - a yeoman generator for scaffolding ASP.NET 5 applications, run `npm install -g generator-aspnet` to install

--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -10,7 +10,7 @@ MetaDescription: Expand your development workflow with task integration in Visua
 # Integrate with External Tools via Tasks
 
 Lots of tools exist to automate tasks like building, packaging, testing or deploying software systems.
-Examples include [Make](http://en.wikipedia.org/wiki/Make_software), [Ant](http://ant.apache.org/), [Gulp](http://gulpjs.com/),
+Examples include [Make](https://en.wikipedia.org/wiki/Make_software), [Ant](http://ant.apache.org/), [Gulp](http://gulpjs.com/),
 [Jake](http://jakejs.com/), [Rake](http://rake.rubyforge.org/) and [MSBuild](https://github.com/Microsoft/msbuild).
 
 These tools are mostly run from the command line and automate jobs outside the inner software development loop (edit, compile, test and debug).  Given their importance in the development life-cycle, it is very helpful to be able run them and analyze their results from within VS Code.
@@ -205,7 +205,7 @@ as **prinft**. Compiling it with [gcc](https://gcc.gnu.org/) will produce the fo
 helloWorld.c:5:3: warning: implicit declaration of function ‘prinft’
 ```
 
-We want to produce a problem matcher that can capture the message in the output and show a corresponding problem in VS Code.  Problem matchers heavily rely on [regular expressions](http://en.wikipedia.org/wiki/Regular_expression). The section below assumes
+We want to produce a problem matcher that can capture the message in the output and show a corresponding problem in VS Code.  Problem matchers heavily rely on [regular expressions](https://en.wikipedia.org/wiki/Regular_expression). The section below assumes
 you are familiar with regular expressions.
 
 >**Tip:** We have found the [RegEx101 playground](https://regex101.com/) a really good way to develop and test regular expressions.

--- a/docs/editor/versioncontrol.md
+++ b/docs/editor/versioncontrol.md
@@ -15,7 +15,7 @@ And don't forget that the command prompt is still your friend.
 >**Note:** VS Code will leverage your machine's Git installation, so you need
 to [install Git](http://git-scm.com/download) first before you get these features.
 
->**Tip:** VS Code will work with any Git repo - local or remote.  If you don't already have a private hosted Git provider, [Visual Studio Team Services](http://www.visualstudio.com/products/visual-studio-team-services-vs) is a great free option. [Click here to sign-up](http://go.microsoft.com/fwlink/?LinkID=307137&campaign=o~msft~code~vc).
+>**Tip:** VS Code will work with any Git repo - local or remote.  If you don't already have a private hosted Git provider, [Visual Studio Team Services](https://www.visualstudio.com/products/visual-studio-team-services-vs) is a great free option. [Click here to sign-up](https://go.microsoft.com/fwlink/?LinkID=307137&campaign=o~msft~code~vc).
 
 ## Overview
 

--- a/docs/extensions/example-debuggers.md
+++ b/docs/extensions/example-debuggers.md
@@ -23,7 +23,7 @@ When the debug session ends, the adapter is stopped.
 
 Debug adapters are part of VS Code's extensible architecture: they are contributed as extensions. What sets them apart from other extensions is the fact that the debug adapter code is not running in the extension host, but as a separate standalone program. The reasons for this are twofold: first, it makes it possible to implement the adapter in the language most suitable for the given debugger or runtime. Second, a standalone program can more easily run in elevated mode if the need arises.
 
-Visual Studio Code ships two debug extensions, one for Node.js and one for Mono. More are available from the [VS Code Marketplace](http://marketplace.visualstudio.com/vscode/Debuggers) or you can create a debug extension yourself.
+Visual Studio Code ships two debug extensions, one for Node.js and one for Mono. More are available from the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode/Debuggers) or you can create a debug extension yourself.
 
 This document will show you how to create a new debug extension.
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -54,7 +54,7 @@ Selecting the snippet with `tab` results in:
 
 
 ## ES6 Support
-VS Code supports ES6 (ECMAScript 6, the latest update of JavaScript) and understands the new ES6 syntax elements and their semantics. By default, you get suggestions for ES6 types, like `Promise`, `Set`, `Map`, `String.startsWith`. A good overview of the new ES6 features can be found [here](http://github.com/lukehoban/es6features).
+VS Code supports ES6 (ECMAScript 6, the latest update of JavaScript) and understands the new ES6 syntax elements and their semantics. By default, you get suggestions for ES6 types, like `Promise`, `Set`, `Map`, `String.startsWith`. A good overview of the new ES6 features can be found [here](https://github.com/lukehoban/es6features).
 
 We have a sample on GitHub that shows off some of the ES6 love in VS Code:
 

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -11,7 +11,7 @@ MetaDescription: In Visual Studio Code we have support for all common languages.
 # Languages
 
 ## What Languages are Supported
-In Visual Studio Code, we have support for many languages out of the box and more through language extensions available on the [VS Code Marketplace](http://marketplace.visualstudio.com/vscode/Languages).
+In Visual Studio Code, we have support for many languages out of the box and more through language extensions available on the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode/Languages).
 
 >**Tip:** You can also add support for your favorite language through TextMate colorizers.  See [Colorizers](/docs/customization/colorizer.md) to learn how to integrate TextMate .tmLanguage syntax files into VS Code.
 
@@ -51,7 +51,7 @@ Now you know that VS Code has support for the languages you care about. Read on.
 
 **Q: Can I contribute my own language service?**
 
-**A:** Not yet but soon. Help us prioritize this in our [user voice](http://go.microsoft.com/fwlink/?LinkID=533482) site.
+**A:** Not yet but soon. Help us prioritize this in our [user voice](https://go.microsoft.com/fwlink/?LinkID=533482) site.
 
 **Q: Can I map additional file extensions to a language?**
 

--- a/docs/runtimes/office.md
+++ b/docs/runtimes/office.md
@@ -8,7 +8,7 @@ MetaDescription: This page walks you through how to scaffold out a project for V
 ---
 
 # Office Add-ins with VS Code
-[Office Add-ins](http://dev.office.com/getting-started/addins) run inside an Office application and can interact with the contents of the Office document using the rich JavaScript API.
+[Office Add-ins](https://dev.office.com/getting-started/addins) run inside an Office application and can interact with the contents of the Office document using the rich JavaScript API.
 
 ![Office Add-in overview](images/office/officeaddinoverview.png)
 

--- a/docs/supporting/errors.md
+++ b/docs/supporting/errors.md
@@ -9,7 +9,7 @@ MetaDescription: Several error conditions can easily be resolved by the user thi
 
 Some errors that happen in Visual Studio Code can be worked around or resolved by you.  This topic describes several of the most common error conditions, and what you can do to resolve them.
 
-If these steps don't help you, you probably hit a bug. You can check our [reported issues](http://github.com/microsoft/vscode/issues) list to see if others have had the same issue.
+If these steps don't help you, you probably hit a bug. You can check our [reported issues](https://github.com/microsoft/vscode/issues) list to see if others have had the same issue.
 
 ## 20001
 >**Error:** Cannot start OmniSharp because Mono version >=3.10.0 is required

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -8,7 +8,7 @@ MetaDescription: Our docs contain a Common Questions section. Here are items tha
 # Visual Studio Code FAQ
 Our docs contain a **Common Questions** section as needed for specific topics. We've captured items here that don't fit in the other topics.
 
-If you don't see an answer to your question here, check our previously [reported issues](http://github.com/microsoft/vscode/issues) and our [Updates](/Updates) notes.
+If you don't see an answer to your question here, check our previously [reported issues](https://github.com/microsoft/vscode/issues) and our [Updates](/Updates) notes.
 
 ## How do I update to the latest version?
 See [how to update](howtoupdate). You'll find downloads for Linux (32-bit and 64-bit) and OS X, and both an installer and download for Windows.
@@ -54,7 +54,7 @@ To modify the update channel, go to `File | Preferences | User Settings` and add
 ```
 
 ## Windows - Trouble with the installer
-Try using the [zip file](http://go.microsoft.com/fwlink/?LinkID=615207) instead of the installer.  To use this unzip VS Code in your `Program Files` folder.
+Try using the [zip file](https://go.microsoft.com/fwlink/?LinkID=615207) instead of the installer.  To use this unzip VS Code in your `Program Files` folder.
 
 >**Note:** When VS Code is installed via a Zip you will need to manually update it for each release.
 
@@ -62,7 +62,7 @@ Try using the [zip file](http://go.microsoft.com/fwlink/?LinkID=615207) instead 
 ## Windows - Icons are missing
 I installed Visual Studio Code on my Windows 7 or 8 machine. Why are some icons not appearing in the workbench and editor?
 
-VS Code uses [SVG](http://en.wikipedia.org/wiki/Scalable_Vector_Graphics) icons and we have found instances where the .SVG file extension is associated with something other than `image/svg+xml`. We're considering options to fix it, but for now here's a workaround:
+VS Code uses [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) icons and we have found instances where the .SVG file extension is associated with something other than `image/svg+xml`. We're considering options to fix it, but for now here's a workaround:
 
 Using the Command Prompt:
 
@@ -171,7 +171,7 @@ From File | Preferences | User Settings, add the following option to disable cra
 
 ## How to disable telemetry reporting 
  
-VS Code collects usage data and sends it to Microsoft to help improve our products and services.  Read our [privacy statement](http://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409) to learn more. 
+VS Code collects usage data and sends it to Microsoft to help improve our products and services.  Read our [privacy statement](https://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409) to learn more. 
  
 If you don’t wish to send usage data to Microsoft, please follow the instructions below to disable its collection. 
  

--- a/docs/supporting/howtoupdate.md
+++ b/docs/supporting/howtoupdate.md
@@ -14,13 +14,13 @@ The following shows you how to update to the latest release of Visual Studio Cod
 Auto-updates are not supported for Linux.
 
 ## Updating on Linux
-* Download the VS Code zip file: [64-bit](http://go.microsoft.com/fwlink/?LinkID=534108) or [32-bit](http://go.microsoft.com/fwlink/?LinkID=615206).
+* Download the VS Code zip file: [64-bit](https://go.microsoft.com/fwlink/?LinkID=534108) or [32-bit](https://go.microsoft.com/fwlink/?LinkID=615206).
 * Open the zip and run **Code**
 
 ## Updating on OS X
 You need to do this only if auto-update did not complete.
 
-* Download the VS Code zip file from [here](http://go.microsoft.com/fwlink/?LinkID=534106).
+* Download the VS Code zip file from [here](https://go.microsoft.com/fwlink/?LinkID=534106).
 * Open the zip file and drag **Code** over to **Applications**.
 * Launch **Code**.
 
@@ -30,8 +30,8 @@ You need to do this only if auto-update did not complete.
 
 **Important:** Close any running instances of VS Code before attempting to update (to avoid VS Code not being able to start after you update).
 
-* Run the installer from [here](http://go.microsoft.com/fwlink/?LinkID=534107).
-* If you have trouble with the Windows installer, download the VS Code zip file from [here](http://go.microsoft.com/fwlink/?LinkID=615207).
+* Run the installer from [here](https://go.microsoft.com/fwlink/?LinkID=534107).
+* If you have trouble with the Windows installer, download the VS Code zip file from [here](https://go.microsoft.com/fwlink/?LinkID=615207).
 
 ## Common Questions
 

--- a/docs/tools/vscecli.md
+++ b/docs/tools/vscecli.md
@@ -153,4 +153,4 @@ This will always invoke the [TypeScript](http://www.typescriptlang.org/) compile
 
 **Q: I can't unpublish my extension through the `vsce` tool?**
 
-**A:** You may have changed your extension ID or publisher name. You can also manage your extensions directly on the Marketplace by going to the [manage page](http://marketplace.visualstudio.com/manage).  You can update or unpublish your extension from your publisher manage page.
+**A:** You may have changed your extension ID or publisher name. You can also manage your extensions directly on the Marketplace by going to the [manage page](https://marketplace.visualstudio.com/manage).  You can update or unpublish your extension from your publisher manage page.


### PR DESCRIPTION
These patches change http links to https for domains that support HTTPS, for better privacy and security.