### PR TITLE
Update C# documentation to remove 'dotnet restore' instructions

### DIFF
--- a/docs/other/dotnet.md
+++ b/docs/other/dotnet.md
@@ -32,17 +32,9 @@ If you'd like to get started with a simple "Hello World" program on .NET Core, f
   * Type `dotnet new console`.
   * This creates a `Program.cs` file in your folder with a simple "Hello World" program already written.
 
-2. Resolve the build assets by typing `dotnet restore`.
+2. When the project folder is first opened in VS Code, a notification will appear at the top of the window asking if you'd like to add the required assets to build and debug your project. Select **Yes**.
 
-> Tip: .NET Core Tools are now MSBuild-based. This means a `.csproj` project file will be created instead of a `project.json`. [Read more](https://blogs.msdn.microsoft.com/dotnet/2016/11/16/announcing-net-core-tools-msbuild-alpha/).
-
-  * Running `restore` pulls down the required packages declared in the `project.json` file.
-  * You'll see a new `project.lock.json` file in your project folder.
-  * This file contains information about your project's dependencies to make subsequent restores quicker.
-  
-3. When the project folder is first opened in VS Code, a notification will appear at the top of the window asking if you'd like to add the required assets to build and debug your project. Select **Yes**.
-
-4. Run the "Hello World" program by typing `dotnet run` in the command prompt (or terminal).
+3. Run the "Hello World" program by typing `dotnet run` in the command prompt (or terminal).
 
 Watch a video tutorial for further setup help on [Windows](https://channel9.msdn.com/Blogs/dotnet/Get-started-VSCode-Csharp-NET-Core-Windows), [macOS](https://channel9.msdn.com/Blogs/dotnet/Get-started-VSCode-NET-Core-Mac), or [Linux](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-Csharp-dotnet-Core-Ubuntu).
 


### PR DESCRIPTION
As of .NET Core 2, a restore now happens automatically so there is no need to explain how to do this.