### PR TITLE
Change `-p` to the more explicit `--load`

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -170,7 +170,7 @@ The limit can be increased to its maximum by editing `/etc/sysctl.conf` and addi
 fs.inotify.max_user_watches=524288
 ```
 
-The new value can then be loaded in by running `sudo sysctl -p`. Note that [Arch Linux](https://www.archlinux.org/) works a little differently, [view this page for advice](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers).
+The new value can then be loaded in by running `sudo sysctl --load`. Note that [Arch Linux](https://www.archlinux.org/) works a little differently, [view this page for advice](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers).
 
 While 524288 is the maximum number of files that can be watched, if you're in an environment that is particularly memory constrained, you may wish to lower the number. Each file watch [takes up 540 bytes (32-bit) or ~1kB (64-bit)](https://stackoverflow.com/a/7091897/1156119), so assuming that all 524288 watches are consumed that results in an upper bound of around 256MB (32-bit) or 512MB (64-bit).
 


### PR DESCRIPTION
Using the clearer version of this option helps readers understand what they're being asked to actually do when running commands from the internet.

Note: I'm admittedly not sure whether `--load` is available on all platforms and versions, though it seems likely that it is present.