### PR TITLE
Remove non-existent language id (fix highlight.js error)

### DIFF
--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -221,7 +221,7 @@ To test the language server do the following:
 * Now go back to the VS Code instance with the extension (client) and press `kb(workbench.action.debug.start)` to launch an additional `Extension Development Host` instance of VS Code that executes the extension code.
 * Create a test.txt file in the root folder and paste the following content:
 
-```plaintext
+```
 typescript lets you write JavaScript the way you really want to.
 typescript is a typed superset of JavaScript that compiles to plain JavaScript.
 Any browser. Any host. Any OS. Open Source.


### PR DESCRIPTION
```shell
WARNING -- WILL NOT HIGHLIGHT CODE BLOCK (```)
at /vscode-docs/docs/extensions/example-language-server.md
DUE TO ERROR :::Unknown language: "plaintext"
```