### PR TITLE
Clarification for OpenSuse

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -66,6 +66,7 @@ The yum repository above also works for openSUSE and SLE based systems, the foll
 
 ```bash
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
 sudo sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/zypp/repos.d/vscode.repo'
 ```
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -62,7 +62,7 @@ sudo yum install code
 
 ### openSUSE and SLE based distributions
 
-The yum repository above also works for openSUSE and SLE based systems, the following script will install the key and repository:
+The yum repository above also works for openSUSE and SLE based systems, the following script will install the key and repository: (NOTE: One Line at a time in case system requests password for sudo)
 
 ```bash
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc


### PR DESCRIPTION
Added a line between initial two OpenSuse commands for install.    If system requests password for initial command, and the user had pasted both lines.  It advises incorrect password.   Even after putting the correct password, the second command is not executed. (repo is not added).    This change just tries to clarify that a little bit...