### PR TITLE
Updating Live Share annoucement post that it is now in Public Preview.

### DIFF
--- a/blogs/2017/11/15/live-share.md
+++ b/blogs/2017/11/15/live-share.md
@@ -12,6 +12,8 @@ Author: Amanda Silver
 
 November 15, 2017 Amanda Silver, [@amandaksilver](https://twitter.com/amandaksilver)
 
+>**Update (May 7, 2018):** Visual Studio Live Share is now publicly available. You can [get started using Live Share](https://www.visualstudio.com/services/live-share/) today!
+
 We are excited to announce that we’re working on “Visual Studio Live Share”, which enables developers using Visual Studio 2017 or Visual Studio Code to collaborate in real-time! Learn more about Live Share and the upcoming limited private preview [here](/visual-studio-live-share).
 
 ## What is Live Share?


### PR DESCRIPTION
Now that Live Share is in public preview, we want to add a note to the original announcement blog post that people can readily download it and use it. 