### PR TITLE
Fixed spelling mistakes and comma punctuation errors

### DIFF
--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -23,7 +23,7 @@ or
 code-insiders .
 ```
 
-**Note**: Windows and Linux installations should add the VS Code binaries location to your system path. If this isn't the case, you can manually add the location to the Path/$PATH environment variable. For example on Windows, VS Code is installed under `Program Files\Microsoft VS Code\bin`. To review platform specific setup instructions, see [Setup](/docs/setup/setup-overview.md).
+**Note**: Windows and Linux installations should add the VS Code binaries location to your system path. If this isn't the case, you can manually add the location to the Path/$PATH environment variable. For example, on Windows, VS Code is installed under `Program Files\Microsoft VS Code\bin`. To review platform specific setup instructions, see [Setup](/docs/setup/setup-overview.md).
 
 ## Core CLI options
 
@@ -112,7 +112,7 @@ Open a file to line and column
 vscode://file/FULL/PATH/TO/FILE:LINE:COLUMN
 ```
 
-> **Note:** You can use the URL in applications such as browsers or file explorers that can parse and redirect the URL. For example on Windows, you could pass a `vscode://` URL directly to the Windows Explorer or to the command line as `start vscode://file/FULL/PATH/TO/FILE`.
+> **Note:** You can use the URL in applications such as browsers or file explorers that can parse and redirect the URL. For example, on Windows, you could pass a `vscode://` URL directly to the Windows Explorer or to the command line as `start vscode://file/FULL/PATH/TO/FILE`.
 
 ## Next Steps
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -50,7 +50,7 @@ The top level **Debug** menu has the most common debug commands:
 
 To debug a simple app in VS Code, press `kb(workbench.action.debug.start)` and VS Code will try to debug your currently active file.
 
-However for most debugging scenarios, creating a launch configuration file is beneficial because it allows you to configure and save debugging setup details. VS Code keeps debugging configuration information in a `launch.json` file located in a `.vscode` folder in your workspace (project root folder) or in your [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration) or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
+However, for most debugging scenarios, creating a launch configuration file is beneficial because it allows you to configure and save debugging setup details. VS Code keeps debugging configuration information in a `launch.json` file located in a `.vscode` folder in your workspace (project root folder) or in your [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration) or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
 
 To create a `launch.json` file, open your project folder in VS Code (**File** > **Open Folder**) and then click on the Configure gear icon on the Debug view top bar.
 
@@ -110,7 +110,7 @@ As soon as a debugging session starts, the **DEBUG CONSOLE** panel is displayed 
 
 ![debug session](images/debugging/debug-session.png)
 
-In addition the _debug status_ appears in the Status Bar showing the active debug configuration. By clicking on the debug status, a user can change the active launch configuration and then start debugging without the need to open the Debug view.
+In addition, the _debug status_ appears in the Status Bar showing the active debug configuration. By clicking on the debug status, a user can change the active launch configuration and then start debugging without the need to open the Debug view.
 
 ![Debug status](images/debugging/debug-status.png)
 
@@ -139,7 +139,7 @@ Breakpoints can be toggled by clicking on the **editor margin**. Finer breakpoin
 
 * Breakpoints in the editor margin are normally shown as red filled circles.
 * Disabled breakpoints have a filled gray circle.
-* When a debugging sessions starts, breakpoints that cannot be registered with the debugger change to a gray hollow circle. The same might happen if the source is edited while a debug session without live-edit support is running.
+* When a debugging session starts, breakpoints that cannot be registered with the debugger change to a gray hollow circle. The same might happen if the source is edited while a debug session without live-edit support is running.
 
 The **Reapply All Breakpoints** command sets all breakpoints again to their original location. This is helpful if your debug environment is "lazy" and "misplaces" breakpoints in source code that has not yet been executed.
 

