### PR TITLE
Disable blue outline on scroll to top button

### DIFF
--- a/release-notes/css/inproduct_releasenotes.css
+++ b/release-notes/css/inproduct_releasenotes.css
@@ -45,6 +45,7 @@ h4 {
     border-radius: 50%;
     cursor: pointer;
     box-shadow: 1px 1px 1px rgba(0,0,0,.25);
+    outline: none;
 }
 
 #scroll-to-top:hover {


### PR DESCRIPTION
**Bug**
Ugly blue outline on scroll to top button in release notes:

![screen shot 2017-05-24 at 2 09 26 pm](https://cloud.githubusercontent.com/assets/12821956/26425729/c91d444e-408a-11e7-8b7f-16c7aed6c4f6.png)


**Fix**
Disable this outline