### PR TITLE
Trivial fixes in Python topic

### DIFF
--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -916,7 +916,7 @@ Although you can create the file by hand, you can also use the `pip freeze` comm
 
 Anyone (or any build server) that receives a copy of the project needs only to run the `pip install -r requirements.txt` command to reinstall the packages on which the app depends within the active environment.
 
-### Create a super user and enable the administrative interface
+### Create a superuser and enable the administrative interface
 
 By default, Django provides an administrative interface for a web app that's protected by authentication. The interface is implemented through the build-in `django.contrib.admin` app, which is included by default in the project's `INSTALLED_APPS` list (`settings.py`), and authentication is handled with the built-in `django.contrib.auth` app, which is also in `INSTALLED_APPS` by default.
 

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -676,8 +676,8 @@ Throughout this tutorial, all the app code is contained in a single `app.py` fil
 
 1. Run the app in the debugger again to make sure everything works. To run the app outside of the VS Code debugger, use the following steps:
 
-    a. Set an environment variable for `FLASK_APP`. On Linux and MacOS, use `export set FLASK_APP=webapp`; on Windows use `set FLASK_APP=webapp`.
-    b. In the `hello_app` folder, launch the program using `python3 -m flask run` (Linux/MacOS) or `python -m flask run` (Windows).
+    1. Set an environment variable for `FLASK_APP`. On Linux and MacOS, use `export set FLASK_APP=webapp`; on Windows use `set FLASK_APP=webapp`.
+    1. In the `hello_app` folder, launch the program using `python3 -m flask run` (Linux/MacOS) or `python -m flask run` (Windows).
 
 If you have any problems, feel free to file an issue for thus tutorial in the [VS Code docs repo](https://github.com/Microsoft/vscode-docs/issues).
 

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -675,6 +675,7 @@ Throughout this tutorial, all the app code is contained in a single `app.py` fil
     ![Modified project structure with separate files and folders for parts of the app](images/flask/project-structure.png)
 
 1. Run the app in the debugger again to make sure everything works. To run the app outside of the VS Code debugger, use the following steps:
+
     a. Set an environment variable for `FLASK_APP`. On Linux and MacOS, use `export set FLASK_APP=webapp`; on Windows use `set FLASK_APP=webapp`.
     b. In the `hello_app` folder, launch the program using `python3 -m flask run` (Linux/MacOS) or `python -m flask run` (Windows).
 

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -675,7 +675,6 @@ Throughout this tutorial, all the app code is contained in a single `app.py` fil
     ![Modified project structure with separate files and folders for parts of the app](images/flask/project-structure.png)
 
 1. Run the app in the debugger again to make sure everything works. To run the app outside of the VS Code debugger, use the following steps:
-
     1. Set an environment variable for `FLASK_APP`. On Linux and MacOS, use `export set FLASK_APP=webapp`; on Windows use `set FLASK_APP=webapp`.
     1. In the `hello_app` folder, launch the program using `python3 -m flask run` (Linux/MacOS) or `python -m flask run` (Windows).
 


### PR DESCRIPTION
I think Django is pretty consistent about using the single word "superuser" and the use of the two words "super user" in the section title was the only use I found which didn't match.

The sub-list in the Flask page wasn't being formatted as a list (including [in the online VS Code docs](https://code.visualstudio.com/docs/python/tutorial-flask#_refactor-the-project-to-support-further-development)) so it was hard to read.