### PR TITLE
Add manual instructions for adding VS Code to PATH

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -27,6 +27,15 @@ You can also run VS Code from the terminal by typing 'code' after adding it to t
 
 - Restart the terminal for the new `$PATH` value to take effect. You'll be able to type 'code .' in any folder to start editing files in that folder.
 
+To manually add VS Code to your path:
+
+```bash
+cat << EOF >> ~/.bash_profile
+# Add Visual Studio Code (code)
+export PATH="$PATH:/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin"
+EOF
+```
+
 > **Note:** If you still have the old `code` alias in your `.bash_profile` (or equivalent) from an early VS Code version, remove it and replace it by executing the **Shell Command: Install 'code' command in PATH** command.
 
 ## Updates


### PR DESCRIPTION
Adding `code` to my PATH didn't work using the Command Palette. Adding instructions to manually add this.