### PR TITLE
Update information on Portable Mode for Windows

### DIFF
--- a/docs/editor/portable.md
+++ b/docs/editor/portable.md
@@ -9,11 +9,13 @@ MetaDescription: Visual Studio Code supports a Portable Mode.
 ---
 # Portable Mode
 
-Visual Studio Code supports [Portable Mode](https://en.wikipedia.org/wiki/Portable_application). This mode enables all data created and maintained by VS Code to live near itself, so it can be moved around across environments.
+Visual Studio Code supports [Portable Mode](https://en.wikipedia.org/wiki/Portable_application). This mode enables all data created and maintained by VS Code to live near itself, so it can be moved around across environments. 
+
+This mode also provides a way to set the installation folder location for VS Code extension, useful for **Windows** corporate environments that prevent extensions from being installed in the AppData folder.
 
 Portable Mode is supported on the ZIP download for Windows and Linux, as well as the regular Application download for macOS.
 
-> **Note:** Do not attempt to configure portable mode on a **Windows installation**. Portable mode is only supported on the ZIP archive.
+> **Note:** Do not attempt to configure portable mode on a **Windows installation**. Portable mode is only supported on the ZIP archive, and will not auto update.
 
 ## Enable Portable Mode
 


### PR DESCRIPTION
Provide further info that Portable Mode can help in corporate environments or if you want to change the extension installation folder. 

Make it clear that this mode prevents auto updates.