### PR TITLE
Correct an invalid command name

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -73,7 +73,7 @@ Component | folder to exclude
 
 When your JavaScript project is growing too large, it is often because of library folders like `node_modules`. If VS Code detects that your project is growing too large, it will prompt you to edit the `exclude` list.
 
->**Tip:** Sometimes changes to configuration, such as adding or editing a `jsconfig.json` file are not picked up correctly. Running the **Reload Java Script** command should reload the project and pick up the changes.
+>**Tip:** Sometimes changes to configuration, such as adding or editing a `jsconfig.json` file are not picked up correctly. Running the **Reload JavaScript Project** command should reload the project and pick up the changes.
 
 ### jsconfig Options
 


### PR DESCRIPTION
The JavaScript language docs reference a `Reload Java Script` command, which doesn't exist in Command Palette. This PR changes the command reference to `Reload JavaScript Project`, which does exist in Command Palette.