### PR TITLE
Wrap <img> tags in paragraphs

### DIFF
--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -306,7 +306,7 @@ Instead of placing breakpoints directly in source code, a debugger can support c
 
 A 'function breakpoint' is created by pressing the **+** button in the **BREAKPOINTS** section header and entering the function name:
 
-<img alt="function breakpoint" src="https://az754404.vo.msecnd.net/public/function-breakpoint.gif" />
+![function breakpoint](https://az754404.vo.msecnd.net/public/function-breakpoint.gif)
 
 ## Data inspection
 

--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -44,7 +44,7 @@ The workspace setting file is located under the `.vscode` folder in your project
 
 When you open settings, we show **Default Settings** to search and discover settings you are looking for. When you search using the big Search bar, it will not only show and highlight the settings matching your criteria, but also filter out those which are not matching. This makes finding settings quick and easy. There are actions available inside **Default Settings** and `settings.json` editors which will help you quickly copy or update a setting.
 
-<img alt="settings groups" src="https://az754404.vo.msecnd.net/public/default-settings.gif" />
+![settings groups](https://az754404.vo.msecnd.net/public/default-settings.gif)
 
 **Note**: VS Code extensions can also add their own custom settings and they will be visible in the **Default Settings** list at runtime.
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -275,7 +275,7 @@ Alternatively you can start your program `server.js` via **nodemon** directly wi
 
 The Node debugger supports restarting execution at a stack frame. This can be useful in situations where you have found a problem in your source code and you want to rerun a small portion of the code with modified input values. Stopping and then restarting the full debug session can be very time-consuming. The **Restart Frame** action allows you to re-enter the current function after you have changed variables with the **Set Value** action:
 
-<img alt="restart frame" src="https://az754404.vo.msecnd.net/public/restartFrame.gif" />
+![restart frame](https://az754404.vo.msecnd.net/public/restartFrame.gif)
 
 Note that **Restart Frame** won't unroll any state changes, so it may not always work as expected.
 


### PR DESCRIPTION
This ensures that there are vertical margins between the images and their surrounding text.

For example, the following markdown:

```markdown
foo

<img src="http://www.example.com/some-image.png" />

bar
```

is rendered as the following HTML:

```html
<p>foo</p>
<img alt="some text" src="http://www.example.com/some-image.png" />
<p>bar</p>
```

while

```markdown
foo

![some text](http://www.example.com/some-image.png)

bar
```

is rendered as:

```html
<p>foo</p>
<p>
  <img alt="some text" src="" />
</p>
<p>bar</p>
```

We still use `<img>` tags at some other places because we need finer control over the images to overcome the limitations of Markdown so we embed inline attributes (such as `style="..."`, `width="..."`, or `<center><img src="..." /></center`) in those `<img>` tags.