### PR TITLE
Fixed typo

### DIFF
--- a/docs/extensionAPI/language-support.md
+++ b/docs/extensionAPI/language-support.md
@@ -718,7 +718,7 @@ In addition, your language server needs to respond to the `textDocument/codeLens
 #### Direct Implementation
 
 ```typescript
-class GoRCodeLensProvider implements vscode.CodeLensProvider {
+class GoCodeLensProvider implements vscode.CodeLensProvider {
     public provideCodeLenses(document: TextDocument, token: CancellationToken):
         CodeLens[] | Thenable<CodeLens[]> {
     ...


### PR DESCRIPTION
GoRCodeLensProvider => GoCodeLensProvider

Below the fixed line there is `GoCodeLensProvider` call, not the `GoRCodeLensProvider` call