--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -66,7 +66,7 @@ For example:
 }
 ```
 
-Emmet has no knowledge of these new languages, and so you might feel Emmet suggestions showing up in non HTML/CSS context. To avoid this you can use the following setting.
+Emmet has no knowledge of these new languages, and so you might feel Emmet suggestions showing up in non HTML/CSS context. To avoid this, you can use the following setting.
 
 ```json
 "emmet.showExpandedAbbreviation": "inMarkupAndStylesheetFilesOnly"

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -175,7 +175,7 @@ Integrated Terminal sessions can now be renamed using the **Terminal: Rename** (
 
 ### Forcing key bindings to pass through the terminal
 
-While focus is in the integrated terminal, many key bindings will not work as the keystrokes are passed to and consumed by the terminal itself. The `terminal.integrated.commandsToSkipShell` setting can be used to get around this. It contains an array of command names whose key bindings will skip processing by the shell and instead be processed by the VS Code key binding system. By default this includes all terminal key bindings in addition to a select few commonly used key bindings.
+While focus is in the integrated terminal, many key bindings will not work as the keystrokes are passed to and consumed by the terminal itself. The `terminal.integrated.commandsToSkipShell` setting can be used to get around this. It contains an array of command names whose key bindings will skip processing by the shell and instead be processed by the VS Code key binding system. By default, this includes all terminal key bindings in addition to a select few commonly used key bindings.
 
 ## Next Steps
 

--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -109,7 +109,7 @@ By default, VS Code shows snippets and completion proposals in one widget. You c
 
 ### Suggestion selection
 
-By default, VS Code pre-selects the previously used suggestion in the suggestion list. This is very useful as you can quickly insert the same completion multiple times. If you'd like different behavior, for example, alway select the top item in the suggestion list, you can use the `editor.suggestSelection` setting.
+By default, VS Code pre-selects the previously used suggestion in the suggestion list. This is very useful as you can quickly insert the same completion multiple times. If you'd like different behavior, for example, always select the top item in the suggestion list, you can use the `editor.suggestSelection` setting.
 
 The available `editor.suggestSelection` values are:
 

--- a/docs/editor/multi-root-workspaces.md
+++ b/docs/editor/multi-root-workspaces.md
@@ -208,7 +208,7 @@ You can also see the three **Add Config** commands for the folders, `tslint`, `t
 
 ![debugging template dropdown](images/multi-root-workspaces/add-launch-config.png)
 
-[Variables](/docs/editor/variables-reference.md) used in a configuration (for example `${workspaceFolder}` or the now deprecated `${workspaceRoot}`) are resolved relative to the folder they belong to. It is possible to scope a variable per workspace folder by appending the root folder's name to a variable (seperated by a colon).
+[Variables](/docs/editor/variables-reference.md) used in a configuration (for example `${workspaceFolder}` or the now deprecated `${workspaceRoot}`) are resolved relative to the folder they belong to. It is possible to scope a variable per workspace folder by appending the root folder's name to a variable (separated by a colon).
 
 ### Workspace launch configurations
 
@@ -217,7 +217,7 @@ Workspace scoped launch configurations live in the `"launch"` section of the wor
 ![Workspace Settings](images/multi-root-workspaces/workspace-settings.png)
 
 
-Alternatively new launch configurations can be added via the "Add Config (workspace)" entry of the Launch Configuration drop-down menu:
+Alternatively, new launch configurations can be added via the "Add Config (workspace)" entry of the Launch Configuration drop-down menu:
 
 ![Add Config](images/multi-root-workspaces/add-config.png)
 

--- a/docs/editor/tasks-appendix.md
+++ b/docs/editor/tasks-appendix.md
@@ -156,8 +156,8 @@ interface TaskDescription {
     args?: string[];
 
     /**
-     * Defines the group to which this tasks belongs. Also supports to mark
-     * a tasks as the default task in a group.
+     * Defines the group to which this task belongs. Also supports to mark
+     * a task as the default task in a group.
      */
     group?: "build" | "test" | { kind: "build" | "test"; isDefault: boolean };
 
@@ -305,7 +305,7 @@ interface ProblemPattern {
     file: number;
 
     /**
-     * The match group index of the problems's location. Valid location
+     * The match group index of the problem's location. Valid location
      * patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn).
      * If omitted the line and column properties are used.
      */

--- a/docs/editor/tasks-v1-appendix.md
+++ b/docs/editor/tasks-v1-appendix.md
@@ -289,7 +289,7 @@ export interface ProblemPattern {
 	file: number;
 
 	/**
-	 * The match group index of the problems's location. Valid location
+	 * The match group index of the problem's location. Valid location
 	 * patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn).
 	 * If omitted the line and column properties are used.
 	 */

--- a/docs/editor/tasks-v1.md
+++ b/docs/editor/tasks-v1.md
@@ -79,7 +79,7 @@ To see the exact command VS Code is running, you can enable the `echoCommand` se
 
 ## command and tasks[]
 
-`tasks.json` takes a single `command` value which can be a task runner like gulp or grunt or any command line tool like a compiler or linter. By default the `command` will show up in the **Tasks: Run Task** dropdown.
+`tasks.json` takes a single `command` value which can be a task runner like gulp or grunt or any command line tool like a compiler or linter. By default, the `command` will show up in the **Tasks: Run Task** dropdown.
 
 You can also define multiple tasks in a `tasks` array in order to pass different arguments or use different settings when the `command` is run.
 
@@ -144,13 +144,13 @@ If you want to run multiple different commands you can specify different command
 }
 ```
 
-The first task start the TypeScript compiler in watch mode, the second one starts the gulp build. If a tasks specifies a local command to run the task name is not included into the command line (`suppressTaskName` is `true` by default for these tasks). Since a local command can specify local arguments, there is no need for adding it by default. If a `tasks.json` file specifies both global and task local commands, the task local commands win over the global command. There is no merging between a global and a task local command.
+The first task starts the TypeScript compiler in watch mode, the second one starts the gulp build. If a task specifies a local command to run, the task name is not included into the command line (`suppressTaskName` is `true` by default for these tasks). Since a local command can specify local arguments, there is no need for adding it by default. If a `tasks.json` file specifies both global and task local commands, the task local commands win over the global command. There is no merging between a global and a task local command.
 
 ## Binding keyboard shortcuts to tasks
 
 If you need to run a task frequently, you can also define a keyboard shortcut for the task.
 
-For example to bind `ctrl+h` to the `build` task from above, add the following to your `keybindings.json` file:
+For example, to bind `ctrl+h` to the `build` task from above, add the following to your `keybindings.json` file:
 
 ```json
 {

--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -168,7 +168,7 @@ We are working on more auto-detection support, so this list will get smaller and
 
 The task's properties have the following semantic:
 
-- **label**: The tasks's label used in the user interface.
+- **label**: The task's label used in the user interface.
 - **type**: The task's type. For a custom task, this can either be `shell` or `process`. If `shell` is specified, the command is interpreted as a shell command (for example: bash, cmd, or PowerShell). If `process` is specified, the command is interpreted as a process to execute. If `shell` is used, any arguments to the command should be embedded into the `command` property to support proper argument quoting. For example, if the test script accepts a `--debug` argument then the command property would be: `./scripts/test.sh --debug`.
 - **command**: The actual command to execute.
 - **windows**: Any Windows specific properties. Will be used instead of the default properties when the command is executed on the Windows operating system.
@@ -195,7 +195,7 @@ Sometimes you want to control how the Integrated Terminal panel behaves when run
 - **echo**: Controls whether the executed command is echoed in the terminal. Default is `true`.
 - **panel**: Controls whether the terminal instance is shared between task runs. Possible values are:
   - *shared*: The terminal is shared and the output of other task runs are added to the same terminal.
-  - *dedicated*: The terminal is dedicated to a specific task. If that task is executed again, the terminal is reused. However the output of a different task is presented in a different terminal.
+  - *dedicated*: The terminal is dedicated to a specific task. If that task is executed again, the terminal is reused. However, the output of a different task is presented in a different terminal.
   - *new*: Every execution of that task is using a new clean terminal.
 
 You can modify the terminal panel behavior for auto-detected tasks as well. For example, if you want to change the output behavior for the **npm: run lint** from the ESLint example from above, add the `presentation` property to it:
@@ -428,7 +428,7 @@ Tasks frequently act with files on disk. If these files are stored on disk with 
 
 If you need to tweak the encoding you should check whether it makes sense to change the default encoding used by our operating system or at least changing it for the shell you use by tweaking the shell's profile file.
 
-If you only need to tweak it for a specific task then add the OS specific command necessary to change the encoding to the tasks command line. The following example is for Windows using code page of 437 as its default. The task shows the output of a file containing Cyrillic characters and therfore needs code page 866. The task to list the file looks like this assuming that the default shell is set to `cmd.exe`:
+If you only need to tweak it for a specific task then add the OS specific command necessary to change the encoding to the tasks command line. The following example is for Windows using code page of 437 as its default. The task shows the output of a file containing Cyrillic characters and therefore needs code page 866. The task to list the file looks like this assuming that the default shell is set to `cmd.exe`:
 
 ```json
 {

--- a/docs/extensionAPI/activation-events.md
+++ b/docs/extensionAPI/activation-events.md
@@ -10,7 +10,7 @@ MetaDescription: To support lazy activation of Visual Studio Code extensions (pl
 
 # Activation Events - package.json
 
-Extensions are activated lazily in VS Code.  As a result you need to provide VS Code with context as to when your extension should be activated.  We support the following activation events:
+Extensions are activated lazily in VS Code.  As a result, you need to provide VS Code with context as to when your extension should be activated.  We support the following activation events:
 
 * [`onLanguage:${language}`](/docs/extensionAPI/activation-events.md#activationeventsonlanguage)
 * [`onCommand:${command}`](/docs/extensionAPI/activation-events.md#activationeventsoncommand)

--- a/docs/extensionAPI/api-debugging.md
+++ b/docs/extensionAPI/api-debugging.md
@@ -94,7 +94,7 @@ GitHub Project | Description | Implementation Language
 In this section we give a high-level overview of the interaction between VS Code and a debug adapter.
 This should help you in your implementation of a debug adapter based on the Debug Adapter Protocol.
 
-When a debug sessions starts, VS Code launches the debug adapter executable and talks to it through *stdin* and *stdout*. VS Code sends an **initialize** request to configure the adapter with information about the path format (native or URI) and whether line and column values are 0 or 1 based.
+When a debug session starts, VS Code launches the debug adapter executable and talks to it through *stdin* and *stdout*. VS Code sends an **initialize** request to configure the adapter with information about the path format (native or URI) and whether line and column values are 0 or 1 based.
 If your adapter is derived from the TypeScript or C# default implementation `DebugSession`, you don't have to handle the initialize request yourself.
 
 Depending on the 'request' attribute used in the launch configuration created by the user, VS Code either sends a *launch* or an *attach* request.

--- a/docs/extensionAPI/extension-manifest.md
+++ b/docs/extensionAPI/extension-manifest.md
@@ -198,7 +198,7 @@ If you have other badges you would like to use, please open a Github [issue](htt
 
 ## Combining Extension Contributions
 
-The `yo code` generator lets you easily package TextMate themes, colorizers and snippets and create new extensions.  When the generator is run, it creates a complete standalone extension package for each option.  However it is often more convenient to have a single extension which combines multiple contributions.  For example, if you are adding support for a new language, you'd like to provide users with both the language definition with colorization and also snippets and perhaps even debugging support.
+The `yo code` generator lets you easily package TextMate themes, colorizers and snippets and create new extensions.  When the generator is run, it creates a complete standalone extension package for each option.  However, it is often more convenient to have a single extension which combines multiple contributions.  For example, if you are adding support for a new language, you'd like to provide users with both the language definition with colorization and also snippets and perhaps even debugging support.
 
 To combine extension contributions, edit an existing extension manifest `package.json` and add the new contributions and associated files.
 

--- a/docs/extensionAPI/language-support.md
+++ b/docs/extensionAPI/language-support.md
@@ -291,7 +291,7 @@ Diagnostics are a way to indicate issues with the code.
 
 #### Language Server Protocol
 
-Your language server send the `textDocument/publishDiagnostics` message to the language client. The message carries an array of diagnostic items for a resource URI.
+Your language server sends the `textDocument/publishDiagnostics` message to the language client. The message carries an array of diagnostic items for a resource URI.
 
 **Note**: The client does not ask the server for diagnostics. The server pushes the diagnostic information to the client.
 
@@ -589,7 +589,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 >
 >Nothing additional.
 
-## Show all All Symbol Definitions in Folder
+## Show all Symbol Definitions in Folder
 
 Allow the user to quickly navigate to symbol definitions anywhere in the folder (workspace) opened in VS Code.
 

--- a/docs/extensionAPI/overview.md
+++ b/docs/extensionAPI/overview.md
@@ -21,7 +21,7 @@ Topic|Description
 -----|-----------
 **[package.json Extension Manifest](/docs/extensionAPI/extension-manifest.md)**|Every Visual Studio Code extension needs a manifest file `package.json` at the root of the extension folder. This document provides an overview of the structure of that file and the mandatory fields.
 **[Contribution Points](/docs/extensionAPI/extension-points.md)**|Building on the base `package.json`, there are a number of additional extension points you can contribute to e.g. commands, themes, debuggers,...
-**[Activation Events](/docs/extensionAPI/activation-events.md)**|VS Code lazily activates extensions. This document outlines the activation options supported in `package.json` e.g. when a specific file type is loaded, when a command is fired, etc
+**[Activation Events](/docs/extensionAPI/activation-events.md)**|VS Code lazily activates extensions. This document outlines the activation options supported in `package.json` e.g. when a specific file type is loaded, when a command is fired, etc.
 **[API vscode namespace](/docs/extensionAPI/vscode-api.md)**|Review the full vscode namespace API reference.
 **[API complex commands](/docs/extensionAPI/vscode-api-commands.md)**|See the VS Code complex command API reference.
 **[Debugging API](/docs/extensionAPI/api-debugging.md)**|Learn the details about integrating debuggers into VS Code.

--- a/docs/extensionAPI/patterns-and-principles.md
+++ b/docs/extensionAPI/patterns-and-principles.md
@@ -47,7 +47,7 @@ VS Code is implemented using web technologies (HTML, CSS) and web technologies a
 
 ### Protocol based extensions
 
-A common extension pattern in VS Code is to execute extension code in a separate process that communicates with VS Code through a protocol. Examples of this in VS Code are the language servers and debug adapters.  Typically this protocol uses stdin/stdout to communicate between the processes using a JSON payload. Using separate processes provides good isolation boundaries which helps VS Code preserve the stability of the core editor. In addition, this allows extenders to pick the programming language that is most appropriate for the particular extension implementation.
+A common extension pattern in VS Code is to execute extension code in a separate process that communicates with VS Code through a protocol. Examples of this in VS Code are the language servers and debug adapters.  Typically, this protocol uses stdin/stdout to communicate between the processes using a JSON payload. Using separate processes provides good isolation boundaries which helps VS Code preserve the stability of the core editor. In addition, this allows extenders to pick the programming language that is most appropriate for the particular extension implementation.
 
 ## Extensibility Patterns
 

--- a/docs/extensions/example-debuggers.md
+++ b/docs/extensions/example-debuggers.md
@@ -15,7 +15,7 @@ These debug extensions differ from other extensions in that their implementation
 
 ![VS Code extensibility architecture](images/example-debuggers/extensibility-architecture.png)
 
-The reasons for implementing the debug adapters as standalone excutables are twofold: first, it makes it possible to implement the adapter in the language most suitable for the given debugger or runtime. Second, a standalone program can more easily run in elevated mode if this is required by the underlying debugger or runtime.
+The reasons for implementing the debug adapters as standalone executables are twofold: first, it makes it possible to implement the adapter in the language most suitable for the given debugger or runtime. Second, a standalone program can more easily run in elevated mode if this is required by the underlying debugger or runtime.
 
 In order to avoid problems with local firewalls, VS Code communicates with the adapter through stdin/stdout instead of using a more sophisticated mechanism (e.g. sockets).
 
@@ -93,7 +93,7 @@ Since we already had an active debug session for the extension the VS Code debug
 
 ![Debugging Extension and Server](images/example-debuggers/debug-extension-server.png)
 
-Now we are able to debug both the extension and the debug adapter simultanously.
+Now we are able to debug both the extension and the debug adapter simultaneously.
 A faster way to arrive here is by using the **Extension + Server** launch configuration which launches both sessions automatically.
 
 An alternative, even simpler approach for debugging the extension and the debug adapter can be found [below](https://code.visualstudio.com/docs/extensions/example-debuggers#_alternative-approach-to-develop-a-debug-extension).

--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -10,7 +10,7 @@ MetaDescription: Learn how to create Language Servers for Visual Studio Code.  T
 
 # Example - Language Server
 
-Language servers allow you to add your own validation logic to files open in VS Code. Typically you just validate programming languages. However validating other file types is useful as well. A language server could, for example, check files for inappropriate language.
+Language servers allow you to add your own validation logic to files open in VS Code. Typically, you just validate programming languages. However, validating other file types is useful as well. A language server could, for example, check files for inappropriate language.
 
 In general, validating a programming language can be expensive. Especially when validation requires parsing multiple files and building up abstract syntax trees. To avoid that performance cost, language servers in VS Code are executed in a separate process. This architecture also makes it possible that language servers can be written in other languages besides TypeScript/JavaScript and that they can support expensive additional language features like code completion or `Find All References`.
 
@@ -336,7 +336,7 @@ documents.onDidChangeContent((change) => {
 * If the start and end positions are the same, VS Code will squiggle the word at that position.
 * If you want to squiggle until the end of the line, then set the character of the end position to Number.MAX_VALUE.
 
-To test the language server do the following:
+To test the language server, do the following:
 
 * press `kb(workbench.action.tasks.build)` to start the build task. The task compiles both the client and the server.
 * open the debug viewlet, select the `Launch Client` launch configuration and press the `Start Debugging` button to launch an additional `Extension Development Host` instance of VS Code that executes the extension code.

--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -24,7 +24,7 @@ The easiest way to create a new workbench color theme is to start with an existi
 
 - Switch to the color theme that you want to modify.
 - Open the [settings](/docs/getstarted/settings.md) and make changes to view and editor colors using the `workbench.colorCustomizations`. Changes are applied live to your VS Code instance and no refreshing or reloading is necessary.
-- A complete list of all themable colors can be found in the [color reference](https://code.visualstudio.com/docs/getstarted/theme-color-reference).
+- A complete list of all themeable colors can be found in the [color reference](https://code.visualstudio.com/docs/getstarted/theme-color-reference).
 
 ### Syntax highlighting colors
 
@@ -255,7 +255,7 @@ It is recommended to use [WOFF](https://developer.mozilla.org/en-US/docs/Web/Gui
 - Set 'woff' as the format.
 - the weight property values are defined [here](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Values).
 - the style property values are defined [here](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-style#Values).
-- the size should be relative to the font size where the icon is used. Therefore always use percentage.
+- the size should be relative to the font size where the icon is used. Therefore, always use percentage.
 
 ```json
     "fonts": [

--- a/docs/extensions/yocode.md
+++ b/docs/extensions/yocode.md
@@ -74,7 +74,7 @@ Check out `vsc-extension-quickstart.md`. It's a quick guide with the next steps.
 
 Creates an extension that contributes a language with colorizer.
 
-* Prompts for the location (URL or file path) of an existing TextMate language file (.tmLanguage, .plist or .json). This file will be imported to the new extension. To start a new grammar you can skip this by passing an empty name.
+* Prompts for the location (URL or file path) of an existing TextMate language file (.tmLanguage, .plist or .json). This file will be imported to the new extension. To start a new grammar, you can skip this by passing an empty name.
 * Prompts for the extension identifier and will create a folder of that name in the current directory.
 
 Once created, open VS Code on the created folder and run the extension to test the colorization. Check out `vsc-extension-quickstart.md` for the next steps. Have a look at the language configuration file that has been created and defines configuration options such what style of comments and brackets the language uses.

--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -902,13 +902,13 @@ Below are the Visual Studio Code default settings and their values. You can also
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
 
-  // Defines space handling after opening and before closing non empty braces. Requires TypeScript >= 2.3.0.
+  // Defines space handling after opening and before closing non-empty braces. Requires TypeScript >= 2.3.0.
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
 
-  // Defines space handling after opening and before closing non empty brackets.
+  // Defines space handling after opening and before closing non-empty brackets.
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
 
-  // Defines space handling after opening and before closing non empty parenthesis.
+  // Defines space handling after opening and before closing non-empty parenthesis.
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
 
   // Defines space handling after opening and before closing template string braces. Requires TypeScript >= 2.0.6.
@@ -974,13 +974,13 @@ Below are the Visual Studio Code default settings and their values. You can also
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
 
-  // Defines space handling after opening and before closing non empty braces. Requires TypeScript >= 2.3.0.
+  // Defines space handling after opening and before closing non-empty braces. Requires TypeScript >= 2.3.0.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true,
 
-  // Defines space handling after opening and before closing non empty brackets.
+  // Defines space handling after opening and before closing non-empty brackets.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
 
-  // Defines space handling after opening and before closing non empty parenthesis.
+  // Defines space handling after opening and before closing non-empty parenthesis.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
 
   // Defines space handling after opening and before closing template string braces. Requires TypeScript >= 2.0.6.
@@ -1463,7 +1463,7 @@ Below are the Visual Studio Code default settings and their values. You can also
   "emmet.extensionsPath": null,
 
   // Enable Emmet abbreviations in languages that are not supported by default. Add a mapping here between the language and emmet supported language.
-  //  Eg: {"vue-html": "html", "javascript": "javascriptreact"}
+  //  E.g.: {"vue-html": "html", "javascript": "javascriptreact"}
   "emmet.includeLanguages": {},
 
   // Preferences used to modify behavior of some actions and resolvers of Emmet.

--- a/docs/getstarted/theme-color-reference.md
+++ b/docs/getstarted/theme-color-reference.md
@@ -385,7 +385,7 @@ Merge conflict decorations are shown when the editor contains special diff range
 - `merge.incomingHeaderBackground`: Incoming header background in inline merge conflicts. The color must not be opaque to not hide underlying decorations.
 - `merge.incomingContentBackground`: Incoming content background in inline merge conflicts. The color must not be opaque to not hide underlying decorations.
 - `merge.border`: Border color on headers and the splitter in inline merge conflicts.
-- `merge.commonContentBackground`: Common ancester content background in inline merge-conflicts. The color must not be opaque to not hide underlying decorations.
+- `merge.commonContentBackground`: Common ancestor content background in inline merge-conflicts. The color must not be opaque to not hide underlying decorations.
 - `merge.commonHeaderBackground`: Common ancestor header background in inline merge-conflicts. The color must not be opaque to not hide underlying decorations.
 - `editorOverviewRuler.currentContentForeground`: Current overview ruler foreground for inline merge conflicts.
 - `editorOverviewRuler.incomingContentForeground`: Incoming overview ruler foreground for inline merge conflicts.

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -112,7 +112,7 @@ There is no need to edit the `settings.json` file directly. It is better to use 
 2. Use the cursor keys to preview the icons of the theme.
 3. Select the theme you want and hit `kbstyle(Enter)`.
 
-By default, no file icon set is configured, therefore the File Explorer shows no icons. Once an icon theme is selected, the selected theme will be remembered and set again when VS Code is started the next time .
+By default, no file icon set is configured, therefore the File Explorer shows no icons. Once an icon theme is selected, the selected theme will be remembered and set again when VS Code is started the next time.
 
 VS code ships with two icon themes; **Minimal** and **Seti**. To install more icon themes, select the **Find more in the Marketplace...** item in the icon theme picker.
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -50,7 +50,7 @@ When you have more than one editor open you can switch between them quickly by h
 
 ## Minimap - outline view
 
-A Minimap (outline view) gives you a high level overview of your source code which is very useful for quick navigation and code understanding. A file's minimap is shown in the right side of the editor. You can click or drap the shaded area to quickly jump to different sections of your file.
+A Minimap (outline view) gives you a high level overview of your source code which is very useful for quick navigation and code understanding. A file's minimap is shown in the right side of the editor. You can click or drag the shaded area to quickly jump to different sections of your file.
 
 ![minimap](images/userinterface/minimap.png)
 

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -200,7 +200,7 @@ ColumnLimit: 0
 
 If you'd like to use a different version of clang-format than the one that ships with the extension, you can use the `C_Cpp.clang_format_path` [setting](/docs/getstarted/settings.md) and set its value to the path where the clang-format binary is installed.
 
-For example on the Windows platform:
+For example, on the Windows platform:
 
 ```json
   "C_Cpp.clang_format_path": "C:\\Program Files (x86)\\LLVM\\bin\\clang-format.exe"

--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -160,7 +160,7 @@ This will create a sample `tasks.json` file in the workspace `.vscode` folder.  
 
 As this is the only command in the file, you can execute it by pressing `kb(workbench.action.tasks.build)` (**Run Build Task**).  The sample Sass/Less file should not have any compile problems, so by running the task all that happens is a corresponding `styles.css` file is created.
 
-Since in more complex environments there can be more than one build task we prompt you to pick the task to execute after pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). In addition we allow you to scan the output for compile problems (errors and warnings). Depending on the compiler select an apropriate entry in the list to scan the tool output for errors and warnings. If you don't want to scan the output select **Never scan the build output** from the presented list.
+Since in more complex environments there can be more than one build task we prompt you to pick the task to execute after pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). In addition, we allow you to scan the output for compile problems (errors and warnings). Depending on the compiler select an appropriate entry in the list to scan the tool output for errors and warnings. If you don't want to scan the output select **Never scan the build output** from the presented list.
 
 At this point, you should see an additional file show up in the file list `sample.html`.
 
@@ -238,7 +238,7 @@ What is happening here?
 
 ### Step 3: Run the gulp default task
 
-To complete the tasks integration with VS Code, we will need to modify the task configuration from before to run the default Gulp task we just created. You can either delete the `tasks.json` file or empty it only keeping the `"version": "2.0.0"` property. Now execute **Run Task** from the global **Tasks** menu. Observe that you are presented with a picker listing the tasks defined in the gulp file. Select **gulp: default** to start the task. We allow you to scan the output for compile problems. Depending on the compiler select an apropriate entry in the list to scan the tool output for errors and warnings. If you don't want to scan the output select **Never scan the build output** from the presented list. At this point, if you create and/or modify Less or SASS files, you see the respective CSS files generated and/or changes reflected on save. You can also enable [Auto Save](/docs/editor/codebasics.md#saveauto-save) to make things even more streamlined.
+To complete the tasks integration with VS Code, we will need to modify the task configuration from before to run the default Gulp task we just created. You can either delete the `tasks.json` file or empty it only keeping the `"version": "2.0.0"` property. Now execute **Run Task** from the global **Tasks** menu. Observe that you are presented with a picker listing the tasks defined in the gulp file. Select **gulp: default** to start the task. We allow you to scan the output for compile problems. Depending on the compiler select an appropriate entry in the list to scan the tool output for errors and warnings. If you don't want to scan the output select **Never scan the build output** from the presented list. At this point, if you create and/or modify Less or SASS files, you see the respective CSS files generated and/or changes reflected on save. You can also enable [Auto Save](/docs/editor/codebasics.md#saveauto-save) to make things even more streamlined.
 
 If you want to make the **gulp: default** task the default build task executed when pressing `kb(workbench.action.tasks.build)` run **Configure Default Build Task** from the global **Tasks** menu and select **gulp: default** from the presented list.
 
@@ -279,7 +279,7 @@ argumentsInColorFunction | Warn when an invalid number of parameters in color fu
 unknownProperties | Warn when using an unknown property | warning
 ieHack | Warn when using an IE hack `*propertyName` or `_propertyName` | ignore
 unknownVendorSpecificProperties | Warn when using an unknown vendor-specific property | ignore
-propertyIgnoredDueToDisplay | Warn when using a property that is ignored due to the display. For example with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect. | warning
+propertyIgnoredDueToDisplay | Warn when using a property that is ignored due to the display. For example, with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect. | warning
 important | Warn when using `!important` as it is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored. | ignore
 float | Warn when using `float` as floats lead to fragile CSS that is easy to break if one aspect of the layout changes. | ignore
 idSelector | Warn when using selectors for an id `#id` as selectors should not contain IDs because these rules are too tightly coupled with the HTML. | ignore

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -13,7 +13,7 @@ Visual Studio Code provides basic support for HTML programming out of the box. T
 
 ## IntelliSense
 
-As you type in HTML, we offer suggestions via HTML IntelliSense.  In the image below you can see a suggested HTML element closure `</div>` as well as a context specific list of suggested elements.
+As you type in HTML, we offer suggestions via HTML IntelliSense.  In the image below, you can see a suggested HTML element closure `</div>` as well as a context specific list of suggested elements.
 
 ![HTML IntelliSense](images/html/htmlintellisense.png)
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -384,10 +384,10 @@ VS Code provides several formatting settings for JavaScript. They can all be fou
 // Defines space handling after function keyword for anonymous functions
 "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": boolean,
 
-// Defines space handling after opening and before closing non empty parenthesis
+// Defines space handling after opening and before closing non-empty parenthesis
 "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": boolean,
 
-// Defines space handling after opening and before closing non empty brackets
+// Defines space handling after opening and before closing non-empty brackets
 "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": boolean,
 
 // Defines whether an open brace is put onto a new line for functions or not

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -193,7 +193,7 @@ To use **markdown-it** to compile the Markdown file, change the contents as foll
 
 ### Step 4: Run the Build Task
 
-Since in more complex environments there can be more than one build task we prompt you to pick the task to execute after pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). In addition we allow you to scan the output for compile problems. Since we only want to convert the Markdown file to HTML select **Never scan the build output** from the presented list.
+Since in more complex environments there can be more than one build task we prompt you to pick the task to execute after pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). In addition, we allow you to scan the output for compile problems. Since we only want to convert the Markdown file to HTML select **Never scan the build output** from the presented list.
 
 At this point, you should see an additional file show up in the file list `sample.html`.
 

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -84,7 +84,7 @@ The Python extension provides a wide variety of settings for its various feature
 
 ## Other popular Python extensions
 
-Additional Python language support can be added to to VS Code by installing other popular Python extensions. For Jupyter support, we recommend the "Jupyter" extension from Don Jayamanne.
+Additional Python language support can be added to VS Code by installing other popular Python extensions. For Jupyter support, we recommend the "Jupyter" extension from Don Jayamanne.
 
 1. Open the **Extensions** view (`kb(workbench.view.extensions)`).
 1. Filter the extension list by typing 'python'.

--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -224,7 +224,7 @@ VS Code ships with a recent stable version of the TypeScript language service an
 
 ![TypeScript status bar version](images/typescript/status-bar-version.png)
 
->**Tip:** To get a specific TypeScript version, specify `@version` during npm install. For example for TypeScript 2.2.1, you would use `npm install --save-dev typescript@2.2.1`. To preview the next version of TypeScript, run `npm install --save-dev typescript@next`.
+>**Tip:** To get a specific TypeScript version, specify `@version` during npm install. For example, for TypeScript 2.2.1, you would use `npm install --save-dev typescript@2.2.1`. To preview the next version of TypeScript, run `npm install --save-dev typescript@next`.
 
 To use a different TypeScript version by default, configure `typescript.tsdk` in your user settings to point to a directory containing the TypeScript `tsserver.js` file. You can find the TypeScript installation location using `npm list -g typescript`. The `tsserver.js` file is usually in the `lib` folder.
 

--- a/docs/nodejs/extensions.md
+++ b/docs/nodejs/extensions.md
@@ -12,7 +12,7 @@ MetaSocialImage: /assets/images/nodejs_javascript_vscode.png
 
 Visual Studio Code supports many features for JavaScript and Node.js development. The features that ship with the downloaded product are the core features: debugging, IntelliSense, code navigation, etc.
 
-In addition to these core features, you can install a large number of quality extensions to add features to VS Code for JavaScript development.
+In addition, to these core features, you can install a large number of quality extensions to add features to VS Code for JavaScript development.
 
 > **Tip:** To see how to install and manage your extensions, please refer to the [extension documentation](/docs/editor/extension-gallery.md).
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -360,7 +360,7 @@ Two frequently used applications of remote debugging are:
 
 * **debugging Node.js in the Linux subsystem on Windows:**
 
-  If you want to run Node.js in the Linux subsystem on Windows (WSL), you can use the approach from above as well. However to make this even simpler, we've introduced a `useWSL` flag to automatically configure everything so that Node.js runs in the Linux subsystem and source is mapped to files in your workspace.
+  If you want to run Node.js in the Linux subsystem on Windows (WSL), you can use the approach from above as well. However, to make this even simpler, we've introduced a `useWSL` flag to automatically configure everything so that Node.js runs in the Linux subsystem and source is mapped to files in your workspace.
 
   Here is the simplest debug configuration for debugging `hello.js` in WSL:
 
@@ -380,7 +380,7 @@ If you need to set a breakpoint in a script that is not part of your workspace a
 
 ![Loaded Scripts Explorer](images/nodejs-debugging/loaded-scripts-explorer.gif)
 
- Alternatively you can use the **Debug: Open Loaded Script** action (`kb(extension.node-debug.pickLoadedScript)`) which opens a Quick Pick, where you can filter and select the script to open.
+ Alternatively, you can use the **Debug: Open Loaded Script** action (`kb(extension.node-debug.pickLoadedScript)`) which opens a Quick Pick, where you can filter and select the script to open.
 
 ![Opening Loaded Script with Quick Pick](images/nodejs-debugging/loaded-scripts.gif)
 
@@ -466,7 +466,7 @@ Make sure to use a Node.js version >= 5.11 since earlier versions do not work in
 
 ### Function breakpoints
 
-The Node.js debugger only supports function breakpoints when the "legacy" protocol is used (that is when targeting Node.js < 8.0 versions). In addition be aware of the following limitations when using function breakpoints:
+The Node.js debugger only supports function breakpoints when the "legacy" protocol is used (that is when targeting Node.js < 8.0 versions). In addition, be aware of the following limitations when using function breakpoints:
 
 - Function breakpoints only work for global, non-native functions.
 - Function breakpoints can only be created if the function has been defined (and has been seen by the debugger).
@@ -506,7 +506,7 @@ This breakpoint validation occurs when a session starts and the breakpoints are 
 
 VS Code Node.js debugging has a feature to avoid source code that you don't want to step through (AKA 'Just My Code'). This feature can be enabled with the `skipFiles` attribute in your launch configuration. `skipFiles` is an array of glob patterns for script paths to skip.
 
-For example using:
+For example, using:
 
 ```typescript
   "skipFiles": [

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -138,7 +138,7 @@ By default, the Python extension loads a file named `.env` in the current worksp
 
 A debug configuration also contains an `envFile` property that also defaults to the `.env` file in the current workspace (see [Debugging - standard configuration and options](debugging.md#standard-configuration-and-options)). This property allows you to easily set variables for debugging purposes that replace those used in the default `.env` file.
 
-For example, when developing a web application you might want to easily switch between development and production servers. Instead of coding the different URLs and other settings into your application directly, you could use separate definitions files for each. For example:
+For example, when developing a web application, you might want to easily switch between development and production servers. Instead of coding the different URLs and other settings into your application directly, you could use separate definitions files for each. For example:
 
 **dev.env file**
 

--- a/docs/python/unit-testing.md
+++ b/docs/python/unit-testing.md
@@ -42,7 +42,7 @@ Each framework also has specific configuration settings as described in the foll
 | promptToConfigure | `true` | Specifies whether VS Code prompts to configure a test framework if potential tests are discovered. |
 | debugPort | `3000` | Port number used for debugging of UnitTest tests. |
 
-The default arguments for UnitTest as as follows:
+The default arguments for UnitTest are as follows:
 
 - `-v` sets default verbosity. Remove this argument for simpler output.
 - `-s .` specifies the starting directory for discovering tests. If you have tests in a "test" folder, you can change this to `-s test` (meaning `"-s", "test"` in the arguments array).
@@ -73,7 +73,7 @@ You can also configure pytest using a `pytest.ini` file as described on [PyTest 
 | nosetestPath | `"nosetests"` | Path to Nose. Use a full path if Nose is located outside the current environment. |
 | nosetestArgs | `[]` | Arguments to pass to Nose, with each argument specified as an item in the array. See [Nose usage options](http://nose.readthedocs.io/en/latest/usage.html#options). |
 
-You can also configure nose wuth a `.noserc` or `nose.cfg` file as described on [Nose configuration](http://nose.readthedocs.io/en/latest/usage.html#configuration).
+You can also configure nose with a `.noserc` or `nose.cfg` file as described on [Nose configuration](http://nose.readthedocs.io/en/latest/usage.html#configuration).
 
 ## Test discovery
 
@@ -103,7 +103,7 @@ Tests are run using any of the following actions:
 
 | Command | Description |
 | --- | --- |
-| Run All Unit Tests | Searches for an runs all unit tests in the workspace and its subfolders. |
+| Run All Unit Tests | Searches for and runs all unit tests in the workspace and its subfolders. |
 | Run Current Unit Test File | Runs the test in the file that's currently viewed in the editor. |
 | Run Failed Unit Tests | Re-runs any tests that failed in a previous test run. Runs all test if no tests have been run yet. |
 | Run Unit Test File... | Prompts for a specific test filename, then runs the test in that file. |

--- a/docs/setup/additional-components.md
+++ b/docs/setup/additional-components.md
@@ -25,7 +25,7 @@ You'll find the components above mentioned often in our documentation and walkth
 
 ## VS Code extensions
 
-You can extend the VS Code editor itself through [extensions](/docs/editor/extension-gallery.md). The VS Code community has built hundreds of useful extension available on the VS Code [Marketplace](https://marketplace.visualstudio.com/VSCode).
+You can extend the VS Code editor itself through [extensions](/docs/editor/extension-gallery.md). The VS Code community has built hundreds of useful extensions available on the VS Code [Marketplace](https://marketplace.visualstudio.com/VSCode).
 
 <div class="marketplace-extensions-top"></div>
 


### PR DESCRIPTION
I fixed several spelling mistakes and punctuation errors.

I know the use of a comma after a short introductory phrase is considered optional for phrases of four words or less, but Microsoft's grammar checker prefers the comma to be there, so I made the changes.  I hope that's not contentious.