### PR TITLE
Add section on ts 2.1 to 1.8 release notes

### DIFF
--- a/release-notes/v1_8.md
+++ b/release-notes/v1_8.md
@@ -17,7 +17,7 @@ Welcome to the November release of Visual Studio Code. There are a number of sig
 * **[Git clone](#git-clone)** - Clone your repo from within VS Code.
 * **[New Selection menu](#selection-menu)** - Easily discover and use the editor selection commands.
 * **[JavaScript IntelliSense in HTML](#javascript-language-support-in-html)** - Get full JavaScript language support in HTML files.
-* **[TypeScript 2.1](#typescript-21)** - Improved language support for JavaScript and TypeScript.
+* **[TypeScript Update](#typescript-update)** - Improved language support for JavaScript and TypeScript.
 * **[Markdown preview improvements](#markdown-preview-improvements)** - New settings for font family, size and line height, hide YAML front matter.
 * **[UI for Multitarget Debugging](#multitarget-debugging)** - Launch simultaneous debug sessions.
 
@@ -233,11 +233,15 @@ Coding assistance for JavaScript embedded in HTML is back! You get code completi
 
 ![JavaScript editing in HTML](images/1_8/javascript-in-html.gif)
 
-### TypeScript 2.1
+### TypeScript Update
 
-We now use [TypeScript 2.1](https://blogs.msdn.microsoft.com/typescript/2016/12/07/announcing-typescript-2-1/) for JavaScript and TypeScript language support. TypeScript 2.1 brings a number of new language and tooling features, including: [support for Object Rest and Spread](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-spread-and-rest), support for [async function when targeting ES5 and ES3](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#downlevel-async-functions), [configuration inheritance](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#configuration-inheritance), and much more.
+We now use [TypeScript 2.1](https://blogs.msdn.microsoft.com/typescript/2016/12/07/announcing-typescript-2-1/) for JavaScript and TypeScript language support. TypeScript 2.1 brings a number of new language and tooling features, including:
 
-[Read about what's new in TypeScript 2.1](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-21)
+* [Support for Object Rest and Spread](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-spread-and-rest). This was a heavily requested feature request by JS developers working with React. Now you no longer need to disable JavaScript validation when  using Object Spread/Rest.
+* Support for [async function when targeting ES5 and ES3](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#downlevel-async-functions).
+* [Configuration inheritance](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#configuration-inheritance)
+
+And much more. [Read about what's new in TypeScript 2.1](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-21)
 
 ### CSS improvements
 

--- a/release-notes/v1_8.md
+++ b/release-notes/v1_8.md
@@ -17,6 +17,7 @@ Welcome to the November release of Visual Studio Code. There are a number of sig
 * **[Git clone](#git-clone)** - Clone your repo from within VS Code.
 * **[New Selection menu](#selection-menu)** - Easily discover and use the editor selection commands.
 * **[JavaScript IntelliSense in HTML](#javascript-language-support-in-html)** - Get full JavaScript language support in HTML files.
+* **[TypeScript 2.1](#typescript-21)** - Improved language support for JavaScript and TypeScript.
 * **[Markdown preview improvements](#markdown-preview-improvements)** - New settings for font family, size and line height, hide YAML front matter.
 * **[UI for Multitarget Debugging](#multitarget-debugging)** - Launch simultaneous debug sessions.
 
@@ -231,6 +232,12 @@ These commands are not bound to any keyboard shortcuts by default.
 Coding assistance for JavaScript embedded in HTML is back! You get code completions and signature help for DOM and JQuery APIs, validation, hovers, Find References and Go To Definition, symbol highlighting and outline (Ctrl + Shift + o) and format. Note that the language support doesn't follow script includes, it only knows about definitions made in the same file.
 
 ![JavaScript editing in HTML](images/1_8/javascript-in-html.gif)
+
+### TypeScript 2.1
+
+We now use [TypeScript 2.1](https://blogs.msdn.microsoft.com/typescript/2016/12/07/announcing-typescript-2-1/) for JavaScript and TypeScript language support. TypeScript 2.1 brings a number of new language and tooling features, including: [support for Object Rest and Spread](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-spread-and-rest), support for [async function when targeting ES5 and ES3](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#downlevel-async-functions), [configuration inheritance](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#configuration-inheritance), and much more.
+
+[Read about what's new in TypeScript 2.1](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-21)
 
 ### CSS improvements
 


### PR DESCRIPTION
Adds section explaining upgrade to Typescript 2.1 in VSCode 1.8 