### PR TITLE
Fix vsce steps for packaging with baseImagesUrl or baseContentUrl

### DIFF
--- a/docs/tools/vscecli.md
+++ b/docs/tools/vscecli.md
@@ -98,7 +98,7 @@ Here are some tips for making your extension look great on the Marketplace:
 
 - Any `README.md` file at the root of your extension will be used to populate the extension's gallery page's contents. **Note:** since the gallery doesn't serve images yet, you may find images and/or links to be broken in the extension's gallery page. `vsce` can fix this for you in two different ways:
 - If you add a `repository` field to your `package.json` and if it is a public GitHub repository, `vsce` will automatically detect it and adjust the links accordingly.
-- You can override that behavior and/or set it by using the `--baseContentUrl` and `--baseImagesUrl` flags when running `vsce publish`.
+- You can override that behavior and/or set it by using the `--baseContentUrl` and `--baseImagesUrl` flags when running `vsce package`. Then publish the extension by passing the path to the packaged `.vsix` file as an argument to `vsce publish`. 
 - You can set the banner background color by setting `galleryBanner.color` to the intended hex value in `package.json`.
 - You can set an icon by setting `icon` to a relative path to a squared `128px` PNG file included in your extension, in `package.json`.
 


### PR DESCRIPTION
Update the docs to reflect that the `vsce` options `--baseContentUrl` and `--baseImagesUrl` belong to the `package` command, not the `publish` command. 

reference: https://github.com/Microsoft/vscode-vsce/blob/master/src/main.ts