### PR TITLE
updated with CSX info

### DIFF
--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -43,6 +43,7 @@ Visual Studio Code uses the power of [Roslyn](https://github.com/dotnet/roslyn) 
 
 - .NET Core projects
 - MSBuild projects
+- C# scripts (CSX)
 
 On startup the best matching projects are loaded automatically but you can also choose your projects manually.  The status bar will show what projects have been loaded and also allows you to select a different set of projects. To do so, click on the status bar projects item and select *Change projects…*.  In the image below a single project has been picked up:
 
@@ -52,7 +53,7 @@ The available options include:
 
 * Selecting a ```project.json``` file will open a .NET Core project and VS Code will load that project plus the referenced projects.
 * Selecting a ```*.sln``` file opens a MSBuild-project. It will load the referenced ```*.csproj``` projects and sibling or descendant ```project.json``` files but no other project files that are referenced from the solution file.
-* Selecting a ```folder``` will make VS Code scan for ```*.sln``` and ```project.json``` files and VS Code will attempt to load them all.
+* Selecting a ```folder``` will make VS Code scan for ```*.sln```, ```project.json``` and ```*.csx``` files (C# scripts) and VS Code will attempt to load them all.
 
 Once the project is loaded the enhanced experiences light up...
 


### PR DESCRIPTION
Omnisharp and VS Code support CSX files (C# scripts) for a few months now. Updated the docs accordingly.