### PR TITLE
Blog/docs tweet titles; Updates tweet descriptions

### DIFF
--- a/scripts/templates/blog-template.html
+++ b/scripts/templates/blog-template.html
@@ -20,7 +20,7 @@
                 </ul>
             <a class="twitter-share-button"
                 href="https://twitter.com/share"
-                data-text="New blog from VS Code"
+                data-text="{$ Title $}"
                 data-via="Code"
                 data-counturl="https://code.visualstudio.com/blogs/{$ Link $}"
                 data-count="vertical">

--- a/scripts/templates/portaldocs-template.html
+++ b/scripts/templates/portaldocs-template.html
@@ -27,7 +27,7 @@
                 </ul>
 				<a class="twitter-share-button"
 				   href="https://twitter.com/share"
-				   data-text="Sharing this doc"
+				   data-text="{$ Title $}"
                    data-via="Code"
 				   data-counturl="https://code.visualstudio.com/Docs/{$ Link $}"
 				   data-count="vertical">

--- a/scripts/templates/releasenotes-template.html
+++ b/scripts/templates/releasenotes-template.html
@@ -19,7 +19,7 @@
                 </ul>
 				<a class="twitter-share-button"
 				   href="https://twitter.com/share"
-				   data-text="Sharing this doc"
+				   data-text="{$ Title $}"
                    data-via="Code"
 				   data-counturl="https://code.visualstudio.com/Updates/{$ Link $}"
 				   data-count="vertical">

--- a/scripts/templates/releasenotes-template.html
+++ b/scripts/templates/releasenotes-template.html
@@ -19,7 +19,7 @@
                 </ul>
 				<a class="twitter-share-button"
 				   href="https://twitter.com/share"
-				   data-text="{$ Title $}"
+				   data-text="{$ MetaDescription $}"
                    data-via="Code"
 				   data-counturl="https://code.visualstudio.com/Updates/{$ Link $}"
 				   data-count="vertical">


### PR DESCRIPTION
Regarding 
https://github.com/Microsoft/vscode-website/issues/408

Since we can only fit a 140 characters, descriptions are sometimes too long (except for the Updates pages which tend to be short).  Also, updates pages' descriptions seem to be more powerful than their sister titles.