### PR TITLE
Highlight boolean constant as code

### DIFF
--- a/release-notes/v1_11.md
+++ b/release-notes/v1_11.md
@@ -153,7 +153,7 @@ You can quickly tell if the Git extension is enabled by looking at the **Activit
 
 ### Turn off occurrences highlight
 
-There is a new option, `editor.occurrencesHighlight` that can be set to false to turn off highlighting of the selected word or word under cursor in cases where these highlights are computed by a rich language service.
+There is a new option, `editor.occurrencesHighlight` that can be set to `false` to turn off highlighting of the selected word or word under cursor in cases where these highlights are computed by a rich language service.
 
 ### Auto guess encoding of files
 


### PR DESCRIPTION
To comply with the rest of the document, highlight the boolean constant
'false' as code.