### PR TITLE
dead link

### DIFF
--- a/docs/editor/multi-root-workspaces.md
+++ b/docs/editor/multi-root-workspaces.md
@@ -252,7 +252,7 @@ If the individual launch configuration names are not unique, the qualifying fold
   }]
 ```
 
-In addition to `compounds` the `launch` section of the workspace configuration file can contain regular launch configurations too. Just make sure that all used variables are explicitly scoped to a specific folder because otherwise they are not valid for the workspace. You can find more details about explicitly scoped variables in the section [below](#scoped-configuration-variables-for-launchjson-and-taskjson).
+In addition to `compounds` the `launch` section of the workspace configuration file can contain regular launch configurations too. Just make sure that all used variables are explicitly scoped to a specific folder because otherwise they are not valid for the workspace. You can find more details about explicitly scoped variables in the section [Variables Reference](/docs/editor/variables-reference.md#_variables-scoped-per-workspace-folder).
 
 Here is an example for a launch configuration where the program lives in a folder "Program" and where all files from a folder "Library" should be skipped when stepping:
 


### PR DESCRIPTION
I linked to the variable reference topic on work-space scoped variables. The anchored link didn't exists on the page