### PR TITLE
fixed url to open a file to line and column

### DIFF
--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -90,7 +90,7 @@ vscode://file/FULL/PATH/TO/FILE
 Open a file to line and column
 
 ```
-vscode://file/FULL/PATH/TO/FILE?LINE:COLUMN
+vscode://file/FULL/PATH/TO/FILE:LINE:COLUMN
 ```
 
 > Note: You can use the URL in applications such as browsers or file explorers that can parse and redirect the URL. For example on Windows, you could pass a `vscode://` URL directly to the Windows Explorer or to the command line as `start vscode://file/FULL/PATH/TO/FILE`.


### PR DESCRIPTION
url to open a file to line and column uses ':', not '?'.