### PR TITLE
Add Run command to keyboard shortcuts

### DIFF
--- a/docs/customization/keybindings.md
+++ b/docs/customization/keybindings.md
@@ -214,6 +214,7 @@ Key|Command|Command id
 ---|-------|----------
 `kb(editor.debug.action.toggleBreakpoint)`|Toggle Breakpoint|`editor.debug.action.toggleBreakpoint`
 `kb(workbench.action.debug.continue)`|Start, Continue|`workbench.action.debug.continue`
+`kb(workbench.action.debug.run)`|Run (without debugging)|`workbench.action.debug.continue`
 `kb(workbench.action.debug.pause)`|Pause|`workbench.action.debug.pause`
 `kb(workbench.action.debug.stepInto)`|Step Into|`workbench.action.debug.stepInto`
 `kb(workbench.action.debug.stepOut)`|Step Out|`workbench.action.debug.stepOut`


### PR DESCRIPTION
Run without debugging was added some time ago: https://github.com/Microsoft/vscode/issues/2780
but it's not on the keybindings page and also not in the online pdf/docx
I would edit the docx but since it's compressed/binary and thus won't turn up in the diff well, I'll leave that to a member.