### PR TITLE
Changing link to Python extension

### DIFF
--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -9,7 +9,7 @@ MetaDescription: Learn about Visual Studio Code features (code completion, debug
 ---
 # Python on Visual Studio Code
 
-Working with Python in Visual Studio Code, using the [Microsoft Python extension](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python), is simple, fun, productive. The extension leverages all of VS Code's power to provide auto complete and IntelliSense, linting, debugging, and unit testing, along with control over your Python environments.
+Working with Python in Visual Studio Code, using the [Microsoft Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python), is simple, fun, productive. The extension leverages all of VS Code's power to provide auto complete and IntelliSense, linting, debugging, and unit testing, along with control over your Python environments.
 
 ## Autocomplete and IntelliSense
 


### PR DESCRIPTION
Python extension is now under Microsoft namespace, changing link to avoid 404 Not Found