### PR TITLE
Add apt-transport-https

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -33,6 +33,7 @@ sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode s
 Then update the package cache and install the package using:
 
 ```bash
+sudo apt-get install apt-transport-https
 sudo apt-get update
 sudo apt-get install code # or code-insiders
 ```


### PR DESCRIPTION
Installed ```apt-transport-https``` before ```apt-get update``` as it's a dependency for external repositories accessed via https.