### PR TITLE
Docs: change Launch.json console attributes

### DIFF
--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -194,7 +194,7 @@ Many debuggers support some of the following attributes:
 * `cwd` - current working directory for finding dependencies and other files
 * `port` - port when attaching to a running process
 * `stopOnEntry` - break immediately when the program launches
-* `console` - what kind of console to use, for example, `internalConsole`, `integratedTerminal`, `externalTerminal`.
+* `console` - what kind of console to use, for example, `none`, `integratedTerminal`, `externalTerminal`.
 
 ## Variable substitution
 


### PR DESCRIPTION
Seems like `internalConsole` is not available as option, as shown in the attached image.

![screen shot 2018-04-09 at 18 51 17](https://user-images.githubusercontent.com/10677263/38511146-71cec714-3c27-11e8-8c90-3120ac464250.png)
