### PR TITLE
Remove confusing `$` from test command.

### DIFF
--- a/tutorials/functions-extension/getting-started.md
+++ b/tutorials/functions-extension/getting-started.md
@@ -52,7 +52,7 @@ Before we continue, ensure that you have all the prerequisites installed and con
 
 In VS Code, you should see your Azure email address in the Status Bar and your subscription in the **AZURE FUNCTIONS** explorer.
 
-Verify that you have the Azure Functions tools installed by opening a terminal and running `$ func`.
+Verify that you have the Azure Functions tools installed by opening a terminal (or PowerShell/Command Prompt) and running `func`.
 
 ```bash
 $ func


### PR DESCRIPTION
I've gotten two emails now from people that are entering the `$` when
testing that the tools are installed so this removes that.