### PR TITLE
Add documentation how to install using Chocolatey

### DIFF
--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -22,6 +22,17 @@ You can also find a Zip archive [here](/docs/?dv=winzip).
 
 >**Tip:** Setup will optionally add Visual Studio Code to your `%PATH%`, so from the console you can simply type `code .` to open VS Code on that folder. You will need to restart your console after the installation for the change to the `%PATH%` environmental variable to take effect.
 
+### Chocolatey
+
+Visual Studio Code is also available as [Chocolatey package](https://chocolatey.org/packages/VisualStudioCode).
+After [installing Chocolatey](https://chocolatey.org/install) you can install Visual Studio Code like this:
+
+```dos
+choco install visualstudiocode
+```
+
+>**Tip:** For a list of possible parameters which can be passed see the [Visual Studio Code Chocolatey package](https://chocolatey.org/packages/VisualStudioCode).
+
 ## Updates
 
 VS Code ships monthly [releases](/updates) and supports auto-update when a new release is available. If you're prompted by VS Code, accept the newest update and it will be installed (you won't need to do anything else to get the latest bits). If you'd rather control VS Code updates manually, see [How do I opt out of auto-updates](/docs/supporting/faq.md#how-do-i-opt-out-of-vs-code-autoupdates).


### PR DESCRIPTION
Add documentation how to install Visual Studio Code using [Chocolatey](https://chocolatey.org).