### PR TITLE
Auto-completion feature inside `extensions.json`

### DIFF
--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -212,7 +212,7 @@ An example `extensions.json` could be:
 
 which recommends two linter extensions, TSLint and ESLint, as well as the Chrome debugger extension.
 
-An extension is identified using its publisher name and extension identifier `publisher.extension`. You can see the name on the extension's detail page.
+An extension is identified using its publisher name and extension identifier `publisher.extension`. You can see the name on the extension's detail page. VS Code will provide you auto-completion for installed extensions inside these files.
 
 ![Extension identifier](images/extension-gallery/extension-identifier.png).
 


### PR DESCRIPTION
I've been a user of the recommendation system in VS Code for a while and I didn't know of the auto-completion feature until it was pointed out to me by a member of the vscode team in this comment https://github.com/Microsoft/vscode/pull/50419#issuecomment-399203239 of this pull request https://github.com/Microsoft/vscode/pull/50419, since it is not present in the documentation.

Naturally, the phrasing and positioning could be different.
