### PR TITLE
Windows 10 Yeoman Fix

### DIFF
--- a/docs/extensions/yocode.md
+++ b/docs/extensions/yocode.md
@@ -114,6 +114,6 @@ If you want to load your extension each time VS Code runs, copy your project ('s
 
 **A:** Try starting the Yeoman generator with just `yo` and then select the `Code` generator.
 
-**A:** If the arrows keys still do not respond, try starting Yeoman from an elevated shell. To do this search right click the shell and select `Run as administrator`.
+**A:** If the arrows keys still do not respond, try starting Yeoman from an elevated shell. To do this right click the shell and select `Run as administrator`.
 
 ![yo workaround](images/yocode/yo-workaround.png)

--- a/docs/extensions/yocode.md
+++ b/docs/extensions/yocode.md
@@ -114,4 +114,6 @@ If you want to load your extension each time VS Code runs, copy your project ('s
 
 **A:** Try starting the Yeoman generator with just `yo` and then select the `Code` generator.
 
+**A:** If the arrows keys still do not respond, try starting Yeoman from an elevated shell. To do this search right click the shell and select `Run as administrator`.
+
 ![yo workaround](images/yocode/yo-workaround.png)

--- a/docs/extensions/yocode.md
+++ b/docs/extensions/yocode.md
@@ -114,6 +114,6 @@ If you want to load your extension each time VS Code runs, copy your project ('s
 
 **A:** Try starting the Yeoman generator with just `yo` and then select the `Code` generator.
 
-**A:** If the arrows keys still do not respond, try starting Yeoman from an elevated shell. To do this right click the shell and select `Run as administrator`.
+**A:** If the arrows keys still do not respond, try starting Yeoman from an elevated shell. To do this, right-click the shell and select `Run as administrator`.
 
 ![yo workaround](images/yocode/yo-workaround.png)


### PR DESCRIPTION
The documentation for how to fix Yeoman in Windows 10 didn't work for me. I had to run command prompt with admin privileges before the arrow keys would work. I've gone ahead and updated the documentation in this pull request.

It seems as though this is actually being caused by an NPM bug:
https://github.com/nodejs/node/issues/13557