### PR TITLE
Remove highlighting of standard text

### DIFF
--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -60,7 +60,7 @@ You can read these values from your extension using `vscode.workspace.getConfigu
 
 Contribute an entry consisting of a title and a command to invoke to the Command Palette (`kb(workbench.action.showCommands)`).
 
->**Note:** When a command is invoked (from a key binding or from the Command Palette), VS Code will emit an `activationEvent` `onCommand:${command}`.
+>**Note:** When a command is invoked (from a key binding or from the Command Palette), VS Code will emit an activationEvent `onCommand:${command}`.
 
 ### Example
 


### PR DESCRIPTION
The word "activationEvent" is wrongly highlighted.
As it is just standard text and to align with the other usages of the same word within this document, I think the highlighting should be removed.