### PR TITLE
fixed ES5 in "target": "es5"

### DIFF
--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -31,7 +31,7 @@ A simple `tsconfig.json` looks like this for ES5, AMD modules and source maps:
 ```json
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "es5",
         "module": "amd",
         "sourceMap": true
     }

--- a/docs/runtimes/nodejs.md
+++ b/docs/runtimes/nodejs.md
@@ -93,7 +93,7 @@ You can give even more hints to Visual Studio Code through a configuration file 
 ```json
 {
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "es5",
 		"module": "commonjs"
 	}
 }


### PR DESCRIPTION
This is a fix of a typo in "target": "es5". 