### PR TITLE
Update intro video for getting started and debugging

### DIFF
--- a/docs/getstarted/introvideos.md
+++ b/docs/getstarted/introvideos.md
@@ -16,22 +16,12 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 
 <ul class="video-list">
 	<li class="video">
-		<a href="/docs/introvideos/quicktour">
-			<img src="https://img.youtube.com/vi/pI1skOo2yjk/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
-			<div class="info">
-				<h2 class="title faux-h3">Quick Tour using JavaScript</h2>
-				<p class="description">Check out the key features of VS Code in a quick overview.</p>
-				<span class="duration"><span class="sr-only">Duration </span>3<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
-			</div>
-		</a>
-	</li>
-	<li class="video">
 		<a href="/docs/introvideos/basics">
-			<img src="https://img.youtube.com/vi/SYRwSyjD8oI/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
+			<img src="https://img.youtube.com/vi/Sdg0ef2PpBw/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
 			<div class="info">
-				<h2 class="title faux-h3">Setup and Basics</h2>
-				<p class="description">Install and learn the basics of your new editor.</p>
-				<span class="duration"><span class="sr-only">Duration </span>5<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
+				<h2 class="title faux-h3">Getting started</h2>
+				<p class="description">Install and learn the basics of getting started with Visual Studio Code.</p>
+				<span class="duration"><span class="sr-only">Duration </span>3<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
 			</div>
 		</a>
 	</li>
@@ -77,10 +67,10 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 	</li>
 	<li class="video">
 		<a href="/docs/introvideos/debugging">
-			<img src="https://img.youtube.com/vi/6cOsxaNC06c/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
+			<img src="https://img.youtube.com/vi/2oFKNL7vYV8/mqdefault.jpg" alt aria-hidden="true" class="thumb"/>
 			<div class="info">
 				<h2 class="title faux-h3">Debugging</h2>
-				<p class="description">Debug a simple Node.js application.</p>
+				<p class="description">Getting started with Node.js debugging in VS Code.</p>
 				<span class="duration"><span class="sr-only">Duration </span>5<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
 			</div>
 		</a>

--- a/docs/introvideos/basics.md
+++ b/docs/introvideos/basics.md
@@ -1,35 +1,36 @@
 ---
 Order:
 Area: introvideos
-TOCTitle: Setup and Basics
+TOCTitle: Getting started
 ContentId: baf150cd-6daf-4604-87db-a7c70a6706a7
-PageTitle: Setup and Basic Use of Visual Studio Code
+PageTitle:  Getting started with Visual Studio Code
 DateApproved: 3/6/2017
 MetaDescription: Download and learn the basics of Visual Studio Code.
 MetaSocialImage: images/opengraph/introvideos.png
 ---
 
-# Setup and Basics of VS Code
+# Getting started with Visual Studio Code
 
 In this tutorial, we walk you through setting up Visual Studio Code and give an overview of the basic features.
 
-<iframe src="https://www.youtube.com/embed/SYRwSyjD8oI?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/Sdg0ef2PpBw?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
 ## Outline
 
 * Download and install VS Code.
-* Explore VS Code features in the **Interactive Editor Playground**.
+* Visual Studio Code Insiders edition
 * See an overview of the user interface.
-* Customize your editor with the **View** menu and by changing the color theme.
-* Change your keyboard shortcuts using a Keymap extension.
-* Focus on your source code with Zen Mode.
+* Install langauge support for your favorite langauge.
+* Change your keyboard shortcuts and migrate easy from other editors using keybinding extensions.
+* Customize your editor with themes.
+* Explore VS Code features in the **Interactive Editor Playground**.
 
 ## Learn More
 
 * [User Interface](/docs/getstarted/userinterface.md) - View the documentation for VS Code.
 * [Setup Overview](/docs/setup/setup-overview.md) - Documentation for getting up and running with VS Code, including platform specific setup.
 * [Keyboard Shortcuts](/docs/getstarted/keybindings.md) - Customize your own shortcuts, download a reference sheet, or install a Keymap extension.
-* [Keymaps in the Marketplace](https://marketplace.visualstudio.com/search?target=VSCode&category=Keymaps&sortBy=Downloads) - Install a Keymap extension to bring the keybindings from your previous editor to VS Code.
+* [Keybinding extensions](https://marketplace.visualstudio.com/search?target=VSCode&category=Keymaps&sortBy=Downloads) - Install a Keymap extension to bring the keybindings from your previous editor to VS Code.
 
 ## Next Video
 

--- a/docs/introvideos/debugging.md
+++ b/docs/introvideos/debugging.md
@@ -11,20 +11,18 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 # Debugging in VS Code
 
-Debugging is a core feature of Visual Studio Code. In this tutorial, we will show you how to configure and use debugging basics. We will walk you through debugging a Node.js application.
+Debugging is a core feature of Visual Studio Code. In this tutorial, we will show you how to configure and use debugging basics. We will walk you through how you get started with Node.js debugging in VS Code.
 
 > **Tip:** To use the debugging features demonstrated in this video for Node.js, you will need to first install [nodejs](https://nodejs.org/en/).
 
-<iframe src="https://www.youtube.com/embed/6cOsxaNC06c?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/2oFKNL7vYV8?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
 ## Outline
-
 * Debugging that "just works".
-* Using a `launch.json` configuration file.
-* Set regular and conditional breakpoints.
-* Inspect your program's state and variables.
-* Step through your source code and use the `skipFiles` option to debug "just your code."
-* Multi-target debugging.
+* Single file debugging
+* Using a `launch.json` configuration files
+* The difference between launch and attach debug configurations.
+* Use Watches to inspect your program's state and variables.
 
 ## Learn More
 


### PR DESCRIPTION
Fixes #1706 

Changes:
- removes first intro video
- replaces basics with "getting started"
- updates debugging video.