### PR TITLE
Fix reference to wrong window title variable

### DIFF
--- a/release-notes/v1_10.md
+++ b/release-notes/v1_10.md
@@ -184,8 +184,8 @@ You can compose the title with the following variables (shown here for `/Users/D
 
 The `window.title` has the following defaults:
 
-* Windows/Linux: `${dirty}${activeEditorName}${separator}${rootName}${separator}${appName}`
-* macOS: `${activeEditorName}${separator}${rootName}`
+* Windows/Linux: `${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}`
+* macOS: `${activeEditorShort}${separator}${rootName}`
 
 >**Note:** We no longer support `window.showFullPath` in favor of the `window.title` setting. The variable `${activeEditorLong}` will give you the full path.
 


### PR DESCRIPTION
Used window title variable in defaults is ${activeEditorShort} - not ${activeEditorName}.