### PR TITLE
Add documentation for editor.action.insertCursorAtEndOfEachLineSelected

### DIFF
--- a/docs/customization/keybindings.md
+++ b/docs/customization/keybindings.md
@@ -32,6 +32,7 @@ Key|Command|Command id
 `kb(editor.action.addSelectionToNextFindMatch)`|Add Selection To Next Find Match|`editor.action.addSelectionToNextFindMatch`
 `kb(editor.action.moveSelectionToNextFindMatch)`|Move Last Selection To Next Find Match|`editor.action.moveSelectionToNextFindMatch`
 `kb(cursorUndo)`|Undo last cursor operation|`cursorUndo`
+`kb(editor.action.insertCursorAtEndOfEachLineSelected)`|Insert cursor at end of each line selected|`editor.action.insertCursorAtEndOfEachLineSelected`
 `kb(editor.action.selectHighlights)`|Select all occurrences of current selection|`editor.action.selectHighlights`
 `kb(editor.action.changeAll)`|Select all occurrences of current word|`editor.action.changeAll`
 `kb(expandLineSelection)`|Select current line|`expandLineSelection`


### PR DESCRIPTION
This functionality already exists but isn't documented. See also https://visualstudio.uservoice.com/forums/293070-visual-studio-code/suggestions/9508236-selection-split-into-lines-multi-cursor