### PR TITLE
add exitcrash argument to cleanly exit debugger

### DIFF
--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -260,14 +260,13 @@ Alternatively you can start your program `server.js` via **nodemon** directly wi
     "type": "node",
     "request": "launch",
     "runtimeExecutable": "nodemon",
+    "runtimeArgs": [ "--exitcrash" ],
     "program": "${workspaceRoot}/server.js",
     "restart": true,
     "console": "integratedTerminal",
     "internalConsoleOptions": "neverOpen"
 }
 ```
-
->**Tip:** Pressing the **Stop** button stops the debug session and disconnects from Node.js, but **nodemon** (and Node.js) will continue to run. To stop **nodemon**, you will have to kill it from the command line (which is easily possible if you use the `integratedTerminal` as shown above).
 
 >**Tip:** In case of syntax errors, **nodemon** will not be able to start Node.js successfully until the error has been fixed. In this case, VS Code will continue trying to attach to Node.js but eventually give up (after 10 seconds). To avoid this, you can increase the timeout by adding a `timeout` attribute with a larger value (in milliseconds).
 


### PR DESCRIPTION
The `--exitcrash` argument can save you from having to manually kill the nodemon process.