### PR TITLE
Remove escape from manual path example

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -34,7 +34,7 @@ To manually add VS Code to your path:
 ```bash
 cat << EOF >> ~/.bash_profile
 # Add Visual Studio Code (code)
-export PATH="\$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 EOF
 ```
 


### PR DESCRIPTION
The "manually add VS code to your path" code is not copy-pasteable because there is an escape (`\`) before the `$`.