### PR TITLE
Corrected the typo in 'cwd'

### DIFF
--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -95,7 +95,7 @@ Specifies how program output is displayed.
 
 ### `cwd`
 
-Specifies the current working directly for the program being debugged, defaulting to the current folder. The standard configuration uses `${workspaceFolder}` to use the project folder.
+Specifies the current working directory for the program being debugged, defaulting to the current folder. The standard configuration uses `${workspaceFolder}` to use the project folder.
 
 ### `debugOptions`
 


### PR DESCRIPTION
The previous word was "directly", but the meaning is "directory".