### PR TITLE
Fixed bash functions to support names with spaces

### DIFF
--- a/docs/editor/setup.md
+++ b/docs/editor/setup.md
@@ -21,12 +21,12 @@ Getting up and running with VS Code is quick and easy.  Follow the platform spec
 >**Tip:** If you want to run VS Code from the terminal, append the following to your `~/.bash_profile` file (`~/.zshrc` in case you use `zsh`) and then either restart the terminal or type `source ~/.bash_profile`:
 >
 >```bash
->function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args $*; }
+>function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args "$@"; }
 >```
 >If you are using the prerelease [Insiders](/docs/supporting/FAQ.md#how-can-i-test-prerelease-versions-of-vs-code) build, you would use:
 >
 >```bash
->function code-insiders () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCodeInsiders" --args $*; }
+>function code-insiders () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCodeInsiders" --args "$@"; }
 >```
 
 Now, you can simply type `code .` in any folder to start editing files in that folder.


### PR DESCRIPTION
The section in [Setting up Visual Studio Code](https://code.visualstudio.com/docs/editor/setup) on OS X has a problem. Specifically, the tip for running VS Code from the OS X terminal contains a bug. The code in question:

    function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCode" --args $*; }

There are two issues here. First, the unquoted `$*` is subject to word splitting and globbing. As is, this function will not work with file names containing spaces, something well within the user domain on OS X. For example, `code foo\ bar` will cause VS Code to open windows to two new buffers, one for `foo` and one for `bar`, when the intent was to open the file `foo bar` (note the embedded space).

The fix is simple. Replace `$*` with `"$@"`, which treats `foo\ bar` (or `'foo bar'` for that matter) as a single argument, which is precisely what we want. Of course, the updated function continues to work with file names that don't contain spaces.

For details on these issues, see [Use "$@" (with quotes) to prevent whitespace problems](https://github.com/koalaman/shellcheck/wiki/SC2048) and [Double quote to prevent globbing and word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086).