### PR TITLE
Add terminal.integrated.commandsToSkipShell docs

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -116,6 +116,10 @@ Copy and paste on Linux & Windows can be done using `kbstyle(Ctrl+Ins)` and `kbs
 
 > Pre-release: This is changing in the upcoming version to `kbstyle(Ctrl+Shift+C)` and `kbstyle(Ctrl+Shift+V)`. This change is available now in the [Insiders build](https://code.visualstudio.com/insiders).
 
+### Forcing keybindings to pass through the terminal
+
+While focus is in the integrated terminal, many keybindings will not work as the keystrokes are passed to and consumed by the terminal itself. The `terminal.integrated.commandsToSkipShell` setting can be used to get around this. It contains an array of command names whose keybindings will skip processing by the shell and instead be processed by the VS Code keybinding system. By default this includes all terminal keybindings in addition to a select few commonly used keybidnings.
+
 ## Common Questions
 
 ### Why is VS Code shortcut X not working when the terminal has focus?


### PR DESCRIPTION
Fixes #556

---

Note this is for `vnext`. @gregvanl feel free to merge and make your own improvements. I wasn't sure if an example was needed, it might get messy as the default set is quite big and may change across versions.