### PR TITLE
Chromium SUID sandbox error can be ignored

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -58,7 +58,7 @@ Once you have installed VS Code, these topics will help you learn more about VS 
 
 I'm getting a "Running without the SUID sandbox" error?
 
-Unfortunately, this is a known issue that we're still investigating.
+You can safely ignore this error.
 
 ### Debian and Moving Files to Trash
 


### PR DESCRIPTION
It's being removed in Chromium so it's probably not worth the effort to fix and validate it