### PR TITLE
Add parameterHints prop

### DIFF
--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -91,6 +91,9 @@ The settings shown below are the default settings. You can change these settings
 
     // Enable word based suggestions
     "editor.wordBasedSuggestions": true
+    
+    // Enable parameter hints
+    "editor.parameterHints": true
 }
 ```
 


### PR DESCRIPTION
Parameter hints is an intellisense feature, so it should be present. (+ It was hard to find the way to disable property info popup without knowledge of the exact keywords)