### PR TITLE
📦 ADD: editorIndentGuide.activeBackground

### DIFF
--- a/docs/getstarted/theme-color-reference.md
+++ b/docs/getstarted/theme-color-reference.md
@@ -266,6 +266,7 @@ To see the editor white spaces, enable **Toggle Render Whitespace**.
 To see the editor indent guides, set `"editor.renderIndentGuides": true`.
 
 - `editorIndentGuide.background`: Color of the editor indentation guides.
+- `editorIndentGuide.activeBackground`: Color of the active editor indentation guide.
 
 To see editor rulers, define their location with `"editor.rulers"`
 


### PR DESCRIPTION
Add `editorIndentGuide.activeBackground` reference to the colors which became available `April 2018 (version 1.23)`

**DEMO**: Theme [Shades of Purple](https://marketplace.visualstudio.com/items?itemName=ahmadawais.shades-of-purple)

![image](https://on.ahmda.ws/rLAs/c)