### PR TITLE
Improve Cmder common question

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -164,6 +164,10 @@ The basics of the terminal have been covered in this document, read on to find o
 
 ```bat
 @echo off
+IF "%*" NEQ "" ( 
+    CMD %*
+    EXIT %ERRORLEVEL% 
+)
 SET CurrentWorkingDirectory=%CD%
 SET CMDER_ROOT=C:\cmder (your path to cmder)
 CALL "%CMDER_ROOT%\vendor\init.bat"

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -164,8 +164,10 @@ The basics of the terminal have been covered in this document, read on to find o
 
 ```bat
 @echo off
-IF "%*" NEQ "" ( 
-    CMD %*
+SET ARGS=%*
+IF "%ARGS:~0,5%" EQU "/d /c" ( 
+    REM Tasks call the terminal expecting it runs and exits
+    %ARGS:~6%
     EXIT %ERRORLEVEL% 
 )
 SET CurrentWorkingDirectory=%CD%


### PR DESCRIPTION
VsCode use the integrated terminal to run Tasks Builds and expects the terminal to exit after executing.
This requirement was not accounted in Cmder bat script.