### PR TITLE
explicitly show which package.json file is referred to

### DIFF
--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -118,7 +118,7 @@ Next look at the [`configuration`](https://code.visualstudio.com/docs/extensionA
 
 This section contributes `configuration` settings to VS Code. The example will explain how these settings are sent over to the language server on startup and on every change of the settings.
 
-The actual Language Client code and the corresponding `package.json` is in the `/client` folder. The interesting part in the `package.json` file is that it adds a dependency to the `vscode` extension host API and the `vscode-languageclient` library:
+The actual Language Client code and the corresponding `package.json` is in the `/client` folder. The interesting part in the `/client/package.json` file is that it adds a dependency to the `vscode` extension host API and the `vscode-languageclient` library:
 
 ```json
 "dependencies": {


### PR DESCRIPTION
With the current wording, it's not obvious to see if `package.json` file refers to the one in root directory, or client directory.