### PR TITLE
Fix snippet example prefix inconsistency

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -38,7 +38,7 @@ The example below is a `For Loop` snippet for `JavaScript`.
 ```json
 {
     "For_Loop": {
-        "prefix": "new",
+        "prefix": "for",
         "body": [
             "for (var ${1:index} = 0; ${1:index} < ${2:array}.length; ${1:index}++) {",
             "\tvar ${3:element} = ${2:array}[${1:index}];",


### PR DESCRIPTION
Fixed inconsistency with text below:

> `prefix` defines how this snippet is selected from IntelliSense and tab completion. In this case `for`.