### PR TITLE
Update jsconfig.md

### DIFF
--- a/docs/languages/jsconfig.md
+++ b/docs/languages/jsconfig.md
@@ -90,6 +90,22 @@ Option  | Description
 `baseUrl`|Base directory to resolve non-relative module names.
 `paths`|Specify path mapping to be computed relative to baseUrl option.
 
+> **Tip:** For Intellisense to work with webpack aliases you need to specify the paths keys with `glob`. For example for alias 'ClientApp'
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "ClientApp/*": ["./ClientApp/*"]
+    }
+  }
+}
+```
+>and then to use the alias
+```js
+import Something from 'ClientApp/foo'
+```
+
 ## Best Practices
 
 Whenever possible, you should exclude folders with JavaScript files that are not part of the source code for your project.


### PR DESCRIPTION
Add a paths example that utilizes pattern webpack aliases, because adding /* in the path key is non trivial and different than the webpack implementation