### PR TITLE
Improve git commit input validation documentation

### DIFF
--- a/release-notes/v1_20.md
+++ b/release-notes/v1_20.md
@@ -293,6 +293,8 @@ The Git extension now provides commit message length validation:
 
 ![Git input validation](images/1_20/git-input-validation.gif)
 
+You can configure the validation's behaviour using the `git.inputValidation` setting, which has the following possible values: `always`, `warn` and `none`. The previous screenshot showcases the `always` option, while the default is `warn`.
+
 ### Setting for editor diff decorations
 
 Control when and how inline diff decorations show up in the editor using the `scm.diffDecorations` setting. Possible values are `all`, `gutter`, `overview` and `none`.


### PR DESCRIPTION
@gregvanl This should still go into a _recovery_ docs build. Thanks!