### PR TITLE
Link to JSON schema changed to http://json-schema.org/

### DIFF
--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -46,7 +46,7 @@ You can format your JSON document using `kb(editor.action.formatDocument)` or **
 
 ## JSON Schemas & Settings
 
-To understand the structure of JSON files, we use [JSON schemas](https://spacetelescope.github.io/understanding-json-schema/). JSON schemas describe the shape of the JSON file, as well as value sets, default values, and descriptions.
+To understand the structure of JSON files, we use [JSON schemas](http://json-schema.org/). JSON schemas describe the shape of the JSON file, as well as value sets, default values, and descriptions.
 
 Servers like [JSON Schema Store](http://schemastore.org) provide schemas for most of the common JSON based configuration files. However, schemas can also be defined in a file in the VS Code workspace, as well as the VS Code settings files.
 


### PR DESCRIPTION
I'm new to JSON schemas and after visiting both

- https://spacetelescope.github.io/understanding-json-schema/ (the original link)
- http://json-schema.org/ (the proposed change)

the later one felt much more useful and had these [helpful examples](http://json-schema.org/examples.html).