### PR TITLE
Update color sublime url

### DIFF
--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -120,7 +120,7 @@ You can use the **Developer Tools: Inspect TM Scopes** command from the **Comman
 }
 ```
 
->**Tip:** [ColorSublime](http://colorsublime.com) has hundreds of existing TextMate themes to choose from.  Pick a theme you like and copy the Download link to use in the Yeoman generator or into your extension. It will be in a format like `"http://colorsublime.com/theme/download/(number)"`
+>**Tip:** [ColorSublime](https://colorsublime.github.io) has hundreds of existing TextMate themes to choose from.  Pick a theme you like and copy the Download link to use in the Yeoman generator or into your extension. It will be in a format like `"https://raw.githubusercontent.com/Colorsublime/Colorsublime-Themes/master/themes/(name).tmTheme"`
 
 ## Test a new color theme
 

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -67,7 +67,7 @@ A pre-configured set of syntax tokens ('comments', 'strings', ...) is available 
 
 ## Using existing TextMate Themes
 
-You can add existing TextMate color themes (.tmTheme) to VS Code. For example, the [Color Sublime](http://colorsublime.com/) site has hundreds of TextMate themes available. See the [Adding a new Theme](/docs/extensions/themes-snippets-colorizers.md#adding-a-new-theme) topic in our Extension Authoring section to learn more.
+You can add existing TextMate color themes (.tmTheme) to VS Code. For example, the [Color Sublime](https://colorsublime.github.io/) site has hundreds of TextMate themes available. See the [Adding a new Theme](/docs/extensions/themes-snippets-colorizers.md#adding-a-new-theme) topic in our Extension Authoring section to learn more.
 
 ## Icon Themes
 

--- a/release-notes/v0_8_0.md
+++ b/release-notes/v0_8_0.md
@@ -30,7 +30,7 @@ When you update to version 0.8.0, VS Code will rename the folder to the new name
 
 
 ## Additional Themes
-VS Code is now able to apply TextMate syntax color themes (.tmTheme). We picked some themes from (http://colorsublime.com/) and made them available under `File | Preferences | Color Theme`. In one of the next releases, users will be able to extend this list with their own favorite themes.
+VS Code is now able to apply TextMate syntax color themes (.tmTheme). We picked some themes from (https://colorsublime.github.io/) and made them available under `File | Preferences | Color Theme`. In one of the next releases, users will be able to extend this list with their own favorite themes.
 
 Open the Color Theme picker with `File | Preferences | Color Theme` and use the up and down keys to change the selection and preview the themes.
 

--- a/release-notes/v0_9_0.md
+++ b/release-notes/v0_9_0.md
@@ -64,7 +64,7 @@ When the generator is finished, copy the complete output folder to a new folder 
 ## Customization - Adding Themes
 You can also add new TextMate theme files (.tmTheme) to your VS Code installation.
 
-[ColorSublime](http://colorsublime.com) has hundreds of existing TextMate themes to choose from.  Pick a theme you like and copy the Download link to use in the Yeoman generator.  The 'code' generator will prompt you for the URL or file location of the .tmTheme file, the theme name as well as other information for the theme.
+[ColorSublime](https://colorsublime.github.io) has hundreds of existing TextMate themes to choose from.  Pick a theme you like and copy the Download link to use in the Yeoman generator.  The 'code' generator will prompt you for the URL or file location of the .tmTheme file, the theme name as well as other information for the theme.
 
 ![yo code theme](images/0_9_0/yocodetheme.png)
 


### PR DESCRIPTION
The domain of color sublime was recently changed (https://github.com/Colorsublime/Colorsublime-Themes/issues/364) in favor of a github.io (https://colorsublime.github.io) alternative.

And since they went fully static, the download links also changed to just point to the raw files on the repo.