### PR TITLE
Updated required .NET Framework version

### DIFF
--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -17,7 +17,7 @@ MetaDescription: Get Visual Studio Code up and running on Windows
 
 You can also find a Zip archive [here](/docs/?dv=winzip).
 
->**Note:** .NET Framework 4.5.2 or higher is required for VS Code.  If you are using Windows 7, make sure you have at least [.NET Framework 4.5.2](https://www.microsoft.com/en-us/download/details.aspx?id=42643) installed.
+>**Note:** .NET Framework 4.6 or higher is required for VS Code.  If you are using Windows 7, make sure you have at least [.NET Framework 4.6](https://www.microsoft.com/en-us/download/details.aspx?id=48130) installed.
 
 >**Tip:** Setup will optionally add Visual Studio Code to your `%PATH%`, so from the console you can type 'code .' to open VS Code on that folder. You will need to restart your console after the installation for the change to the `%PATH%` environmental variable to take effect.
 


### PR DESCRIPTION
When trying to run VS Code on a PC with Windows 7 (64 bit) that only had .NET Framework 4.5.2 installed (as per this guide), an error popped up when opening VS Code stating that the required .NET Framework version is 4.6. After updating .NET Framework on the PC, VS Code ran without issues. Hence the higher version requirement for the .NET Framework should be reflected in the documentation.