### PR TITLE
Fixed vscode-api-commands.md typo

### DIFF
--- a/docs/extensionAPI/vscode-api-commands.md
+++ b/docs/extensionAPI/vscode-api-commands.md
@@ -92,7 +92,7 @@ let success = await commands.executeCommand('vscode.previewHtml', uri);
 * _(returns)_ A promise that resolves to an array of Command-instances.
 
 
-`vscode.executeCodeLensProvider` - Execute completion item provider.
+`vscode.executeCodeLensProvider` - Execute completion lens provider.
 
 * _uri_ Uri of a text document
 * _(returns)_ A promise that resolves to an array of CodeLens-instances.


### PR DESCRIPTION
There was a super small typo probably from copying and pasting