### PR TITLE
language identifiers reference

### DIFF
--- a/docs/extensions/language-support.md
+++ b/docs/extensions/language-support.md
@@ -29,7 +29,7 @@ To make it easier for you to decide what to implement first and what to improve 
 
 ### Language identifiers
 
-VS Code maps different language configurations and providers to specific programming languages through a [language identifier](/docs/languages/overview.md#language-id). This is a lowercase string representing the programming language or file type. For example, JavaScript has a language id of `javascript` and Markdown files `markdown`.
+VS Code maps different language configurations and providers to specific programming languages through a [language identifier](/docs/languages/identifiers). This is a lowercase string representing the programming language or file type. For example, JavaScript has a language id of `javascript` and Markdown files `markdown`.
 
 ## Syntax Highlighting
 

--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -1,0 +1,93 @@
+# Language Identifiers
+
+In VS Code, each language mode has a unique specific language identifier. That identifier is rarely seen by the user except in the settings, e.g. when associating file extensions to a language:
+
+```json
+    "files.associations": {
+        "*.myphp": "php"
+    }
+```
+Note that casing matters for exact identifier matching ('Markdown' != 'markdown')
+
+The language identifier becomes essential for VS Code extension developers when adding new language capabilities or when replacing a language support:
+
+- Every language defines its *id* through the `languages` configuration point:
+
+```json
+    "languages": [{
+        "id": "java",
+        "extensions": [ ".java", ".jav" ],
+        "aliases": [ "Java", "java" ]
+    }]
+```
+- language supports are added using the language identifier:
+```json
+    "grammars": [{
+        "language": "groovy",
+        "scopeName": "source.groovy",
+        "path": "./syntaxes/Groovy.tmLanguage"
+    }],
+    "snippets": [{
+        "language": "groovy",
+        "path": "./snippets/groovy.json"
+    }]
+```
+
+```typescript
+languages.registerCompletionItemProvider('php', new PHPCompletionItemProvider(), '.', '$')
+```
+
+When defining a new language identifier, use the following guidelines:
+
+- Use the lowercased programming language name
+- Search for other extensions in the market place to find out if a language identifier has already been used
+
+The following table lists all known language identifiers:
+
+Language | Identifier
+-------- | ----------
+Windows Bat | `bat`
+Clojure | `clojure`
+Coffeescript | `coffeescript`
+C | `c`
+C++ | `cpp`
+C# | `csharp`
+CSS | `css`
+Diff | `diff`
+Dockerfile | `dockerfile`
+F# | `fsharp`
+Git | `git-commit` and `git-rebase`
+Go | `go`
+Groovy | `groovy`
+Handlebars | `handlebars`
+HTML | `html`
+Ini | `ini`
+Java | `java`
+JavaScript | `javascript`
+JSON | `json`
+Less | `less`
+Lua | `lua`
+Makefile | `makefile`
+Markdown | `markdown`
+Objective-C | `objective-c`
+Perl | `perl` and `perl6`
+PHP | `php`
+Powershell | `powershell`
+Pug | `jade`
+Python | `python`
+R | `r`
+Razor (cshtml) | `razor`
+Ruby | `ruby`
+Rust | `rust`
+Sass | `scss` (syntax using curly brackets), `sass` (indented syntax)
+ShaderLab | `shaderlab`
+Shell Script (Bash) | `shellscript`
+SQL | `sql`
+Swift | `swift`
+TypeScript | `typescript`
+Visual Basic | `vb`
+XML | `xml`
+XSL | `xsl`
+YAML | `yaml`
+CSS| `css`
+

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -56,27 +56,11 @@ In VS Code, we default the language support for a file based on its filename ext
 
 VS Code associates a language mode with a specific language identifier so that various VS Code features can be enabled based on the current language mode.
 
-Languages | Identifiers
--------- | ----------
-Java, JavaScript | `java`, `javascript`
-TypeScript | `typescript`
-C, C++, C# | `c`, `cpp`, `csharp`
-CSS, HTML | `css`, `html`
-Less, Sass | `less`, `scss`
-JSON | `json`
-Markdown | `markdown`
-F# | `fsharp`
-PHP | `php`
-Python | `python`
-PowerShell | `powershell`
-Rust | `rust`
-Shell Script (Bash) | `shellscript`
-Swift | `swift`
-Text | `plaintext`
-Visual Basic | `vb`
 XML, XSL, YAML | `xml`, `xsl`, `yaml`
 
 A language identifier is often (but not always) the lowercased programming language name. Note that casing matters for exact identifier matching ('Markdown' != 'markdown'). Unknown language files have the language identifier `plaintext`.
+
+You can find a list of all known identifiers in the [language identifier reference](identifiers.md).
 
 You can see the list of currently installed languages and their identifiers in the **Change Language Mode** (`kb(workbench.action.editor.changeLanguageMode)`) dropdown.
 


### PR DESCRIPTION
For #702

A complete list of all language identifiers as used by users (file associations) and developers.
The idea is that language extensions can add their identifiers there as well.