### PR TITLE
Add support for macOS NSFindPboard as an action

### DIFF
--- a/release-notes/v1_19.md
+++ b/release-notes/v1_19.md
@@ -32,6 +32,7 @@ Key|Command|Command id
 * [31667](https://github.com/Microsoft/vscode/issues/31667): Configuration values are missing from files on remote network drives
 * [18733](https://github.com/Microsoft/vscode/issues/18733): Dragging a tab can show visual glitch when tab not fully visible
 * [30530](https://github.com/Microsoft/vscode/issues/30530): Keyboard Shortcut to Skip Preview Using Quick Open
+* [11233](https://github.com/Microsoft/vscode/issues/11233): Add support for macOS NSFindPboard as an action
 
 ## Thank You
 


### PR DESCRIPTION
Add support for macOS's NSFindPboard, which is a global shared find buffer. This allows one to put text into the find buffer from other native apps like Chrome, TextEdit, Safari, Sublime, etc. and then switch to other Cocoa apps and use cmd-g to find next matching text. 

Pull request for this change is https://github.com/Microsoft/vscode/pull/35956