### PR TITLE
Document key binding for `Reset Zoom`

### DIFF
--- a/docs/customization/keybindings.md
+++ b/docs/customization/keybindings.md
@@ -155,6 +155,7 @@ Key|Command|Command id
 `kb(workbench.action.toggleFullScreen)`|Toggle Full Screen|`workbench.action.toggleFullScreen`
 `kb(workbench.action.zoomIn)`|Zoom in|`workbench.action.zoomIn`
 `kb(workbench.action.zoomOut)`|Zoom out|`workbench.action.zoomOut`
+`kb(workbench.action.zoomReset)`|Reset Zoom|`workbench.action.zoomReset`
 `kb(workbench.action.toggleSidebarVisibility)`|Toggle Sidebar Visibility|`workbench.action.toggleSidebarVisibility`
 `kb(workbench.view.debug)`|Show Debug|`workbench.view.debug`
 `kb(workbench.view.explorer)`|Show Explorer / Toggle Focus|`workbench.view.explorer`


### PR DESCRIPTION
Key was added in https://github.com/Microsoft/vscode/commit/207a8e33145c09aaeaa99e44ee7599a4112cfbd4