### PR TITLE
Update introvideos.md with correct video durations

### DIFF
--- a/docs/getstarted/introvideos.md
+++ b/docs/getstarted/introvideos.md
@@ -71,7 +71,7 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 			<div class="info">
 				<h2 class="title faux-h3">Debugging</h2>
 				<p class="description">Getting started with Node.js debugging in VS Code.</p>
-				<span class="duration"><span class="sr-only">Duration </span>5<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
+				<span class="duration"><span class="sr-only">Duration </span>8<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
 			</div>
 		</a>
 	</li>
@@ -81,7 +81,7 @@ Start your journey with Visual Studio Code with this set of introductory videos.
 			<div class="info">
 				<h2 class="title faux-h3">Version Control</h2>
 				<p class="description">Learn how to use Git version control in VS Code.</p>
-				<span class="duration"><span class="sr-only">Duration </span>4<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
+				<span class="duration"><span class="sr-only">Duration </span>3<span aria-hidden="true"> min</span><span class="sr-only"> minutes</span></span>
 			</div>
 		</a>
 	</li>


### PR DESCRIPTION
All the other videos are done using the number of whole minutes of the video - i.e. rounding down to the next minute. (3:54 -> 3 minutes)

Alternatively the durations could be to the nearest minute, but it would involve changing more of them (3:54 -> 4 minutes). Either way, the duration for "Debugging" is way out as it is now.