### PR TITLE
Use href="#" instead of Script to Scroll to Top of Release Notes

### DIFF
--- a/release-notes/v1_10.md
+++ b/release-notes/v1_10.md
@@ -622,5 +622,5 @@ Contributions to `vscode-html-languageservice`:
 * [Cody Hoover (@hoovercj)](https://github.com/hoovercj):  Add findDocumentSymbols [PR #7](https://github.com/Microsoft/vscode-html-languageservice/pull/7)
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0); event.preventDefault(); event.stopPropagation()"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_5.md
+++ b/release-notes/v1_5.md
@@ -427,5 +427,5 @@ Last but certainly not least, a big *__Thank You!__* to the following folks that
 * [Jun Han (@formulahendry)](https://github.com/formulahendry): Run entire text in terminal if selection is empty [PR #9480](https://github.com/Microsoft/vscode/pull/9480)
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0)"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_6.md
+++ b/release-notes/v1_6.md
@@ -571,5 +571,5 @@ Last but certainly not least, a big *__Thank You!__* to the following folks that
 * [Eklavya @eklavyamirani](https://github.com/eklavyamirani) Markdown syntax highlighting to support alternative header styles [PR #11066](https://github.com/Microsoft/vscode/pull/11066)
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0)"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_7.md
+++ b/release-notes/v1_7.md
@@ -406,5 +406,5 @@ Last but certainly not least, a big *__Thank You!__* to the following folks that
 * [Robert Stoll (@robstoll)](https://github.com/robstoll):  fixed regexp pattern, violated rule was missing [PR #107](https://github.com/Microsoft/vscode-tslint/pull/107)
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0)"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_8.md
+++ b/release-notes/v1_8.md
@@ -604,5 +604,5 @@ Contributions to `vscode-css-languageservice`:
 
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0)"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_9.md
+++ b/release-notes/v1_9.md
@@ -826,5 +826,5 @@ Contributions to `vscode-generator-code`:
 * [Spencer Elliott (@elliottsj)](https://github.com/elliottsj): Use `code` markup for `<user home>` in quickstarts [#61](https://github.com/Microsoft/vscode-generator-code/pull/61)
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
-<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll(0,0); event.preventDefault(); event.stopPropagation()"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/scripts/gulpfile.common.js
+++ b/scripts/gulpfile.common.js
@@ -131,7 +131,7 @@ exports.compileMarkdown = function(file, article) {
 	fileContents = fileContents.replace(/\(#/g, "(#_"); 
 
 	// remove the markdown stylesheet and scroll-to-top button that we intend only for the release notes that show in the product
-	fileContents = fileContents.replace('<a id="scroll-to-top" role="button" aria-label="scroll to top" onclick="scroll\(0,0\)"><span class="icon"><\/span><\/a>\n<link rel="stylesheet" type="text\/css" href="css\/inproduct_releasenotes.css"\/>', ""); 
+	fileContents = fileContents.replace('<a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"><\/span><\/a>\n<link rel="stylesheet" type="text\/css" href="css\/inproduct_releasenotes.css"\/>', ""); 
 
 	// Render markdown
 	article.Content = md.render(fileContents);


### PR DESCRIPTION
Changes from using an inline script to scroll to the top of the page to using a href.