### PR TITLE
Menu option just View -> Integrated Terminal

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -15,7 +15,7 @@ In Visual Studio Code, you can open an integrated terminal, initially starting a
 To open the terminal:
 
 * Use the `kb(workbench.action.terminal.toggleTerminal)` keyboard shortcut with the backtick character.
-* Use the **View** | **Toggle Integrated Terminal** menu command.
+* Use the **View** | **Integrated Terminal** menu command.
 * From the **Command Palette** (`kb(workbench.action.showCommands)`), use the **View:Toggle Integrated Terminal** command.
 
 ![Terminal](images/integrated-terminal/integrated-terminal.png)


### PR DESCRIPTION
The menu no longer says "Toggle Integrated Terminal". It's just "Integrated Terminal". Looking at v1.8.1