### PR TITLE
add Link to the javascript snippets file

### DIFF
--- a/docs/customization/userdefinedsnippets.md
+++ b/docs/customization/userdefinedsnippets.md
@@ -34,7 +34,7 @@ You can define your own snippets for specific languages.  To open up a snippet f
 
 Snippets are defined in a JSON format and stored in a per user `(languageId).json` file. For example, Markdown snippets go in a `markdown.json` file.
 
-The example below is a `For Loop` snippet for `JavaScript`.
+The example below is a `For Loop` snippet for [`JavaScript`](https://github.com/Microsoft/vscode/blob/master/extensions/javascript/snippets/javascript.json).
 
 ```json
     "For Loop": {


### PR DESCRIPTION
I would have liked to be directed to the place where I can get some inspiration through seeing how the existing snippets are defined.