### PR TITLE
Tasks: document use of config settings

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -375,6 +375,24 @@ Below is an example of a custom task configuration that passes the current opene
 }
 ```
 
+
+Similarly, you can reference your project's configuration settings by prefixing the name with `config:` — for example, `${config:python.pythonPath}`. Below is an example of a custom task configuration which executes autopep8 on the current file using your project's selected Python executable:
+
+```json
+{
+    "label": "autopep8 current file",
+    "type": "process",
+    "command": "${config:python.pythonPath}",
+    "args": [
+        "-m",
+        "autopep8",
+        "-i",
+        "${file}"
+    ]
+}
+```
+
+
 ## Operating system specific properties
 
 The task system supports defining values (for example, the command to be executed) specific to an operating system. To do so, put an operating system specific literal into the `tasks.json` file and specify the corresponding properties inside that literal.


### PR DESCRIPTION
I recently needed to run some tasks using a specific Python virtualenv
and hadn't known that this was possible before searching through the
issue tracker and finding a maintainer's comment:

https://github.com/Microsoft/vscode/issues/23597#issuecomment-290329622