### PR TITLE
Mark the preview html command as deprecated

### DIFF
--- a/docs/extensionAPI/vscode-api-commands.md
+++ b/docs/extensionAPI/vscode-api-commands.md
@@ -11,13 +11,6 @@ MetaDescription: Visual Studio Code extensions (plug-ins) complex commands Refer
 
 This document lists the set of Visual Studio Code complex commands. They are called complex commands because they require parameters and often return a value. You can use the commands in conjunction with the `executeCommand` API.
 
-The following is a sample of how to preview a HTML document:
-
-```javascript
-let uri = Uri.parse('file:///some/path/to/file.html');
-let success = await commands.executeCommand('vscode.previewHtml', uri);
-```
-
 ## Commands
 
 `vscode.executeWorkspaceSymbolProvider` - Execute all workspace symbol provider.
@@ -158,12 +151,12 @@ let success = await commands.executeCommand('vscode.previewHtml', uri);
 
 `vscode.previewHtml` - Render the HTML of the resource in an editor view.
 
+**🚨 The previewHtml command is deprecated. Please use the [webview api](https://code.visualstudio.com/docs/extensions/webview) instead**
+
 * _uri_ - Uri of the resource to preview.
 * _column_ - (optional) Column in which to preview.
 * _label_ - (optional) An human readable string that is used as title for the preview.
 * _options_ - (optional) Options for controlling webview environment.
-
-See [working with the HTML preview](/docs/extensionAPI/vscode-api-commands.md#working-with-the-html-preview) for more information about the HTML preview's integration with the editor and for best practices for extension authors.
 
 
 `vscode.openFolder` - Open a folder or workspace in the current window or new window depending on the newWindow argument.
@@ -291,79 +284,3 @@ The layout is described as object with an initial (optional) orientation (0 = ho
   * 'to': String value providing where to move.
   * 'by': String value providing the unit for move (by tab or by group).
   * 'value': Number value providing how many positions or an absolute position to move.
-
-## Working With the HTML Preview
-
-### Styling
-
-The body element of the displayed HTML is dynamically annotated with one of the following CSS classes in order to communicate the kind of color theme VS Code is currently using: `vscode-light`, `vscode-dark`, or `vscode-high-contrast`.
-
-### Links
-
-Links contained in the document will be handled by VS Code whereby it supports `file`-resources and [virtual](https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L3295) resources as well as triggering commands using the `command` scheme. Use the query part of a command-uri to pass along JSON encoded arguments. Note that URL encoding must be applied.
-
-The snippet below defines a command link that calls the _previewHtml_ command and passes along an URI:
-
-```javascript
-  let href = encodeURI('command:vscode.previewHtml?' + JSON.stringify(someUri));
-  let html = '<a href="' + href + '">Show Resource...</a>.';
-```
-
-### Security Tips
-
-As an extension author, if you use an HTML preview, you are responsible for protecting users from potentially malicious content. The primary danger is that an attacker could craft a malicious workspace that uses your HTML preview to execute scripts or perform other insecure activities. In addition to normal web security best practices, here are a few specific tips and tricks to help protect users.
-
-### Sanitizing Content
-
-As a first line of defense, when constructing an HTML document for the preview, make sure to appropriately sanitize all input that comes from workspace settings or from files on a user's system. For HTML content, consider using a whitelist of safe tags and attributes. Libraries such as [sanitize-html](https://www.npmjs.com/package/sanitize-html) can help with this.
-
-### Disabling Scripts
-
-If your preview does not need to execute JavaScript, you can further enhance security by disabling script execution entirely. One way to accomplish this is by loading untrusted content inside of an `iframe`  with the `sandbox` attribute set. In this case, the content would be loaded using the `srcdoc` attribute:
-
-```html
-<iframe sandbox srcdoc="<!DOCTYPE html>..."></iframe>
-```
-
-If your preview still needs to load some local resources such as images, try using `sandbox="allow-same-origin"` instead:
-
-```html
-<iframe sandbox="allow-same-origin" srcdoc="<!DOCTYPE html>..."></iframe>
-```
-
-`sandbox="allow-same-origin"` disables script execution inside the `iframe` but allows loading resources from a user's system, such as stylesheets and images. In general, it is best to disable access to local resources unless your preview absolutely needs it.
-
-### Using a Content Security Policy
-
-If your preview's functionality depends on scripts, consider disabling scripts that come from untrusted user content using a [content security policy](https://developer.mozilla.org/docs/Web/HTTP/CSP). Content security policy allow fine grained control over which resources may be loaded.
-
-For example, here's a content security policy that allows images from anywhere, allows stylesheets from a user's local system, and disables all scripts:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src *; style-src 'self'; script-src 'none';">
-  <title>...</title>
-</head>
-<body>
-  Content
-</body>
-</html>
-```
-
-To selectively enable scripts, the best approach for the HTML preview is to use a dynamically generated [nonce](https://developers.google.com/web/fundamentals/security/csp/) to whitelist certain trusted scripts:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src *; style-src 'self'; script-src 'nonce-123456';">
-  <title>...</title>
-</head>
-<body>
-  Content
-  <script nonce="123456" src="file:///path/to/extension/my_trusted_script.js"></script>
-</body>
-</html>
-```

--- a/docs/extensionAPI/vscode-api-commands.md
+++ b/docs/extensionAPI/vscode-api-commands.md
@@ -13,10 +13,10 @@ This document lists the set of Visual Studio Code complex commands. They are cal
 
 The following is a sample of how to open a new folder in VS Code:
 
- ```javascript
- let uri = Uri.file('/some/path/to/folder');
- let success = await commands.executeCommand('vscode.openFolder', uri);
- ```
+```javascript
+let uri = Uri.file('/some/path/to/folder');
+let success = await commands.executeCommand('vscode.openFolder', uri);
+```
 
 ## Commands
 

--- a/docs/extensionAPI/vscode-api-commands.md
+++ b/docs/extensionAPI/vscode-api-commands.md
@@ -11,6 +11,13 @@ MetaDescription: Visual Studio Code extensions (plug-ins) complex commands Refer
 
 This document lists the set of Visual Studio Code complex commands. They are called complex commands because they require parameters and often return a value. You can use the commands in conjunction with the `executeCommand` API.
 
+The following is a sample of how to open a new folder in VS Code:
+
+ ```javascript
+ let uri = Uri.file('/some/path/to/folder');
+ let success = await commands.executeCommand('vscode.openFolder', uri);
+ ```
+
 ## Commands
 
 `vscode.executeWorkspaceSymbolProvider` - Execute all workspace symbol provider.


### PR DESCRIPTION
Adds a note to the `previewHtml` command that it is now deprecated. Delete the supporting material around this command, most of which is now covered by the webview documentation