### PR TITLE
Fix typo in extensions word-count example

### DIFF
--- a/docs/extensions/example-word-count.md
+++ b/docs/extensions/example-word-count.md
@@ -115,7 +115,7 @@ class WordCounter {
         docContent = docContent.replace(/(< ([^>]+)<)/g, '').replace(/\s+/g, ' ');
         docContent = docContent.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
         let wordCount = 0;
-        if (docContent != "") {
+        if (docContent !== "") {
             wordCount = docContent.split(" ").length;
         }
 


### PR DESCRIPTION
Make use of consistent strict inequality (`!==`) symbol.