### PR TITLE
Change typo in autopep8Args

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -92,7 +92,7 @@ The following settings apply to the individual formatters. The Python extension 
 Example custom arguments:
 
 ```json
-"python.formatting.autopep8Args": ["--max-line-length 120", "--experimental"],
+"python.formatting.autopep8Args": ["--max-line-length=120", "--experimental"],
 "python.formatting.yapfArgs": ["--style", "{based_on_style: chromium, indent_width: 20}"]
 ```
 


### PR DESCRIPTION
Specify autopep8Args with "=" between argument and value instead of space