### PR TITLE
Obsolete allowJs in compilerOptions

### DIFF
--- a/docs/languages/jsconfig.md
+++ b/docs/languages/jsconfig.md
@@ -15,7 +15,7 @@ The presence of `jsconfig.json` file in a directory indicates that the directory
 
 > **Tip:** If you are not using JavaScript, you do not need to worry about `jsconfig.json`.
 
-> **Tip:** `jsconfig.json` is a descendent of `tsconfig.json`, which is a configuration file for TypeScript. `jsconfig.json` is `tsconfig.json` with `"allowJs"` attribute set to `true`.
+> **Tip:** `jsconfig.json` is a descendent of `tsconfig.json`, which is a configuration file for TypeScript. `jsconfig.json` is `tsconfig.json` with `"checkJs"` attribute set to `true`.
 
 ## Why do I need a jsconfig.json file?
 


### PR DESCRIPTION
Docs still reference `allowJs` which has been replaced by `checkJs`.