### PR TITLE
Simplify PGP key installation instructions

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -25,8 +25,7 @@ Installing the .deb package will automatically install the apt repository and si
 The repository and key can also be installed manually with the following script:
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 


### PR DESCRIPTION
By using `apt-add-key` which is the de-facto standard on Debian/Ubuntu afaik.