### PR TITLE
improve the cmder terminal

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -164,8 +164,10 @@ The basics of the terminal have been covered in this document, read on to find o
 
 ```bat
 @echo off
+SET CurrentWorkingDirectory=%CD%
 SET CMDER_ROOT=C:\cmder (your path to cmder)
-"%CMDER_ROOT%\vendor\init.bat"
+CALL "%CMDER_ROOT%\vendor\init.bat"
+CD /D %CurrentWorkingDirectory%
 ```
 
 then in your VS Code user settings, add the following to your `settings.json` file:


### PR DESCRIPTION
The cmder terminal always change back to the current user directory, so record the working directory and change back to the working directory after cmder init.