### PR TITLE
example-language-server: link url

### DIFF
--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -543,7 +543,7 @@ For **lsp-sample**, you can set this setting: `"languageServerExample.trace.serv
 
 ![LSP Log](images/example-language-server/lsp-log.png)
 
-As Language Servers can be chatty (5 seconds of real-world usage can produce 5000 lines of log), we also provide a tool to visualize and filter the communication between Language Client / Server. You can save all logs from the channel into a file, and load that file with the [Language Server Protocol Inspector](https://github.com/Microsoft/language-server-protocol-inspector) at https://microsoft.github.io/language-server-protocol/inspector.
+As Language Servers can be chatty (5 seconds of real-world usage can produce 5000 lines of log), we also provide a tool to visualize and filter the communication between Language Client / Server. You can save all logs from the channel into a file, and load that file with the [Language Server Protocol Inspector](https://github.com/Microsoft/language-server-protocol-inspector) at [https://microsoft.github.io/language-server-protocol/inspector](https://microsoft.github.io/language-server-protocol/inspector).
 
 ![LSP Inspector](images/example-language-server/lsp-inspector.png)
 


### PR DESCRIPTION
link does not work in https://code.visualstudio.com/docs/extensions/example-language-server