### PR TITLE
Fix typo in reactjs-tutorial.md

### DIFF
--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -32,7 +32,7 @@ This may take a few minutes to install. You can now create a new React applicati
 create-react-app my-app
 ```
 
-where `my-app` is the name of the folder for your application. This may take a few minutes to create the React application and install it's dependencies.
+where `my-app` is the name of the folder for your application. This may take a few minutes to create the React application and install its dependencies.
 
 Let's quickly run our React application by navigating to the new folder and typing `npm start` to start the web server and open the application in a browser:
 


### PR DESCRIPTION
Was: it's dependencies. Changed it to its dependencies.