### PR TITLE
Fix #713 - node sourcemap troubleshooting

### DIFF
--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -330,14 +330,15 @@ When you build your `app.ts` file in TypeScript with source maps enabled, it eit
 Finally, the debug adapter searches for the full path of `app.ts` in this resulting list of `.ts` files. If there's a match, it has found the source map file to use when mapping `app.ts` to `app.js`. If there is no match, then it can't bind the breakpoint, and it will turn gray.
 
 Here are some things to try when your breakpoints turn gray.
-* First and most important: do you have `"sourceMaps": true` in your launch config?
+* Do you have `"sourceMaps": true` in your launch config?
 * Did you build with source maps enabled? Are there `.js.map` files, or inlined source maps in your `.js` files?
 * Did you set the `outFiles` property in your launch config? It should be a glob pattern for an absolute path that matches your `.js` files.
 * Try the new experimental `node2` debug adapter. It can handle some more of the more complex source map cases.
 * Are the `sourceRoot` and `sources` properties in your source map correct? Can they be combined to get the correct path to the `.ts` file?
 * Are you using Webpack? By default, it outputs paths with a `webpack:///` prefix, which the debug adapter can't resolve. You can change this in your Webpack config with the `devtoolModuleFilenameTemplate` option, or try using `node2`, which provides some extra options for resolving these paths.
 * Have you opened the folder in VS Code with the incorrect case? It's possible to open folder `foo/` from the command line like `code FOO` in which case source maps may not be resolved correctly.
-* Try adding a `debugger` statement. If it breaks into the `.ts` file there, but breakpoints at that spot don't bind, that is useful information to include with a Github issue. If it breaks into a `.ts` file that says "read-only inline content from source map" next to it in Open Editors, then that's a sure sign that the source is inlined in the source map, and the path in the source map is incorrect.
+* Try searching for help with your particular setup on Stack Overflow or by filing an issue on Github.
+* Try adding a `debugger` statement. If it breaks into the `.ts` file there, but breakpoints at that spot don't bind, that is useful information to include with a Github issue.
 
 
 ### Attaching VS Code to Node.js

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -323,16 +323,16 @@ VS Code supports both the **inlined source maps** and the **inlined source**.
 
 A common issue when debugging with source maps is that you'll set a breakpoint, and it will turn gray. If you hover the cursor over it, you'll see the message, `"Breakpoint ignored because generated code not found (source map problem?)"`. What now? There are a range of issues that can lead to this. First, a quick explanation of how the Node debug adapter handles source maps.
 
-When you set a breakpoint in `app.ts`, the debug adapter has to figure out the path to `app.js`, the transpiled version of your TypeScript file, which is what is actually running in Node. But, there is not a straightforward way to figure this out starting from the `.ts` file. Instead, the debug adapter uses the `outFiles` attribute in the launch config to find all the transpiled `.js` files, and parses them for a source map, which contains the locations of its associated `.ts` files.
+When you set a breakpoint in `app.ts`, the debug adapter has to figure out the path to `app.js`, the transpiled version of your TypeScript file, which is what is actually running in Node. But, there is not a straightforward way to figure this out starting from the `.ts` file. Instead, the debug adapter uses the `outFiles` attribute in the `launch.json` to find all the transpiled `.js` files, and parses them for a source map, which contains the locations of its associated `.ts` files.
 
 When you build your `app.ts` file in TypeScript with source maps enabled, it either produces an `app.js.map` file, or a source map inlined as a base64-encoded string in a comment at the bottom of the `app.js` file. To find the `.ts` files associated with this map, the debug adapter looks at two properties in the source map, `sources`, and `sourceRoot`. `sourceRoot` is optional - if present, it is prepended to each path in `sources`, which is an array of paths. The result is an array of absolute or relative paths to `.ts` files. Relative paths are resolved relative to the source map.
 
 Finally, the debug adapter searches for the full path of `app.ts` in this resulting list of `.ts` files. If there's a match, it has found the source map file to use when mapping `app.ts` to `app.js`. If there is no match, then it can't bind the breakpoint, and it will turn gray.
 
 Here are some things to try when your breakpoints turn gray.
-* Do you have `"sourceMaps": true` in your launch config?
+* Do you have `"sourceMaps": true` in your `launch.json`?
 * Did you build with source maps enabled? Are there `.js.map` files, or inlined source maps in your `.js` files?
-* Did you set the `outFiles` property in your launch config? It should be a glob pattern for an absolute path that matches your `.js` files.
+* Did you set the `outFiles` property in your `launch.json`? It should be a glob pattern for an absolute path that matches your `.js` files.
 * Try the new experimental `node2` debug adapter. It can handle some more of the more complex source map cases.
 * Are the `sourceRoot` and `sources` properties in your source map correct? Can they be combined to get the correct path to the `.ts` file?
 * Are you using Webpack? By default, it outputs paths with a `webpack:///` prefix, which the debug adapter can't resolve. You can change this in your Webpack config with the `devtoolModuleFilenameTemplate` option, or try using `node2`, which provides some extra options for resolving these paths.

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -17,7 +17,7 @@ One of the key features of Visual Studio Code is its great debugging support. VS
 
 ## Debugger Extensions
 
