### PR TITLE
Update docs on cmder

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -207,7 +207,7 @@ The basics of the terminal have been covered in this document, read on to find o
 
 **Q: Can I use Cmder's shell with the terminal on Windows?**
 
-**A:** Yes, to use the [Cmder](http://cmder.net/) shell in VS Code, you need to create a `vscode.bat` file in your cmder path with the following contents (edit the cmder path if neccessary):
+**A:** Yes, to use the [Cmder](http://cmder.net/) shell in VS Code, you need to create a `vscode.bat` file in your cmder path with the following contents (edit the cmder path if necessary):
 
 ```bat
 @echo off

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -207,12 +207,12 @@ The basics of the terminal have been covered in this document, read on to find o
 
 **Q: Can I use Cmder's shell with the terminal on Windows?**
 
-**A:** Yes, to use the [Cmder](http://cmder.net/) shell in VS Code, you need to create a `vscode.bat` file in your cmder path with the following contents:
+**A:** Yes, to use the [Cmder](http://cmder.net/) shell in VS Code, you need to create a `vscode.bat` file in your cmder path with the following contents (edit the cmder path if neccessary):
 
 ```bat
 @echo off
 SET CurrentWorkingDirectory=%CD%
-SET CMDER_ROOT=C:\cmder (your path to cmder)
+SET CMDER_ROOT=C:\cmder
 CALL "%CMDER_ROOT%\vendor\init.bat"
 CD /D %CurrentWorkingDirectory%
 ```


### PR DESCRIPTION
The comment in the vscode.bat snippet causes the batch file to not work. This can cause confusion for beginners who may think it is okay to leave it in there, and may not understand what they are doing wrong. My update takes the comment out of the batch file.