### PR TITLE
Update link to "Create a Docker group"

### DIFF
--- a/docs/azure/docker.md
+++ b/docs/azure/docker.md
@@ -133,7 +133,7 @@ The default connection of the extension is to connect to the local docker daemon
 
 ## Running commands on Linux
 
-By default, Docker runs as the root user on Linux, requiring other users to access it with `sudo`. This extension does not assume root access, so you will need to create a Unix group called "docker" and add users to it. Instructions can be found here: [Create a Docker group](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group)
+By default, Docker runs as the root user on Linux, requiring other users to access it with `sudo`. This extension does not assume root access, so you will need to create a Unix group called "docker" and add users to it. Instructions can be found here: [Create a Docker group](https://docs.docker.com/install/linux/linux-postinstall/)
 
 ## Next Steps
 


### PR DESCRIPTION
Updated the link to point to the right file in the Docker Docs.

The current link doesn't point to the right file anymore.