### PR TITLE
Updated tutorial-flask, minor changes for programs

### DIFF
--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -248,7 +248,7 @@ Debugging gives you the opportunity to pause a running program on a particular l
 
 During your work with Flask or any other library, you may want to examine the code in those libraries themselves. VS Code provides two convenient commands that navigate directly to the definitions of classes and other objects in any code:
 
-- **Go to Definition** jumps from your code into the code that defines an object. For example, in `views.py`, right-click on the `Flask` class (in the line `app = Flask(__name__)`) and select **Go to Definition** (or use `kb(editor.action.goToDeclaration)`), which navigates to the class definition in the Flask library.
+- **Go to Definition** jumps from your code into the code that defines an object. For example, in `app.py`, right-click on the `Flask` class (in the line `app = Flask(__name__)`) and select **Go to Definition** (or use `kb(editor.action.goToDeclaration)`), which navigates to the class definition in the Flask library.
 
 - **Peek Definition** (`kb(editor.action.previewDeclaration)`, also on the right-click context menu), is similar, but displays the class definition directly in the editor. Press `kbstyle(Escape)` to close the Peek window.
 
@@ -623,7 +623,7 @@ Throughout this tutorial, all the app code is contained in a single `app.py` fil
         return app.send_static_file('data.json')
     ```
 
-1. Create a file `__init.py__` with the following contents, also cut from `app.py`:
+1. Create a file `__init__.py` with the following contents, also cut from `app.py`:
 
     ```python
     from flask import Flask


### PR DESCRIPTION
In the Go to Definition and Peed Definition Commands the directions referenced view.py which has not been created yet during the tutorial, updated to app.py instead.

The naming of __init.py__ is incorrect, changed to __init__.py