### PR TITLE
Update NVDA recommendation

### DIFF
--- a/docs/editor/accessibility.md
+++ b/docs/editor/accessibility.md
@@ -62,7 +62,7 @@ Read-only files never trap the `kbstyle(Tab)` key. The **Integrated Terminal** p
 
 VS Code supports screen readers in the editor using a strategy based on paging the text. We have tested using the [NVDA screen reader](https://www.nvaccess.org), but we expect all screen readers to benefit from this support.
 
-> When using NVDA on Windows, we recommend to install [this plugin](https://files.derekriemer.com/globalEditorTimer-1.0.nvda-addon) from [Derek Riemer](https://github.com/derekriemer), which increases NVDA's timeout for receiving a caret move event from 30ms to 200ms. This plugin will no longer be needed when NVDA ships a new version [where the built-in timeout is increased from 30ms to 100ms](https://github.com/nvaccess/nvda/pull/7201).
+> When using NVDA on Windows, we recommend to update to NVDA 2017.3 or higher. NVDA 2017.3 increases NVDA's timeout for receiving a caret move event from 30ms to 100ms. This version is the first one [where the built-in timeout is increased from 30ms to 100ms](https://github.com/nvaccess/nvda/pull/7201).
 
 The **Go to Next/Previous Error or Warning** actions (`kb(editor.action.marker.next)` and `kb(editor.action.marker.prev)`) allow screen readers to announce the error or warning messages.
 


### PR DESCRIPTION
NVDA 2017.3 has shipped with a change that no longer makes necessary the usage of a NVDA plugin for a good experience with VS Code.