### PR TITLE
Removed an extra call to updateWordCount

### DIFF
--- a/docs/extensions/example-word-count.md
+++ b/docs/extensions/example-word-count.md
@@ -162,7 +162,6 @@ class WordCounterController {
 
     constructor(wordCounter: WordCounter) {
         this._wordCounter = wordCounter;
-        this._wordCounter.updateWordCount();
 
         // subscribe to selection change and editor activation events
         let subscriptions: Disposable[] = [];


### PR DESCRIPTION
It looks unnecessary to call twice in the same function.
Besides, the second call has a comment.