### PR TITLE
Fixed inconsistency in markdown

### DIFF
--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -87,8 +87,7 @@ Open VS Code on an empty folder and create a `sample.md` file.
 Place the following source code in that file:
 
 ```markdown
-Hello Markdown in VS Code!
-====================
+# Hello Markdown in VS Code!
 
 This is a simple introduction to compiling Markdown in VS Code.
 


### PR DESCRIPTION
The markdown example should not use two different kinds of headers.