### PR TITLE
change markdown syntax from json to javascript

### DIFF
--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -818,7 +818,7 @@ You can set `"debug.inlineValues": true` to see variable values inline in the de
 Select **Tasks** from the top-level menu, run the command **Configure Tasks...**, then select the type of task you'd like to run.
 This will generate a `task.json` file with content like the following. See the [Tasks](/docs/editor/tasks.md) documentation for more details.
 
-```json
+```javascript
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format


### PR DESCRIPTION
The comment was showing up as highlighted red before because comments are not allowed in JSON.