### PR TITLE
Update definition to declaration

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -111,9 +111,9 @@ Where type inference does not provide the desired type information, (or just for
 
 This [document](https://github.com/Microsoft/TypeScript/wiki/JsDoc-support-in-JavaScript) describes the **JSDoc** annotations currently supported.
 
-### TypeScript definition file
+### TypeScript declaration files
 
- You can also get IntelliSense for libraries through the use of type definition `.d.ts` files. [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) is a repository of typings files for all major JavaScript libraries and environments. The typings are easily managed using [Typings](https://github.com/typings/typings), the TypeScript Definition manager.
+ You can also get IntelliSense for libraries through the use of type declaration `.d.ts` files. [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) is a repository of typings files for all major JavaScript libraries and environments. The typings are easily managed using [Typings](https://github.com/typings/typings), the TypeScript Definition manager.
 
 For example `typings install dt~node --global` installs all the typings for the built-in Node.js modules. If your project has a `jsconfig.json` file, then make sure that `typings` is contained in the project context defined by the location of the `jsconfig.json` file. If you have no `jsconfig.json`, then you need to manually add a `/// reference`  to the `.d.ts` from each JavaScript file.
 


### PR DESCRIPTION
The semantically correct term for TypeScript `.d.ts` files is declaration not definition.