### PR TITLE
Explain we have opened two VS Code instances (lang svr example)

### DIFF
--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -30,6 +30,7 @@ Clone the repository and then do:
 > npm install
 > code .
 ```
+The above installs all dependencies and opens two VS Code instances: one for the server code and one for the client code.
 
 ## Explaining the 'Client'
 


### PR DESCRIPTION
I was not a very dutiful reader and somewhat skimmed the initial commands which lead me to pointing one instance of VS Code at the entire cloned repository.

Later when I read,
> Go to the VS Code instance containing the server code (see above) and press [...]

I was lost because I did not remember reading anything about opening dedicated instances.  A quick text search for _instance_ did not find anything earlier in the document, so I had to go back and re-read.

This adds a brief explanatory sentence that might be caught by a reader or at least provides something to search for when you encounter the text "see above".