### PR TITLE
Add stuff I didn't know about authoring (language) extensions

### DIFF
--- a/docs/extensionAPI/extension-manifest.md
+++ b/docs/extensionAPI/extension-manifest.md
@@ -36,7 +36,7 @@ Name | Required | Type | Details
 `devDependencies` | | `object` | Any development Node.js dependencies your extension needs. Exactly the same as [npm's `devDependencies`](https://docs.npmjs.com/files/package.json#devdependencies).
 `extensionDependencies` | | `array` | An array with the ids of extensions that this extension depends on. These other extensions will be installed when the primary extension is installed. The id of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.
 `scripts` | | `object` | Exactly the same as [npm's `scripts`](https://docs.npmjs.com/misc/scripts) but with [extra VS Code specific fields](/docs/extensions/publish-extension.md#pre-publish-step).
-`icon` | | `string` | The path to a 128x128 pixel icon.
+`icon` | | `string` | The path to the icon of at least 128x128 pixels (256x256 for Retina screens).
 
 Also check [npm's `package.json` reference](https://docs.npmjs.com/files/package.json).
 

--- a/docs/extensionAPI/extension-manifest.md
+++ b/docs/extensionAPI/extension-manifest.md
@@ -226,7 +226,7 @@ Below is an extension manifest which includes a LaTex language definition (langu
         "grammars": [{
             "language": "latex",
             "scopeName": "text.tex.latex",
-            "path": "./syntaxes/latex.tmLanguage"
+            "path": "./syntaxes/latex.tmLanguage.json"
         }],
         "snippets": [{
             "language": "latex",

--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -423,9 +423,13 @@ Contribute a TextMate grammar to a language. You must provide the `language` thi
 ```json
 "contributes": {
     "grammars": [{
-        "language": "shellscript",
-        "scopeName": "source.shell",
-        "path": "./syntaxes/Shell-Unix-Bash.tmLanguage"
+        "language": "markdown",
+        "scopeName": "text.html.markdown",
+        "path": "./syntaxes/markdown.tmLanguage.json",
+        "embeddedLanguages": {
+            "meta.embedded.block.frontmatter": "yaml",
+            ...
+        }
     }]
 }
 ```

--- a/docs/extensionAPI/language-support.md
+++ b/docs/extensionAPI/language-support.md
@@ -48,11 +48,13 @@ In order to support syntax highlighting, your extension needs to register a Text
         {
             "language": "markdown",
             "scopeName": "text.html.markdown",
-            "path": "./syntaxes/markdown.tmLanguage"
+            "path": "./syntaxes/markdown.tmLanguage.json"
         }
     ], ...
 }
 ```
+
+VS Code recognizes two formats for grammar files, Plist (`.tmLanguage`) and JSON (`.tmLanguage.json`). Plist files are really verbose, so people usually compile them from other languages like YAML. If you're creating a brand new grammar, we recommend using a JSON grammar to avoid a build step.
 
 >**Basic**
 >

--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -431,7 +431,7 @@ When you're adding a new language to VS Code, it is also great to add language [
         "grammars": [{
             "language": "latex",
             "scopeName": "text.tex.latex",
-            "path": "./syntaxes/latex.tmLanguage"
+            "path": "./syntaxes/latex.tmLanguage.json"
         }],
         "snippets": [
             {
@@ -473,7 +473,7 @@ Language supports are added using the language identifier:
     "grammars": [{
         "language": "groovy",
         "scopeName": "source.groovy",
-        "path": "./syntaxes/Groovy.tmLanguage"
+        "path": "./syntaxes/Groovy.tmLanguage.json"
     }],
     "snippets": [{
         "language": "groovy",
@@ -573,7 +573,7 @@ To learn about what scopes are used where, check out the [TextMate documentation
         "grammars": [{
             "language": "asp",
             "scopeName": "source.asp",
-            "path": "./syntaxes/asp.tmLanguage"
+            "path": "./syntaxes/asp.tmLanguage.json"
         }]
     }
 }
@@ -610,7 +610,7 @@ For example, the setting below adds the `.mmd` file extension to the `markdown` 
         "grammars": [{
             "language": "xml",
             "scopeName": "text.xml",
-            "path": "./syntaxes/BetterXML.tmLanguage"
+            "path": "./syntaxes/BetterXML.tmLanguage.json"
         }]
     }
 }

--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -490,6 +490,45 @@ When defining a new language identifier, use the following guidelines:
 
 You can find a list of known language identifiers in the [language identifier reference](/docs/languages/identifiers.md).
 
+## Embedded languages
+
+Languages can embed other languages in order to provide syntax highlighting and features of those languages. A common example of this is Markdown, it can have YAML front matter, fenced code blocks etc.
+
+An implementation of CSS code blocks in our `.tmLanguage.json` file might look like this:
+
+```json
+"patterns": [
+    {
+        "begin": "^```css$",
+        "end": "^```$",
+        "contentName": "meta.embedded.block.css",
+        "patterns": [
+            { "include": "source.css" }
+        ]
+    }
+]
+```
+
+`source.css` is the scope name used by CSS language, it will provide proper syntax highlighting for the code between the lines matched by `begin` and `end`.
+
+In order to inherit other CSS features we marked the block by using `contentName`, that way we can map its value in `contributes.grammars.embeddedLanguages` in `package.json`:
+
+```json
+"contributes": {
+    "grammars": [{
+        "language": "markdown",
+        "scopeName": "text.html.markdown",
+        "path": "./syntaxes/markdown.tmLanguage.json",
+        "embeddedLanguages": {
+            "meta.embedded.block.css": "css",
+            ...
+        }
+    }]
+}
+```
+
+We mapped it to the ID of the language that we want to inherit features from. For example, now if we press `kbstyle(ctrl/)` inside a CSS code block, VS Code will use CSS comments instead of Markdown!
+
 ## Next Steps
 
 If you'd like to learn more about VS Code extensibility, try these topics:

--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -36,7 +36,7 @@ Language supports are added using the language identifier:
     "grammars": [{
         "language": "groovy",
         "scopeName": "source.groovy",
-        "path": "./syntaxes/Groovy.tmLanguage"
+        "path": "./syntaxes/Groovy.tmLanguage.json"
     }],
     "snippets": [{
         "language": "groovy",

--- a/release-notes/May_2016.md
+++ b/release-notes/May_2016.md
@@ -187,7 +187,7 @@ Extensions can now contribute TextMate grammars that inject new rules into the e
 "grammars": [
   {
     "scopeName": "source.todo",
-    "path": "./syntaxes/todo.tmLanguage",
+    "path": "./syntaxes/todo.tmLanguage.json",
     "injectTo": [  "source.js", "source.ts" ]
   }
 ]


### PR DESCRIPTION
- The recommended icon size should be 256x256. We'll always want icons to be sharp on every screen, so I added this note in parenthesis.

- I added the documentation for `contributes.grammars.embeddedLanguages`. This field is very useful because VS Code seems to use it to inherit language _features_, not just syntax highlighting.

- It took me a long time to figure out that the grammar file doesn't have to be a Plist file. generator-code does a good job of making that clear, but I didn't use it at first because I didn't know how to answer all its questions. I added the `.json` extension to all `.tmLanguage` files in code examples and explained that using JSON is more convenient to use.