### PR TITLE
Update integrated-terminal.md

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -14,7 +14,7 @@ In Visual Studio Code, you can open an integrated terminal, initially starting a
 
 To open the terminal:
 
-* Use the `kb(workbench.action.terminal.toggleTerminal)` keyboard shortcut with the backtick character.
+* Use the `kb(workbench.action.terminal.toggleTerminal)` keyboard shortcut with the "'" (singlequote) character.
 * Use the **View** | **Toggle Integrated Terminal** menu command.
 * From the **Command Palette** (`kb(workbench.action.showCommands)`), use the **View:Toggle Integrated Terminal** command.
 


### PR DESCRIPTION
it is no more backtick char .  Tested on Windows 10 , 64 bit PRO.  Studio Code Version 1.6.0 ,  shell version 1.3.7 , Node 6.5.0