### PR TITLE
Document workaround for keyboard dispatching

### DIFF
--- a/release-notes/v1_11.md
+++ b/release-notes/v1_11.md
@@ -78,6 +78,8 @@ On Linux and OSX, we have made significant changes in how keyboard shortcuts are
 
 You can read more in [our wiki](https://github.com/Microsoft/vscode/wiki/Keybindings) or in the [plan item](https://github.com/Microsoft/vscode/issues/17521).
 
+> Note: If you experience issues with `KeyboardEvent.code` based dispatching on OSX or Linux, you can use the setting `"keyboard.dispatch": "keyCode"` to force VS Code to dispatch on `KeyboardEvent.keyCode`.
+
 ### Text search improvements
 
 Search is now powered by the excellent tool [ripgrep](https://github.com/BurntSushi/ripgrep), from Andrew Gallant ([@BurntSushi](https://github.com/BurntSushi)), and searching should now be significantly faster. If you encounter an issue and need to revert to the previous search experience, you can set the option `"search.useRipgrep": false`.


### PR DESCRIPTION
@gregvanl I have added a note documenting a workaround in case keyboard dispatching does not work with scan codes.