### PR TITLE
Change json code blocks language identifier to 'json5' to support comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ If you are listing out multiple key bindings, you can use a table.
 
 For source code we use the fenced code block notation ```` ``` ````.
 
->**Note:** You can add an optional language identifier to enable syntax highlighting in your fenced code block. E.g. ```` ```json ```` or ```` ```javascript ````. [Read more →](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting)
+>**Note:** You can add an optional language identifier to enable syntax highlighting in your fenced code block. E.g. ```` ```json5 ```` or ```` ```javascript ````. [Read more →](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting)
 
 Some JavaScript code...
 

--- a/blogs/2016/03/11/ExtensionsRoundup.md
+++ b/blogs/2016/03/11/ExtensionsRoundup.md
@@ -34,7 +34,7 @@ Here are the instructions for various Ruby versions. I am using Ruby v2.0.x.
 
 Create a `launch.json` file in `.vscode` folder and add the following:
 
-```json
+```json5
 {
   "version": "0.2.0",
   "configurations": [

--- a/blogs/2016/10/31/js_roundup_2.md
+++ b/blogs/2016/10/31/js_roundup_2.md
@@ -39,7 +39,7 @@ Although not necessarily a JavaScript extension, Git Project Manager is a favori
 
 To use this extension, first install it and then add the following configuration to your `settings.json` file.
 
-```json
+```json5
 "gitProjectManager.baseProjectsFolders": [
     "/path/to/your/base/project/folders"
 ]
@@ -80,7 +80,7 @@ These extensions are in preview because we want your feedback. There are still m
 3. Add a JSON object to `contributes.keybindings` section of `package.json` as seen below ([Atom](https://github.com/waderyan/vscode-atom-keybindings/blob/master/package.json#L25) and [Sublime Text](https://github.com/Microsoft/vscode-sublime-keybindings/blob/master/package.json#L25)).
 4. Open a pull request.
 
-```json
+```json5
 {
     "mac": "<keyboard shortcut for mac>",
     "linux": "<keyboard shortcut for linux",

--- a/blogs/2016/11/15/formatters-best-practices.md
+++ b/blogs/2016/11/15/formatters-best-practices.md
@@ -63,7 +63,7 @@ A common misunderstanding is that when contributing a formatter, you must suppor
 
 What happens when there are multiple formatters for one language? This can be a problem when different formatters' actions contradict. In the October release, we added settings to enable or disable the default formatters that ship with VS Code. The best practice is for extension authors to add a similar setting as what we did in VS Code as shown below.
 
-```json
+```json5
 "html.format.enable": true,
 "javascript.format.enable": true,
 "typescript.format.enable": true,
@@ -80,7 +80,7 @@ Last, we want to bring more awareness to formatters and have added a new ["Forma
 
 To summarize, an extension that implements the formatting extension API properly will do the following :
 
-1. Register formatters via [registerDocumentFormattingEditProvider](https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L4172).  
+1. Register formatters via [registerDocumentFormattingEditProvider](https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L4172).
 2. Implement the formatting logic per the [DocumentFormattingEditProvider interface](https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L2143).
 3. Have a setting to enable / disable the formatter.
 4. Add the "Formatters" category to the extension manifest.

--- a/blogs/2017/01/15/connect-nina-e2e.md
+++ b/blogs/2017/01/15/connect-nina-e2e.md
@@ -192,7 +192,7 @@ Select the extension named `Debugger for Chrome` and click the `Install` button.
 
 Type `CTRL+P`, enter/select `launch.json` and replace the contents of that file with the following:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "compounds": [

--- a/blogs/2017/02/08/syntax-highlighting-optimizations.md
+++ b/blogs/2017/02/08/syntax-highlighting-optimizations.md
@@ -357,7 +357,7 @@ To make things a bit more complicated, TextMate themes also support parent selec
 
 Here are two Monokai theme rules (as JSON here for brevity; the original is in XML):
 
-```json
+```json5
 ...
 // Function name
 { "scope": "entity.name.function", "fontStyle": "", "foreground":"#A6E22E" }
@@ -403,7 +403,7 @@ Perhaps the biggest breakthrough we've had is that we **don't need to store toke
 
 Here's how a very simple theme might look like:
 
-```json
+```json5
 theme = [
   {                                  "foreground": "#F8F8F2"                           },
   { "scope": "var",                  "foreground": "#F8F8F2"                           },
@@ -420,7 +420,7 @@ theme = [
 When loading it, we will generate an id for each unique color that shows up in the theme and store it into a color map (similar as we did for token types above):
 
 
-```json
+```json5
 //                          1          2          3          4          5           6
 colorMap = ["reserved", "#F8F8F2", "#00FF00", "#0000FF", "#100000", "#200000", "#300000"]
 theme = [

--- a/blogs/2017/03/07/extension-pack-roundup.md
+++ b/blogs/2017/03/07/extension-pack-roundup.md
@@ -45,7 +45,7 @@ To include an extension, your extension manifest file (`package.json`) needs the
 
 For my CodeLens Roundup, this is what my extension manifest file looked like:
 
-```json
+```json5
 "extensionDependencies": [
     "eamodio.gitlens",
     "VisualStudioOnlineApplicationInsights.application-insights",

--- a/blogs/2017/04/10/sublime-text-roundup.md
+++ b/blogs/2017/04/10/sublime-text-roundup.md
@@ -27,7 +27,7 @@ VS Code has several features you can enable to more closely match the coding exp
 
 VS Code has an excellent minimap, but it requires a setting change. Use the following setting to turn on the minimap:
 
-```json
+```json5
 "editor.minimap.enabled": true
 ```
 
@@ -35,7 +35,7 @@ VS Code has an excellent minimap, but it requires a setting change. Use the foll
 
 Format on paste is a fantastic feature when moving source code around. Use this setting to enable format on paste:
 
-```json
+```json5
 "editor.formatOnPaste": true
 ```
 
@@ -43,7 +43,7 @@ Format on paste is a fantastic feature when moving source code around. Use this 
 
 Sublime Text and VS Code order snippets differently in their code completion widgets. To make VS Code work more like Sublime Text, use this setting to put snippets at the top:
 
-```json
+```json5
 "editor.snippetSuggestions": "top"
 ```
 

--- a/blogs/2017/12/20/chrome-debugging.md
+++ b/blogs/2017/12/20/chrome-debugging.md
@@ -67,7 +67,7 @@ Break-on-load breakpoints are powered by DOM Instrumentation Breakpoints in Chro
 
 We are releasing break-on-load breakpoints as an experimental feature for our Chrome Debugger, and you can enable the feature by setting the new `breakOnLoad` property to `true` in your `launch.json` configuration:
 
