### PR TITLE
Fix broken image on intro videos overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 .DS_Store
 .vscode/spell.json
+
+.idea

--- a/docs/introvideos/overview.md
+++ b/docs/introvideos/overview.md
@@ -28,7 +28,7 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 	</li>
 	<li class="video">
 		<a href="/docs/introvideos/basics">
-			<img src="https://img.youtube.com/vi/fpqy0ZkavWM/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
+			<img src="https://img.youtube.com/vi/LUl_WXt8ohA/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
 			<div class="info">
 				<h2 class="title faux-h3">Setup and Basics</h2>
 				<p class="description">Install and learn the basics of your new editor.</p>


### PR DESCRIPTION
There is a broken image on the intro videos overview page. This will fix it. 

[Problem Page](https://code.visualstudio.com/docs/introvideos/overview)

![image](https://cloud.githubusercontent.com/assets/2449568/19527721/fa7fb75e-95dd-11e6-8b94-4f6002466493.png)

After Fix

![image](https://cloud.githubusercontent.com/assets/2449568/19527745/0db9b342-95de-11e6-87eb-cdc81ad0c87b.png)

Cause is that @pjmeyer and I deleted a video yesterday that wasn't being used. I failed to realize that the image of that old video was still being used. 
