### PR TITLE
Fix typo in Python unit test config example

### DIFF
--- a/docs/python/unit-testing.md
+++ b/docs/python/unit-testing.md
@@ -111,8 +111,8 @@ To enable Nose:
 
 ```json
 "python.unitTest.unittestEnabled": false,
-"python.unitTest.pyTestEnabled": true,
-"python.unitTest.nosetestsEnabled": false,
+"python.unitTest.pyTestEnabled": false,
+"python.unitTest.nosetestsEnabled": true,
 ```
 
 ## Test discovery


### PR DESCRIPTION
Change the Nose configuration example to enable Nose as opposed to pyTest