### PR TITLE
Change Turkish Language ID to 'tr'

### DIFF
--- a/docs/getstarted/locales.md
+++ b/docs/getstarted/locales.md
@@ -37,7 +37,7 @@ Display Language | Locale
 Bulgarian | `bg`
 Hungarian | `hu`
 Portuguese (Brazil) | `pt-br`
-Turkish | `trk`
+Turkish | `tr`
 
 ## Setting the Language
 


### PR DESCRIPTION
Issue in loading logic of VS Code fixed. Now support 'tr'. No longer support 'trk'