### PR TITLE
Correcting invalid type value in configuration example.

### DIFF
--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -45,7 +45,7 @@ You can read these values from your extension using `vscode.workspace.getConfigu
 				"description": "Complete functions with their parameter signature."
 			},
 			"typescript.tsdk": {
-				"type": "string",
+				"type": ["string", "null"],
 				"default": null,
 				"description": "Specifies the folder path containing the tsserver and lib*.d.ts files to use."
 			}


### PR DESCRIPTION
The example configuration shown contains an invalid type specifier that does not allow for a default value of null (the default value used in the example). Corrected this example to match the actual value used in the real typescript.tsdk setting definition.