-```json
+```json5
 {
     "type": "chrome",
     "request": "launch",

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -166,7 +166,7 @@ You can invoke these from the **Command Palette** (`kb(workbench.action.showComm
 
 VS Code has default formatters for JavaScript, TypeScript, JSON, and HTML. Each language has specific formatting options (for example, `html.format.indentInnerHtml`) which you can tune to your preference in your user or workspace [settings](/docs/getstarted/settings.md). You can also disable the default language formatter if you have another extension installed that provides formatting for the same language.
 
-```json
+```json5
 "html.format.enable": false
 ```
 
@@ -204,7 +204,7 @@ Since the 1.22 release, folding ranges can also be computed based on syntax toke
 
 If you prefer to switch back to indentation based folding for one (or all) of the languages above, use:
 
-```json
+```json5
   "[html]": {
     "editor.foldingStrategy": "indentation"
   },
@@ -236,7 +236,7 @@ To fold and unfold only the regions defined by markers use:
 
 VS Code lets you control text indentation and whether you'd like to use spaces or tab stops. By default, VS Code inserts spaces and uses 4 spaces per `kbstyle(Tab)` key. If you'd like to use another default, you can modify the `editor.insertSpaces` and `editor.tabSize` [settings](/docs/getstarted/settings.mg).
 
-```json
+```json5
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
 ```
@@ -253,7 +253,7 @@ You can click on the Status Bar indentation display to bring up a drop-down with
 
 >**Note:** VS Code auto-detection checks for indentations of 2, 4, 6 or 8 spaces. If your file uses a different number of spaces, the indentation may not be correctly detected. For example, if your convention is to indent with 3 spaces, you may want to turn off `editor.detectIndentation` and explicitly set the tab size to 3.
 
-```json
+```json5
     "editor.detectIndentation": false,
     "editor.tabSize": 3,
 ```
@@ -299,7 +299,7 @@ Yes, expand the Search view text box to include a replace text field. You can se
 
 You can control word wrap through the `editor.wordWrap` [setting](/docs/getstarted/settings.md). By default, `editor.wordWrap` is `off` but if you set to it to `on`, text will wrap on the editor's viewport width.
 
-```json
+```json5
     "editor.wordWrap": "on"
 ```
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -62,7 +62,7 @@ VS Code will try to automatically detect your debug environment but if this fail
 
 Here is the launch configuration generated for Node.js debugging:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -214,7 +214,7 @@ Many debuggers support some of the following attributes:
 
 To avoid having to use absolute paths in debug configurations, VS Code makes commonly used paths and other values available as variables and supports variable substitution inside strings in `launch.json`. Examples are `${workspaceFolder}` for the root path of a workspace folder, `${file}` for the file open in the active editor, and `${env:Name}` for an environment variable 'Name'. You can see a full list of predefined variables in the [Variables Reference](/docs/editor/variables-reference.md) or by invoking IntelliSense inside the `launch.json` string attributes.
 
-```json
+```json5
 {
     "type": "node",
     "request": "launch",
@@ -231,7 +231,7 @@ To avoid having to use absolute paths in debug configurations, VS Code makes com
 
 Below is an example that passes `"args"` to the program differently on Windows than on Linux and macOS:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -252,7 +252,7 @@ Below is an example that passes `"args"` to the program differently on Windows t
 Valid operating properties are `"windows"` for Windows, `"linux"` for Linux and `"osx"` for macOS. Properties defined in an operating system specific scope override properties defined in the global scope.
 
 In the example below debugging the program always _stops on entry_ except for macOS:
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -274,7 +274,7 @@ In the example below debugging the program always _stops on entry_ except for ma
 
 VS Code supports adding a `"launch"` object inside your User [settings](/docs/getstarted/settings.md). This `"launch"` configuration will then be shared across your workspaces. For example:
 
-```json
+```json5
 "launch": {
     "version": "0.2.0",
     "configurations": [{
@@ -339,7 +339,7 @@ Using multi-target debugging is simple: after you've started a first debug sessi
 
 An alternative way to start multiple debug session is by using a so-called _compound_ launch configuration. A compound launch configuration lists the names of two or more launch configurations that should be launched in parallel. Compound launch configurations show up in the launch configuration drop down menu.
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [

--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -23,7 +23,7 @@ When you start typing an Emmet abbreviation, you will see the abbreviation displ
 
 If you want to use the `kbstyle(Tab)` key for expanding the Emmet abbreviations, add the following setting:
 
-```json
+```json5
 "emmet.triggerExpansionOnTab": true
 ```
 
@@ -37,7 +37,7 @@ If you have disabled the `editor.quickSuggestions` [setting](/docs/getstarted/se
 
 If you don't want to see Emmet abbreviations in suggestions at all, then use the following setting:
 
-```json
+```json5
 "emmet.showExpandedAbbreviation": "never"
 ```
 
@@ -47,7 +47,7 @@ You can still use the command **Emmet: Expand Abbreviation** to expand your abbr
 
 To ensure Emmet suggestions are always on top in the suggestion list, add the following settings:
 
-```json
+```json5
 "emmet.showSuggestionsAsSnippets": true,
 "editor.snippetSuggestions": "top"
 ```
@@ -58,7 +58,7 @@ To enable the Emmet abbreviation expansion in file types where it is not availab
 
 For example:
 
-```json
+```json5
 "emmet.includeLanguages": {
     "javascript": "javascriptreact",
     "vue-html": "html",
@@ -68,7 +68,7 @@ For example:
 
 Emmet has no knowledge of these new languages, and so you might feel Emmet suggestions showing up in non HTML/CSS context. To avoid this, you can use the following setting.
 
-```json
+```json5
 "emmet.showExpandedAbbreviation": "inMarkupAndStylesheetFilesOnly"
 ```
 
@@ -88,7 +88,7 @@ Prefix your CSS abbreviations with `-` to get all applicable vendor prefixes inc
 
 Below are a few examples of how you can control which vendors get applied to which CSS property by updating the `emmet.preferences` setting:
 
-```json
+```json5
 {
     "emmet.preferences": {
         "css.webkitProperties": "border-right,animation",
@@ -109,7 +109,7 @@ Filters are special post-processors that modify the expanded abbreviation before
 
 Below is an example of the first approach using the `emmet.syntaxProfiles` setting to apply the `bem` filter for all the abbreviations in HTML files:
 
-```json
+```json5
 "emmet.syntaxProfiles": {
     "html": {
         "filters": "bem"
@@ -149,7 +149,7 @@ The format for the `filter.commentAfter` preference is different in VS Code Emme
 
 For example, instead of:
 
-```json
+```json5
 "emmet.preferences": {
     "filter.commentAfter": "\n<!-- /<%= attr('id', '#') %><%= attr('class', '.') %> -->"
 }
@@ -157,7 +157,7 @@ For example, instead of:
 
 in VS Code, you would use a simpler:
 
-```json
+```json5
 "emmet.preferences": {
     "filter.commentAfter": "\n<!-- /[#ID][.CLASS] -->"
 }
@@ -173,7 +173,7 @@ Custom Emmet snippets need to be defined in a json file named `snippets.json`. T
 
 Below is an example for the contents of this `snippets.json` file.
 
-```json
+```json5
 {
     "html": {
         "snippets": {
@@ -236,7 +236,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
     Make sure to use language ids for both sides of the mapping.
 
     For example:
-    ```json
+    ```json5
     "emmet.includeLanguages": {
         "javascript": "javascriptreact",
         "vue-html": "html",
@@ -253,7 +253,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
     See [Emmet Customization of output profile](https://docs.emmet.io/customization/syntax-profiles/#create-your-own-profile) to learn how you can customize the output of your HTML abbreviations.
 
     For example:
-    ```json
+    ```json5
     "emmet.syntaxProfiles": {
         "html": {
             "attr_quotes": "single"
@@ -269,7 +269,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
     Customize variables used by Emmet snippets.
 
     For example:
-    ```json
+    ```json5
     "emmet.variables": {
         "lang": "de",
         "charset": "UTF-16"
@@ -339,7 +339,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
 
     For example, instead of the older format
 
-    ```json
+    ```json5
     "emmet.preferences": {
         "filter.commentAfter": "\n<!-- /<%= attr('id', '#') %><%= attr('class', '.') %> -->"
     }
@@ -347,7 +347,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
 
     you would use
 
-    ```json
+    ```json5
     "emmet.preferences": {
         "filter.commentAfter": "\n<!-- /[#ID][.CLASS] -->"
     }
@@ -370,7 +370,7 @@ Custom tags when used in an expression like `MyTag>YourTag` or `MyTag.someclass`
 
 Add the following setting to enable expanding of Emmet abbreviations using tab which will expand custom tags in all cases.
 
-```json
+```json5
 "emmet.triggerExpansionOnTab": true
 ```
 

--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -222,7 +222,7 @@ In a [multi-root workspace](/docs/editor/multi-root-workspaces.md), the command 
 
 An example `extensions.json` could be:
 
-```json
+```json5
 {
     "recommendations": [
         "eg2.tslint",

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -56,7 +56,7 @@ The shell used defaults to `$SHELL` on Linux and macOS, PowerShell on Windows 10
 
 Correctly configuring your shell on Windows is a matter of locating the right executable and updating the setting. Below are a list of common shell executables and their default locations:
 
-```json
+```json5
 // Command Prompt
 "terminal.integrated.shell.windows": "C:\\Windows\\System32\\cmd.exe"
 // PowerShell
@@ -79,7 +79,7 @@ You can pass arguments to the shell when it is launched.
 
 For example, to enable running bash as a login shell (which runs `.bash_profile`), pass in the `-l` argument (with double quotes):
 
-```json
+```json5
 // Linux
 "terminal.integrated.shellArgs.linux": ["-l"]
 ```
@@ -181,7 +181,7 @@ Integrated Terminal sessions can now be renamed using the **Terminal: Rename** (
 
 By default, the terminal will open at the folder that is opened in the Explorer. The `terminal.integrated.cwd` setting allows specifying a custom path to open instead:
 
-```json
+```json5
 {
     "terminal.integrated.cwd": "/home/user"
 }
@@ -233,7 +233,7 @@ CD /D %CurrentWorkingDirectory%
 
 then in your VS Code user settings, add the following to your `settings.json` file:
 
-```json
+```json5
 "terminal.integrated.shell.windows": "C:\\WINDOWS\\System32\\cmd.exe",
 "terminal.integrated.shellArgs.windows": ["/K", "C:\\cmder\\vscode.bat"]
 ```
@@ -242,7 +242,7 @@ then in your VS Code user settings, add the following to your `settings.json` fi
 
 Yes, to use the [Cygwin](http://cygwin.com/) shell, you will first need to install the chere package and then add the following settings to your `settings.json` file:
 
-```json
+```json5
 "terminal.integrated.shell.windows": "C:\\Cygwin\\bin\\bash.exe",
 "terminal.integrated.shellArgs.windows": ["/bin/xhere", "/bin/bash"]
 ```
@@ -261,7 +261,7 @@ If you want to put the default Integrated Terminal shell back to the default (Po
 
 For example, if you have set your default terminal to bash, you will find `terminal.integrated.shell.windows` in your `settings.json` pointing to your bash location.
 
-```json
+```json5
 "terminal.integrated.shell.windows": "C:\\WINDOWS\\System32\\bash.exe",
 ```
 
@@ -271,7 +271,7 @@ Remove the entry to use the built-in VS Code default or set it to another shell 
 
 The easy fix for this is to use the 64-bit version. If you must use the 32-bit version you need to use the `sysnative` path when configuring your paths instead of `System32`:
 
-```json
+```json5
 "terminal.integrated.shell.windows": "C:\\WINDOWS\\sysnative\\cmd.exe",
 ```
 
@@ -281,14 +281,14 @@ Normally `kbstyle(Cmd+k)`/`kbstyle(Ctrl+k)` clears the terminal on macOS/Windows
 
 macOS:
 
-```json
+```json5
 { "key": "cmd+k",                 "command": "workbench.action.terminal.clear",
                                      "when": "terminalFocus" },
 ```
 
 Windows:
 
-```json
+```json5
 { "key": "ctrl+k",                "command": "workbench.action.terminal.clear",
                                      "when": "terminalFocus" },
 ```
@@ -331,7 +331,7 @@ rm -R /usr/local/bin/npm /usr/local/lib/node_modules/npm/bin/npm-cli.js
 
 Yes, you can specify [Powerline](https://powerline.readthedocs.io) fonts with the `terminal.integrated.fontFamily` [setting](/docs/getstarted/settings.md).
 
-```json
+```json5
 "terminal.integrated.fontFamily": "Meslo LG M DZ for Powerline"
 ```
 

--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -125,7 +125,7 @@ The key bindings shown below are the default key bindings. You can change these 
 
 > **Note:** There are many more key bindings relating to IntelliSense. Open the **Default Keyboard Shortcuts** (**File** > **Preferences** > **Keyboard Shortcuts**) and search for "suggest".
 
-```json
+```json5
 [
     {
         "key": "ctrl+space",

--- a/docs/editor/multi-root-workspaces.md
+++ b/docs/editor/multi-root-workspaces.md
@@ -86,7 +86,7 @@ The schema of `.code-workspace` is fairly straightforward. You have an array of 
 
 You can override the display name of your folders with the `name` attribute for a clearer display in the Explorer. For example, you could more clearly name your project folders such as 'Product' and 'Documentation':
 
-```json
+```json5
 {
     "folders": [
         {
@@ -128,7 +128,7 @@ There are only a few changes to the VS Code UI when you are using multi-root wor
 
 If you'd always like to see the folder displayed in the tabbed header, you can use the `workbench.editor.labelFormat` [setting](/docs/getstarted/settings.md) "medium" or "long" values to show the folder or full paths.
 
-```json
+```json5
 "workbench.editor.labelFormat": "medium"
 ```
 
@@ -156,7 +156,7 @@ With multiple root folders in one workspace, it is possible to have a `.vscode` 
 
 User settings are supported as with single folder project and you can also set global Workspace settings which will apply to all folders in your multi-root Workspace. Global Workspace settings will be stored in your `.code-workspace` file.
 
-```json
+```json5
 {
     "folders": [
         {
@@ -223,7 +223,7 @@ Alternatively, new launch configurations can be added via the "Add Config (works
 
 A compound launch configuration can reference the individual launch configurations by name as long as the names are unique within the workspace, for example:
 
-```json
+```json5
   "compounds": [{
       "name": "Launch Server & Client",
       "configurations": [
@@ -235,7 +235,7 @@ A compound launch configuration can reference the individual launch configuratio
 
 If the individual launch configuration names are not unique, the qualifying folder can be specified with a more verbose "folder" syntax:
 
-```json
+```json5
   "compounds": [{
       "name": "Launch Server & Client",
       "configurations": [
@@ -256,7 +256,7 @@ In addition to `compounds` the `launch` section of the workspace configuration f
 
 Here is an example for a launch configuration where the program lives in a folder "Program" and where all files from a folder "Library" should be skipped when stepping:
 
-```json
+```json5
 "launch": {
   "configurations": [{
       "type": "node",
@@ -301,7 +301,7 @@ Below are some of the popular extensions which have already adopted the multi-ro
 
 VS Code supports folder level extension recommendations through the `extensions.json` files under the folder's `.vscode` subfolder. You can also provide global Workspace extension recommendations by adding them to your `.code-workspace` file. You can use the **Extensions: Configure Recommended Extensions (Workspace)** command to open your Workspace file and add extension identifiers ({publisherName}.{extensionName}) to the `extensions.recommendations` array.
 
-```json
+```json5
 {
     "folders": [
         {

--- a/docs/editor/refactoring.md
+++ b/docs/editor/refactoring.md
@@ -49,7 +49,7 @@ Renaming is common operation related to refactoring source code and VS Code has 
 
 The `editor.action.codeAction` command lets you configure keybindings for specific Code Actions. This keybinding for example triggers the **Extract function** refactoring Code Actions:
 
-```json
+```json5
 {
   "key": "ctrl+shift+r ctrl+e",
   "command": "editor.action.codeAction",
@@ -67,7 +67,7 @@ Using the above keybinding, if only a single `"refactor.extract.function"` Code 
 
 You can also control how/when Code Actions are automatically applied using the `apply` argument:
 
-```json
+```json5
 {
   "key": "ctrl+shift+r ctrl+e",
   "command": "editor.action.codeAction",

--- a/docs/editor/tasks-v1.md
+++ b/docs/editor/tasks-v1.md
@@ -41,7 +41,7 @@ Select the **Tasks: Configure Task Runner** command and you will see a list of t
 
 You should now see a `tasks.json` file in your workspace `.vscode` folder with the following content:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "command": "echo",
@@ -85,7 +85,7 @@ You can also define multiple tasks in a `tasks` array in order to pass different
 
 Here's a simple example passing different arguments to the `echo` command:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "command": "echo",
@@ -122,7 +122,7 @@ There are also `tasks` specific properties. One useful property is `isBuildComma
 
 If you want to run multiple different commands you can specify different commands per task. A `tasks.json` file using commands per task looks like this:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "tasks": [
@@ -152,7 +152,7 @@ If you need to run a task frequently, you can also define a keyboard shortcut fo
 
 For example, to bind `ctrl+h` to the `build` task from above, add the following to your `keybindings.json` file:
 
-```json
+```json5
 {
     "key": "ctrl+h",
     "command": "workbench.action.tasks.runTask",
@@ -166,7 +166,7 @@ When authoring tasks configurations, it is useful to have a set of predefined co
 
 Below is an example of a configuration that passes the current opened file to the TypeScript compiler.
 
-```json
+```json5
 {
     "command": "tsc",
     "args": ["${file}"]
@@ -179,7 +179,7 @@ The task system supports defining values (for example, the command to be execute
 
 Below is an example that uses the Node.js executable as a command and is treated differently on Windows and Linux:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "windows": {
@@ -195,7 +195,7 @@ Valid operating properties are `windows` for Windows, `linux` for Linux and `osx
 
 In the example below:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "showOutput": "never",
@@ -209,7 +209,7 @@ Output from the executed task is never brought to front except for Windows where
 
 Tasks local commands can be made operating specific as well. The syntax is the same as for global commands. Here an example that adds an OS specific argument to a command:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "tasks": [
@@ -310,7 +310,7 @@ If you don't already have a `tasks.json` under your workspace `.vscode` folder, 
 
 For this example, select `Gulp` from the list. Given a `gulpfile.js` like the example above, this will generate a `tasks.json` file like this:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -339,7 +339,7 @@ Since we execute the Mono compiler to compile C# files, we should use the `$msCo
 
 The `problemMatcher` property will then be:
 
-```json
+```json5
             "problemMatcher": [
                 "$msCompile"
             ]
@@ -367,7 +367,7 @@ We want to produce a problem matcher that can capture the message in the output 
 
 A matcher that captures the above warning (and errors) looks like:
 
-```json
+```json5
 {
     // The problem is owned by the cpp language service.
     "owner": "cpp",
@@ -395,7 +395,7 @@ Please note that the file, line and message properties are mandatory.
 
 Here is a finished `tasks.json` file with the code above (comments removed) wrapped with the actual task details:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "command": "gcc",
@@ -444,7 +444,7 @@ To do this we use an array of problem patterns for the `pattern` property. This 
 
 The following problem pattern matches the output from ESLint in stylish mode - but still has one small issue which we will resolve next.  The code below has a first regular expression to capture the file name and the second to capture the line, column, severity, message and error code:
 
-```json
+```json5
 {
     "owner": "javascript",
     "fileLocation": ["relative", "${workspaceFolder}"],
@@ -486,7 +486,7 @@ The information captured by all previous patterns is combined with the informati
 
 Here is a problem matcher to fully capture ESLint stylish problems:
 
-```json
+```json5
 {
     "owner": "javascript",
     "fileLocation": ["relative", "${workspaceFolder}"],
@@ -538,7 +538,7 @@ To capture this information, a problem matcher can provide a `watching` property
 
 For the tsc compiler, this looks like follows:
 
-```json
+```json5
 "watching": {
     "activeOnStart": true,
     "beginsPattern": "^\\s*\\d{1,2}:\\d{1,2}:\\d{1,2}(?: AM| PM)? - File change detected\\. Starting incremental compilation\\.\\.\\.",
@@ -550,7 +550,7 @@ In addition to the `watching` property on the problem matcher, the task itself h
 
 A full handcrafted `tasks.json` for a tsc task running in watch mode looks like this:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "command": "tsc",

--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -57,7 +57,7 @@ The first entry executes the TypeScript compiler and translates the TypeScript f
 
 You can also define the TypeScript build or watch task as the default build task so that it is executed directly when triggering **Run Build Task** (`kb(workbench.action.tasks.build)`). To do so, select **Configure Default Build Task** from the global **Tasks** menu. This shows you a picker with the available build tasks. Select **tsc: build** or **tsc: watch** and VS Code will generate a `tasks.json` file. The one shown below make the **tsc: build** task the default build task:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -96,7 +96,7 @@ Executing the task produces one error shown in the **Problems** view:
 
 In addition, VS Code created a `tasks.json` file with the following content:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -123,7 +123,7 @@ For Gulp, Grunt, and Jake, the task auto-detection works the same. Below is an e
 
 Task auto detection can be disabled using the following settings:
 
-```json
+```json5
 {
     "typescript.tsc.autoDetect": "off",
     "grunt.autoDetect": "off",
@@ -143,7 +143,7 @@ Not all tasks or scripts can be auto-detected in your workspace. Sometimes it is
 
 We are working on more auto-detection support, so this list will get smaller and smaller in the future. Since we want to write our own custom task, select **Others** from the list. This opens the `tasks.json` file with a task skeleton. Replace the contents with the following:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -181,7 +181,7 @@ To see the full set of task properties and values, you can review the [tasks.jso
 Shell commands need special treatment when it comes to commands and arguments that contains spaces or other special characters like `$`. By default the task system support the following behaviour:
 
 * if a single command is provided the task system passes the command as is to the underlying shell. If the command needs quoting or escaping to function properly the command need to contain the proper quotes or escape characters. For example to list the directory of a folder containing spaces in its name the command executed in bash should look like this: `ls 'folder with spaces'`.
-```json
+```json5
 {
   "label": "dir",
   "type": "shell",
@@ -189,7 +189,7 @@ Shell commands need special treatment when it comes to commands and arguments th
 }
 ```
 * if a command and arguments are provided the task system will used single quotes if the command or arguments contain spaces. For `cmd.exe` double quotes are used. So a shell command like below is executed in PowerShell as `dir 'folder with spaces'`.
-```json
+```json5
 {
   "label": "dir",
   "type": "shell",
@@ -200,7 +200,7 @@ Shell commands need special treatment when it comes to commands and arguments th
 }
 ```
 * if you want to control how the argument is quoted, the argument can be a literal specifying the value and a quoting style. Below an example that uses escaping instead of quoting for an argument with spaces.
-```json
+```json5
 {
   "label": "dir",
   "type": "shell",
@@ -235,7 +235,7 @@ You can also compose tasks out of simpler tasks with the `dependsOn` property. F
 
 The `tasks.json` file looks like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -280,7 +280,7 @@ Sometimes you want to control how the Integrated Terminal panel behaves when run
 
 You can modify the terminal panel behavior for auto-detected tasks as well. For example, if you want to change the output behavior for the **npm: run lint** from the ESLint example from above, add the `presentation` property to it:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -303,7 +303,7 @@ You can modify the terminal panel behavior for auto-detected tasks as well. For 
 
 You can also mix custom tasks with configurations for detected tasks. A `tasks.json` that configures the **npm: run lint** task and adds a custom **Run Test** tasks looks like this:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -373,7 +373,7 @@ Executing **Run Task** from the global **Tasks** menu will show the following pi
 
 Press the gear icon. This will create the following `tasks.json` file:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -415,7 +415,7 @@ If you need to run a task frequently, you can define a keyboard shortcut for the
 
 For example, to bind `Ctrl+H` to the **Run tests** task from above, add the following to your `keybindings.json` file:
 
-```json
+```json5
 {
     "key": "ctrl+h",
     "command": "workbench.action.tasks.runTask",
@@ -429,7 +429,7 @@ When authoring tasks configurations, it is useful to have a set of predefined co
 
 Below is an example of a custom task configuration that passes the current opened file to the TypeScript compiler.
 
-```json
+```json5
 {
     "label": "TypeScript compile",
     "type": "shell",
@@ -444,7 +444,7 @@ Similarly, you can reference your project's configuration settings by prefixing 
 
 Below is an example of a custom task configuration which executes autopep8 on the current file using your project's selected Python executable:
 
-```json
+```json5
 {
     "label": "autopep8 current file",
     "type": "process",
@@ -464,7 +464,7 @@ The task system supports defining values (for example, the command to be execute
 
 Below is an example that uses the Node.js executable as a command and is treated differently on Windows and Linux:
 
-```json
+```json5
 {
     "label": "Run Node",
     "type": "process",
@@ -481,7 +481,7 @@ Valid operating properties are `windows` for Windows, `linux` for Linux, and `os
 
 Task properties can also be defined in the global scope. If present, they will be used for specific tasks unless they define the same property with a different value. In the example below, there is a global `presentation` property that defines that all tasks should be executed in a new panel:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -510,7 +510,7 @@ If you need to tweak the encoding you should check whether it makes sense to cha
 
 If you only need to tweak it for a specific task then add the OS specific command necessary to change the encoding to the tasks command line. The following example is for Windows using code page of 437 as its default. The task shows the output of a file containing Cyrillic characters and therefore needs code page 866. The task to list the file looks like this assuming that the default shell is set to `cmd.exe`:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -566,7 +566,7 @@ We want to produce a problem matcher that can capture the message in the output 
 
 A matcher that captures the above warning (and errors) looks like this:
 
-```json
+```json5
 {
     // The problem is owned by the cpp language service.
     "owner": "cpp",
@@ -594,7 +594,7 @@ Please note that the file, line and message properties are mandatory.
 
 Here is a finished `tasks.json` file with the code above (comments removed) wrapped with the actual task details:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -652,7 +652,7 @@ To do this we use an array of problem patterns for the `pattern` property. This 
 
 The following problem pattern matches the output from ESLint in stylish mode - but still has one small issue which we will resolve next.  The code below has a first regular expression to capture the file name and the second to capture the line, column, severity, message and error code:
 
-```json
+```json5
 {
     "owner": "javascript",
     "fileLocation": ["relative", "${workspaceFolder}"],
@@ -694,7 +694,7 @@ The information captured by all previous patterns is combined with the informati
 
 Here is a problem matcher to fully capture ESLint stylish problems:
 
-```json
+```json5
 {
     "owner": "javascript",
     "fileLocation": ["relative", "${workspaceFolder}"],
@@ -746,7 +746,7 @@ To capture this information, a problem matcher can provide a `background` proper
 
 For the `tsc` compiler, an appropriate `background` property looks like this:
 
-```json
+```json5
 "background": {
     "activeOnStart": true,
     "beginsPattern": "^\\s*\\d{1,2}:\\d{1,2}:\\d{1,2}(?: AM| PM)? - File change detected\\. Starting incremental compilation\\.\\.\\.",
@@ -758,7 +758,7 @@ In addition to the `background` property on the problem matcher, the task itself
 
 A full handcrafted `tasks.json` for a `tsc` task running in watch mode looks like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -813,7 +813,7 @@ Here is a migration guide:
 
 Consider the following `0.1.0` configuration:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "isShellCommand": true,
@@ -832,7 +832,7 @@ Consider the following `0.1.0` configuration:
 
 The corresponding `2.0.0` configuration would look like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -847,7 +847,7 @@ The corresponding `2.0.0` configuration would look like this:
 
 - **taskSelector**: Move the command into the task and specify the task selector inside the command.
 
-```json
+```json5
 {
     "version": "0.1.0",
     "command": "msbuild",
@@ -865,7 +865,7 @@ The corresponding `2.0.0` configuration would look like this:
 
 A corresponding `2.0.0` configuration would look like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -899,7 +899,7 @@ That was tasks - let's keep going...
 
 You can override a task's shell with the `options.shell` property. You can set this per task, globally, or per platform. For example, to use cmd.exe on Windows, your `tasks.json` would include:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "windows": {

--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -35,7 +35,7 @@ You can define your own snippets, either global snippets or snippets for a speci
 
 Snippets are defined in a JSON format. The example below is a `For Loop` snippet you would use for JavaScript:
 
-```json
+```json5
 {
     "For_Loop": {
         "prefix": "for",
@@ -68,7 +68,7 @@ Global snippets that are applicable whenever you are editing and are stored in `
 
 The sample below is the `For Loop` again but this time it is scoped to JavaScript *and* TypeScript.
 
-```json
+```json5
 {
     "For_Loop": {
         "prefix": "for",
@@ -210,7 +210,7 @@ You can also use existing TextMate snippets (.tmSnippets) with VS Code. See the 
 
 You can create custom [keybindings](/docs/getstarted/keybindings.md) to insert specific snippets. Open `keybindings.json` (**Preferences: Open Keyboard Shortcuts File**), which defines all your keybindings, and add a keybinding passing `"snippet"` as an extra argument:
 
-```json
+```json5
 {
   "key": "cmd+k 1",
   "command": "editor.action.insertSnippet",
@@ -225,7 +225,7 @@ The keybinding will invoke the **Insert Snippet** command but instead of prompti
 
 Also, instead of using the `snippet` argument value to define your snippet inline, you can reference an existing snippet by using the `langId` and `name` arguments :
 
-```json
+```json5
 {
   "key": "cmd+k 1",
   "command": "editor.action.insertSnippet",

--- a/docs/editor/variables-reference.md
+++ b/docs/editor/variables-reference.md
@@ -53,7 +53,7 @@ So you will have the following values for each variable:
 
 You can also reference environment variables through **${env:Name}** syntax (for example, `${env:PATH}`).
 
-```json
+```json5
 {
     "type": "node",
     "request": "launch",
@@ -85,7 +85,7 @@ For example, in a multi root workspace with folders `Server` and `Client`, a `${
 
 No, the predefined variables are not supported in strings in `settings.json` files. Some [settings](/docs/getstarted/settings.md) like `window.title` have their own variables:
 
-```json
+```json5
   "window.title": "${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}"
 ```
 

--- a/docs/extensionAPI/activation-events.md
+++ b/docs/extensionAPI/activation-events.md
@@ -26,7 +26,7 @@ We also provide an overview of the [`package.json` extension manifest](/docs/ext
 
 This activation event is emitted and interested extensions will be activated whenever a file that resolves to a certain language gets opened.
 
-```json
+```json5
 ...
 "activationEvents": [
     "onLanguage:python"
@@ -38,7 +38,7 @@ The `onLanguage` event takes a [language identifier](/docs/languages/identifiers
 
 Multiple languages can be declared with separate `onLanguage` entries in the `activationEvents` array.
 
-```json
+```json5
 "activationEvents": [
     "onLanguage:json",
     "onLanguage:markdown",
@@ -51,7 +51,7 @@ Multiple languages can be declared with separate `onLanguage` entries in the `ac
 
 This activation event is emitted and interested extensions will be activated whenever a command is being invoked:
 
-```json
+```json5
 ...
 "activationEvents": [
     "onCommand:extension.sayHello"
@@ -63,7 +63,7 @@ This activation event is emitted and interested extensions will be activated whe
 
 This activation event is emitted and interested extensions will be activated before a debug session is started:
 
-```json
+```json5
 ...
 "activationEvents": [
     "onDebug"
@@ -84,7 +84,7 @@ There are two more fine-grained `onDebug` activation events:
 
 This activation event is emitted and interested extensions will be activated whenever a folder is opened and the folder contains at least one file that matches a glob pattern.
 
-```json
+```json5
 ...
 "activationEvents": [
     "workspaceContains:**/.editorconfig"
@@ -96,7 +96,7 @@ This activation event is emitted and interested extensions will be activated whe
 
 This activation event is emitted and interested extensions will be activated whenever a file or folder from a specific *scheme* is read. This is usually the `file`-scheme, but with custom file system providers more schemes come into place, e.g `ftp` or `ssh`.
 
-```json
+```json5
 ...
 "activationEvents": [
     "onFileSystem:sftp"
@@ -108,7 +108,7 @@ This activation event is emitted and interested extensions will be activated whe
 
 This activation event is emitted and interested extensions will be activated whenever a view of the specified id is expanded:
 
-```json
+```json5
 ...
 "activationEvents": [
     "onView:nodeDependencies"
@@ -120,7 +120,7 @@ This activation event is emitted and interested extensions will be activated whe
 
 This activation event is emitted and interested extensions will be activated whenever a system-wide Uri for that extension is opened. The Uri scheme is fixed to either `vscode` or `vscode-insiders`. The Uri authority must be the extension's identifier. The rest of the Uri is arbitrary.
 
-```json
+```json5
 ...
 "activationEvents": [
     "onUri"
@@ -138,7 +138,7 @@ If the `vscode.git` extension defines `onUri` as an activation event, it will be
 
 This activation event is emitted and interested extensions will be activated whenever VS Code starts up. To ensure a great end user experience, please use this activation event in your extension only when no other activation events combination works in your use-case.
 
-```json
+```json5
 ...
 "activationEvents": [
     "*"

--- a/docs/extensionAPI/api-markdown.md
+++ b/docs/extensionAPI/api-markdown.md
@@ -15,7 +15,7 @@ Markdown extensions allow you to extend and enhance Visual Studio Code's built-i
 
 Extensions can contribute CSS to change the look or layout of the Markdown preview. Stylesheets are registered using the `markdown.previewStyles` contribution in your extension's `package.json`:
 
-```json
+```json5
 "contributes": {
     "markdown.previewStyles": [
         "./style.css"
@@ -35,7 +35,7 @@ The VS Code Markdown preview supports the [CommonMark specification](https://spe
 
 To contribute a markdown-it plugin, first add a `"markdown.markdownItPlugins"` contribution in your extension's `package.json`:
 
-```json
+```json5
 "contributes": {
     "markdown.markdownItPlugins": true
 }
@@ -74,7 +74,7 @@ You may also want to review:
 
 For advanced functionality, extensions may contribute scripts that are executed inside of the Markdown preview.
 
-```json
+```json5
 "contributes": {
     "markdown.previewScripts": [
         "./main.js"

--- a/docs/extensionAPI/api-scm.md
+++ b/docs/extensionAPI/api-scm.md
@@ -115,7 +115,7 @@ stage(...resourceStates: SourceControlResourceState[]): Promise<void>;
 
 When creating them, `SourceControl` and `SourceControlResourceGroup` instances require you to provide an `id` string. These values will be populated in the `scmProvider` and `scmResourceGroup` context keys, respectively. You can rely on these [context keys](/docs/getstarted/keybindings.md#when-clause-contexts) in the `when` clauses of your menu items. Here's how Git is able to show a menu item for its `git.stage` command:
 
-```json
+```json5
 {
   "command": "git.stage",
   "when": "scmProvider == git && scmResourceGroup == merge",

--- a/docs/extensionAPI/extension-manifest.md
+++ b/docs/extensionAPI/extension-manifest.md
@@ -44,7 +44,7 @@ Also check [npm's `package.json` reference](https://docs.npmjs.com/files/package
 
 Here is a complete `package.json`
 
-```json
+```json5
 {
     "name": "wordcount",
     "displayName": "Word Count",
@@ -105,14 +105,14 @@ Here are a few examples:
 
 Provide a good display name and description. This is important for the Marketplace and in product displays.  These strings are also used for text search in VS Code and having relevant keywords will help a lot.
 
-```json
+```json5
     "displayName": "Word Count",
     "description": "Markdown Word Count Example - reports out the number of words in a Markdown file.",
 ```
 
 An Icon and a contrasting banner color looks great on the Marketplace page header.  The `theme` attribute refers to the font to be used in the banner - `dark` or `light`.
 
-```json
+```json5
 {
     "icon": "images/icon.png",
     "galleryBanner": {
@@ -124,7 +124,7 @@ An Icon and a contrasting banner color looks great on the Marketplace page heade
 
 There are several optional links (`bugs`, `homepage`, `repository`) you can set and these are displayed under the **Resources** section of the Marketplace.
 
-```json
+```json5
 {
     "license": "SEE LICENSE IN LICENSE.txt",
     "homepage": "https://github.com/Microsoft/vscode-wordcount/blob/master/README.md",
@@ -150,7 +150,7 @@ Set a `category` for your extension.  Extensions in the same `category` are grou
 
 >**Note:** Only use the values that make sense for your extension. Allowed values are `[Programming Languages, Snippets, Linters, Themes, Debuggers, Formatters, Keymaps, SCM Providers, Other, Extension Packs, Language Packs]`. Use `Programming Languages` for general language features like syntax highlighting and code completions. The category `Language Packs` is reserved for display language extensions (for example, localized Bulgarian).
 
-```json
+```json5
 {
     "categories": [
         "Linters", "Programming Languages", "Other"
@@ -212,7 +212,7 @@ To combine extension contributions, edit an existing extension manifest `package
 
 Below is an extension manifest which includes a LaTex language definition (language identifier and file extensions), colorization (`grammar`), and snippets.
 
-```json
+```json5
 {
     "name": "language-latex",
     "description": "LaTex Language Support",
@@ -256,7 +256,7 @@ An Extension Pack can include other contributions or be a bundling extension tha
 
 For example, here is an Extension Pack for PHP that includes a debugger, language service, and formatter:
 
-```json
+```json5
 {
   "extensionDependencies": [
       "felixfbecker.php-debug",
@@ -270,7 +270,7 @@ When installing an Extension Pack, VS Code will now also install its extension d
 
 Extension packs should be categorized in the `Extension Packs` Marketplace category:
 
-```json
+```json5
 {
   "categories": [
       "Extension Packs"

--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -41,7 +41,7 @@ You can read these values from your extension using `vscode.workspace.getConfigu
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "configuration": {
         "type": "object",
@@ -72,7 +72,7 @@ The following example contributes default editor configurations for the `markdow
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "configurationDefaults": {
         "[markdown]": {
@@ -91,7 +91,7 @@ Contribute an entry consisting of a title and a command to invoke to the **Comma
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "commands": [{
         "command": "extension.sayHello",
@@ -132,7 +132,7 @@ In addition to a title, commands can also define icons which VS Code will show i
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "menus": {
         "editor/title": [{
@@ -153,7 +153,7 @@ When registering commands in `package.json`, they will automatically be shown in
 
 The snippet below makes the 'Hello World' command only visible in the **Command Palette** when something is selected in the editor:
 
-```json
+```json5
 "commands": [{
     "command": "extension.sayHello",
     "title": "Hello World"
@@ -206,7 +206,7 @@ The **editor title menu** has these default groups:
 
 The order inside a group depends on the title or an order-attribute. The group-local order of a menu item is specified by appending `@<number>` to the group identifier as shown below:
 
-```json
+```json5
 "editor/title": [{
     "when": "editorHasSelection",
     "command": "extension.Command",
@@ -228,7 +228,7 @@ Contributing a key binding will cause the Default Keyboard Shortcuts to display 
 
 Defining that `kbstyle(Ctrl+F1)` under Windows and Linux and `kbstyle(Cmd+F1)` under macOS trigger the `"extension.sayHello"` command:
 
-```json
+```json5
 "contributes": {
     "keybindings": [{
         "command": "extension.sayHello",
@@ -274,7 +274,7 @@ If your language configuration file name is or ends with `language-configuration
 
 ### Example
 
-```json
+```json5
 ...
 "contributes": {
     "languages": [{
@@ -290,7 +290,7 @@ If your language configuration file name is or ends with `language-configuration
 
 language-configuration.json
 
-```json
+```json5
 {
     "comments": {
         "lineComment": "//",
@@ -340,7 +340,7 @@ Contribute a debugger to VS Code. A debugger contribution has the following prop
 * `variables` introduces substitution variables and binds them to commands implemented by the debugger extension.
 * `languages` those languages for which the debug extension could be considered the "default debugger".
 * `adapterExecutableCommand` the command ID where the debug adapters executable path and arguments are dynamically calculated. The command returns a structure with this format:
-  ```json
+  ```json5
   command: "<executable>",
   args: [ "<argument1>", "<argument2>", ... ]
   ```
@@ -348,7 +348,7 @@ Contribute a debugger to VS Code. A debugger contribution has the following prop
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "debuggers": [{
         "type": "node",
@@ -404,7 +404,7 @@ For a full walkthrough on how to integrate a `debugger`, go to [Debuggers](/docs
 
 Usually a debugger extension will also have a `contributes.breakpoints` entry where the extension lists the language file types for which setting breakpoints will be enabled.
 
-```json
+```json5
 "contributes": {
     "breakpoints": [
         {
@@ -425,7 +425,7 @@ Contribute a TextMate grammar to a language. You must provide the `language` thi
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "grammars": [{
         "language": "markdown",
@@ -449,7 +449,7 @@ Contribute a TextMate theme to VS Code. You must specify a label, whether the th
 
 ### Example
 
-```json
+```json5
 "contributes": {
     "themes": [{
         "label": "Monokai",
@@ -469,7 +469,7 @@ Contribute snippets for a specific language. The `language` attribute is the [la
 
 The example below shows adding snippets for the Go language.
 
-```json
+```json5
 "contributes": {
     "snippets": [{
         "language": "go",
@@ -482,7 +482,7 @@ The example below shows adding snippets for the Go language.
 
 Contribute a validation schema for a specific type of `json` file.  The `url` value can be either a local path to a schema file included in the extension or a remote server URL such as a [json schema store](http://schemastore.org/json).
 
-```json
+```json5
 "contributes": {
     "jsonValidation": [{
         "fileMatch": ".jshintrc",
@@ -503,7 +503,7 @@ Contribute a view to VS Code. You must specify an identifier and name for the vi
 
 When the user opens the view, VS Code will then emit an activationEvent `onView:${viewId}` (e.g. `onView:nodeDependencies` for the example below). You can also control the visibility of the view by providing the `when` context value.
 
-```json
+```json5
 "contributes": {
     "views": {
         "explorer": [
@@ -525,7 +525,7 @@ Extension writers should create a [TreeView](https://code.visualstudio.com/docs/
 
 Contribute a view container into which [Custom views](#contributes.views) can be contributed. You must specify an identifier, title and an icon for the view container. At present, you can contribute them to the Activity Bar (`activitybar`) only. Below example shows how the `Package Explorer` view container is contributed to the Activity Bar and how views are contributed to it.
 
-```json
+```json5
 "contributes": {
         "viewsContainers": {
             "activitybar": [
@@ -570,7 +570,7 @@ Contribute a view container into which [Custom views](#contributes.views) can be
 
 Contribute problem matcher patterns. These contributions work in both the output panel runner and in the terminal runner. Below is an example to contribute a problem matcher for the gcc compiler in an extension:
 
-```json
+```json5
 "contributes": {
     "problemMatchers": [
         {
@@ -592,7 +592,7 @@ Contribute problem matcher patterns. These contributions work in both the output
 
 This problem matcher can now be used in a `tasks.json` file via a name reference `$gcc`. An example looks like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -616,7 +616,7 @@ Contributes named problem patterns that can be used in problem matchers (see abo
 
 Contributes and defines an object literal structures that allows to uniquely identifiy a contributed task in the system. A task definition has at minimum a `type` property but it usually defines additional propertiies. For example a task definition for a task representing a script in a package.json file looks like this:
 
-```json
+```json5
 "taskDefinitions": [
     {
         "type": "npm",
@@ -654,7 +654,7 @@ let task = new vscode.Task({ type: 'npm', script: 'test' }, ....);
 
 Contributes new themable colors. These colors can be used by the extension in editor decorators and in the status bar. Once defined, users can customize the color in the `workspace.colorCustomization` setting and user themes can set the color value.
 
-```json
+```json5
 "contributes": {
   "colors": [{
       "id": "superstatus.error",
@@ -674,7 +674,7 @@ Color default values can be defined for light, dark and high contrast theme and 
 
 Contributes [TypeScript server plugins](https://github.com/Microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin) that augment VS Code's JavaScript and TypeScript support:
 
-```json
+```json5
 "contributes": {
    "typescriptServerPlugins": [
       {
@@ -686,7 +686,7 @@ Contributes [TypeScript server plugins](https://github.com/Microsoft/TypeScript/
 
 The above example extension contributes the [`typescript-styled-plugin`](https://github.com/Microsoft/typescript-styled-plugin) which adds styled-component IntelliSense for JavaScript and TypeScript. This plugin will be loaded from the extension and must be listed as a `dependency`:
 
-```json
+```json5
 {
     "dependencies": {
         "typescript-styled-plugin": "*"

--- a/docs/extensionAPI/language-support.md
+++ b/docs/extensionAPI/language-support.md
@@ -35,7 +35,7 @@ VS Code maps different language configurations and providers to specific program
 
 In order to support syntax highlighting, your extension needs to register a TextMate grammar `.tmLanguage` for its language in its `package.json` file.
 
-```json
+```json5
 "contributes": {
     "languages": [
         {
@@ -69,7 +69,7 @@ VS Code recognizes two formats for grammar files, Plist (`.tmLanguage`) and JSON
 
 With code snippets, you can provide useful source code templates with placeholders. You need to register a file that contains the snippets for your language in your extension's `package.json` file. You can learn about VS Code's snippet schema in [Creating Your Own Snippets](/docs/editor/userdefinedsnippets.md#creating-your-own-snippets).
 
-```json
+```json5
 "contributes": {
     "snippets": [
         {
@@ -84,7 +84,7 @@ With code snippets, you can provide useful source code templates with placeholde
 >
 >Provide snippets with placeholders such as this example for `markdown`:
 >
->```json
+>```json5
 >"Insert ordered list": {
 >    "prefix": "ordered list",
 >    "body": [
@@ -101,7 +101,7 @@ With code snippets, you can provide useful source code templates with placeholde
 >
 >Provide snippets that use explicit tab stops to guide the user and use nested placeholders such as this example for `groovy`:
 >
->```json
+>```json5
 >"key: \"value\" (Hash Pair)": {
 >        "prefix": "key",
 >        "body": "${1:key}: ${2:\"${3:value}\"}"
@@ -114,7 +114,7 @@ With code snippets, you can provide useful source code templates with placeholde
 
 You can provide a language configuration in your extension's `package.json` file.
 
-```json
+```json5
 "contributes": {
     "languages": [
         {
@@ -135,7 +135,7 @@ You can provide a language configuration in your extension's `package.json` file
 >
 >Here is an example from `TypeScript`:
 >
->```json
+>```json5
 >{
 >    "comments": {
 >        "lineComment": "//",
@@ -192,7 +192,7 @@ Hovers show information about the symbol/object that's below the mouse cursor. T
 
 In the response to the `initialize` method, your language server needs to announce that it provides hovers.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -242,7 +242,7 @@ Code completions provide context sensitive suggestions to the user.
 
 In the response to the `initialize` method, your language server needs to announce that it provides completions and whether or not it supports the `completionItem\resolve` method to provide additional information for the computed completion items.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -347,7 +347,7 @@ When the user enters a function or method, display information about the functio
 
 In the response to the `initialize` method, your language server needs to announce that it provides signature help.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -399,7 +399,7 @@ Allow the user to see the definition of variables/functions/methods right where 
 
 In the response to the `initialize` method, your language server needs to announce that it provides goto-definition locations.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -449,7 +449,7 @@ Allow the user to see all the source code locations where a certain variable/fun
 
 In the response to the `initialize` method, your language server needs to announce that it provides symbol reference locations.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -500,7 +500,7 @@ Allow the user to see all occurrences of a symbol in the open editor.
 
 In the response to the `initialize` method, your language server needs to announce that it provides symbol document locations.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -550,7 +550,7 @@ Allow the user to quickly navigate to any symbol definition in the open editor.
 
 In the response to the `initialize` method, your language server needs to announce that it provides symbol document locations.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -600,7 +600,7 @@ Allow the user to quickly navigate to symbol definitions anywhere in the folder 
 
 In the response to the `initialize` method, your language server needs to announce that it provides global symbol locations.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -650,7 +650,7 @@ Provide the user with possible corrective actions right next to an error or warn
 
 In the response to the `initialize` method, your language server needs to announce that it provides Code Actions.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -701,7 +701,7 @@ Provide the user with actionable, contextual information that is displayed inter
 
 In the response to the `initialize` method, your language server needs to announce that it provides CodeLens results and whether it supports the `codeLens\resolve` method to bind the CodeLens to its command.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -757,7 +757,7 @@ Allow the user to rename a symbol and update all references to the symbol.
 
 In the response to the `initialize` method, your language server needs to announce that it provides for renaming.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -808,7 +808,7 @@ Provide the user with support for formatting whole documents.
 
 In the response to the `initialize` method, your language server needs to announce that it provides document formatting.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -857,7 +857,7 @@ Provide the user with support for formatting a selected range of lines in a docu
 
 In the response to the `initialize` method, your language server needs to announce that it provides formatting support for ranges of lines.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -910,7 +910,7 @@ Provide the user with support for formatting text as they type.
 
 In the response to the `initialize` method, your language server needs to announce that it provides formatting as the user types. It also needs to tell the client on which characters formatting should be triggered. `moreTriggerCharacters` is optional.
 
-```json
+```json5
 {
     ...
     "capabilities" : {
@@ -964,7 +964,7 @@ Allow the user to preview and modify colors in the document.
 
 In the response to the `initialize` method, your language server needs to announce that it provides color information.
 
-```json
+```json5
 {
     ...
     "capabilities" : {

--- a/docs/extensions/developing-extensions.md
+++ b/docs/extensions/developing-extensions.md
@@ -186,7 +186,7 @@ Here are the steps:
 * Set the minimal version of VS Code that your extension requires in the `engine` field of the `package.json`.
 * Add a `postinstall` script to your `package.json` like this:
 
-```json
+```json5
 "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install"
 }

--- a/docs/extensions/example-content-provider.md
+++ b/docs/extensions/example-content-provider.md
@@ -148,7 +148,7 @@ Next modify the extension's `package.json` file with your command name `examplep
 
 Update the `"activationEvents"`:
 
-```json
+```json5
 "activationEvents": [
     "onCommand:exampleprovider.open"
 ],
@@ -156,7 +156,7 @@ Update the `"activationEvents"`:
 
 as well as the `"contributes"` section:
 
-```json
+```json5
 "contributes": {
     "commands": [
         {

--- a/docs/extensions/example-debuggers.md
+++ b/docs/extensions/example-debuggers.md
@@ -100,7 +100,7 @@ An alternative, even simpler approach for debugging the extension and the debug 
 
 Set a breakpoint at the beginning of method `launchRequest(...)` in file `src/mockDebug.ts` and as a last step configure the mock debugger to connect to the debug adapter server by adding a `debugServer` attribute for port `4711` to your mock test launch config:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -131,7 +131,7 @@ So let's have a closer look at the `package.json` of Mock Debug.
 
 Like every VS Code extension, the `package.json` declares the fundamental properties **name**, **publisher**, and **version** of the extension. Use the **categories** field to make the extension easier to find in the VS Code Extension Marketplace.
 
-```json
+```json5
 {
     "name": "mock-debug",
     "displayName": "Mock Debug",
@@ -229,7 +229,7 @@ Since VS Code runs on different platforms, we have to make sure that the debug a
 
 1. If your debug adapter implementation needs different executables on different platforms, the **program** attribute can be qualified for specific platforms like this:
 
-    ```json
+    ```json5
     "debuggers": [{
         "type": "gdb",
         "windows": {
@@ -246,7 +246,7 @@ Since VS Code runs on different platforms, we have to make sure that the debug a
 
 1. A combination of both approaches is possible too. The following example is from the Mono Debug adapter which is implemented as a mono application that needs a runtime on macOS and Linux but not on Windows:
 
-    ```json
+    ```json5
     "debuggers": [{
         "type": "mono",
         "program": "./bin/monoDebug.exe",
@@ -298,7 +298,7 @@ The `MockConfigurationProvider` in `src/extension.ts` implements `resolveDebugCo
 A debug configuration provider is registered for a specific debug type via `vscode.debug.registerDebugConfigurationProvider` typically in the extension's `activate` function.
 To ensure that the `DebugConfigurationProvider` is registered early enough, the extension must be activated as soon as the debug functionality is used. This can be easily achieved by configuring extension activation for the `onDebug` event in the `package.json`:
 
-```json
+```json5
 "activationEvents": [
     "onDebug",
     // ...

--- a/docs/extensions/example-hello-world.md
+++ b/docs/extensions/example-hello-world.md
@@ -89,7 +89,7 @@ Let's go through the purpose of all these files and explain what they do:
 
 #### Example TypeScript extension manifest
 
-```json
+```json5
 {
     "name": "myFirstExtension",
     "description": "",

--- a/docs/extensions/example-language-server.md
+++ b/docs/extensions/example-language-server.md
@@ -90,7 +90,7 @@ Let's first take a look at `/package.json`, which describes the capabilities of 
 
 First look the [`activationEvents`](https://code.visualstudio.com/docs/extensionAPI/activation-events):
 
-```json
+```json5
 "activationEvents": [
     "onLanguage:plaintext"
 ]
@@ -100,7 +100,7 @@ This section tells VS Code to activate the extension as soon as a plain text fil
 
 Next look at the [`configuration`](https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributesconfiguration) section:
 
-```json
+```json5
 "configuration": {
     "type": "object",
     "title": "Example configuration",
@@ -119,7 +119,7 @@ This section contributes `configuration` settings to VS Code. The example will e
 
 The actual Language Client code and the corresponding `package.json` is in the `/client` folder. The interesting part in the `/client/package.json` file is that it adds a dependency to the `vscode` extension host API and the `vscode-languageclient` library:
 
-```json
+```json5
 "dependencies": {
     "vscode": "^1.1.18",
     "vscode-languageclient": "^4.1.4"
@@ -201,7 +201,7 @@ In the example, the server is also implemented in TypeScript and executed using 
 
 The source code for the Language Server is at `/server`. The interesting section in the server's `package.json` file is:
 
-```json
+```json5
 "dependencies": {
     "vscode-languageserver": "^4.1.3"
 }
@@ -717,7 +717,7 @@ It is possible to do Unit Test in any testing framework of your choice. Here we 
 
 Open `.vscode/launch.json`, and you can find a `E2E` test target:
 
-```json
+```json5
 {
     "name": "Language Server E2E Test",
     "type": "extensionHost",

--- a/docs/extensions/example-tasks.md
+++ b/docs/extensions/example-tasks.md
@@ -18,7 +18,7 @@ The following description is based on the [Rake task provider example](https://g
 
 To uniquely identify a task in the system, an extension contributing a task needs to define the properties that identify a task. In the Rake example, the task definition looks like this:
 
-```json
+```json5
 "taskDefinitions": [
     {
         "type": "rake",

--- a/docs/extensions/example-word-count.md
+++ b/docs/extensions/example-word-count.md
@@ -198,7 +198,7 @@ context.subscriptions.push(wordCounter);
 
 Second, we must make sure the extension is activated upon the opening of a `Markdown` file.  To do this, we'll need to modify the `package.json` file.  Previously the extension was activated via the `extension.sayHello` command which we no longer need and so we can delete the entire `contributes` attribute from `package.json`:
 
-```json
+```json5
     "contributes": {
         "commands":
             [{
@@ -211,7 +211,7 @@ Second, we must make sure the extension is activated upon the opening of a `Mark
 
 Now change your extension so that it is activated upon the opening of a *Markdown* file by updating the `activationEvents` attribute to this:
 
-```json
+```json5
     "activationEvents": [
         "onLanguage:markdown"
     ]

--- a/docs/extensions/publish-extension.md
+++ b/docs/extensions/publish-extension.md
@@ -147,7 +147,7 @@ If you want to share your extension with others privately, you can send them you
 
 When authoring an extension, you will need to describe what is the extension's compatibility to Visual Studio Code itself. This can done via the `engines.vscode` field inside `package.json`:
 
-```json
+```json5
 {
   "engines": {
     "vscode": "^1.8.0"
@@ -199,7 +199,7 @@ You should ignore all files not needed at runtime. For example, if your extensio
 
 It's possible to add a pre-publish step to your manifest file. The command will be called every time the extension is packaged.
 
-```json
+```json5
 {
     "name": "uuid",
     "version": "0.0.1",

--- a/docs/extensions/testing-extensions.md
+++ b/docs/extensions/testing-extensions.md
@@ -42,7 +42,7 @@ You can create more `test.ts` files under the `test` folder and they will automa
 
 The `Extension Tests` configuration is defined in the project's `.vscode\launch.json` file.  It is similar the `Extension` configuration with the addition of the `--extensionTestsPath` argument which points to the compiled test files (assuming this is a TypeScript project).
 
-```json
+```json5
 {
     "name": "Extension Tests",
     "type": "extensionHost",
@@ -62,7 +62,7 @@ The `Extension Tests` configuration is defined in the project's `.vscode\launch.
 
 You can set the file or folder that the test instance should open by inserting the path at the front of the argument list for the launch configuration.
 
-```json
+```json5
 "args": [
     "file or folder name",
     "--extensionDevelopmentPath=${workspaceFolder}",
@@ -76,7 +76,7 @@ This way you can run your tests with predictable content and folder structure.
 
 By default, the debug instance of VS Code will load any extension you've previously installed alongside the one you are developing. If you want to disable those extensions, add `"--disable-extensions"` to the argument list in the launch configuration.
 
-```json
+```json5
 "args": [
     "--disable-extensions",
     "--extensionDevelopmentPath=${workspaceFolder}",
@@ -106,7 +106,7 @@ In order to enable automated extension tests, the `vscode` npm module provides a
 
 To enable this test command, open your `package.json` and add the following entry to the `scripts` section:
 
-```json
+```json5
 "test": "node ./node_modules/vscode/bin/test"
 ```
 

--- a/docs/extensions/themes-snippets-colorizers.md
+++ b/docs/extensions/themes-snippets-colorizers.md
@@ -63,7 +63,7 @@ Here are some example theming rules. The  `scope` property lists the rules scope
 
 - Scope selector support prefix matching and matching against parent scopes
 
-```json
+```json5
 {
     "name": "Variables",
     "scope": "variable",
@@ -111,7 +111,7 @@ You can use the **Developer: Inspect TM Scopes** command from the **Command Pale
 - Copy the theme file generated from your settings to the new extension.
 - To use a existing TextMate theme, you can tell the extension generator to import a TextMate theme file and package it for use in VS Code. Alternatively, if you have already downloaded the theme, replace the `tokenColors` section with a link to the `.tmTheme` file to use.
 
-```json
+```json5
 {
     "type": "dark",
     "colors": {
@@ -158,7 +158,7 @@ You can create your own icon theme from icons (preferably SVG) and from icon fon
 
 To begin, create a VS Code extension and add the `iconTheme` contribution point.
 
-```json
+```json5
 "contributes": {
     "iconThemes": [
         {
@@ -182,7 +182,7 @@ An icon association maps a file type ('file', 'folder', 'json-file'...) to an ic
 
 The `iconDefinitions` section contains all definitions. Each definition has an id, which will be used to reference the definition. A definition can be referenced also by more than one file association.
 
-```json
+```json5
     "iconDefinitions": {
         "_folder_dark": {
             "iconPath": "./images/Folder_16x_inverse.svg"
@@ -208,7 +208,7 @@ Additionally each of these associations can be refined for 'light' and 'highCont
 
 Each file association points to an icon definition.
 
-```json
+```json5
 "file": "_file_dark",
 "folder": "_folder_dark",
 "folderExpanded": "_folder_open_dark",
@@ -263,7 +263,7 @@ It is recommended to use [WOFF](https://developer.mozilla.org/docs/Web/Guide/WOF
 - the style property values are defined [here](https://developer.mozilla.org/docs/Web/CSS/@font-face/font-style#Values).
 - the size should be relative to the font size where the icon is used. Therefore, always use percentage.
 
-```json
+```json5
     "fonts": [
         {
             "id": "turtles-font",
@@ -328,7 +328,7 @@ Now add an extension manifest package.json file to the extension folder.  The sn
 
 Below is an example manifest for Markdown snippets:
 
-```json
+```json5
 {
     "name": "DM-Markdown",
     "publisher": "mscott",
@@ -373,7 +373,7 @@ When the generator is finished, open the created folder in Visual Studio Code. H
 
 Here is an example for a language with XML-like brackets:
 
-```json
+```json5
 {
     "comments": {
         "lineComment": "",
@@ -415,7 +415,7 @@ We also have recommendations on how to make your extension look great on the VS 
 
 When you're adding a new language to VS Code, it is also great to add language [snippets](/docs/editor/userdefinedsnippets.md) to support common editing actions. It is easy to [combine multiple extensions](/docs/extensionAPI/extension-manifest.md#combining-extension-contributions) like snippets and colorizers into the same extension. You can modify the colorizer extension manifest `package.json` to include a `snippets` contribution and the snippets.json.
 
-```json
+```json5
 {
     "name": "language-latex",
     "description": "LaTeX Language Support",
@@ -453,7 +453,7 @@ When you're adding a new language to VS Code, it is also great to add language [
 
 In VS Code, each language mode has a unique specific language identifier. That identifier is rarely seen by the user except in the settings, e.g. when associating file extensions to a language:
 
-```json
+```json5
     "files.associations": {
         "*.myphp": "php"
     }
@@ -465,7 +465,7 @@ The language identifier becomes essential for VS Code extension developers when 
 
 Every language defines its *id* through the `languages` configuration point:
 
-```json
+```json5
     "languages": [{
         "id": "java",
         "extensions": [ ".java", ".jav" ],
@@ -475,7 +475,7 @@ Every language defines its *id* through the `languages` configuration point:
 
 Language supports are added using the language identifier:
 
-```json
+```json5
     "grammars": [{
         "language": "groovy",
         "scopeName": "source.groovy",
@@ -502,7 +502,7 @@ Languages can embed other languages in order to provide syntax highlighting and 
 
 An implementation of CSS code blocks in our `.tmLanguage.json` file might look like this:
 
-```json
+```json5
 "patterns": [
     {
         "begin": "^```css$",
@@ -519,7 +519,7 @@ An implementation of CSS code blocks in our `.tmLanguage.json` file might look l
 
 In order to inherit other CSS features we marked the block by using `contentName`, that way we can map its value in `contributes.grammars.embeddedLanguages` in `package.json`:
 
-```json
+```json5
 "contributes": {
     "grammars": [{
         "language": "markdown",
@@ -562,7 +562,7 @@ Be sure you have correctly specified the `language` identifier for your snippet 
 
 Yes, the `yo code` generator provides the default file extensions from the .tmLanguage file but you can easily add more file extensions to a `languages` contribution `extensions` array.  In the example below, the `.asp` file extension has been added to the default `.asa` file extension.
 
-```json
+```json5
 {
     "name": "asp",
     "version": "0.0.1",
@@ -591,7 +591,7 @@ Yes. To extend an existing colorizer, you can associate a file extension to an e
 
 For example, the setting below adds the `.mmd` file extension to the `markdown` colorizer:
 
-```json
+```json5
     "files.associations": {
         "*.mmd": "markdown"
     }
@@ -601,7 +601,7 @@ For example, the setting below adds the `.mmd` file extension to the `markdown` 
 
 Yes. You override the colorizer by providing a new `grammars` element for an existing language id. Also, add a `extensionDependencies` attribute that contains the name of the extension that defines the grammar that you want to replace.
 
-```json
+```json5
 {
     "name": "override-xml",
     "version": "0.0.1",

--- a/docs/extensions/webview.md
+++ b/docs/extensions/webview.md
@@ -33,7 +33,7 @@ To explain the webview API, we are going to build a simple extension called **Ca
 
 Here's the `package.json` for the first version of the **Cat Coding** extension. You can find the complete code for the example app [here](https://github.com/Microsoft/vscode-extension-samples/blob/master/webview-sample/README.md). The first version of our extension [contributes a command](/docs/extensionAPI/extension-points.md#contributescommands) called `catCoding.start`. When a user invokes this command, we will show a simple webview with our cat in it. Users will be able to invoke this command from the **Command Palette** as **Cat Coding: Start new cat coding session** or even create a keybinding for it if they are so inclined.
 
-```json
+```json5
 {
   "name": "cat-coding",
   "description": "Cat Coding",
@@ -737,7 +737,7 @@ By implementing a `WebviewPanelSerializer`, your webviews can be automatically r
 
 To make our coding cats persist across VS Code restarts, first add a `onWebviewPanel` activation event to the extension's `package.json`:
 
-```json
+```json5
 "activationEvents": [
     ...,
     "onWebviewPanel:catCoding"

--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -66,7 +66,7 @@ All keyboard shortcuts in VS Code can be customized via the `keybindings.json` f
 
 The keyboard shortcuts dispatching is done by analyzing a list of rules that are expressed in JSON. Here are some examples:
 
-```json
+```json5
 // Keybindings that are active when the focus is in the editor
 { "key": "home",            "command": "cursorHome",                  "when": "editorTextFocus" },
 { "key": "shift+home",      "command": "cursorHomeSelect",            "when": "editorTextFocus" },
@@ -130,7 +130,7 @@ You can invoke a command with arguments. This is useful if you often perform the
 
 The following is an example overriding the `kbstyle(Enter)` key to print some text:
 
-```json
+```json5
   { "key": "enter", "command": "type",
                     "args": { "text": "Hello World" },
                     "when": "editorTextFocus" }
@@ -144,7 +144,7 @@ You can write a key binding rule that targets the removal of a specific default 
 
 Here is an example:
 
-```json
+```json5
 // In Default Keyboard Shortcuts
 ...
 { "key": "tab", "command": "tab", "when": ... },
@@ -198,7 +198,7 @@ There is also a widget that helps input the key binding rule when editing `keybi
 
 Using scan codes, it is possible to define keybindings which do not change with the change of the keyboard layout. For example:
 
-```json
+```json5
 { "key": "cmd+[Slash]", "command": "editor.action.commentLine",
                            "when": "editorTextFocus" }
 ```
@@ -314,7 +314,7 @@ Panel Identifiers:
 
 The `editor.action.codeAction` command lets you configure keybindings for specific [Refactorings](/docs/editor/refactoring.md) (Code Actions). For example, the keybinding below triggers the **Extract function** refactoring Code Actions:
 
-```json
+```json5
 {
   "key": "ctrl+shift+r ctrl+e",
   "command": "editor.action.codeAction",
@@ -572,7 +572,7 @@ In the **Default Keyboard Shortcuts**, open `Quick Outline` by pressing `kb(work
 
 Find a rule that triggers the action in the **Default Keyboard Shortcuts** and write a modified version of it in your `keybindings.json` file:
 
-```json
+```json5
 // Original, in Default Keyboard Shortcuts
 { "key": "ctrl+shift+k",          "command": "editor.action.deleteLines",
                                      "when": "editorTextFocus" },
@@ -585,7 +585,7 @@ Find a rule that triggers the action in the **Default Keyboard Shortcuts** and w
 
 Use the `editorLangId` context key in your `when` clause:
 
-```json
+```json5
 { "key": "shift+alt+a",           "command": "editor.action.blockComment",
                                      "when": "editorTextFocus && editorLangId == csharp" },
 ```

--- a/docs/getstarted/locales.md
+++ b/docs/getstarted/locales.md
@@ -33,7 +33,7 @@ Save `locale.json` and restart VS Code to use the new display language.
 
 The example below sets VS Code to display Simplified Chinese `zh-CN`:
 
-```json
+```json5
 {
     // Defines VS Code's display language.
     "locale":"zh-CN"

--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -89,7 +89,7 @@ You can also configure language based settings by directly opening `settings.jso
 
 The following examples customize editor settings for language modes `typescript` and `markdown`.
 
-```json
+```json5
 {
   "[typescript]": {
     "editor.formatOnSave": true,
@@ -129,7 +129,7 @@ The first time you open a workspace which defines any of these settings, VS Code
 
 Below are the Visual Studio Code default settings and their values. You can also view the default values in the Settings editor.
 
-```json
+```json5
 {
 // Commonly Used
 
@@ -1691,7 +1691,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     "editor.tabSize": 2,
     "editor.autoIndent": false
   },
- 
+
 // Node Debug
 
   // Automatically attach node debugger when node.js was launched in debug mode from integrated terminal.

--- a/docs/getstarted/theme-color-reference.md
+++ b/docs/getstarted/theme-color-reference.md
@@ -11,7 +11,7 @@ MetaDescription: Reference for Visual Studio Code theme colors.
 
 You can customize your active Visual Studio Code [color theme](/docs/getstarted/themes.md) with the `workbench.colorCustomizations` user [setting](/docs/getstarted/settings.md).
 
-```json
+```json5
 {
     "workbench.colorCustomizations": {
         "activityBar.background": "#00AA00"

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -24,7 +24,7 @@ Color themes let you modify the colors in Visual Studio Code's user interface to
 
 The active color theme is stored in your user [settings](/docs/getstarted/settings.md) (keyboard shortcut `kb(workbench.action.openSettings)`).
 
-```json
+```json5
   // Specifies the color theme used in the workbench.
   "workbench.colorTheme": "Default Dark+"
 }
@@ -56,7 +56,7 @@ You can use IntelliSense while setting `workbench.colorCustomizations` values or
 
 To customize a specific theme only, use the following syntax:
 
-```json
+```json5
 "workbench.colorCustomizations": {
     "[Monokai]": {
         "sideBar.background": "#347890"
@@ -76,7 +76,7 @@ A pre-configured set of syntax tokens ('comments', 'strings', ...) is available 
 
 Again, to customize a specific theme only, use the following syntax:
 
-```json
+```json5
 "editor.tokenColorCustomizations": {
     "[Monokai]": {
         "comments": "#229977"
@@ -123,7 +123,7 @@ You can also browse the [VS Code Marketplace](https://marketplace.visualstudio.c
 
 The active File Icon theme is persisted in your user [settings](/docs/getstarted/settings.md) (keyboard shortcut `kb(workbench.action.openSettings)`).
 
-```json
+```json5
   // Specifies the icon theme used in the workbench.
   "workbench.iconTheme": "vs-seti"
 }

--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -173,25 +173,25 @@ Keyboard Shortcut: `kb(workbench.action.openSettings)`
 
 Format on paste
 
-```json
+```json5
 "editor.formatOnPaste": true
 ```
 
 Change the font size
 
-```json
+```json5
 "editor.fontSize": 18
 ```
 
 Change the zoom level
 
-```json
+```json5
 "window.zoomLevel": 5
 ```
 
 Font ligatures
 
-```json
+```json5
 "editor.fontFamily": "Fira Code",
 "editor.fontLigatures": true
 ```
@@ -202,7 +202,7 @@ Font ligatures
 
 Auto Save
 
-```json
+```json5
 "files.autoSave": "afterDelay"
 ```
 
@@ -210,25 +210,25 @@ You can also toggle Auto Save from the top-level menu with the **File** > **Auto
 
 Format on save
 
-```json
+```json5
 "editor.formatOnSave": true,
 ```
 
 Change the size of Tab characters
 
-```json
+```json5
 "editor.tabSize": 4
 ```
 
 Spaces or Tabs
 
-```json
+```json5
 "editor.insertSpaces": true
 ```
 
 Render whitespace
 
-```json
+```json5
 "editor.renderWhitespace": "all"
 ```
 
@@ -236,7 +236,7 @@ Ignore files / folders
 
 Removes these files / folders from your editor window.
 
-```json
+```json5
 "files.exclude": {
         "somefolder/": true,
         "somefile": true
@@ -245,7 +245,7 @@ Removes these files / folders from your editor window.
 
 Remove these files / folders from search results.
 
-```json
+```json5
 "search.exclude": {
     "someFolder/": true,
     "somefile": true
@@ -258,7 +258,7 @@ And many, many [other customizations](/docs/getstarted/settings.md).
 
 For those settings you only want for specific languages, you can scope the settings by the language identifier. You can find a list of commonly used language ids in the [Language Identifiers](/docs/languages/identifiers.md) reference.
 
-```json
+```json5
 "[languageid]": {
 
 }
@@ -272,7 +272,7 @@ For those settings you only want for specific languages, you can scope the setti
 
 Enabled by default for many file types. Create your own schema and validation in `settings.json`
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -285,7 +285,7 @@ Enabled by default for many file types. Create your own schema and validation in
 
 or for a schema defined in your workspace
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -298,7 +298,7 @@ or for a schema defined in your workspace
 
 or a custom schema
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -372,7 +372,7 @@ Further reading:
 
 Open User Settings `settings.json` with `kb(workbench.action.openSettings)`
 
-```json
+```json5
 "files.autoSave": "afterDelay"
 ```
 
@@ -444,7 +444,7 @@ Keyboard Shortcut: `kb(workbench.action.quickOpen)`
 
 Create language associations for files that aren't detected correctly. For example, many configuration files with custom file extensions are actually JSON.
 
-```json
+```json5
 "files.associations": {
     ".database": "json"
 }
@@ -633,7 +633,7 @@ your linter however you'd like. Consult the [ESLint specification](https://eslin
 
 Here is configuration to use ES6.
 
-```json
+```json5
 {
     "env": {
         "browser": true,
@@ -689,7 +689,7 @@ See IntelliSense for your `package.json` file.
 
 **File** > **Preferences** > **User Snippets** (**Code** > **Preferences** > **User Snippets** on macOS), select the language, and create a snippet.
 
-```json
+```json5
 "create component": {
     "prefix": "component",
     "body": [
@@ -818,7 +818,7 @@ You can set `"debug.inlineValues": true` to see variable values inline in the de
 Select **Tasks** from the top-level menu, run the command **Configure Tasks...**, then select the type of task you'd like to run.
 This will generate a `task.json` file with content like the following. See the [Tasks](/docs/editor/tasks.md) documentation for more details.
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -92,7 +92,7 @@ You can select multiple files in the **File Explorer** and **OPEN EDITORS** view
 
 **Note:** In earlier VS Code releases, clicking with the `Ctrl/Cmd` key pressed would open a file in a new Editor Group to the side. If you would still like this behavior, you can use the `workbench.list.multiSelectModifier` setting to change multi-selection to use the `Alt` key.
 
-```json
+```json5
 "workbench.list.multiSelectModifier": "alt"
 ```
 
@@ -217,7 +217,7 @@ When you have more open items than can fit in the title area, you can use the **
 
 If you don't want to use Tabs, you can disable the feature by setting the `workbench.editor.showTabs` [setting](/docs/getstarted/settings.md) to false:
 
-```json
+```json5
     "workbench.editor.showTabs": false
 ```
 
@@ -229,7 +229,7 @@ By default, new Tabs are added to the right of the existing Tabs but you can con
 
 For example, you might like new tabbed items to appear on the left:
 
-```json
+```json5
     "workbench.editor.openPositioning": "left"
 ```
 
@@ -315,7 +315,7 @@ You can change keybindings for `kbstyle(Ctrl+Tab)` to show you a list of all ope
 
 Edit your [keybindings](/docs/getstarted/keybindings.md) and add the following:
 
-```json
+```json5
 { "key": "ctrl+tab", "command": "workbench.action.openPreviousEditorFromHistory" },
 { "key": "ctrl+tab", "command": "workbench.action.quickOpenNavigateNext", "when": "inQuickOpen" },
 ```
@@ -326,13 +326,13 @@ If you liked the behavior of VS Code closing an entire group when closing one ed
 
 macOS:
 
-```json
+```json5
 { "key": "cmd+w", "command": "workbench.action.closeEditorsInGroup" }
 ```
 
 Windows/Linux:
 
-```json
+```json5
 { "key": "ctrl+w", "command": "workbench.action.closeEditorsInGroup" }
 ```
 
@@ -363,7 +363,7 @@ The indent guide colors are customizable as are most VS Code UI elements. To [cu
 
 For example, to make the indent guides bright blue, add the following to your `settings.json`:
 
-```json
+```json5
 "workbench.colorCustomizations": {
     "editorIndentGuide.background": "#0000ff"
 }

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -45,7 +45,7 @@ This will generate a `c_cpp_properties.json` file that allows you to add additio
 
 Below you can see that the MinGW C++ compiler has been set as the default compiler for Windows. The extension will use that information to determine the system include path and defines so that they don't need to be added to `c_cpp_properties.json`.
 
-```json
+```json5
 {
     "name": "Win32",
     "includePath": [
@@ -80,7 +80,7 @@ Below you can see that the MinGW C++ compiler has been set as the default compil
 
 You should now see a `tasks.json` file in your workspace `.vscode` folder that looks something like:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -98,7 +98,7 @@ You should now see a `tasks.json` file in your workspace `.vscode` folder that l
 
 If you'd like to be able to build your application with **Tasks: Run Build Task** (`kb(workbench.action.tasks.build)`), you can add it to the `build` group.
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -135,7 +135,7 @@ For more information on tasks, see [Integrate with External Tools via Tasks](/do
 
 Below is an example using the MinGW GDB debugger:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -183,7 +183,7 @@ By default, the clang-format style is set to "file" which means it looks for a `
 
 The "Visual Studio" clang-format style is not yet an official OOTB clang-format style but it implies the following clang-format settings:
 
-```json
+```json5
 UseTab: (VS Code current setting)
 IndentWidth: (VS Code current setting)
 BreakBeforeBraces: AllMan
@@ -196,7 +196,7 @@ If you'd like to use a different version of clang-format than the one that ships
 
 For example, on the Windows platform:
 
-```json
+```json5
   "C_Cpp.clang_format_path": "C:\\Program Files (x86)\\LLVM\\bin\\clang-format.exe"
 ```
 
@@ -266,7 +266,7 @@ You can debug Windows applications created using Cygwin or MinGW by using VS Cod
 
 For example:
 
-```json
+```json5
     "miDebuggerPath": "c:\\mingw\\bin\\gdb.exe"
 ```
 
@@ -310,13 +310,13 @@ If there are additional directories where the debugger can find symbol files (fo
 
 For example:
 
-```json
+```json5
     "additionalSOLibSearchPath": "/path/to/symbols;/another/path/to/symbols"
 ```
 
 or
 
-```json
+```json5
     "symbolSearchPath": "C:\\path\\to\\symbols;C:\\another\\path\\to\\symbols"
 ```
 
@@ -326,7 +326,7 @@ The source file location can be changed if the source files are not located in t
 
 For example:
 
-```json
+```json5
 "sourceFileMap": {
     "/build/gcc-4.8-fNUjSI/gcc-4.8-4.8.4/build/i686-linux-gnu/libstdc++-v3/include/i686-linux-gnu": "/usr/include/i686-linux-gnu/c++/4.8",
     "/build/gcc-4.8-fNUjSI/gcc-4.8-4.8.4/build/i686-linux-gnu/libstdc++-v3/include": "/usr/include/c++/4.8"

--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -37,12 +37,12 @@ Clicking on a color preview will launch the integrated color picker which suppor
 
 You can hide VS Code's color previews by setting the following [setting](/docs/getstarted/settings.md):
 
-```json
+```json5
 "editor.colorDecorators": false
 ```
 
 To just disable it for css, Less and SCSS, use
-```json
+```json5
 "[css]": {
     "editor.colorDecorators": false
 }
@@ -58,7 +58,7 @@ Additionally you can use the following region markers to define a folding range:
 
 If you prefer to switch to indentation based folding for CSS, Less and SCSS, use:
 
-```json
+```json5
 "[css]": {
     "editor.foldingStrategy": "indentation"
 },
@@ -78,7 +78,7 @@ VS Code also supports [User Defined Snippets](/docs/editor/userdefinedsnippets.m
 There is support for CSS version <= 2.1, Sass version <= 3.2 and Less version <= 2.3.
 
 >**Note:** You can disable VS Code's default CSS, Sass or Less validation by setting the corresponding `.validate` User or Workspace [setting](/docs/getstarted/settings.md) to false.
->```json
+>```json5
 >"css.validate": false
 >```
 
@@ -146,7 +146,7 @@ The next step is to set up the task configuration.  To do this, run **Tasks** > 
 
 This will create a sample `tasks.json` file in the workspace `.vscode` folder.  The initial version of file has an example to run an arbitrary command. We will modify that configuration for transpiling Sass/Less instead:
 
-```json
+```json5
 // Sass configuration
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
@@ -163,7 +163,7 @@ This will create a sample `tasks.json` file in the workspace `.vscode` folder.  
 }
 ```
 
-```json
+```json5
 // Less configuration
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -25,7 +25,7 @@ You can trigger suggestions at any time by pressing `kb(editor.action.triggerSug
 
 You can also control which built-in code completion providers are active. Override these in your user or workspace [settings](/docs/getstarted/settings.md) if you prefer not to see the corresponding suggestions.
 
-```json
+```json5
 // Configures if the built-in HTML language suggests Angular V1 tags and properties.
 "html.suggest.angular1": true,
 
@@ -48,7 +48,7 @@ The matching closing tag is inserted when `/` of the closing tag is entered.
 
 You can turn off autoclosing tags with the following [setting](/docs/getstarted/settings.md):
 
-```json
+```json5
 "html.autoClosingTags": false
 ```
 
@@ -72,7 +72,7 @@ The HTML language support performs validation on all embedded JavaScript and CSS
 
 You can turn that validation off with the following settings:
 
-```json
+```json5
 // Configures if the built-in HTML language support validates embedded scripts.
 "html.validate.scripts": true,
 
@@ -89,7 +89,7 @@ Additionally you can use the following region markers to define a folding range:
 
 If you prefer to switch to indentation based folding for HTML use:
 
-```json
+```json5
 "[html]": {
     "editor.foldingStrategy": "indentation"
 },
@@ -132,7 +132,7 @@ If you'd like to use HTML Emmet abbreviations with other languages, you can asso
 
 For example, to use Emmet HTML abbreviations inside JavaScript:
 
-```json
+```json5
 {
     "emmet.includeLanguages": {
         "javascript": "html"

--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -10,7 +10,7 @@ MetaDescription: Visual Studio Code language mode identifiers
 
 In Visual Studio Code, each [language mode](/docs/languages/overview.md#changing-the-language-for-the-selected-file) has a unique specific language identifier. That identifier is rarely seen by the user except in the settings, for example, when associating file extensions to a language:
 
-```json
+```json5
     "files.associations": {
         "*.myphp": "php"
     }
@@ -22,7 +22,7 @@ The language identifier becomes essential for VS Code extension developers when 
 
 Every language defines its *id* through the `languages` configuration point:
 
-```json
+```json5
     "languages": [{
         "id": "java",
         "extensions": [ ".java", ".jav" ],
@@ -32,7 +32,7 @@ Every language defines its *id* through the `languages` configuration point:
 
 Language supports are added using the language identifier:
 
-```json
+```json5
     "grammars": [{
         "language": "groovy",
         "scopeName": "source.groovy",

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -37,7 +37,7 @@ In this image you can see IntelliSense, including the method signature, paramete
 
 Type declaration files are automatically downloaded and managed by Visual Studio Code for packages listed in your project's `package.json`.
 
-```json
+```json5
     "dependencies": {
         "lodash": "^4.17.0"
     }
@@ -45,7 +45,7 @@ Type declaration files are automatically downloaded and managed by Visual Studio
 
 If you are using Visual Studio Code 1.8+, you can alternately explicitly list packages to acquire type declaration files for in your `jsconfig.json`.
 
-```json
+```json5
     "typeAcquisition": {
         "include": [
             "lodash"
@@ -67,7 +67,7 @@ If you have npm installed but still see a warning message, you can explicitly te
 
 For example on Windows, you would add a path like this to your `settings.json` file:
 
-```json
+```json5
   "typescript.npm": "C:\\Program Files\\nodejs\\npm.cmd"
 ```
 
@@ -95,7 +95,7 @@ Illustrated below is a project with a `client` and `server` folder, showing two 
 
 Below is a simple template for `jsconfig.json` file which defines the JavaScript `target` to be `ES6` and the `exclude` attribute excludes the `node_modules` folder. You can copy and paste this code into your `jsconfig.json` file.
 
-```json
+```json5
 {
     "compilerOptions": {
         "target": "ES6"
@@ -113,7 +113,7 @@ You can explicitly set the files in your project using the `include` attribute. 
 
 Here is an example with an explicit `include` attribute:
 
-```json
+```json5
 {
     "compilerOptions": {
         "target": "ES6"
@@ -251,7 +251,7 @@ A linter extension may require an external tool. The steps below show how to set
 
 It is recommended that you enable the linter rules that warn about undefined and unused variables. To do this, put the following options in your `.eslintrc.json` file.
 
-```json
+```json5
 "no-undef": 1,
 "no-unused-vars": 1,
 ```
@@ -314,7 +314,7 @@ To enable type checking for JavaScript files that are part of a `jsconfig.json` 
 
 `jsconfig.json`:
 
-```json
+```json5
 {
     "compilerOptions": {
         "checkJs": true
@@ -328,7 +328,7 @@ To enable type checking for JavaScript files that are part of a `jsconfig.json` 
 
 `tsconfig.json`:
 
-```json
+```json5
 {
     "compilerOptions": {
         "allowJs": true,
@@ -369,7 +369,7 @@ If you want to continue using `// @ts-check` but are confident that these are no
 
 To start, [create a `jsconfig.json`](#javascript-project-jsconfigjson) at the root of your project:
 
-```json
+```json5
 {
     "compilerOptions": { },
     "exclude": [
@@ -399,7 +399,7 @@ declare var CAN_NOTIFY: number;
 
 The [Babel](https://babeljs.io) transpiler turns ES6 files into readable ES5 JavaScript with Source Maps. You can easily integrate **Babel** into your workflow by adding the configuration below to your `tasks.json` file (located under the workspace's `.vscode` folder). The `group` setting makes this task the default **Task: Run Build Task** gesture.  `isBackground` tells VS Code to keep running this task in the background. To learn more, go to [Tasks](/docs/editor/tasks.md).
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [

--- a/docs/languages/jsconfig.md
+++ b/docs/languages/jsconfig.md
@@ -45,7 +45,7 @@ By default the JavaScript language service will analyze and provide IntelliSense
 
 The `exclude` attribute (a glob pattern) tells the language service what files are and are not part of your source code. This keeps performance at a high level. If IntelliSense is slow, add folders to your `exclude` list (VS Code will prompt you to do this if it detects the slow down).
 
-```json
+```json5
 {
     "compilerOptions": {
         "target": "es6"
@@ -62,7 +62,7 @@ The `exclude` attribute (a glob pattern) tells the language service what files a
 
 Alternatively, you can explicitly set the files in your project using the `include` attribute (a glob pattern). If no `include` attribute is present, then this defaults to including all files in the containing directory and subdirectories. When a `include` attribute is specified, only those files are included. Here is an example with an explicit `include` attribute.
 
-```json
+```json5
 {
     "compilerOptions": {
         "target": "es6"
@@ -97,7 +97,7 @@ For IntelliSense to work with webpack aliases, you need to specify the `paths` k
 
 For example, for alias 'ClientApp':
 
-```json
+```json5
 {
   "compilerOptions": {
     "baseUrl": ".",

--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -61,7 +61,7 @@ VS Code extensions can also define schemas and schema mapping. That's why VS Cod
 
 In the following example, the JSON file specifies that its contents follow the [CoffeeLint](http://www.coffeelint.org/) schema.
 
-```json
+```json5
 {
    "$schema": "http://json.schemastore.org/coffeelint",
    "line_endings": "unix"
@@ -74,7 +74,7 @@ Please note that this syntax is VS Code-specific and not part of the [JSON Schem
 
 The following excerpt from User [settings](/docs/getstarted/settings.md) shows how `.babelrc` files are mapped to the [babelrc](https://babeljs.io/docs/usage/babelrc) schema located on [http://json.schemastore.org/babelrc](http://json.schemastore.org/babelrc).
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -90,7 +90,7 @@ The following excerpt from User [settings](/docs/getstarted/settings.md) shows h
 
 To map a schema that is located in the workspace, use a relative path. In this example, a file in the workspace root called `myschema.json` will be used as the schema for all files ending with `.foo.json`.
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -104,7 +104,7 @@ To map a schema that is located in the workspace, use a relative path. In this e
 
 To map a schema that is defined in the User or Workspace settings, use the `schema` property. In this example, a schema is defined that will be used for all files named `.myconfig`.
 
-```json
+```json5
 "json.schemas": [
     {
         "fileMatch": [
@@ -131,7 +131,7 @@ Schemas and schema associations can also be defined by an extension. Check out t
 JSON schemas describe the shape of the JSON file, as well as value sets and default values which are used by the JSON language support to provide completion proposals.
 If you are a schema author and want to provide even more customized completion proposals, you can also specify snippets in the schema. The following example shows a schema for a key binding settings file defining a snippet:
 
-```json
+```json5
 {
     "type": "array",
     "title": "Keybindings configuration",

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -75,7 +75,7 @@ You can also use your own CSS in the Markdown preview with the `"markdown.styles
 
 For example, to load a stylesheet called `Style.css` at the root of your current workspace, use **File** > **Preferences** > **Settings** to bring up the workspace `settings.json` file and make this update:
 
-```json
+```json5
 // Place your settings in this file to overwrite default and user settings.
 {
     "markdown.styles": [
@@ -164,7 +164,7 @@ The next step is to set up the task configuration file `tasks.json`.  To do this
 
 This generates a `tasks.json` file in your workspace `.vscode` folder with the following content:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -181,7 +181,7 @@ This generates a `tasks.json` file in your workspace `.vscode` folder with the f
 
 To use **markdown-it** to compile the Markdown file, change the contents as follows:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -207,7 +207,7 @@ At this point, you should see an additional file show up in the file list `sampl
 
 If you want to make the **Compile Markdown** task the default build task to run execute **Configure Default Build Task** from the global **Tasks** menu and select **Compile Markdown** from the presented list. The final `tasks.json` file will then look like this:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
@@ -281,7 +281,7 @@ To complete the tasks integration with VS Code, we will need to modify the task 
 
 If you want to make the **gulp: default** task the default build task executed when pressing `kb(workbench.action.tasks.build)` run **Configure Default Build Task** from the global **Tasks** menu and select **gulp: default** from the presented list. The final `tasks.json` file will then look like this:
 
-```json
+```json5
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -65,7 +65,7 @@ You can add new file extensions to an existing language with the `files.associat
 
 For example, the setting below adds the `.myphp` file extension to the `php` language identifier:
 
-```json
+```json5
     "files.associations": {
         "*.myphp": "php"
     }
@@ -98,7 +98,7 @@ Yes, with the `files.associations` [setting](/docs/getstarted/settings.md) you c
 
 Here is an example that will associate more file extensions to the PHP language:
 
-```json
+```json5
 "files.associations": {
     "*.php4": "php",
     "*.php5": "php"
@@ -107,7 +107,7 @@ Here is an example that will associate more file extensions to the PHP language:
 
 You can also configure full file paths to languages if needed. The following example associates all files in a folder `somefolder` to PHP:
 
-```json
+```json5
 "files.associations": {
     "**/somefolder/*.*": "php"
 }

--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -47,7 +47,7 @@ To set the PHP executable path, open your **User or Workspace Settings** and add
 
 ### Windows
 
-```json
+```json5
 {
     "php.validate.executablePath": "c:/php/php.exe"
 }
@@ -55,7 +55,7 @@ To set the PHP executable path, open your **User or Workspace Settings** and add
 
 ### Linux and macOS
 
-```json
+```json5
 {
     "php.validate.executablePath": "/usr/bin/php"
 }

--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -51,7 +51,7 @@ Typically the first step in any new TypeScript project is to add in a `tsconfig.
 
 A simple `tsconfig.json` looks like this for ES5, **CommonJS** [modules](http://www.commonjs.org/specs/modules/1.0) and source maps:
 
-```json
+```json5
 {
     "compilerOptions": {
         "target": "es5",
@@ -205,7 +205,7 @@ This pattern will match on any JavaScript file (`**/*.js`) but only if a sibling
 
 To exclude JavaScript files generated from both `.ts` and `.tsx` source files, use this expression:
 
-```json
+```json5
 "**/*.js": { "when": "$(basename).ts" },
 "**/**.js": { "when": "$(basename).tsx" }
 ```
@@ -230,7 +230,7 @@ To use a different TypeScript version by default, configure `typescript.tsdk` in
 
 For example:
 
-```json
+```json5
 {
    "typescript.tsdk": "/usr/local/lib/node_modules/typescript/lib"
 }
@@ -238,7 +238,7 @@ For example:
 
 You can also configure a specific version of TypeScript in a particular workspace by adding a `typescript.tsdk` workspace setting pointing to the directory of the `tsserver.js` file:
 
-```json
+```json5
 {
    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/docs/nodejs/angular-tutorial.md
+++ b/docs/nodejs/angular-tutorial.md
@@ -127,7 +127,7 @@ We need to initially configure the [debugger](/docs/editor/debugging.md). To do 
 
 We need to make one change for our example: change the port of the `url` from `8080` to `4200`. Your `launch.json` should look like this:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -127,7 +127,7 @@ Instead of launching the Node.js program directly with node, you can use 'npm' s
 
 Let's look at an 'npm' example. If your `package.json` has a 'debug' script, for example:
 
-```json
+```json5
   "scripts": {
     "debug": "node --nolazy --inspect-brk=9229 myProgram.js"
   },
@@ -135,7 +135,7 @@ Let's look at an 'npm' example. If your `package.json` has a 'debug' script, for
 
 the corresponding launch configuration would look like this:
 
-```json
+```json5
 {
     "name": "Launch via NPM",
     "type": "node",
@@ -153,7 +153,7 @@ the corresponding launch configuration would look like this:
 
 If you are using '[nvm](https://github.com/creationix/nvm)' (or '[nvm-windows](https://github.com/coreybutler/nvm-windows)')  to manage your Node.js versions, it is possible to specify a `runtimeVersion` attribute in a launch configuration for selecting a specific version of Node.js:
 
-```json
+```json5
 {
     "type": "node",
     "request": "launch",
@@ -165,7 +165,7 @@ If you are using '[nvm](https://github.com/creationix/nvm)' (or '[nvm-windows](h
 
 If you are using '[nvs](https://github.com/jasongin/nvs)' to manage your Node.js versions, it is possible to use `runtimeVersion` attribute to select a specific version of Node.js:
 
-```json
+```json5
 {
     "type": "node",
     "request": "launch",
@@ -183,7 +183,7 @@ Make sure to have those Node.js versions installed that you want to use with the
 
 The VS Code Node debugger supports loading environment variables from a file and passing them to the Node.js runtime. To use this feature, add an attribute `envFile` to your launch configuration and specify the absolute path to the file containing the environment variables:
 
-```json
+```json5
    //...
    "envFile": "${workspaceFolder}/.env",
    "env": { "USER": "john doe" }
@@ -259,7 +259,7 @@ This option requires more work but in contrast to the previous two options it al
 
 The simplest "attach" configuration looks like this:
 
-```json
+```json5
 {
     "name": "Attach to Process",
     "type": "node",
@@ -272,7 +272,7 @@ The port `9229` is the default debug port of the `--inspect` and `--inspect-brk`
 
 If you want to attach to a Node.js process that hasn't been started in debug mode, you can do this by specifying the process ID of the Node.js process as a string:
 
-```json
+```json5
 {
     "name": "Attach to Process",
     "type": "node",
@@ -285,7 +285,7 @@ Since it is a bit laborious to repeatedly find the process ID and enter it in th
 
 By using the `PickProcess` variable the launch configuration looks like this:
 
-```json
+```json5
 {
     "name": "Attach to Process",
     "type": "node",
@@ -335,7 +335,7 @@ tsc --sourceMap --outDir bin app.ts
 
 This is the corresponding launch configuration for a TypeScript program:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -384,7 +384,7 @@ Here are some things to try when your breakpoints turn gray:
 
 The Node.js debugger supports remote debugging for versions of Node.js >= 4.x. Specify a remote host via the `address` attribute. Here is an example:
 
-```json
+```json5
 {
     "type": "node",
     "request": "attach",
@@ -396,7 +396,7 @@ The Node.js debugger supports remote debugging for versions of Node.js >= 4.x. S
 
 By default, VS Code will stream the debugged source from the remote Node.js folder to the local VS Code and show it in a read-only editor. You can step through this code, but cannot modify it. If you want VS Code to open the editable source from your workspace instead, you can setup a mapping between the remote and local locations. A `localRoot` and a `remoteRoot` attribute can be used to map paths between a local VS Code project and a (remote) Node.js folder. This works even locally on the same system or across different operating systems. Whenever a code path needs to be converted from the remote Node.js folder to a local VS Code path, the `remoteRoot` path is stripped off the path and replaced by `localRoot`. For the reverse conversion, the `localRoot` path is replaced by the `remoteRoot`.
 
-```json
+```json5
 {
     "type": "node",
     "request": "attach",
@@ -420,7 +420,7 @@ Two frequently used applications of remote debugging are:
 
   Here is the simplest debug configuration for debugging `hello.js` in WSL:
 
-  ```json
+  ```json5
   {
       "type": "node",
       "request": "launch",
@@ -452,7 +452,7 @@ nodemon --inspect server.js
 
 you can attach the VS Code debugger to it with the following launch configuration:
 
-```json
+```json5
 {
     "name": "Attach to node",
     "type": "node",
@@ -464,7 +464,7 @@ you can attach the VS Code debugger to it with the following launch configuratio
 
 Alternatively you can start your program `server.js` via **nodemon** directly with a launch config and attach the VS Code debugger:
 
-```json
+```json5
 {
     "name": "Launch server.js via nodemon",
     "type": "node",
@@ -489,7 +489,7 @@ The Node debugger has a mechanism that tracks all subprocesses of a debuggee and
 
 The feature is enabled by setting the launch config attribute `autoAttachChildProcesses` to true:
 
-```json
+```json5
 {
   "type": "node",
   "request": "launch",
@@ -572,7 +572,7 @@ all code in the `node_modules` and `lib` folders in your project will be skipped
 
 Built-in **core modules** of Node.js can be referred to by the 'magic name' `<node_internals>` in a glob pattern. The following example skips all internal modules:
 
-```json
+```json5
   "skipFiles": [
      "<node_internals>/**/*.js"
    ]
@@ -630,7 +630,7 @@ To write your own debugger extension, visit:
 
 Yes, if you've created symlinks with `npm link`, you can debug symlink sources by telling the Node.js runtime to honor those symlinks. Use the node.exe `--preserve-symlinks` [switch](https://nodejs.org/api/cli.html#cli_preserve_symlinks) in your launch configuration `runtimeArgs` attribute. `runtimeArgs`, an array of strings, are passed to the debugging session runtime executable, which defaults to node.exe.
 
-```json
+```json5
 {
     "runtimeArgs": [
         "--preserve-symlinks"

--- a/docs/nodejs/nodejs-tutorial.md
+++ b/docs/nodejs/nodejs-tutorial.md
@@ -170,7 +170,7 @@ You can also write code that references modules in other files. For example, in 
 
 You will need to create a debugger configuration file `launch.json` for your Express application. Click on the Debug icon in the **Activity Bar** and then the Configure gear icon at the top of the Debug view to create a default `launch.json` file.  Select the **Node.js** environment by ensuring that the `type` property in `configurations` is set to `"node"`.  When the file is first created, VS Code will look in `package.json` for a `start` script and will use that value as the `program` (which in this case is `"${workspaceFolder}\\bin\\www`) for the **Launch Program** configuration.
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [

--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -132,7 +132,7 @@ We need to initially configure the [debugger](/docs/editor/debugging.md). To do 
 
 We need to make one change for our example: change the port of the `url` from `8080` to `3000`. Your `launch.json` should look like this:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -189,7 +189,7 @@ Once the ESLint extension is installed and VS Code reloaded, you'll want to crea
 
 The command will create a `.eslintrc.json` file in your project root:
 
-```json
+```json5
 {
     "env": {
         "browser": true,
@@ -225,7 +225,7 @@ ESLint will now analyze open files and shows a warning in `index.js` about 'App'
 
 Let's add an error rule for extra semi-colons:
 
-```json
+```json5
  "rules": {
         "no-const-assign": "warn",
         "no-this-before-super": "warn",

--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -93,7 +93,7 @@ Unity creates a number of additional files that can clutter your workspace in VS
 
 To do this, add the following JSON to your [workspace settings](/docs/getstarted/settings.md).
 
-```json
+```json5
     // Configure glob patterns for excluding files and folders.
     "files.exclude": {
         "**/.git": true,

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -62,7 +62,7 @@ By default, the debugger uses the same `python.pythonPath` workspace setting as 
 
 There are two standard configurations in `launch.json` that run the active file in the editor in either the integrated terminal (inside VS Code) or the external terminal (outside of VS Code):
 
-```json
+```json5
 {
     "name": "Python: Current File (Integrated Terminal)",
     "type": "python",
@@ -83,7 +83,7 @@ The specific settings are described in the following sections.
 
 > **Tip**: It's often helpful in a project to create a configuration that runs a specific startup file. For example, if you always want to always launch `startup.py` whenever you start the debugger, create a configuration entry as follows:
 >
-> ```json
+> ```json5
 > {
 >     "name": "Python: startup.py",
 >     "type": "python",
@@ -111,13 +111,13 @@ Specifies the mode in which to start debugging:
 
 Provides the fully qualified path to the python program's entry module (startup file). The value `${file}`, often used in default configurations, uses the currently active file in the editor. By specifying a specific startup file, you can always be sure of launching your program with the same entry point regardless of which files are open. For example:
 
-```json
+```json5
 "program": "/Users/Me/Projects/PokemonGo-Bot/pokemongo_bot/event_handlers/__init__.py",
 ```
 
 You can also rely on a relative path from the workspace root. For example, if the root is `/Users/Me/Projects/PokemonGo-Bot` then you can use the following:
 
-```json
+```json5
 "program": "${workspaceFolder}/pokemongo_bot/event_handlers/__init__.py",
 ```
 
@@ -129,7 +129,7 @@ If not specified, this setting defaults to the interpreter identified in the `py
 
 You can specify platform-specific paths by placing `pythonPath` within a parent object named `osx`, `windows`, or `linux`. For example, the configuration for PySpark uses the following values:
 
-```json
+```json5
 "osx": {
     "pythonPath": "^\"\\${env:SPARK_HOME}/bin/spark-submit\""
 },
@@ -147,7 +147,7 @@ Alternately, you can use a custom environment variable that's defined on each pl
 
 Specifies arguments to pass to the Python program. Each argument should be contained within quotes, for example:
 
-```json
+```json5
 "args": [
     "--quiet", "--norepeat"
 ],
@@ -330,7 +330,7 @@ To debug an app that requires administrator privileges, use `"console": "externa
 
 ### Flask debugging
 
-```json
+```json5
 {
     "name": "Python: Flask",
     "type": "python",
@@ -354,7 +354,7 @@ The `"jinja": true` setting also enables debugging for Flask's default Jinja tem
 
 If you want to run Flask's development server in development mode, use the following configuration:
 
-```json
+```json5
 {
     "name": "Python: Flask (development mode)",
     "type": "python",
@@ -381,7 +381,7 @@ Google App Engine launches an app by itself, so launching it in the VS Code debu
 
 1. Create a `tasks.json` file with the following contents:
 
-    ```json
+    ```json5
     {
         "version": "2.0.0",
         "tasks": [

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -33,7 +33,7 @@ To enable IntelliSense for packages that are installed in other, non-standard lo
 
 **Windows:**
 
-```json
+```json5
 "python.autoComplete.extraPaths": [
     "C:/Program Files (x86)/Google/google_appengine",
     "C:/Program Files (x86)/Google/google_appengine/lib" ]
@@ -41,7 +41,7 @@ To enable IntelliSense for packages that are installed in other, non-standard lo
 
 **macOS/Linux:**
 
-```json
+```json5
 "python.autoComplete.extraPaths": [
     "~/.local/lib/Google/google_appengine",
     "~/.local/lib/Google/google_appengine/lib" ]
@@ -49,13 +49,13 @@ To enable IntelliSense for packages that are installed in other, non-standard lo
 
 The `python.autoComplete.preloadModules` setting also allows you speed up autocomplete for specific packages by preloading their information. For example:
 
-```json
+```json5
 "python.autoComplete.preloadModules": ["numpy", "pandas", "matplotlib"],
 ```
 
 Finally, the `python.autocomplete.addBrackets` setting (default false) determines whether VS Code automatically adds parentheses (`()`) when autocompleting a function name. For example, if you set `addBrackets` to true:
 
-```json
+```json5
   "python.autoComplete.addBrackets": true,
 ```
 
@@ -107,7 +107,7 @@ The following settings apply to the individual formatters. The Python extension 
 
 When using custom arguments, each top-level element of an argument string that's separated by space on the command line must be a separate item in the args list. For example:
 
-```json
+```json5
 "python.formatting.autopep8Args": ["--max-line-length", "120", "--experimental"],
 "python.formatting.yapfArgs": ["--style", "{based_on_style: chromium, indent_width: 20}"]
 "python.formatting.blackArgs": ["--line-length", "100"]
@@ -130,7 +130,7 @@ When using the black formatter, VS Code issues the following warning when pastin
 
 To prevent this warning, add the following entry to your user or workspace settings to disable format on paste for Python files:
 
-```json
+```json5
 "[python]": {
     "editor.formatOnPaste": false
 }
@@ -179,7 +179,7 @@ Invoked by:
 
 Custom arguments to isort are specified in the `python.sortImports.args` setting, where each top-level element, as separated by spaces on the command line, is a separate item in the array:
 
-```json
+```json5
 "python.sortImports.args": ["-rc", "--atomic"],
 ```
 
@@ -191,7 +191,7 @@ Further configurations can be stored in an `.isort.cfg` file as documented on [C
 
 To automatically sort imports whenever you save a file, add the following entry to your user or workspace settings:
 
-```json
+```json5
 "[python]": {
     "editor.codeActionsOnSave": {
         "source.organizeImports": true

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -127,27 +127,27 @@ If VS Code does not automatically locate an interpreter you want to use, you can
 
     - Windows:
 
-      ```json
+      ```json5
       "python.pythonPath": "c:/python36/python.exe"
       ```
 
     - macOS/Linux:
 
-      ```json
+      ```json5
       "python.pythonPath": "/home/python36/python"
       ```
 
 1. You can also use `python.pythonPath` to point to a virtual environment, for example:
 
     Windows:
-    ```json
+    ```json5
     {
         "python.pythonPath": "c:/dev/ala/venv/Scripts/python.exe"
     }
     ```
 
     macOS/Linux:
-    ```json
+    ```json5
     {
         "python.pythonPath": "/home/abc/dev/ala/venv/bin/python"
     }
@@ -156,7 +156,7 @@ If VS Code does not automatically locate an interpreter you want to use, you can
 
 A system environment variable can be used in the path setting using the syntax `${env:VARIABLE}`. For example:
 
-```json
+```json5
 {
     "python.pythonPath": "${env:PYTHON_INSTALL_LOC}"
 }

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -68,7 +68,7 @@ To select a different linter, use the **Python: Select Linter** command. You can
 
 Custom arguments are specified in the appropriate arguments setting for each linter. Each top-level element of an argument string that's separated by a space on the command line must be a separate item in the args list. For example:
 
-```json
+```json5
 "python.linting.pylintArgs": ["--reports", "12", "--disable-msg", "I0011"],
 "python.linting.flake8Args": ["--ignore=E24,W504", "--verbose"]
 "python.linting.pydocstyleArgs": ["--ignore=D400", "--ignore=D4"]
@@ -123,7 +123,7 @@ For the complete list of Pylint messages, see [readable-pylint-messages](https:/
 
 See [Pylint command line arguments](https://pylint.readthedocs.io/en/latest/user_guide/run.html#command-line-options) for general switches. Command line arguments can be used to load Pylint plugins, such as that for Django:
 
-```json
+```json5
 "python.linting.pylintArgs": ["--load-plugins", "pylint_django"]
 ```
 
@@ -160,13 +160,13 @@ The generated file contains sections for all the Pylint options, along with docu
 
 See [pycodestyle Command Line Interface](http://www.pydocstyle.org/en/2.1.1/usage.html#cli-usage) for general options. For example, to ignore error D400 (first line should end with a period), add the following line to your `settings.json` file:
 
-```json
+```json5
 "python.linting.pydocstyleArgs": ["--ignore=D400"]
 ```
 
 A code prefix also instructs pydocstyle to ignore specific categories of errors. For example, to ignore all Docstring Content issues (D4XXX errors), add the following line to `settings.json`:
 
-```json
+```json5
 "python.linting.pydocstyleArgs": ["--ignore=D4"]
 ```
 
@@ -193,7 +193,7 @@ The Python extension maps all pydocstyle errors to the Convention (C) category.
 
 See [pycodestyle example usage and output](https://pep8.readthedocs.io/en/latest/intro.html#example-usage-and-output) for general switches. For example, to ignore error E303 (too many blank lines), add the following line to your `settings.json` file:
 
-```json
+```json5
 "python.linting.pep8Args": ["--ignore=E303"]
 ```
 
@@ -214,7 +214,7 @@ The Python extension maps pep8 message categories to VS Code categories through 
 
 See [Invoking Flake8](http://flake8.pycqa.org/en/latest/user/invocation.html) for general switches. For example, to ignore error E303 (too many blank lines), use the following setting:
 
-```json
+```json5
 "python.linting.flake8Args": ["--ignore=E303"]
 ```
 

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -126,7 +126,7 @@ These different configurations are fully explained in [Debugging configurations]
 
 To automatically stop the debugger on the first line when the program starts, add a `"stopOnEntry": true` setting to the "Python: Current File" configuration in `launch.json`, so that the whole configuration appears as follows:
 
-```json
+```json5
 {
     "name": "Python: Current File (Integrated Terminal)",
     "type": "python",
@@ -177,7 +177,7 @@ For full details, see [Debugging configurations](/docs/python/debugging.md), whi
 
 If for some reason VS Code doesn't generate `launch.json` for you, create the `.vscode/launch.json` file within the project folder (creating the `.vscode` folder if you need to), then paste the following contents into `launch.json`:
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [
@@ -202,7 +202,7 @@ SyntaxError: invalid syntax
 
 Select `hello.py` and try again. Alternately, create a debug configuration specifically for the `hello.py` file by adding the following lines in `launch.json` within the `configuration` array. Then select this configuration in the debugger drop-down and start the debugger again.
 
-```json
+```json5
         {
             "name": "Python: hello.py",
             "type": "python",

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -182,7 +182,7 @@ You're probably already wondering if there's an easier way to run the server and
 
 1. Scroll down to and examine the configuration with the name "Python: Django":
 
-    ```json
+    ```json5
     {
         "name": "Python: Django",
         "type": "python",
@@ -579,7 +579,7 @@ Because the three pages you create in the next section extend `layout.html`, it 
 
 1. After VS code opens `html.json`, add the code below within the existing curly braces. (The explanatory comments, not shown here, describe details such as how the `$0` line indicates where VS Code places the cursor after inserting a snippet):
 
-    ```json
+    ```json5
     "Django App: template extending layout.html": {
         "prefix": "djextlayout",
         "body": [

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -195,7 +195,7 @@ Debugging gives you the opportunity to pause a running program on a particular l
 
 1. Scroll down to and examine the configuration with the name "Python: Flask (0.11.x or later)". This configuration contains `"module": "flask",`, which tells VS Code to run Python with `-m flask` when it starts the debugger. It also defines the FLASK_APP environment variable in the `env` property to identify the startup file, which is `app.py` by default, but allows you to easily specify a different file. If you want to change the host and/or port, you can use the `args` array.
 
-    ```json
+    ```json5
     {
         "name": "Python: Flask (0.11.x or later)",
         "type": "python",
@@ -406,7 +406,7 @@ The following sections demonstrate both types of static files.
 
 1. In the `static` folder, create a JSON data file named `data.json` with the following contents (which are just meaningless sample data):
 
-    ```json
+    ```json5
     {
         "01": {
             "note" : "This data is very simple because we're demonstrating only the mechanism."
@@ -512,7 +512,7 @@ Because the three pages you create in the next section extend `layout.html`, it 
 
 1. After VS code opens `html.json`, add the following entry within the existing curly braces (the explanatory comments, not shown here, describe details such as how the `$0` line indicates where VS Code places the cursor after inserting a snippet):
 
-    ```json
+    ```json5
     "Flask App: template extending layout.html": {
         "prefix": "flextlayout",
         "body": [
@@ -662,7 +662,7 @@ Throughout this tutorial, all the app code is contained in a single `app.py` fil
 
 1. Open the debug configuration file `launch.json` and update the `env` property as follows to point to the startup object:
 
-    ```json
+    ```json5
     "env": {
         "FLASK_APP": "hello_app.webapp"
     },

--- a/docs/python/unit-testing.md
+++ b/docs/python/unit-testing.md
@@ -26,7 +26,7 @@ The following steps give you a quick walkthrough of working with test in VS Code
 
 1. Enable the unittest framework by adding the following entries to your user (or workspace) settings. We recommend explicitly enabling one framework and disabling the others as shown here:
 
-    ```json
+    ```json5
     "python.unitTest.unittestEnabled": true,
     "python.unitTest.pyTestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
@@ -93,7 +93,7 @@ It's important that you enable only a single test framework at a time. For this 
 
 To enable unittest, for example, use the following settings:
 
-```json
+```json5
 "python.unitTest.unittestEnabled": true,
 "python.unitTest.pyTestEnabled": false,
 "python.unitTest.nosetestsEnabled": false,
@@ -101,7 +101,7 @@ To enable unittest, for example, use the following settings:
 
 To enable pyTest:
 
-```json
+```json5
 "python.unitTest.unittestEnabled": false,
 "python.unitTest.pyTestEnabled": true,
 "python.unitTest.nosetestsEnabled": false,
@@ -109,7 +109,7 @@ To enable pyTest:
 
 To enable Nose:
 
-```json
+```json5
 "python.unitTest.unittestEnabled": false,
 "python.unitTest.pyTestEnabled": false,
 "python.unitTest.nosetestsEnabled": true,

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -177,7 +177,7 @@ While 524288 is the maximum number of files that can be watched, if you're in an
 
 Another option is to exclude specific workspace directories from the VS Code file watcher with the `files.watcherExclude` [setting](/docs/getstarted/settings.md). The default for `files.watcherExclude` excludes `node_module` and some folders under `.git` but you can add other directories that you don't want VS Code to track.
 
-```json
+```json5
 "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
@@ -189,7 +189,7 @@ Another option is to exclude specific workspace directories from the VS Code fil
 
 We're working on a fix. In the meantime, open the application menu, then choose **File** > **Preferences** > **Settings**. Then set `editor.fontFamily` as shown:
 
-```json
+```json5
     "editor.fontFamily": "Droid Sans Mono, Droid Sans Fallback"
 ```
 

--- a/docs/supporting/errors.md
+++ b/docs/supporting/errors.md
@@ -29,7 +29,7 @@ This error occurs when you have a relative path in your [debug configuration](/d
 
 In the example below, the `program` attribute has a relative path to `app.js` at the root of the workspace (project folder).
 
-```json
+```json5
 {
 "version": "0.2.0",
     "configurations": [
@@ -45,7 +45,7 @@ In the example below, the `program` attribute has a relative path to `app.js` at
 
 The fix is to use an absolute path or better use the `${workspaceFolder}` variable which will resolve to the absolute path of the project folder.
 
-```json
+```json5
 {
 "version": "0.2.0",
     "configurations": [

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -45,7 +45,7 @@ To modify the update channel, go to **File** > **Preferences** > **Settings** (m
 
 If you use the JSON editor for your settings, add the following line:
 
-```json
+```json5
     "update.channel": "none"
 ```
 
@@ -77,7 +77,7 @@ To install the Insiders build, go to the Insiders [download page](/insiders).
 
 When you open a folder, VS Code will search for typical project files to offer you additional tooling (e.g. the solution picker in the status bar to open a solution). If you open a folder with lots of files, the search can take a large amount of time and CPU resources during which VS Code might be slow to respond. We plan to improve this in the future but for now you can exclude folders from the explorer via the `files.exclude` setting and they will not be searched for project files:
 
-```json
+```json5
     "files.exclude": {
         "**/largeFolder": true
     }
@@ -139,7 +139,7 @@ From **File** > **Preferences** > **Settings** (macOS: **Code** > **Preferences*
 
 If you use the JSON editor for your settings, add the following line:
 
-```json
+```json5
     "telemetry.enableTelemetry": false
 ```
 
@@ -157,7 +157,7 @@ From **File** > **Preferences** > **Settings** (macOS: **Code** > **Preferences*
 
 If you use the JSON editor for your settings, add the following line:
 
-```json
+```json5
     "telemetry.enableCrashReporter": false
 ```
 

--- a/release-notes/July_2016.md
+++ b/release-notes/July_2016.md
@@ -39,13 +39,13 @@ Note that quick suggestions and `kbstyle(Tab)` completion might interfere becaus
 
 Either disable quick suggestions:
 
-```json
+```json5
     "editor.quickSuggestions": false
 ```
 
 or remove snippets from the suggest widget:
 
-```json
+```json5
     "editor.snippetSuggestions": "none"
 ```
 

--- a/release-notes/June_2016.md
+++ b/release-notes/June_2016.md
@@ -300,7 +300,7 @@ If a debug extension supports _step back_ we now expose a step back action and b
 
 Initiated by a [user request](https://github.com/Microsoft/vscode/issues/1873), it is now possible to specify OS specific configurations inside a `launch.json`:
 
-```json
+```json5
 {
    "type": "node",
    "request": "launch",
@@ -325,7 +325,7 @@ Since it is not very practical to always having to edit the launch configuration
 
 Here is a launch configuration that uses the `${command:PickProcess}` variable to let the user select a Node.js process before starting the debug session:
 
-```json
+```json5
 {
    "name": "Attach to Process",
    "type": "node",
@@ -347,7 +347,7 @@ It works in two steps:
 
 A menu item is defined for a menu location like `editor/context` and must at least specify the `command` to run. To avoid overly cluttered menus, a menu item should also specify a condition under which it shows. Last, an alternative command and a group into which the item is sorted can be defined. Groups are visually separated and there is a special group called _navigation_ which is the most prominent.
 
-```json
+```json5
 "commands": [{
     "command": "markdown.showPreview",
     "title": "Open Preview",

--- a/release-notes/May_2016.md
+++ b/release-notes/May_2016.md
@@ -92,7 +92,7 @@ It is now possible to write a key binding rule that targets the removal of a spe
 
 Here is an example:
 
-```json
+```json5
 // In Default Keyboard Shortcuts
 ...
 { "key": "tab", "command": "tab", "when": ... },
@@ -121,7 +121,7 @@ For example, here we Peek (`kb(editor.action.previewDeclaration)`) at the defini
 
 The [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) now supports a "fix all problems" command. You can bind the `eslint.fixAllProblems` command to a keyboard shortcut, such as:
 
-```json
+```json5
 [
     { "key": "ctrl+shift+alt+f",   "command": "eslint.fixAllProblems",
                                      "when": "editorTextFocus" }
@@ -183,7 +183,7 @@ More details can be found [here](https://github.com/microsoft/vscode/issues/4615
 
 Extensions can now contribute TextMate grammars that inject new rules into the existing grammars used for syntax highlighting. This makes it possible to add colorization inside string literals or comments, such as highlighting of URLs or TODO markers across multiple languages.
 
-```json
+```json5
 "grammars": [
   {
     "scopeName": "source.todo",

--- a/release-notes/v0_7_0.md
+++ b/release-notes/v0_7_0.md
@@ -82,7 +82,7 @@ We also updated the quick fix code action. *Add /// reference for typing file* w
 
 We added the ability to exclude files and folders from a project via the addition of an `exclude` property in the `jsconfig.json`. This is useful when you want to exclude folders with generated JavaScript code.
 
-```json
+```json5
 {
 	"compilerOptions": {
 		"target": "ES6"

--- a/release-notes/v1_10.md
+++ b/release-notes/v1_10.md
@@ -161,7 +161,7 @@ With these new commands, we now consistently support `kbstyle(Ctrl+P)` and `kbst
 
 For example, on macOS to change the command to open from the File Explorer to be `kbstyle(Enter)` (which normally brings you into rename mode), configure:
 
-```json
+```json5
 {
     "key": "enter",
     "command": "list.select",
@@ -199,7 +199,7 @@ Per [user request](https://github.com/Microsoft/vscode/issues/19431), we have ad
 
 New settings have been added that define the currently active Color and File Icon theme:
 
-```json
+```json5
 {
   // Specifies the color theme used in the workbench.
   "workbench.colorTheme": "Default Dark+",
@@ -278,7 +278,7 @@ Thanks to [Cody Hoover](https://github.com/hoovercj) for the contribution.
 
 The CSS, LESS and SCSS color preview decorators can now be disabled in the settings:
 
-```json
+```json5
   "css.colorDecorators.enable": true,
   "scss.colorDecorators.enable": true,
   "less.colorDecorators.enable": true
@@ -342,7 +342,7 @@ Starting with this release, we now support the colon character ':' as a prefix s
 
 This makes command variables (where the command ID itself uses '.') much more readable:
 
-```json
+```json5
 "processID": "${command:extension.node-debug.pickProcess}"
 ```
 
@@ -352,7 +352,7 @@ It is now possible to have a precondition based on the current debug type. Preco
 
 Here's an example of a shortcut that will only be enabled while you are debugging with `type` 'node':
 
-```json
+```json5
 { "key": "f6", "command": "workbench.action.debug.continue", "when": "debugType == 'node'" }
 ```
 
@@ -386,7 +386,7 @@ You can now bind a keyboard shortcut to any task you want.
 
 Simply add a key binding like this:
 
-```json
+```json5
 {
     "key": "ctrl+h",
     "command": "workbench.action.tasks.runTask",
@@ -402,7 +402,7 @@ As announced in the previous release, we are working on running tasks in the Int
 
 The `tasks.json` file looks like this:
 
-```json
+```json5
 {
     "version": "2.0.0",
     "tasks": [
@@ -465,7 +465,7 @@ When registering commands in `package.json`, they will automatically be shown in
 
 The snippet below makes the 'Hello World' command only visible in the **Command Palette** when something is selected in the editor:
 
-```json
+```json5
 "commands": [{
     "command": "extension.sayHello",
     "title": "Hello World"
@@ -493,7 +493,7 @@ editor.trimAutoWhitespace
 
 Following example contributes default editor settings for the `markdown` language.
 
-```json
+```json5
 contributes": {
     "configurationDefaults": {
         "[markdown]": {

--- a/release-notes/v1_11.md
+++ b/release-notes/v1_11.md
@@ -177,7 +177,7 @@ We have improved the filtering and scoring of suggestions. In addition to prefix
 
 There is no more eager IntelliSense when typing in comments or strings! You can still request completions with `kbstyle(Ctrl+Space)` but quick suggestions, AKA "24x7 IntelliSense", are disabled by default in comments and strings. To tune the suggestions behavior to your needs, we now allow more control over the `editor.quickSuggestions` setting:
 
-```json
+```json5
 "editor.quickSuggestions": {
     "comments": false, // <- no 24x7 IntelliSense in comments
     "strings": true, // but in strings and the other parts of source files

--- a/release-notes/v1_12.md
+++ b/release-notes/v1_12.md
@@ -182,7 +182,7 @@ To enable type checking for JavaScript files that are part of a `jsconfig.json` 
 
 `jsconfig.json`:
 
-```json
+```json5
 {
     "compilerOptions": {
         "checkJs": true
@@ -195,7 +195,7 @@ To enable type checking for JavaScript files that are part of a `jsconfig.json` 
 
 `tsconfig.json`:
 
-```json
+```json5
 {
     "compilerOptions": {
         "allowJs": true,
@@ -225,7 +225,7 @@ You can now more quickly bold or italicize text in a Markdown document using sni
 
 You can also setup a key binding to use these snippets:
 
-```json
+```json5
 {
     "key": "cmd+k 8",
     "command": "editor.action.insertSnippet",

--- a/release-notes/v1_13.md
+++ b/release-notes/v1_13.md
@@ -265,7 +265,7 @@ You can opt into the new tasks version 2.0.0 but please note that this version i
 
 To enable the tasks preview, set the `version` attribute to `"2.0.0"` :
 
-```json
+```json5
 {
   "version": "2.0.0"
 }
@@ -412,7 +412,7 @@ Thanks to [@eamodio](https://github.com/eamodio), with [PR #24570](https://githu
 
 For example, an extension with the `package.json`:
 
-```json
+```json5
 {
   ...
   "activationEvents": [

--- a/release-notes/v1_14.md
+++ b/release-notes/v1_14.md
@@ -105,7 +105,7 @@ In addition, a new command `workbench.action.quickSwitchWindow` was added to qui
 
 As an example, to use this feature with the `Ctrl+R` keyboard shortcut, configure the following rule in the keybindings editor:
 
-```json
+```json5
 {
     "key": "ctrl+r",
     "command": "workbench.action.quickSwitchWindow"
@@ -129,7 +129,7 @@ The following example demonstrates how to configure quick navigate keybindings t
 
 As an example, to use this feature with the `Ctr+J` keyboard shortcut, configure the following rule in the keybindings editor:
 
-```json
+```json5
 {
     "key": "ctrl+j",
     "command": "workbench.action.quickOpenRecent"
@@ -222,7 +222,7 @@ Many cool features come with the new task format:
 
 *  As you can see from the image above, auto-detected tasks are prefixed with the type of task ('npm:', 'gulp:', 'grunt:', 'tsc:', or 'jake:'). If you are referencing an auto-detected task in another file, for example as a `preLaunchTask` in `launch.json`, you will need to update that task reference with the prefix. Assuming you have the following `launch.json` and the "build" task comes from a gulp file,
 
-```json
+```json5
 {
     "version": "0.1.0",
     "configurations": [
@@ -236,7 +236,7 @@ Many cool features come with the new task format:
 
 you now need to change this to:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "configurations": [
@@ -255,7 +255,7 @@ you now need to change this to:
 * Guided default build task selection. Simple run `Configure Default Build Task` from the global menu bar.
 * And of course you can still define your own custom tasks in the `tasks.json` file with full control over how they are executed in the terminal. For example, the tasks below executes a test script in the terminal and uses a new terminal for every test run:
 
-  ```json
+  ```json5
   {
     "version": "2.0.0",
     "tasks": [
@@ -279,7 +279,7 @@ you now need to change this to:
 Consult the [tasks documentation](https://code.visualstudio.com/docs/editor/tasks) for a detailed list of new features and how to use them as well as instructions on how to best convert a `0.1.0` version `tasks.json` file to a `2.0.0`.
 
 Since we are now auto detecting all Gulp, Grunt, Jake and npm tasks available in a workspace you need to qualify the task name with the task runner when referencing it from a launch.json file. Assuming you have the following launch.json
-```json
+```json5
 {
     "version": "0.1.0",
     "configurations": [
@@ -291,7 +291,7 @@ Since we are now auto detecting all Gulp, Grunt, Jake and npm tasks available in
 }
 ```
 and the `"build"` task comes from a gulp file you now need to change this to:
-```json
+```json5
 {
     "version": "0.1.0",
     "configurations": [
@@ -324,7 +324,7 @@ Thanks to a community [pull request](https://github.com/Microsoft/vscode/pull/23
 
 On Windows, it was previously necessary to include the correct file extension in the `runtimeExecutable` path, leading to complicated cross platform configurations:
 
-```json
+```json5
     "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/nodemon",
     "windows": {
         "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/nodemon.cmd"
@@ -333,7 +333,7 @@ On Windows, it was previously necessary to include the correct file extension in
 
 With this release, it is no longer necessary to include the file extension which makes the path portable across all platforms:
 
-```json
+```json5
     "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/nodemon"
 ```
 
@@ -345,7 +345,7 @@ In this release, we have simplified this feature by eliminating the need to set 
 
 With this feature, the debug configuration for globally installed **nodemon** simplifies to:
 
-```json
+```json5
 {
     "name": "Launch server.js via nodemon",
     "type": "node",
@@ -476,7 +476,7 @@ The new Emmet model supports the following Emmet settings:
 
     Add **Emmet: Expand Abbreviation** and **Emmet: Wrap with Abbreviation** support to the language of your choice by providing a mapping to an existing Emmet supported language. The new language goes on the left and the Emmet supported language on the right. Use language ids for both sides of the mapping.
     For example:
-    ```json
+    ```json5
     "emmet.includeLanguages": {
         "javascript": "javascriptreact",
         "vue-html": "html",
@@ -492,7 +492,7 @@ The new Emmet model supports the following Emmet settings:
 
     See [Emmet Customization of output profile](https://docs.emmet.io/customization/syntax-profiles/#create-your-own-profile) to learn how you can customize the output of your HTML abbreviations.
     For example:
-    ```json
+    ```json5
     "emmet.syntaxProfiles": {
         "html": {
             "attr_quotes": "single"
@@ -507,7 +507,7 @@ The new Emmet model supports the following Emmet settings:
 
     Customize variables used by Emmet snippets.
     For example:
-    ```json
+    ```json5
     "emmet.variables": {
         "lang": "de",
         "charset": "UTF-16"
@@ -536,7 +536,7 @@ With this release, you can have auto indentation adjustment while typing, moving
 
 We made some earlier improvements to the indentation rules in the 1.9 release. With this release, language extension authors can declare the indentation rules in a `language-configuration.json` file instead of registering them in the extension activation phase.
 
-```json
+```json5
 {
   "indentationRules": {
     "increaseIndentPattern": "^\\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
@@ -599,7 +599,7 @@ You can now control the visibility of a custom view by providing the `when` cont
 
 Example:
 
-```json
+```json5
 "views": {
     "explorer": [
         {
@@ -760,7 +760,7 @@ export interface WorkspaceConfiguration2 extends WorkspaceConfiguration {
 
 **Note:** The API is still proposed and you will need to enable it per extension. In the `package.json` file of your extension, add the following line:
 
-```json
+```json5
 "enableProposedApi": true
 ```
 

--- a/release-notes/v1_15.md
+++ b/release-notes/v1_15.md
@@ -89,7 +89,7 @@ With snippet choices, a placeholder can be prefilled with a set of values. The s
 
 Below is a working sample specifying a fixed set of color choices:
 
-```json
+```json5
 "color": {
   "prefix": "color",
   "body": "> Pick your favorite color ${1|red,green,blue,pink|}.\n< He likes $1."
@@ -195,7 +195,7 @@ The existing command `workbench.action.quickOpen` can now receive a prefix as an
 
 For example, you can configure a keybinding to bring up **Quick Open** with text prefilled like this:
 
-```json
+```json5
 { "key": "cmd+o", "command": "workbench.action.quickOpen", "args": "my-prefix" }
 ```
 
@@ -359,7 +359,7 @@ Custom Debug Adapter Protocol requests can be sent to a debug session with `Debu
 
 You can now contribute views to the Debug Side Bar.
 
-```json
+```json5
 "contributes": {
   "views": {
     "debug": [
@@ -406,7 +406,7 @@ You can now classify the settings you contribute to `configuration` extension po
 * `window`: Window specific configuration which can be applied to the VS Code window and can be configured in the User and Workspace settings.
 * `resource`: Resource specific configuration, which can be applied to the resources like files and folders and can be configured in the User, Workspace and Folder settings.
 
-```json
+```json5
 "configuration": {
   "type": "object",
   "title": "MyLint",

--- a/release-notes/v1_16.md
+++ b/release-notes/v1_16.md
@@ -266,7 +266,7 @@ The extension host process is now looking at the stack-traces of uncaught errors
 
 Extension can now contribute new themable colors. These colors can be used in decorators and in the Status Bar.
 
-```json
+```json5
   "colors": [{
       "id": "superstatus.error",
       "description": "Color for error message in the status bar.",
@@ -398,7 +398,7 @@ The contents of the workspace file (`*.code-workspace`) was changed during this 
 
 A new workspace file now looks like this:
 
-```json
+```json5
 {
   "folders": [
     {

--- a/release-notes/v1_17.md
+++ b/release-notes/v1_17.md
@@ -138,7 +138,7 @@ The snippet picker drop-down shown by the **Insert Snippet** command now display
 
 The VS Code snippet engine now supports variable transformations. Transformations can change the value of a variable before inserting it. The format is `var_name/regular_expression/format_string/options`. The sample below is a snippet that creates a public Java class whose name is derived from the filename.
 
-```json
+```json5
   "Public Class": {
     "prefix": "pclass",
     "body": [
@@ -194,7 +194,7 @@ The format for the `filter.commentAfter` preference is different and simpler in 
 
 For example, instead of the older format
 
-```json
+```json5
 "emmet.preferences": {
     "filter.commentAfter": "\n<!-- /<%= attr('id', '#') %><%= attr('class', '.') %> -->"
 }
@@ -202,7 +202,7 @@ For example, instead of the older format
 
 you would use
 
-```json
+```json5
 "emmet.preferences": {
     "filter.commentAfter": "\n<!-- /[#ID][.CLASS] -->"
 }
@@ -246,7 +246,7 @@ With this feature, you can add a `useWSL` flag to a debug configuration to make 
 
 Here is the simplest debug configuration for debugging `hello.js` in WSL:
 
-```json
+```json5
 {
     "type": "node",
     "request": "launch",
@@ -457,7 +457,7 @@ interface CompletionContext {
 
 Extensions can now contribute commands to the touch bar on macOS. A new menu identifier `touchBar` was added for this purpose:
 
-```json
+```json5
 "contributes": {
   "menus": {
     "touchBar": [

--- a/release-notes/v1_18.md
+++ b/release-notes/v1_18.md
@@ -117,7 +117,7 @@ The terminal now supports the escape sequence for faint text:
 
 You can already set custom environment variables for Integrated Terminal sessions but now you can also clear existing variables by assigning them to null in the `terminal.integrated.env.<platform>` settings:
 
-```json
+```json5
 "terminal.integrated.env.linux": {
   "HOME": null
 }
@@ -176,7 +176,7 @@ This Quick Fix will install the `@types` definition locally and add it to the `d
 
 VS Code automatically generates both build and build+watch tasks for all `tsconfig.json` files in your workspace. In VS Code 1.18, the `typescript.tsc.autoDetect` setting now lets you control which kinds of tasks are generated:
 
-```json
+```json5
 "typescript.tsc.autoDetect": "build" // only generate build tasks
 "typescript.tsc.autoDetect": "watch" // only generate build+watch tasks
 "typescript.tsc.autoDetect": "on"    // Generate both (default)

--- a/release-notes/v1_20.md
+++ b/release-notes/v1_20.md
@@ -99,7 +99,7 @@ Zoom in and out by clicking, using the scroll wheel (with `Ctrl` on Windows/Linu
 
 You can now fine tune a specific color theme in your user settings:
 
-```json
+```json5
 "editor.tokenColorCustomizations": {
     "[Monokai]": {
         "comments": "#229977"
@@ -160,7 +160,7 @@ The Output panel also now consumes less memory resources with our new implementa
 
 VS Code now supports global snippets meaning snippets that aren't scoped to a single language but can target any kind of files. Using the  **Preferences: Configure User Snippets** command, select the **New Global Snippets file...** option which will open a `.code-snippets` file for new snippets.  Use the `scope` attribute to list the languages that are targeted by a snippet. For instance, the snippet below can add a copyright header for JavaScript and TypeScript files:
 
-```json
+```json5
 "JS & TS Stub": {
   "scope": "javascript,typescript",
   "prefix": "stub",
@@ -197,7 +197,7 @@ We have added new snippet variables to read your clipboard, `CLIPBOARD`, and to 
 
 The new `editor.action.codeAction` command lets you configure keybindings for specific Code Actions. This keybinding for example triggers the Extract function refactoring Code Actions:
 
-```json
+```json5
 {
   "key": "ctrl+shift+r ctrl+e",
   "command": "editor.action.codeAction",
@@ -215,7 +215,7 @@ Using the above keybinding, if only a single `"refactor.extract.function"` Code 
 
 You can also control how/when Code Actions are automatically applied using the `apply` argument:
 
-```json
+```json5
 {
   "key": "ctrl+shift+r ctrl+e",
   "command": "editor.action.codeAction",
@@ -365,7 +365,7 @@ Alternatively new launch configurations can be added via the **Add Config (works
 
 A compound launch configuration can reference the individual launch configurations by name as long as the names are unique within the workspace, for example:
 
-```json
+```json5
   "compounds": [{
       "name": "Launch Server & Client",
       "configurations": [
@@ -377,7 +377,7 @@ A compound launch configuration can reference the individual launch configuratio
 
 If the individual launch configuration names are not unique, the qualifying folder can be specified with a more verbose "folder" syntax:
 
-```json
+```json5
   "compounds": [{
       "name": "Launch Server & Client",
       "configurations": [
@@ -398,7 +398,7 @@ In addition to `compounds` the `launch` section of the workspace configuration f
 
 Here is an example for a launch configuration where the program lives in a folder "Program" and where all files from a folder "Library" should be skipped when stepping:
 
-```json
+```json5
 "launch": {
   "configurations": [{
       "type": "node",
@@ -430,7 +430,7 @@ For node-debug we've added a mechanism that tracks all subprocesses of a debugge
 
 The feature is enabled by setting the launch config attribute `autoAttachChildProcesses` to true:
 
-```json
+```json5
 {
   "type": "node",
   "request": "launch",
@@ -450,7 +450,7 @@ If you are using "nvm" (or "nvm-windows") to manage your Node.js versions it is 
 
 Here is an example launch config:
 
-```json
+```json5
 {
   "type": "node",
   "request": "launch",
@@ -559,7 +559,7 @@ Custom views will become better and better with following additions to the API:
 
 Extension authors can now contribute inline actions to tree items using `inline` group in `view/item/context` menu contribution. For example:
 
-```json
+```json5
 "contributes": {
   "commands": [
     {
@@ -648,7 +648,7 @@ Several menus now have new group identifiers for finer control on command placem
 
 Keyboard shortcut contexts allow users to control when keybindings are active. They are also referred to as [when](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts) clauses because they define *when* a keybinding is active or enabled. In this release, there is a new key-value pair operator for `when` clauses. The expression `key =~ value` treats the right hand side as a regular expression to match against the left hand side. For example, to contribute context menu items for all Docker files, one could use:
 
-```json
+```json5
    "when": "resourceFileName =~ /docker/"
 ```
 

--- a/release-notes/v1_21.md
+++ b/release-notes/v1_21.md
@@ -140,7 +140,7 @@ You can now get CSS Emmet completions in a style attribute in an HTML file when 
 
 To get completions automatically without using the manual trigger, enable the quick suggestions feature for strings in HTML files by adding the following to your settings:
 
-```json
+```json5
 "[html]": {
     "editor.quickSuggestions": {
         "other": true,
@@ -317,7 +317,7 @@ You can provide a tooltip to an item in the view using the property `tooltip` in
 
 If your extension has some clean ups to be done when it is uninstalled from VS Code, you can now do that by registering a `node` script to the uninstall hook `vscode:uninstall` under `scripts` section in extension's `package.json`.
 
-```json
+```json5
 {
   "scripts": {
     "vscode:uninstall": "node ./out/src/lifecycle"
@@ -333,7 +333,7 @@ This script gets executed when the extension is completely uninstalled from VS C
 
 There's a new keybinding context key ('when' clause) available which uses the ID of the currently open view: `activeViewlet`. Example usage:
 
-```json
+```json5
   "when": "activeViewlet == workbench.view.scm"
 ```
 

--- a/release-notes/v1_22.md
+++ b/release-notes/v1_22.md
@@ -53,7 +53,7 @@ Support for TypeScript and JavaScript is also available, and can be enabled by t
 
 If you prefer to switch back to indentation based folding for one (or all) of the languages above, use:
 
-```json
+```json5
   "[html]": {
     "editor.foldingStrategy": "indentation"
   },
@@ -144,7 +144,7 @@ Expanding Emmet abbreviations in large CSS/SCSS/Less files is much faster now. T
 
 Emmet abbreviations in stylesheets are fuzzy matched with [pre-defined snippets](https://github.com/emmetio/snippets/blob/v0.2.9/css.json) to give you the closest matched result. You can control the fuzzy matching accuracy by changing the `css.fuzzySearchMinScore` setting in `emmet.preferences`. `css.fuzzySearchMinScore` sets the minimum score a snippet needs to be considered a match. Increasing the score will result in fewer but more accurate matches. The default value is 0.3 and you can provide any value between 0 and 1.
 
-```json
+```json5
 "emmet.preferences": {
     "css.fuzzySearchMinScore": 0.3
 }
@@ -246,7 +246,7 @@ Logpoints are currently supported by VS Code's built-in Node.js debugger, but we
 
 We have added `postDebugTask` support in `launch.json`. This task is run after a debug session finishes. Similar to `preLaunchTask`, you can reference tasks in your `tasks.json` by a name. Here's an example of a launch configuration using a `postDebugTask`:
 
-```json
+```json5
 {
     "name": "Attach to node server",
     "type": "node",
@@ -291,7 +291,7 @@ The individual process items listed in the picker show the debug port and the de
 
 Tasks have been updated to give users better control over how arguments and the command itself are quoted when executed in a shell like bash or PowerShell. Tasks of type `shell` now support providing the command and its argument separately. Below is an example of a task that list the directory of a folder named `folder with spaces` (observe the space in the name).
 
-```json
+```json5
 {
   "label": "dir",
   "type": "shell",
@@ -304,7 +304,7 @@ Tasks have been updated to give users better control over how arguments and the 
 
 Since the shell tasks specifies the argument separately, VS Code knows that it should be passed as one argument to the 'dir' command and quotes the argument based on the shell used. For `cmd.exe`, VS Code uses `"`, for PowerShell `'`, and for shells under Linux and macOS `'` as well. If you want to control how the argument is quoted, the argument can be a literal specifying the value and a quoting style. For example:
 
-```json
+```json5
 {
   "label": "dir",
   "type": "shell",

--- a/release-notes/v1_23.md
+++ b/release-notes/v1_23.md
@@ -51,7 +51,7 @@ VS Code can now highlight the active indent guide, as you move your cursor betwe
 
 The highlight color name is `editorIndentGuide.activeBackground`, which you can modify in the `workbench.colorCustomizations` setting:
 
-```json
+```json5
 "workbench.colorCustomizations": {
     "editorIndentGuide.activeBackground": "#ff0000"
 }
@@ -61,7 +61,7 @@ The highlight color name is `editorIndentGuide.activeBackground`, which you can 
 
 The new `editor.codeActionsOnSave` setting lets you configure a set of Code Actions that are run when a file is saved. For example, for JavaScript, TypeScript, and other extensions that contribute an organize imports Code Action, you can enable organize imports on save by [setting](https://code.visualstudio.com/docs/getstarted/settings):
 
-```json
+```json5
 "editor.codeActionsOnSave": {
      "source.organizeImports": true
 }
@@ -69,7 +69,7 @@ The new `editor.codeActionsOnSave` setting lets you configure a set of Code Acti
 
 You can also enable or disable which Code Actions are run on save per language using a [language specific setting](https://code.visualstudio.com/docs/getstarted/settings#_language-specific-editor-settings). The following settings enable organize imports on save for TypeScript files only:
 
-```json
+```json5
 "[typescript]": {
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
@@ -234,7 +234,7 @@ The JavaScript and TypeScript organize imports feature is now out of preview. Ru
 
 You can now also configure organize imports to be run on save using the new [`editor.codeActionsOnSave` setting](#run-code-actions-on-save). Here are the settings to enable organize imports on save for TypeScript files:
 
-```json
+```json5
 "[typescript]": {
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
@@ -275,7 +275,7 @@ As more and more extensions are creating custom views and the majority of them a
 
 A new Test contribution is now provided in the Activity Bar for the extensions to contribute Test related views. This Test contribution is empty and hidden by default and is shown whenever views are contributed to it. The example shows how the `mocha` custom view is contributed to the **Test** activity in the Activity Bar.
 
-```json
+```json5
 "contributes": {
     "views": {
         "test": [
@@ -294,7 +294,7 @@ A new Test contribution is now provided in the Activity Bar for the extensions t
 
 An extension can now define additional activities in the Activity Bar using the contribution point `viewsContainers`.
 
-```json
+```json5
 "contributes": {
         "viewsContainers": {
             "activitybar": [
@@ -345,7 +345,7 @@ A command is registered to show each registered view container. In the Package E
 
 You can now contribute Source Control Management (SCM) related custom views into the Source Control view container in the Activity Bar. You can show, hide and re-order these views just like in the Explorer.
 
-```json
+```json5
 "contributes": {
     "views": {
         "scm": [
@@ -420,7 +420,7 @@ A [new extension authoring page](https://code.visualstudio.com/docs/extensions/w
 
 If you want your settings to be applied at application level and not get overridden at a window or resource level, you can do that now by using `application` scope.
 
-```json
+```json5
 "configuration": {
     "properties": {
         "git.path": {

--- a/release-notes/v1_24.md
+++ b/release-notes/v1_24.md
@@ -72,7 +72,7 @@ Use the following keybindings to replace the default global zoom actions:
 
 on macOS:
 
-```json
+```json5
 { "key": "cmd+numpad_add",      "command": "editor.action.fontZoomIn" },
 { "key": "shift+cmd+=",         "command": "editor.action.fontZoomIn" },
 { "key": "cmd+=",               "command": "editor.action.fontZoomIn" },
@@ -85,7 +85,7 @@ on macOS:
 
 on Windows and Linux:
 
-```json
+```json5
 { "key": "ctrl+numpad_add",      "command": "editor.action.fontZoomIn" },
 { "key": "shift+ctrl+=",         "command": "editor.action.fontZoomIn" },
 { "key": "ctrl+=",               "command": "editor.action.fontZoomIn" },
@@ -263,7 +263,7 @@ Syntax aware folding is now enabled by default for JavaScript and TypeScript. A 
 
 The new syntax aware folding should match the old indentation based folding in most cases, however indentation based folding sometimes creates more folding ranges that you may be used to. To revert back to using the old indentation based folding, set:
 
-```json
+```json5
 "[javascript]": {
   "editor.foldingStrategy": "indentation"
 },

--- a/release-notes/v1_25.md
+++ b/release-notes/v1_25.md
@@ -127,7 +127,7 @@ We have new commands for sub-word navigation and sub-word deletion. These comman
 
 Here is an example for how you can bind them:
 
-```json
+```json5
 { "key": "ctrl+alt+right",          "command": "cursorWordPartRight",
                                        "when": "textInputFocus" },
 { "key": "ctrl+shift+alt+right",    "command": "cursorWordPartRightSelect",
@@ -154,7 +154,7 @@ Snippets finally support placeholder transformations. Placeholder transformation
 
 Below is a sample that replaces "Hello World" with its German counterpart:
 
-```json
+```json5
 "HelloWorld": {
   "prefix": "say_hello",
   "body": "${1} ${2} -> ${1/Hello/Hallo/} ${2/World/Welt/}"
@@ -175,7 +175,7 @@ The Integrated Terminal's parser was re-written from the ground up for enhanced 
 
 The terminal currently converts all bold text to use the bright color variant. This is a little inconsistent across terminal emulators and is mostly around for legacy reasons. You can now turn this automatic conversion off to allow the use of non-bright colors for bold text.
 
-```json
+```json5
 {
   "terminal.integrated.drawBoldTextInBrightColors": false
 }
@@ -326,7 +326,7 @@ An experimental setting has been added to enable the new "dynamic texture atlas"
 
 This will eventually be the default, for now you can opt-in with the following setting:
 
-```json
+```json5
 {
   "terminal.integrated.experimentalTextureCachingStrategy": "dynamic"
 }
@@ -356,7 +356,7 @@ The new `vscode.setEditorLayout` deserves a bit of explanation as it allows you 
 
 Example for a 2x2 grid:
 
-```json
+```json5
 { orientation: 0, groups: [{ groups: [{}, {}], size: 0.5 }, { groups: [{}, {}], size: 0.5 }] }
 ```
 
@@ -540,7 +540,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 The extension must also add a `onWebviewPanel` activation event:
 
-```json
+```json5
 "activationEvents": [
     ...,
     "onWebviewPanel:catCoding"
@@ -792,7 +792,7 @@ Key|Command|Command id
 
 The `layoutEditorGroups` command lets you create an editor group layout and assign it a keybinding. The layout is described as an object with an initial (optional) orientation (`0` = horizontal, `1` = vertical) and an array of editor `groups` within. Each editor group can have a `size` and another array of editor `groups` that will be laid out orthogonal to the orientation. If editor group sizes are provided, their sum must be `1` to be applied per row or column. For example:
 
-```json
+```json5
 {
     "key": "Ctrl+0",
     "command": "layoutEditorGroups",

--- a/release-notes/v1_26.md
+++ b/release-notes/v1_26.md
@@ -343,7 +343,7 @@ Defining an Extension Pack now uses a new property called `extensionPack` instea
 
 An Extension Pack should not have any functional dependencies with its bundled extensions and they should be manageable independent of the pack. Below is an example `extensionPack` entry which defines an Extension Pack that bundles several debugger extensions.
 
-```json
+```json5
 "extensionPack": [
     "andreweinand.mock-debug",
     "ms-vscode.mono-debug",

--- a/release-notes/v1_27.md
+++ b/release-notes/v1_27.md
@@ -97,7 +97,7 @@ The **Tasks** menu was renamed to **Terminal** and some more entries for the Int
 
 It's now possible to enable keyboard shortcuts for specific operating systems using `isLinux`, `isMac` and `isWindows` within a keybinding's `when` clause:
 
-```json
+```json5
 {
   "key": "ctrl+o",
   "command": "workbench.action.files.openFolder",
@@ -164,7 +164,7 @@ The built-in JSON language extension now supports the new [JSON Schema Draft-07]
 
 The most interesting addition are the `if`, `then`, `else` keywords to allow conditional schema evaluation.
 
-```json
+```json5
 {
     "type": "integer",
     "minimum": 1,
@@ -235,7 +235,7 @@ Previously, when building Language Server extensions using `vscode-languageclien
 
 `[langId].trace.server` can now output logging information in a machine-readable [JSON format](https://github.com/Microsoft/language-server-protocol-inspector#log-format):
 
-```json
+```json5
 "languageServerExample.trace.server": {
   "format": "json", // or "text"
   "verbosity": "verbose" // or "off" | "messages"

--- a/release-notes/v1_5.md
+++ b/release-notes/v1_5.md
@@ -118,7 +118,7 @@ We always provided an action to reopen an editor after it was closed, `workbench
 
 We decided to remove an (undocumented) key binding to bring up quick open for file search. You can bring back `kbstyle(Cmd+E)` with the following key binding configuration:
 
-```json
+```json5
 { "key": "cmd+e", "command": "workbench.action.quickOpen" }
 ```
 
@@ -140,7 +140,7 @@ The **More Information** action takes you to documentation for how to configure 
 
 New settings have been added to control which built-in code completion providers are active. Use these settings if you prefer not to see the corresponding proposals.
 
-```json
+```json5
 // Configures if the built-in HTML language suggests Angular V1 tags and properties.
 "html.suggest.angular1": true,
 
@@ -169,7 +169,7 @@ You can now associate existing Emmet syntax profiles (such as `html`, `css`) wit
 
 For example, to use Emmet HTML abbreviations inside JavaScript:
 
-```json
+```json5
 {
     "emmet.syntaxProfiles": {
         "javascript": "html"
@@ -179,7 +179,7 @@ For example, to use Emmet HTML abbreviations inside JavaScript:
 
 You can disable Emmet abbreviations for a particular language using the  `emmet.excludeLanguages` setting. The setting below disables Emmet in PHP files:
 
-```json
+```json5
 {
     "emmet.excludeLanguages": [
         "php"
@@ -191,7 +191,7 @@ You can disable Emmet abbreviations for a particular language using the  `emmet.
 
 The `vscode-eslint` and `vscode-tslint` extensions now provide settings to run the linter only on save and not while typing.
 
-```json
+```json5
 {
     "tslint.run": "onSave"
 }

--- a/release-notes/v1_6.md
+++ b/release-notes/v1_6.md
@@ -175,7 +175,7 @@ You can create this file using the **Extensions: Configure Workspace Recommended
 
 For example, this is the `extensions.json` file that we use for the [vscode workspace](https://github.com/Microsoft/vscode/blob/master/.vscode/extensions.json):
 
-```json
+```json5
 {
 	"recommendations": [
 		"eg2.tslint",
@@ -199,7 +199,7 @@ An Extension Pack is represented as an extension that depends on other extension
 
 For example, here is an Extension Pack for PHP that includes a debugger, language service, and formatter:
 
-```json
+```json5
   "extensionDependencies": [
       "felixfbecker.php-debug",
       "felixfbecker.php-intellisense",
@@ -239,7 +239,7 @@ A frequent feature request was to support running 'npm' scripts directly from a 
 
 Let's look at an 'npm' example. If your `package.json` has a 'debug' script, for example:
 
-```json
+```json5
   "scripts": {
     "debug": "node --nolazy --debug-brk=5858 myProgram.js"
   },
@@ -247,7 +247,7 @@ Let's look at an 'npm' example. If your `package.json` has a 'debug' script, for
 
 the corresponding launch configuration would look like this:
 
-```json
+```json5
 {
 	"name": "Launch via NPM",
 	"type": "node",
@@ -274,7 +274,7 @@ In the September release, it is now possible to use multiple glob patterns for i
 
 The following example shows how to configure source maps if the generated code lives in an "out" and "node_modules" directory and you want to exclude the generated test code:
 
-```json
+```json5
 {
   "sourceMaps": true,
   "outFiles": [
@@ -310,7 +310,7 @@ Open the `package.json` file and do the following changes:
 
 The `devDependencies` section should look like this:
 
-```json
+```json5
 "devDependencies": {
     "typescript": "^2.0.3",
     "vscode": "^1.0.0", // Or a higher version if necessary
@@ -322,7 +322,7 @@ The `devDependencies` section should look like this:
 
 and the `scripts` section something like this:
 
-```json
+```json5
 "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
@@ -334,7 +334,7 @@ and the `scripts` section something like this:
 
 The file should look something like this:
 
-```json
+```json5
 {
     "compilerOptions": {
         "module": "commonjs",
@@ -369,7 +369,7 @@ Open the `package.json` file and do the following changes:
 
 The `devDependencies` section should now look something like this:
 
-```json
+```json5
 "devDependencies": {
     "typescript": "^2.0.3",
     "vscode": "^1.0.0", // Or a higher version if necessary
@@ -384,7 +384,7 @@ The `devDependencies` section should now look something like this:
 
 The file should look something like this:
 
-```json
+```json5
 {
     "compilerOptions": {
         "module": "commonjs",

--- a/release-notes/v1_7.md
+++ b/release-notes/v1_7.md
@@ -156,7 +156,7 @@ Note: If you have already been helping us testing the latest grammar using the [
 
 The `vscode-eslint` and `vscode-tslint` extensions now provide settings to automatically correct fixable warnings on save.
 
-```json
+```json5
 {
     "eslint.autoFixOnSave": true,
     "tslint.autoFixOnSave": true,
@@ -285,7 +285,7 @@ We added an additional place where extensions can contribute menu entries, the c
 
 For example:
 
-```json
+```json5
 "commands": [{
     "command": "doSomething",
     "title": "Do Something"

--- a/release-notes/v1_8.md
+++ b/release-notes/v1_8.md
@@ -150,7 +150,7 @@ We added support to invoke commands with arguments to the `keybindings.json` con
 
 The following is an example overriding the `kbstyle(Enter)` key to print some text:
 
-```json
+```json5
   { "key": "enter", "command": "type",
                     "args": { "text": "Hello World" },
                     "when": "editorTextFocus" }
@@ -230,7 +230,7 @@ The following variables can be used:
 
 The following is an example of a snippet that surrounds the selected text with single quotes or, when no text is selected, inserts a `type_here`-placeholder.
 
-```json
+```json5
 "in quotes": {
 	"prefix": "inq",
 	"body": "'${TM_SELECTED_TEXT:${1:type_here}}'"
@@ -310,7 +310,7 @@ Using multi-target debugging is very simple: after you've started a first debug 
 
 An alternative way to start multiple debug session is by using a so-called _compound_ launch configuration. A compound launch configuration lists the names of two or more launch configurations that should be launched in parallel. Compound launch configurations show up in the launch configuration drop down menu.
 
-```json
+```json5
 {
     "version": "0.2.0",
     "configurations": [

--- a/release-notes/v1_9.md
+++ b/release-notes/v1_9.md
@@ -200,7 +200,7 @@ You can also configure language based settings by directly opening `settings.jso
 
 The following examples customize editor settings for language modes `typescript` and `markdown`.
 
-```json
+```json5
 {
   "[typescript]": {
     "editor.formatOnSave": true,
@@ -219,7 +219,7 @@ You can use IntelliSense in Settings editor to help you find allowed language ba
 
 **Note**: The following settings are not currently supported but will be in the next release. Please refer to [#19511](https://github.com/Microsoft/vscode/issues/19511) for more information.
 
-```json
+```json5
 editor.tabSize
 editor.insertSpaces
 editor.detectIndentation
@@ -232,7 +232,7 @@ editor.trimAutoWhitespace
 
 You can now define different commands per task ([#981](https://github.com/Microsoft/vscode/issues/981)). This allows running different commands for different tasks without writing your own shell script. A `tasks.json` file using commands per task looks like this:
 
-```json
+```json5
 {
     "version": "0.1.0",
     "tasks": [
@@ -260,7 +260,7 @@ If a `tasks.json` file specifies both global and task local commands, the task l
 
 A task local command can be made OS specific as well. The syntax is the same as for global commands. Here an example that adds an OS specific argument to a command:
 
-```json
+```json5
 {
     "taskName": "build",
     "command": "gulp",
@@ -290,7 +290,7 @@ We implemented a new task execution engine that uses the terminal instead of the
 
 The support is disabled by default, but early adopters can opt in to give feedback on the new implementation. To do so add the `"_runner": "terminal"` property to the top of your `tasks.json` file
 
-```json
+```json5
 {
     "version": "0.1.0",
     "_runner": "terminal",
@@ -340,7 +340,7 @@ We have added a new setting to enable format on paste ([#13945](https://github.c
 
 You can now bind your favorite snippets to key bindings. A sample that encloses a selection with single quotes looks like this:
 
-```json
+```json5
 {
 	"key": "cmd+k '",
 	"command": "editor.action.insertSnippet",
@@ -557,7 +557,7 @@ We've added some finishing touches to the 'Just My Code' feature introduced in t
 
 The following example skips all internal modules but `events.js`:
 
-  ```json
+  ```json5
   "skipFiles": [
      "<node_internals>/**/*.js",
      "!<node_internals>/events.js"
@@ -583,7 +583,7 @@ If this feature is enabled, VS Code restarts a debug session whenever it detects
 
 This launch configuration (available as a snippet through IntelliSense) makes use of `nodemon` and the `restart` option:
 
-```json
+```json5
 {
 	"type": "node",
 	"request": "launch",
@@ -669,7 +669,7 @@ We've added the following (optional) sub-contribution points to the `debuggers` 
 - `startSessionCommand`<BR>takes the ID of a command which VS Code calls for any "debug" or "run" action targeted for this extension. If a launch configuration was selected, it is passed as an argument to the command (and the extension can massage the launch config as desired). If "debug" or "run" is executed without an existing launch config, an empty launch config is passed to the `startSessionCommand` and the extension is expected to "fill in" missing attributes e.g. based on the file currently open in the editor.
 
 - `adapterExecutableCommand`<BR>VS Code launches a debug adapter by using the (static) attributes `program`, `args`, `runtime` and `runtimeArgs` from the package.json of the corresponding extension. Starting with this milestone an extension can alternatively contribute a command where the debug adapters executable path and arguments are dynamically calculated.<BR>Instead of defining the attributes `program`,  `args`, `runtime` and `runtimeArgs` on a debuggers contribution in the package.json, set a new attribute `adapterExecutableCommand` to the ID of a command that is registered in the extension. Make this command return a structure with this format:
-  ```json
+  ```json5
   command: "<executable>",
   args: [ "<argument1>", "<argument2>", ... ]
   ```

--- a/release-notes/vApril.md
+++ b/release-notes/vApril.md
@@ -117,7 +117,7 @@ You can now specify which external shell VS Code will launch when you use comman
 
 For example, to set PowerShell as your external shell on Windows and Terminator on Linux, use:
 
-```json
+```json5
 {
     "terminal.external.windowsExec": "powershell",
     "terminal.external.linuxExec": "terminator"

--- a/release-notes/vDecember.md
+++ b/release-notes/vDecember.md
@@ -199,7 +199,7 @@ We now show breakpoints in a more intuitive way:
 
 Extensions can now contribute JSON schema associations. The `jsonValidation` contribution point takes a file pattern and the URL of the JSON schema.
 
-```json
+```json5
     "contributes": {
         "jsonValidation": [{
             "fileMatch": ".jshintrc",
@@ -210,7 +210,7 @@ Extensions can now contribute JSON schema associations. The `jsonValidation` con
 
 Alternatively, extensions can also give the path to a schema file in the extension folder:
 
-```json
+```json5
     "contributes": {
         "jsonValidation": [{
             "fileMatch": ".htmlhintrc",

--- a/release-notes/vFebruary.md
+++ b/release-notes/vFebruary.md
@@ -126,7 +126,7 @@ VS Code now ships with the latest [TypeScript 1.8.2](https://blogs.msdn.microsof
 
 If you don't already have a `jsconfig.json` file in your workspace, add a `jsconfig.json` file to the root with the `compilerOptions:module` attribute set:
 
-```json
+```json5
 {
     "compilerOptions": {
         "module": "commonjs"
@@ -257,7 +257,7 @@ nodemon --debug server.js
 
 In VS Code, create an 'attach' launch configuration:
 
-```json
+```json5
 {
     "name": "Attach",
     "type": "node",
@@ -298,7 +298,7 @@ You can either install the **Mono Debug** extension with the VS Code **Extension
 
 The `eslint-stylish` problem matcher changed to use absolute file paths by default. We made this breaking change because the stylish reporter integrated into `eslint` reports absolute paths by default. If you are using an older version of `eslint` with the external stylish reporter that reports relative file paths, you can tweak the `problemMatcher` in a tasks.json file as below to make this combination work:
 
-```json
+```json5
 "problemMatcher": {
     "base": "$eslint-stylish",
     "fileLocation": "relative"
@@ -360,7 +360,7 @@ VS Code will now fallback to installing the latest compatible version of an exte
 
 We now support more OS types for the `debuggers` contribution point (see [#1696](https://github.com/Microsoft/vscode/issues/1696) for details). In addition to `win`, `linux`, and `osx`, adapters can now use `winx86` in their `package.json` to specify options specific to a 32-bit Windows:
 
-```json
+```json5
 "debuggers": [{
     "type": "gdb",
     "win": {

--- a/release-notes/vJanuary.md
+++ b/release-notes/vJanuary.md
@@ -274,7 +274,7 @@ The process of installing a specific version of the API into your extension is s
 
 * Set the minimal version of VS Code that your extension requires in the `engine` field of the `package.json`. For example, when you want to upgrade to the `0.10.8` version of the VS Code API then define
 
-```json
+```json5
     "engines": {
         "vscode": "^0.10.7"
     }
@@ -283,7 +283,7 @@ The process of installing a specific version of the API into your extension is s
 * Make sure your devDependency for the `vscode` module is at least `0.11.0`.
 * Add a `postinstall` script to your `package.json` like this:
 
-```json
+```json5
 "scripts": {
   "postinstall": "node ./node_modules/vscode/bin/install"
 }

--- a/release-notes/vMarch.md
+++ b/release-notes/vMarch.md
@@ -75,7 +75,7 @@ The issue is that the `react-native` typings do not define a `default` export. B
 
 In `jsconfig.json`:
 
-```json
+```json5
  {
     "compilerOptions": {
         "allowSyntheticDefaultImports": true
@@ -187,7 +187,7 @@ A very common request was having a configurable way to associate file names and 
 
 Here is an example that will associate more extensions to the PHP language:
 
-```json
+```json5
 "files.associations": {
     "*.php4": "php",
     "*.php5": "php"
@@ -196,7 +196,7 @@ Here is an example that will associate more extensions to the PHP language:
 
 You can also configure full file paths to languages if needed. The following example associates all files in a folder `somefolder` to PHP:
 
-```json
+```json5
 "files.associations": {
     "**/somefolder/*.*": "php"
 }
@@ -214,7 +214,7 @@ We have also added keyboard commands for column selection.  These are bound on W
 
 For example:
 
-```json
+```json5
 { "key": "shift+alt+down",     "command": "cursorColumnSelectDown",
                                   "when": "editorTextFocus" },
 { "key": "shift+alt+left",     "command": "cursorColumnSelectLeft",
@@ -258,7 +258,7 @@ Visual Studio Code stops by default at the beginning of words when using `kbstyl
 
 For example:
 
-```json
+```json5
 { "key": "ctrl+right",       "command": "cursorWordStartRight",
                                 "when": "editorTextFocus" },
 { "key": "ctrl+shift+right", "command": "cursorWordStartRightSelect",
@@ -279,7 +279,7 @@ Some environments explicitly ask to include a BOM (Byte Order Mark) for UTF-8 en
 
 To save all new files with the UTF-8 BOM encoding, configure the `files.encoding` setting to this:
 
-```json
+```json5
 "files.encoding": "utf8bom"
 ```
 
@@ -305,7 +305,7 @@ When you open VS Code on a folder, it installs a file watcher service on the fol
 
 This setting has the following defaults:
 
-```json
+```json5
 "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/node_modules/**": true


### PR DESCRIPTION
GitHub's code blocks support `json5` syntax highlighting that allows for comments to be written in json code. Since most of the json code blocks in the docs have comments, instead of them showing an ugly red highlight, they should be rendered as proper comments.

With language identifier set as `json`:
![2018-10-01-16-59-github com](https://user-images.githubusercontent.com/31861755/46286057-52874680-c59b-11e8-8f31-25b39dc42db8.png)

...and with language identifier set as `json5`:
![2018-10-01-16-57-github com](https://user-images.githubusercontent.com/31861755/46286043-456a5780-c59b-11e8-8c1b-3fa1f2f84c82.png)
 