### PR TITLE
updated integrated-terminal.md \\ Copy and Paste

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -108,9 +108,7 @@ Copy and paste on OS X can be done using the standard keys, `kbstyle(Cmd+C)` and
 
 #### Linux & Windows
 
-Copy and paste on Linux & Windows can be done using `kbstyle(Ctrl+Ins)` and `kbstyle(Shift+Ins)` respectively. 
-
-> Pre-release: This is changing in the upcoming version to `kbstyle(Ctrl+Shift+C)` and `kbstyle(Ctrl+Shift+V)`. This change is available now in the [Insiders build](https://code.visualstudio.com/insiders).
+Copy and paste on Linux & Windows can be done using `kbstyle(Ctrl+C)` and `kbstyle(Ctrl+V)` respectively. 
 
 ## Common Questions
 


### PR DESCRIPTION
Altered the Copy & Paste commands for Linux % Windows to Ctrl+C and Ctrl+V as this appears to be the default at least as of release 1.4.
I also sent this as feedback on the article, but if I am mistaken feel free to ignore the Pull Request. Thank you.