### PR TITLE
Recognition of top localization contributors in release notes

### DIFF
--- a/release-notes/v1_12.md
+++ b/release-notes/v1_12.md
@@ -448,7 +448,7 @@ Here is a snapshot of top contributors for this release. For detail of project s
 * **Japanese:** Yuichi Nukiyama, EbXpJ6bp.
 * **Chinese (Simplified):** Joel Yang, Ying Feng, YF.
 
-Although below languages have not been enabled in VS Code product yet, lots of contribution there as well. We will look at criteria of language integration into VS Code in May Iteration.
+Although below languages have not been enabled in VS Code product yet, lots of contribution happened there as well. We will look at criteria of language integration into VS Code in May Iteration.
 * **Portuguese (Brazil):** Bruno Sonnino, Felipe Caputo, Rodrigo Crespi, Roberto Fonseca, Marcelo Fernandes, Roberto Nunes, Rodrigo Romano, Luan Moreno Medeiros Maciel, Ilton Sequeira, Douglas Eccker.
 * **Dutch:** Jeroen Hermans, Gerjan.
 * **Polish:** KarbonKitty, Lukasz Korowicki, Paweł Sołtysiak, Jakub Drozdek.

--- a/release-notes/v1_12.md
+++ b/release-notes/v1_12.md
@@ -1,4 +1,4 @@
----
+﻿---
 Order: 21
 TOCTitle: April 2017
 PageTitle: Visual Studio Code April 2017
@@ -435,6 +435,26 @@ Contributions to `vscode-css-languageservice`
 
 * [Dominic Valenciana (@Kiricon)](https://github.com/Kiricon):  Added @error support for sass [PR #24](https://github.com/Microsoft/vscode-css-languageservice/pull/24)
 * [Ryan O'Connor (@rocifier)](https://github.com/rocifier):  added unit tests for real selector formatter and fixed indentation [PR #26](https://github.com/Microsoft/vscode-css-languageservice/pull/26)
+
+## A big thank You to localization contributors
+We opened translation started from this Iteration. We have seen lots of excitement from international community. We now have more than 100 members in Transifex VS Code project team. We appreciate everybody very much for your contribution either on suggesting new translation, voting translation or suggesting process improvement. 
+Here is a snapshot of top contributors for this release. For detail of project status, contributor name list of VS Code community localization project, visit project site at [http://aka.ms/vscodeloc.](http://aka.ms/vscodeloc)
+
+* **French:** Vincent Biret.
+* **Italian:** Piero Azi, Alessandro Burato, Giuliano Latini, Gianluca Bertelli.
+* **German:** Sascha Corti, Jens Suessmeyer, Christian Gräfe, Markus Weber.
+* **Spanish:** German Sak, Santiago Porras Rodríguez, José M. Aguilar, Alberto Poblacion.
+* **Russian:** Aleksey Nemiro,  Kirill Moskvichev, Anton Afonin, Артем Мельниченко, Serge Rodionov, Andrei Pryymak.
+* **Japanese:** Yuichi Nukiyama, EbXpJ6bp.
+* **Chinese (Simplified):** Joel Yang, Ying Feng, YF.
+
+Although below languages have not been enabled in VS Code product yet, lots of contribution there as well. We will look at criteria of language integration into VS Code in May Iteration.
+* **Portuguese (Brazil):** Bruno Sonnino, Felipe Caputo, Rodrigo Crespi, Roberto Fonseca, Marcelo Fernandes, Roberto Nunes, Rodrigo Romano, Luan Moreno Medeiros Maciel, Ilton Sequeira, Douglas Eccker.
+* **Dutch:** Jeroen Hermans, Gerjan.
+* **Polish:** KarbonKitty, Lukasz Korowicki, Paweł Sołtysiak, Jakub Drozdek.
+* **Swedish:** Joakim Olsson.
+* **Turkish:** Adem Coşkuner, Serkan Inci, Sertac Ozercan.
+
 
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
 <a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>


### PR DESCRIPTION
Adding April iteration top localization contributors in Transifex for vscode projects.