### PR TITLE
Update identifiers.md

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -105,6 +105,7 @@ Shell Script (Bash) | `shellscript`
 SQL | `sql`
 Swift | `swift`
 TypeScript | `typescript`
+TypeScript (React) | `typescriptreact`
 TeX | `tex`
 Visual Basic | `vb`
 XML | `xml`


### PR DESCRIPTION
I was tearing my hair out trying to figure out why my custom snippets weren't applying in my `*.tsx` files. I realized the scope was set to `typescript` and the the list of language identifiers does not contain the correct `typescriptreact` identifier.