### PR TITLE
Language change for example-language-server.md

### DIFF
--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -506,8 +506,8 @@ documents.onDidChangeContent(async (change) => {
 
 ### Diagnostics Tips and Tricks
 
-* If the start and end positions are the same, VS Code will squiggle the word at that position.
-* If you want to squiggle until the end of the line, then set the character of the end position to Number.MAX_VALUE.
+* If the start and end positions are the same, VS Code will underline with a squiggle the word at that position.
+* If you want to underline with a squiggle until the end of the line, then set the character of the end position to Number.MAX_VALUE.
 
 To run the Language Server, do the following:
 


### PR DESCRIPTION
Hello,

English is not my native language and I had some trouble understanding this part.
* If the start and end positions are the same, VS Code will **_squiggle_** the word at that position.
* If you want to **_squiggle_** until the end of the line, then set the character of the end position to Number.MAX_VALUE.

I know it might seems unnecessary now that I understand. But I think putting some emphasis on the fact that VS Code is just underlying the word and not really _"doing"_ anything with it can make the documentation more easily understandable.

Let me know what you think.
Thanks a lot for reading,