### PR TITLE
Typo in Quiet Light theme name for release notes v1.11

### DIFF
--- a/release-notes/v1_11.md
+++ b/release-notes/v1_11.md
@@ -36,7 +36,7 @@ The release notes are arranged in the following sections related to VS Code focu
 
 ### Preview: Workbench theming
 
-The first results of the effort on workbench theming are now visible. The built-in themes **Abyss**, **Quite Light**, and **Solarized Dark** take advantage of new color theming capabilities.
+The first results of the effort on workbench theming are now visible. The built-in themes **Abyss**, **Quiet Light**, and **Solarized Dark** take advantage of new color theming capabilities.
 
  ![Abyss theme with more colors](images/1_11/abyss-theme.png)
 


### PR DESCRIPTION
Noticed this when testing out each theme to see how the Workbench theming works.