### PR TITLE
Path export would return an error in terminal

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -34,7 +34,7 @@ To manually add VS Code to your path:
 ```bash
 cat << EOF >> ~/.bash_profile
 # Add Visual Studio Code (code)
-export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+export PATH="$PATH:/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin"
 EOF
 ```
 


### PR DESCRIPTION
Spaces were not escaped correctly in path export causing an error of path not being found when refreshing your shell.