### PR TITLE
Update instructions for installing Functions CLI.

### DIFF
--- a/tutorials/functions-extension/getting-started.md
+++ b/tutorials/functions-extension/getting-started.md
@@ -16,11 +16,22 @@ If you don't have an Azure account, [sign up today](https://azure.microsoft.com/
 
 You need [Visual Studio Code](https://code.visualstudio.com/) installed along with [Node.js and npm](https://nodejs.org/en/download), the Node.js package manager.
 
-To enable local debugging, you need to install the [.NET Core 2.0 SDK](https://www.microsoft.com/net/core) along with the Azure Functions Core tools from npm.
+To enable local debugging, you need to install the [Azure Functions Core tools](https://github.com/Azure/azure-functions-core-tools#installing).
+
+**On macOS**, install using [Homebrew](https://brew.sh/).
+
+```bash
+$ brew tap azure/functions
+$ brew install azure-functions-core-tools
+```
+
+**On WIndows**, install using [npm](https://npmjs.com).
 
 ```bash
 $ npm install -g azure-functions-core-tools@core
 ```
+
+On Linux, follow the instructions in the [GitHub repository](https://github.com/Azure/azure-functions-core-tools#linux).
 
 ## Install the extension
 


### PR DESCRIPTION
The Azure Functions core tools no longer require the .NET core SDK to be
installed. This includes the instructions for macOS and Windows and
links out for Linux because there are a few extra setps depending on
the distro.