### PR TITLE
Fix Electron version numbers in Node.js debugging guide

### DIFF
--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -31,7 +31,7 @@ Runtime   | 'Legacy' Protocol | 'Inspector' Protocol
 ----------|-------------------|----------
 io.js     | all               | no
 node.js   | < 8.x             | >= 6.3 (Windows: >= 6.9)
-Electron  | < 7.4             | >= 7.4
+Electron  | < 1.7.4             | >= 1.7.4
 Chakra    | all               | not yet
 
 Although it appears to be possible that the VS Code Node.js debugger picks the best protocol always automatically,


### PR DESCRIPTION
The current doc shows `7.4` as the version where Electron started supporting the new debugger, but it was actually `1.7.4`. See https://electronjs.org/releases#1.7.4

![image](https://user-images.githubusercontent.com/2289/37174495-86d8bc02-22cb-11e8-9527-11a63061833f.png)
