### PR TITLE
Explain that the `typescript.tsdk` path can be relative to the workspace

### DIFF
--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -152,7 +152,7 @@ This pattern will match on any JavaScript file (`**/*.js`) but only if a sibling
 
 ## Using Newer TypeScript Versions
 
-VS Code ships with a recent stable version of TypeScript in the box.  If you want to use a newer version of TypeScript, you can define the `typescript.tsdk` setting (`File | Preferences | User/Workspace Settings`) pointing to a directory containing the TypeScript `tsserver.js` and the corresponding `lib.*.d.ts` files. This setting supports relative paths so you can easily share this workspace setting with your team and use the latest TypeScript version (`npm install typescript@next`). Refer to this [blog post](https://blogs.msdn.com/b/typescript/archive/2015/07/27/introducing-typescript-nightlies.aspx) for more details on how to install the nightly builds of TypeScript.
+VS Code ships with a recent stable version of TypeScript in the box.  If you want to use a newer version of TypeScript, you can define the `typescript.tsdk` setting (`File | Preferences | User/Workspace Settings`) pointing to a directory containing the TypeScript `tsserver.js` and the corresponding `lib.*.d.ts` files. The directory path can be absolute or relative to the workspace directory. This setting supports relative paths so you can easily share this workspace setting with your team and use the latest TypeScript version (`npm install typescript@next`). Refer to this [blog post](https://blogs.msdn.com/b/typescript/archive/2015/07/27/introducing-typescript-nightlies.aspx) for more details on how to install the nightly builds of TypeScript.
 
 ## Next Steps
 


### PR DESCRIPTION
I added the sentence 

> The directory path can be absolute or relative to the workspace directory. 

See also https://github.com/Microsoft/vscode/issues/3727