### PR TITLE
Update linux.md

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -17,7 +17,7 @@ MetaDescription: Get Visual Studio Code up and running on Linux.
 
 ```bash
  # For .deb
- sudo dpkg -i <file>.deb
+ sudo apt install ./<file>.deb
 
  # For .rpm (Fedora 21 and below)
  sudo yum install <file>.rpm


### PR DESCRIPTION
Use apt instead of dpkg because dpkg doesn't handle dependencies automatically. In general, Ubuntu and Debian are moving away from apt-get to apt.