### PR TITLE
Rework section on customizing the markdown preview

### DIFF
--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -51,25 +51,17 @@ Additionally, double clicking an element in the Markdown preview will automatica
 
 ![Markdown Preview double click switches to editor](images/Markdown/double-click-preview-switch.gif)
 
+### Extending the Markdown preview
+
+Extensions can contribute custom styles and scripts to the markdown preview to change its appearance and add new functionality. Here's a set of example extensions that customize the preview:
+
+<div class="marketplace-extensions-markdown-preview-curated"></div>
+
 ### Using your own CSS
 
-By default, we use a CSS style for the preview that matches the style of VS Code. If you want to use your own CSS for the Markdown preview, update the `"markdown.styles": []` [setting](/docs/getstarted/settings.md) with the comma-separated list of URL(s) for your style sheet(s). Note that `markdown.styles` files must either be served over https or point to a local file within the current workspace.
+You can also use your own CSS in the Markdown preview with the `"markdown.styles": []` [setting](/docs/getstarted/settings.md). This lists URLs for style sheets to load in the markdown preview. These stylesheets can either be https urls, or relative paths to local files in the current workspace.
 
-For instance, in the screen shot above we used a custom CSS that changes the default font for the page and changes the color for the H1 title.
-
-Here is the relevant CSS:
-
-```css
-body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-
-h1 {
-    color: cornflowerblue;
-}
-```
-
-Use **File** > **Preferences** > **Settings** to bring up the workspace `settings.json` file and make this update:
+For example, to load a stylesheet called `Style.css` at the root of your current workspace, use **File** > **Preferences** > **Settings** to bring up the workspace `settings.json` file and make this update:
 
 ```json
 // Place your settings in this file to overwrite default and user settings.


### PR DESCRIPTION
- Adds a new section about extending the markdown preview using extensions

- Updates the 'using your own css' section. The referenced screenshot no longer seems to exist and the documentation was a bit out of date