### PR TITLE
Add snap install instructions

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -16,6 +16,7 @@ MetaDescription: Get Visual Studio Code up and running on Linux.
 Install the snap on [snap supported](https://snapcraft.io/docs/core/install) systems from the store.
 
     snap install vscode --beta --classic
+    sudo snap alias vscode code
 
 ### Debian and Ubuntu based distributions
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -11,6 +11,12 @@ MetaDescription: Get Visual Studio Code up and running on Linux.
 
 ## Installation
 
+### Ubuntu and [snap supported distros](https://snapcraft.io/docs/core/install) 
+
+Install the snap on [snap supported](https://snapcraft.io/docs/core/install) systems from the store.
+
+    snap install vscode --beta --classic
+
 ### Debian and Ubuntu based distributions
 
 The easiest way to install for Debian/Ubuntu based distributions is to download and install the [.deb package (64-bit)](https://go.microsoft.com/fwlink/?LinkID=760868) either through the graphical software center if it's available or through the command line with:


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install vscode --beta --classic` simplifying the installation instructions for your users.

Once the snap is released into the stable channel in the store, users no longer need to add the ```--beta``` and will appear in the desktop Software Center