### PR TITLE
fix sub-word link in v1_25

### DIFF
--- a/release-notes/v1_25.md
+++ b/release-notes/v1_25.md
@@ -21,7 +21,7 @@ Welcome to the June 2018 release of Visual Studio Code. We're very excited to mo
 * **[Outline view](#outline-view)** - Symbol tree outline and navigation for your documents.
 * **[Portable Mode](#portable-mode)** - Run or copy your VS Code setup from a USB thumb drop or file share.
 * **[Hover display options](#hover-display-options)** - Control the appearance of hover information.
-* **[Sub-word navigation](#history-navigation)** - Quickly navigate in camelCase words.
+* **[Sub-word navigation](#subword-support)** - Quickly navigate in camelCase words.
 * **[Floating debug toolbar](#floating-debug-toolbar)** - Keep the debug toolbar always visible without hiding editor tabs.
 * **[Extensions view improvements](#extensions)** - Easily see Enabled, Disabled, and Recommended extensions.
 * **[Preview: Settings editor](#new-settings-editor)** - Now with a "Table of Contents" to organize settings.


### PR DESCRIPTION
Corrected markdown anchor link for sub-word navigation section