### PR TITLE
Typo in "operating system"

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -167,7 +167,7 @@ The HTML formatter is based on the **beautifyjs** library. The formatting option
 
 ## Localization
 
-VS Code is now translated to the following 9 languages: Simplified Chinese, Traditional Chinese, French, German, Italian, Japanese, Korean, Russian and Spanish. By default, VS Code picks up the operation system's language. If you want to configure a specific language, you can either use the command line switch `--locale` to specify a locale when you launch VS Code or use the **Configure Language** action to specify a locale setting to use whenever VS Code is started. Examples are `de` for German or `zh-TW` for Traditional Chinese.
+VS Code is now translated to the following 9 languages: Simplified Chinese, Traditional Chinese, French, German, Italian, Japanese, Korean, Russian and Spanish. By default, VS Code picks up the operating system's language. If you want to configure a specific language, you can either use the command line switch `--locale` to specify a locale when you launch VS Code or use the **Configure Language** action to specify a locale setting to use whenever VS Code is started. Examples are `de` for German or `zh-TW` for Traditional Chinese.
 
 ![Configure Language](images/March/language.png)
 


### PR DESCRIPTION
In release-notes/latest.md It says: "operation system", it should say: "operating system"