### PR TITLE
Updated example code

### DIFF
--- a/docs/extensions/example-word-count.md
+++ b/docs/extensions/example-word-count.md
@@ -59,39 +59,37 @@ Replace the contents of the generated `extension.ts` file with the code shown be
 
 ```javascript
 // The module 'vscode' contains the VS Code extensibility API
-// Import the necessary extensibility types to use in your code below
-import {window, commands, Disposable, ExtensionContext, StatusBarAlignment, StatusBarItem, TextDocument} from 'vscode';
+// Import the module and reference it with the alias vscode in your code below
+import {window, workspace, commands, Disposable, ExtensionContext, StatusBarAlignment, StatusBarItem, TextDocument} from 'vscode';
 
-// This method is called when your extension is activated. Activation is
-// controlled by the activation events defined in package.json.
-export function activate(context: ExtensionContext) {
+// this method is called when your extension is activated. activation is
+// controlled by the activation events defined in package.json
+export function activate(ctx: ExtensionContext) {
 
-    // Use the console to output diagnostic information (console.log) and errors (console.error).
-    // This line of code will only be executed once when your extension is activated.
-    console.log('Congratulations, your extension "WordCount" is now active!');
+    // Use the console to output diagnostic information (console.log) and errors (console.error)
+    // This line of code will only be executed once when your extension is activated
+    console.log('Congratulations, your extension "Wordcount" is now active!');
 
     // create a new word counter
     let wordCounter = new WordCounter();
+    let controller = new WordCounterController(wordCounter);
 
-    var disposable = commands.registerCommand('extension.sayHello', () => {
-        wordCounter.updateWordCount();
-    });
-
-    // Add to a list of disposables which are disposed when this extension is deactivated.
-    context.subscriptions.push(wordCounter);
-    context.subscriptions.push(disposable);
+    // add to a list of disposables which are disposed when this extension
+    // is deactivated again.
+    ctx.subscriptions.push(controller);
+    ctx.subscriptions.push(wordCounter);
 }
 
-class WordCounter {
+export class WordCounter {
 
     private _statusBarItem: StatusBarItem;
 
     public updateWordCount() {
-
+        
         // Create as needed
         if (!this._statusBarItem) {
             this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
-        }
+        } 
 
         // Get the current text editor
         let editor = window.activeTextEditor;
@@ -102,20 +100,19 @@ class WordCounter {
 
         let doc = editor.document;
 
-        // Only update status if an MarkDown file
+        // Only update status if an MD file
         if (doc.languageId === "markdown") {
             let wordCount = this._getWordCount(doc);
 
             // Update the status bar
-            this._statusBarItem.text = wordCount !== 1 ? `${wordCount} Words` : '1 Word';
+            this._statusBarItem.text = wordCount !== 1 ? `$(pencil) ${wordCount} Words` : '$(pencil) 1 Word';
             this._statusBarItem.show();
-        } else { 
+        } else {
             this._statusBarItem.hide();
         }
     }
 
     public _getWordCount(doc: TextDocument): number {
-
         let docContent = doc.getText();
 
         // Parse out unwanted whitespace so the split is accurate
@@ -129,8 +126,35 @@ class WordCounter {
         return wordCount;
     }
 
-    dispose() {
+    public dispose() {
         this._statusBarItem.dispose();
+    }
+}
+
+class WordCounterController {
+
+    private _wordCounter: WordCounter;
+    private _disposable: Disposable;
+
+    constructor(wordCounter: WordCounter) {
+        this._wordCounter = wordCounter;
+        this._wordCounter.updateWordCount();
+
+        // subscribe to selection change and editor activation events
+        let subscriptions: Disposable[] = [];
+        window.onDidChangeTextEditorSelection(this._onEvent, this, subscriptions);
+        window.onDidChangeActiveTextEditor(this._onEvent, this, subscriptions);
+
+        // create a combined disposable from both event subscriptions
+        this._disposable = Disposable.from(...subscriptions);
+    }
+
+    private _onEvent() {
+        this._wordCounter.updateWordCount();
+    }
+
+    public dispose() {
+        this._disposable.dispose();
     }
 }
 ```


### PR DESCRIPTION
The existing example code included the commands.registerCommand('extension.sayHello') which is code for a different example.

Fixed by replacing the sample code with https://github.com/Microsoft/vscode-wordcount/blob/master/extension.ts