### PR TITLE
adding missing go.testOnSave option

### DIFF
--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -69,6 +69,7 @@ On save, the Go extension can run `go build`, `go vet` and your choice of lintin
 - `go.lintOnSave`
 - `go.lintFlags`
 - `go.lintTool`
+- `go.testOnSave`
 
 The errors and warnings from running any/all of the above will be shown red/green squiggly lines in the editor. These also show up in the **Problems** panel  (**View** > **Problems**).
 


### PR DESCRIPTION
This was added by https://github.com/Microsoft/vscode-go/issues/581
`This feature is now available in the latest update (0.6.54) to the Go extension`

related issue https://github.com/Microsoft/vscode-docs/issues/1082