### PR TITLE
Add docs and blog page-specific OpenGraph social metadata

### DIFF
--- a/blogs/2016/04/14/vscode-1.0.md
+++ b/blogs/2016/04/14/vscode-1.0.md
@@ -6,6 +6,7 @@ MetaDescription: Visual Studio Code releases 1.0.
 Date: 2016-04-14
 ShortDescription: Visual Studio Code releases 1.0.
 Author: PJ Meyer
+MetaSocialImage: 2016_04_14_header.png
 ---
 
 # Visual Studio Code 1.0!

--- a/scripts/gulpfile.blog.js
+++ b/scripts/gulpfile.blog.js
@@ -33,7 +33,8 @@ function mapFileToBlogArticle(file) {
         File: null,
         Date: file.data.Date,
         Author: file.data.Author,
-        ShortDescription: file.data.ShortDescription
+        ShortDescription: file.data.ShortDescription,
+        MetaSocialImage: file.data.MetaSocialImage
 	};
 }
 

--- a/scripts/templates/blog-template.html
+++ b/scripts/templates/blog-template.html
@@ -40,5 +40,9 @@
     <meta property="og:type" content="article"/>
     <meta property="og:title" content="{$ Title $}"/>
     <meta property="og:description" content="{$ MetaDescription $}"/>
-    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-docs-documentation.png"/>
+    {% if MetaSocialImage %}
+    <meta property="og:image" content="http://code.visualstudio.com/images/{$ MetaSocialImage $}"/>
+    {% else %}
+    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-blog.png"/>
+    {% endif %}
 {{/section}}

--- a/scripts/templates/blog-template.html
+++ b/scripts/templates/blog-template.html
@@ -32,6 +32,13 @@
 	</div>
 </div>
 {{#section 'meta'}}
-	<meta name="description" content="{$ MetaDescription $}" />
-	<meta name="keywords" content="{$ MetaTags $}" />
+    <meta name="description" content="{$ MetaDescription $}" />
+    <meta name="keywords" content="{$ MetaTags $}" />
+    <!-- Twitter and Facebook OpenGraph Metadata-->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:url" content="http://code.visualstudio.com/blogs/{$ Link $}"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="{$ Title $}"/>
+    <meta property="og:description" content="{$ MetaDescription $}"/>
+    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-docs-documentation.png"/>
 {{/section}}

--- a/scripts/templates/portaldocs-template.html
+++ b/scripts/templates/portaldocs-template.html
@@ -43,6 +43,6 @@
     <meta name="ms.prod" content="vs-code" />
     <meta name="ms.TOCTitle" content="{$ NavTitle $}" />
     <meta name="ms.ContentId" content="{$ ContentId $}" />
-    <meta name="ms.date" content="{$ DateApproved $}"
+    <meta name="ms.date" content="{$ DateApproved $}" />
     <meta name="ms.topic" content="article" />
 {{/section}}

--- a/scripts/templates/portaldocs-template.html
+++ b/scripts/templates/portaldocs-template.html
@@ -45,4 +45,11 @@
     <meta name="ms.ContentId" content="{$ ContentId $}" />
     <meta name="ms.date" content="{$ DateApproved $}" />
     <meta name="ms.topic" content="article" />
+	<!-- Twitter and Facebook OpenGraph Metadata-->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:url" content="http://code.visualstudio.com/docs/{$ Link $}"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="{$ Title $}"/>
+    <meta property="og:description" content="{$ MetaDescription $}"/>
+    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-docs-documentation.png"/>
 {{/section}}

--- a/scripts/templates/portaldocs-template.html
+++ b/scripts/templates/portaldocs-template.html
@@ -51,5 +51,5 @@
     <meta property="og:type" content="article"/>
     <meta property="og:title" content="{$ Title $}"/>
     <meta property="og:description" content="{$ MetaDescription $}"/>
-    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-docs-documentation.png"/>
+    <meta property="og:image" content="http://code.visualstudio.com/opengraphimg/opengraph-blog.png"/>
 {{/section}}


### PR DESCRIPTION
Includes images and other meta-data.

Must be included with the [corresponding PR](https://github.com/Microsoft/vscode-website/pull/284) in the vscode-website repo.