### PR TITLE
Add Linux information to Linting section

### DIFF
--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -33,6 +33,8 @@ Visual Studio Code includes a set of common snippets for PHP.  To access these, 
 
 VS Code uses the official PHP linter (`php -l`) for PHP language diagnostics. This allows VS Code to stay current with PHP linter improvements.
 
+> Tip: Using XAMPP? Install the full version of PHP in order to obtain the development libraries. 
+
 There are three [settings](/docs/getstarted/settings.md) to control the PHP linter:
 
 * `php.validate.enable`: controls whether to enable PHP linting at all. Enabled by default.
@@ -43,9 +45,19 @@ There are three [settings](/docs/getstarted/settings.md) to control the PHP lint
 
 To set the PHP executable path, open your **User or Workspace Settings** and add the `php.validate.executablePath`:
 
+### Windows
+
 ```json
 {
     "php.validate.executablePath": "c:/php/php.exe"
+}
+```
+
+### Linux and OS X
+
+```json
+{
+    "php.validate.executablePath": "/usr/bin/php"
 }
 ```
 


### PR DESCRIPTION
1. Added note to install full version of PHP if using XAMPP.
2. Divided settings.json additions into Windows and Linux.

I know that we cannot predict every configuration, so I'm only using the default values. If anyone thinks I should add a note about this, let me know.