### PR TITLE
Add link to Getting Started Tutorial

### DIFF
--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -29,6 +29,8 @@ Due to this focus, many standard C# project types are not recognized by VS Code.
 
 C# language support is an optional [install from the Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp). You can install it from within VS Code by searching for 'C#' in the **Extensions: Install Extension** dropdown (`kb(workbench.action.showCommands)` and type `ext install`) or if you already have a project with C# files, VS Code will prompt you to install the extension as soon as you open a C# file.
 
+[Tutorial on Getting Started with C# in VS Code with .NET Core](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-using-CSharp-and-NET-Core)
+
 In addition to the [Microsoft C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), the community has produced other extensions. 
 
 <div class="marketplace-extensions-csharp"></div>


### PR DESCRIPTION
Add a link to my "Get started with VS Code using c# and .NET Core" tutorial on channel 9 under the "Installing C# Support" section.