### PR TITLE
Variable transform example - change part 3 pointer

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -145,8 +145,8 @@ The following example inserts the name of the current file without its ending, s
 
 ```
 ${TM_FILENAME/(.*)\\..+$/$1/}
-  |           |         | |
-  |           |         | |-> no options
+  |           |         |  |
+  |           |         |  |-> no options
   |           |         |
   |           |         |-> references the contents of the first
   |           |             capture group


### PR DESCRIPTION
In the "Creating your own snippets" tutorial, the section for Variable transform shows a example. Each part that is required for making a transform is pointed, but i think that part 3 - which is pointed as "no options" should point to the forward slash and not $1 which belongs to part 2 of the transform syntax.

