### PR TITLE
(maint) Update Debug Adapter Protocol link

### DIFF
--- a/docs/extensionAPI/api-debugging.md
+++ b/docs/extensionAPI/api-debugging.md
@@ -72,7 +72,7 @@ Please note that accessing breakpoints initially returns an empty array but trig
 
 ## Debug Adapter Protocol (DAP)
 
-You can find the Debug Adapter Protocol specification expressed as a [JSON schema](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/debugProtocol.json) or as a (generated) [TypeScript definition](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts) file in the
+You can find the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol) specification expressed as a [JSON schema](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/debugProtocol.json) or as a (generated) [TypeScript definition](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts) file in the
 [`vscode-debugadapter-node`](https://github.com/Microsoft/vscode-debugadapter-node) repository.
 Both files show the detailed structure of the individual protocol requests, responses and events.
 The protocol is also available as the NPM module [`vscode-debugprotocol`](https://www.npmjs.com/package/vscode-debugprotocol).


### PR DESCRIPTION
This commit updates the DAP readme to add a link to the official webpage for the Debug Adapter Protocol.