### PR TITLE
Added two hostnames to network.md

### DIFF
--- a/docs/setup/network.md
+++ b/docs/setup/network.md
@@ -23,6 +23,8 @@ If you are behind a firewall which needs to whitelist domains used by VS Code, h
 * `*.gallerycdn.vsassets.io`
 * `rink.hockeyapp.net`
 * `vscode.search.windows.net`
+* `raw.githubusercontent.com`
+* `vsmarketplacebadge.apphb.com`
 
 ## Proxy server support
 


### PR DESCRIPTION
Added `raw.githubusercontent.com` to the section "Common hostnames" of network.md, since access to that host is needed so you can see the screenshots and pictures in the extensions pages at both VS Marketplace website and at the VS Code "Extensions" view.

Also added `vsmarketplacebadge.apphb.com` so the Marketplace Status Badges can be seen inside the VS Code "Extensions" view.