### PR TITLE
extension-manifest Spell example does not use lower case name

### DIFF
--- a/docs/extensionAPI/extension-manifest.md
+++ b/docs/extensionAPI/extension-manifest.md
@@ -46,7 +46,7 @@ Here is a complete `package.json`
 
 ```json
 {
-	"name": "Spell",
+	"name": "spell",
 	"displayName": "Spelling and Grammar Checker",
 	"description": "Detect mistakes as you type and suggest fixes - great for Markdown.",
 	"icon": "images/spellIcon.svg",


### PR DESCRIPTION
Example name does not match the pattern of "^[^A-Z]+$".