### PR TITLE
Markdown external links now open in new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,27 +9,28 @@
     "url": "https://github.com/Microsoft/vscode-docs.git"
   },
   "devDependencies": {
+    "del": "^2.1.0",
     "event-stream": "^3.3.1",
     "gulp": "^3.9.0",
     "gulp-data": "^1.2.0",
     "gulp-front-matter": "^1.2.3",
+    "gulp-git": "^1.6.0",
     "gulp-imagemin": "^2.3.0",
     "gulp-marked": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-slash": "^1.1.3",
+    "gulp-tsb": "1.8.0",
     "gulp-typedoc": "^1.2.1",
     "gulp-util": "^3.0.7",
     "highlight.js": "^8.7.0",
-    "markdown-it": "^4.4.0",
-    "swig": "^1.4.2",
-    "vinyl": "^0.5.1",
-    "gulp-git": "^1.6.0",
-    "del": "^2.1.0",
-    "request": "^2.67.0",
-    "run-sequence": "^1.1.5",
-    "rimraf": "^2.4.4",
+    "markdown-it": "^7.0.1",
+    "markdown-it-external-links": "0.0.5",
     "marked": "^0.3.5",
-    "gulp-tsb": "1.8.0",
-    "node.extend": "^1.1.5"
+    "node.extend": "^1.1.5",
+    "request": "^2.67.0",
+    "rimraf": "^2.4.4",
+    "run-sequence": "^1.1.5",
+    "swig": "^1.4.2",
+    "vinyl": "^0.5.1"
   }
 }

--- a/scripts/gulpfile.common.js
+++ b/scripts/gulpfile.common.js
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
  
 var markdownIt = require('markdown-it');
+var externalLinks = require('markdown-it-external-links');
 var highlightjs = require('highlight.js');
 var swig = require('swig');
 var slash = require('gulp-slash');
@@ -64,6 +65,10 @@ exports.mapFileToArticle = function(file) {
 
 exports.compileMarkdown = function(file, article) {
 	var md = markdownIt({ html: true, langPrefix: '' });
+	md.use(externalLinks, {
+		externalTarget: "_blank",
+		internalDomains: ["code.visualstudio.com"]
+	});
 
 	// Apply custom markdown rules
 	md.renderer.rules.heading_open = function (tokens, idx, options, env, self) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-website/issues/464

@waderyan 
Two things to note:

1. To use this, we needed to upgrade our **markdown-it**, so it could support a `getAttr` method used by the new dependency I added.  Note that I set the required version to `"markdown-it": "^7.0.1"` (latest release).
2. Note that the dev dependencies for **markdown-it-external-links** says that it requires version `^6.0.4` of markdown-it as a devDependency [(see here)](https://david-dm.org/rotorz/markdown-it-external-links?type=dev).  Does this mean I can't use the latest markdown-it as I mentioned earlier?  Everything seems to work fine.

We should check that nothing renders in an unexpected way in the docs on PPE before we roll this out.