### PR TITLE
Fix args expansion for code function in profile

### DIFF
--- a/docs/editor/setup.md
+++ b/docs/editor/setup.md
@@ -21,7 +21,7 @@ Getting up and running with VS Code is quick and easy.  Follow the platform spec
 >**Tip:** If you want to run VS Code from the terminal, append the following to your `~/.bash_profile` file (`~/.zshrc` in case you use `zsh`) and then either restart the terminal or type `source ~/.bash_profile`:
 >
 >```bash
->function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args $*; }
+>function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args "$@"; }
 >```
 
 Now, you can simply type `code .` in any folder to start editing files in that folder.


### PR DESCRIPTION
The advice to use `--args $*` is bad for any filename with spaces in it:

```
touch 'a b'
touch 'c d'
code 'a b' 'c d'
```

The results are:

* `--args $*`: VSC opens four files named `a`, `b`, `c`, and `d`
* `--args "$*"`: VSC opens one file named `a b c d`
* `--args "$@"`: VSS opens two files named `a b` and `c d` (correct)

The `fish` examples might also need checking.