### PR TITLE
Fix the Windows settings path

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -65,7 +65,7 @@ Below is a [copy of the default settings](/docs/getstarted/settings.md#default-s
 
 Depending on your platform, the user settings file is located here:
 
-* **Windows** `%APPDATA%\Code\User\settings.json`
+* **Windows** `%APPDATA%\Roaming\Code\User\settings.json`
 * **Mac** `$HOME/Library/Application Support/Code/User/settings.json`
 * **Linux** `$HOME/.config/Code/User/settings.json`
 


### PR DESCRIPTION
The current path listed is not correct - at least on my Windows 10 machine.