### PR TITLE
remove extraneous comma from example

### DIFF
--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -80,7 +80,7 @@ Here are some example theming rules. The  `scope` property lists the rules scope
         "entity.name.method - source.java"
     ],
     "settings": {
-        "foreground": "#8ab1b0",
+        "foreground": "#8ab1b0"
     }
 }
 ```


### PR DESCRIPTION
The extraneous comma would cause using the example to fail in a JSON theme definition.