### PR TITLE
Explain that Show Explorer key binding also toggles focus

### DIFF
--- a/docs/customization/keybindings.md
+++ b/docs/customization/keybindings.md
@@ -153,8 +153,8 @@ Key|Command|Command id
 `kb(workbench.action.zoomOut)`|Zoom out|`workbench.action.zoomOut`
 `kb(workbench.action.toggleSidebarVisibility)`|Toggle Sidebar Visibility|`workbench.action.toggleSidebarVisibility`
 `kb(workbench.view.debug)`|Show Debug|`workbench.view.debug`
-`kb(workbench.view.explorer)`|Show Explorer|`workbench.view.explorer`
-`kb(workbench.view.git)`|Show Git|`workbench.view.git` 
+`kb(workbench.view.explorer)`|Show Explorer / Toggle Focus|`workbench.view.explorer`
+`kb(workbench.view.git)`|Show Git|`workbench.view.git`
 `kb(workbench.view.search)`|Show Search|`workbench.view.search`
 `kb(workbench.action.search.toggleQueryDetails)`|Toggle Search Details|`workbench.action.search.toggleQueryDetails`
 `kb(workbench.action.terminal.openNativeConsole)`|Open New Command Prompt|`workbench.action.terminal.openNativeConsole`


### PR DESCRIPTION
There's no way to preview how the docs are going to render on the website, right?

There's no default key binding for hiding the explorer?