### PR TITLE
Fix typos in extensions.autoCheckUpdates setting name

### DIFF
--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -105,7 +105,7 @@ There is also an **Enable All Extensions** command in the **More Actions** (`...
 
 ### Extension auto-update
 
-VS Code checks for extension updates and installs them automatically. After an update, you will be prompted to reload VS Code. If you'd rather update your extensions manually, you can disable auto-update with the **Disable Auto Updating Extensions** command which sets the `extensions.autoUpdate` [setting](/docs/getstarted/settings.md)  to `false`. If you don't want VS Code to even check for updates, you can set the `extensions.autoCheckUpdate` setting to false.
+VS Code checks for extension updates and installs them automatically. After an update, you will be prompted to reload VS Code. If you'd rather update your extensions manually, you can disable auto-update with the **Disable Auto Updating Extensions** command which sets the `extensions.autoUpdate` [setting](/docs/getstarted/settings.md)  to `false`. If you don't want VS Code to even check for updates, you can set the `extensions.autoCheckUpdates` setting to false.
 
 ### Update an extension manually
 

--- a/release-notes/v1_26.md
+++ b/release-notes/v1_26.md
@@ -139,7 +139,7 @@ Below is the complete list of settings to control VS Code features that make net
 * `update.channel`
 * `update.showReleaseNotes`
 * `extensions.autoupdate`
-* `extensions.autocheckUpdates`
+* `extensions.autoCheckUpdates`
 * `extensions.showRecommendationsOnlyOnDemand`
 * `workbench.settings.enableNaturalLanguageSearch`
 * `workbench.enableExperiments`


### PR DESCRIPTION
The setting's name is `extensions.autoCheckUpdates` ([vscode source](https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts#L211)).