### PR TITLE
Add a hint for dealing with failed deployments.

### DIFF
--- a/tutorials/app-service-extension/deploy-app.md
+++ b/tutorials/app-service-extension/deploy-app.md
@@ -42,6 +42,8 @@ The output window will open during deployment to indicate the status of the oper
 
 > **Tip:** Be sure that your application is listening on the port provided by the PORT environment variable: `process.env.PORT`.
 
+> Are you seeing the error `You do not have permission to view this directory or page.`? If so, the app probably failed to start correctly. Head to the next step and view the log output to find and fix the error. If you aren't able to fix it, let us know that you had an issue. We're happy to help!
+
 ## Updating the website
 
 You can deploy changes to this app by using the same process and choosing the existing app rather than creating a new one.


### PR DESCRIPTION
This adds a hint on locating the most common error that we've seen to
date and suggest contacting us with more detail if they aren't able to
get the error fixed.