### PR TITLE
Tasks example problemMatcher regexp fix

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -691,7 +691,7 @@ A full handcrafted `tasks.json` for a `tsc` task running in watch mode looks lik
                 "owner": "typescript",
                 "fileLocation": "relative",
                 "pattern": {
-                    "regexp": "^([^\\s].*)\\((\\d+|\\,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(TS\\d+)\\s*:\\s*(.*)$",
+                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(TS\\d+)\\s*:\\s*(.*)$",
                     "file": 1,
                     "location": 2,
                     "severity": 3,


### PR DESCRIPTION
The handcrafted tsc problemMatcher example does not match errors with **location**s that consists of **2 numbers**.

Example:  `src/subfolder/Example.ts(52,42): error TS2300: Duplicate identifier 'DuplicatedIdentifier'.`