-VS Code has built-in debugging support for the [Node.js](https://nodejs.org/) runtime and can debug JavaScript, TypeScript, and any other language that gets transpiled to JavaScript. 
+VS Code has built-in debugging support for the [Node.js](https://nodejs.org/) runtime and can debug JavaScript, TypeScript, and any other language that gets transpiled to JavaScript.
 
 For debugging other languages and runtimes (including [PHP](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug), [Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby), [Go](https://marketplace.visualstudio.com/items?itemName=lukehoban.Go), [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), [Python](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python) and many others), please look for `Debuggers` [extensions](/docs/editor/extension-gallery.md) in our VS Code [Marketplace](https://marketplace.visualstudio.com/vscode/Debuggers).
 
@@ -319,6 +319,27 @@ Source maps can be generated with two kinds of inlining:
 
 VS Code supports both the **inlined source maps** and the **inlined source**.
 
+#### JavaScript Source Map Tips
+
+A common issue when debugging with source maps is that you'll set a breakpoint, and it will turn gray. If you hover the cursor over it, you'll see the message, `"Breakpoint ignored because generated code not found (source map problem?)"`. What now? There are a range of issues that can lead to this. First, a quick explanation of how the Node debug adapter handles source maps.
+
+When you set a breakpoint in `app.ts`, the debug adapter has to figure out the path to `app.js`, the transpiled version of your TypeScript file, which is what is actually running in Node. But, there is not a straightforward way to figure this out starting from the `.ts` file. Instead, the debug adapter uses the `outFiles` attribute in the launch config to find all the transpiled `.js` files, and parses them for a source map, which contains the locations of its associated `.ts` files.
+
+When you build your `app.ts` file in TypeScript with source maps enabled, it either produces an `app.js.map` file, or a source map inlined as a base64-encoded string in a comment at the bottom of the `app.js` file. To find the `.ts` files associated with this map, the debug adapter looks at two properties in the source map, `sources`, and `sourceRoot`. `sourceRoot` is optional - if present, it is prepended to each path in `sources`, which is an array of paths. The result is an array of absolute or relative paths to `.ts` files. Relative paths are resolved relative to the source map.
+
+Finally, the debug adapter searches for the full path of `app.ts` in this resulting list of `.ts` files. If there's a match, it has found the source map file to use when mapping `app.ts` to `app.js`. If there is no match, then it can't bind the breakpoint, and it will turn gray.
+
+Here are some things to try when your breakpoints turn gray.
+* First and most important: do you have `"sourceMaps": true` in your launch config?
+* Did you build with source maps enabled? Are there `.js.map` files, or inlined source maps in your `.js` files?
+* Did you set the `outFiles` property in your launch config? It should be a glob pattern for an absolute path that matches your `.js` files.
+* Try the new experimental `node2` debug adapter. It can handle some more of the more complex source map cases.
+* Are the `sourceRoot` and `sources` properties in your source map correct? Can they be combined to get the correct path to the `.ts` file?
+* Are you using Webpack? By default, it outputs paths with a `webpack:///` prefix, which the debug adapter can't resolve. You can change this in your Webpack config with the `devtoolModuleFilenameTemplate` option, or try using `node2`, which provides some extra options for resolving these paths.
+* Have you opened the folder in VS Code with the incorrect case? It's possible to open folder `foo/` from the command line like `code FOO` in which case source maps may not be resolved correctly.
+* Try adding a `debugger` statement. If it breaks into the `.ts` file there, but breakpoints at that spot don't bind, that is useful information to include with a Github issue.
+
+
 ### Attaching VS Code to Node.js
 
 If you want to attach the VS Code debugger to a Node.js program, launch Node.js as follows:
@@ -396,7 +417,7 @@ In case you didn't already read the Node.js section, take a look at:
 
 To see a tutorial on the basics of Node.js debugging, check out:
 
-* [Intro Video - Debugging](/docs/introvideos/debugging.md) - Introductory video showcasing the basics of debugging. 
+* [Intro Video - Debugging](/docs/introvideos/debugging.md) - Introductory video showcasing the basics of debugging.
 
 To learn about VS Code's task running support, go to:
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -337,7 +337,7 @@ Here are some things to try when your breakpoints turn gray.
 * Are the `sourceRoot` and `sources` properties in your source map correct? Can they be combined to get the correct path to the `.ts` file?
 * Are you using Webpack? By default, it outputs paths with a `webpack:///` prefix, which the debug adapter can't resolve. You can change this in your Webpack config with the `devtoolModuleFilenameTemplate` option, or try using `node2`, which provides some extra options for resolving these paths.
 * Have you opened the folder in VS Code with the incorrect case? It's possible to open folder `foo/` from the command line like `code FOO` in which case source maps may not be resolved correctly.
-* Try adding a `debugger` statement. If it breaks into the `.ts` file there, but breakpoints at that spot don't bind, that is useful information to include with a Github issue.
+* Try adding a `debugger` statement. If it breaks into the `.ts` file there, but breakpoints at that spot don't bind, that is useful information to include with a Github issue. If it breaks into a `.ts` file that says "read-only inline content from source map" next to it in Open Editors, then that's a sure sign that the source is inlined in the source map, and the path in the source map is incorrect.
 
 
 ### Attaching VS Code to Node.js


### PR DESCRIPTION
Please temporarily forget everything you know about sourcemaps, read this, and tell me if it could be helpful.

It might be too much information. On one hand, detailed info on how this process works may help some users help themselves. On the other hand, I don't want to scare users away by making this seem more complicated than it is. Most of the time, debugging with source maps just works. The rest of the time, it's usually one of the first 3 bullet points. 

The important ideas in the paragraphs before the bulleted list are
* We have to get the .js first before we can map .js <-> .ts
* The paths in the source map file have to be correct

If this should be a detailed explanation of everything that happens, it could be expanded. If it should be more of a basic troubleshooting list, it could be cut.

I'm not mentioning the `trace` option since it's not quite official and we should decide how to standardize between node and node2 before documenting it.