### PR TITLE
Removed User Voice references and links. 

### DIFF
--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -104,6 +104,6 @@ From **File** > **Preferences** > **User Settings**, add the following option to
 
 ## Technical Support
 
-You can ask questions and search for answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode), provide suggestions on [UserVoice](http://go.microsoft.com/fwlink/?LinkID=533482), and enter issues directly in our [GitHub repository](https://github.com/Microsoft/vscode/issues).
+You can ask questions and search for answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode) and enter issues and feature requests directly in our [GitHub repository](https://github.com/Microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions).
 
 If you'd like to contact a professional support engineer, you can open a ticket with the [Microsoft assisted support team](https://support.microsoft.com/en-us/assistedsupportproducts).

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -104,6 +104,6 @@ From **File** > **Preferences** > **User Settings**, add the following option to
 
 ## Technical Support
 
-You can ask questions and search for answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode) and enter issues and feature requests directly in our [GitHub repository](https://github.com/Microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions).
+You can ask questions and search for answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode) and enter issues and feature requests directly in our [GitHub repository](https://github.com/Microsoft/vscode/blob/master/CONTRIBUTING.md).
 
 If you'd like to contact a professional support engineer, you can open a ticket with the [Microsoft assisted support team](https://support.microsoft.com/en-us/assistedsupportproducts).


### PR DESCRIPTION
@gregvanl are there other references in docs? I was suprised this was the only one (using global search for "uservoice" and "User Voice")

The connect widget is actually pointing to a forward link so its already updated. We do need to change the icon. Tracking that issue [here](https://github.com/Microsoft/vscode-website/issues/467). 