### PR TITLE
Python linting lintOnSave 

### DIFF
--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -27,7 +27,7 @@ To change the linting behavior across all enabled linters, modify the following 
 | Feature | Setting<br/>(python.linting.) | Default value |
 | --- | --- | --- |
 | Linting in general | enabled | `true` |
-| Linting on file save | lintOnSave | `false` |
+| Linting on file save | lintOnSave | `true` |
 | Maximum number of linting messages | maxNumberOfProblems | `100` |
 | Exclude file and folder patterns | ignorePatterns | `[".vscode/*.py", "**/site-packages/**/*.py"]`  |
 


### PR DESCRIPTION
The default values ​​of python.linting.lintOnSave do not match in the following two documents.

docs/python/settings-reference.md#linting-settings
docs/python/linting.md
