### PR TITLE
Fix "next" links in intro videos

### DIFF
--- a/docs/introvideos/codeediting.md
+++ b/docs/introvideos/codeediting.md
@@ -39,5 +39,5 @@ In this tutorial, we cover code editing, including the features outlined below. 
 
 ## Next Video
 
-* [Git Version Control](/docs/introvideos/versioncontrol.md) - Learn the basics of Git version control.
+* [IntelliSense](/docs/introvideos/intellisense.md) - Set up IntelliSense for intelligent code completion.
 

--- a/docs/introvideos/configure.md
+++ b/docs/introvideos/configure.md
@@ -32,4 +32,4 @@ In this tutorial, we show you how to personalize and extend VS Code.
 
 ## Next Video
 
-* [IntelliSense](/docs/introvideos/intellisense.md) - Set up IntelliSense for intelligent code completion.
+* [Advance Code Editing](/docs/introvideos/codeediting.md) - Learn advanced editing tips and tricks.

--- a/docs/introvideos/intellisense.md
+++ b/docs/introvideos/intellisense.md
@@ -33,4 +33,4 @@ In this tutorial, we show you how to set up IntelliSense for a JavaScript projec
 
 ## Next Video
 
-* [Advanced Code Editing](/docs/introvideos/codeediting.md) - Learn advanced editing tips and tricks.
+* [Git Version Control](/docs/introvideos/versioncontrol.md) - Learn the basics of Git version control.

--- a/docs/introvideos/overview.md
+++ b/docs/introvideos/overview.md
@@ -47,22 +47,22 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 		</a>
 	</li>
 	<li class="video">
-		<a href="/docs/introvideos/intellisense">
-			<img src="https://img.youtube.com/vi/jVIe82TdmqE/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
-			<div class="info">
-				<h2 class="title faux-h3">IntelliSense</h2>
-				<p class="description">Receive intelligent code completions.</p>
-				<span class="duration"><span class="sr-only">Duration </span>5<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
-			</div>
-		</a>
-	</li>
-	<li class="video">
 		<a href="/docs/introvideos/codeediting">
 			<img src="https://img.youtube.com/vi/rsatrlBEFFA/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
 			<div class="info">
 				<h2 class="title faux-h3">Code Editing</h2>
 				<p class="description">Take code editing to the next level.</p>
 				<span class="duration"><span class="sr-only">Duration </span>6<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
+			</div>
+		</a>
+	</li>
+	<li class="video">
+		<a href="/docs/introvideos/intellisense">
+			<img src="https://img.youtube.com/vi/jVIe82TdmqE/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
+			<div class="info">
+				<h2 class="title faux-h3">IntelliSense</h2>
+				<p class="description">Receive intelligent code completions.</p>
+				<span class="duration"><span class="sr-only">Duration </span>5<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
 			</div>
 		</a>
 	</li>


### PR DESCRIPTION
The order of the videos in the first post was not the same as the TOC. Also, the *next* links were not following the correct order.