### PR TITLE
Fix for keybinding improperly rendering in VS Code view of Release notes

### DIFF
--- a/release-notes/v1_18.md
+++ b/release-notes/v1_18.md
@@ -246,7 +246,7 @@ These actions are:
 
 ### Start without debugging shortcut
 
-The default keyboard shortcut on macOS for **Debug: Start Without Debugging** changed to `kbstyle(ctrl + F5)` to avoid a collision with an existing macOS keyboard shortcut.
+The default keyboard shortcut on macOS for **Debug: Start Without Debugging** changed to `kbstyle(Ctrl+F5)` to avoid a collision with an existing macOS keyboard shortcut.
 
 ### Coloring of Debug Console evaluation results based on type
 


### PR DESCRIPTION
After looking into how `kbstyle` gets applied and other uses of it, I could only guess that the spaces were messing up the way the keybinding was rendered when viewing the release notes from within VS Code. 

On Windows this shows `Ctrl Unknown`
On Mac this shows `unassigned`

If this isn't the proper fix, please close.