### PR TITLE
Added links to python formatters

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -87,7 +87,7 @@ On first use of the **Python: Run Selection/Line in Python Terminal** command, V
 
 ## Formatting
 
-The Python extension supports source code formatting using either autopep8 (the default), black, or yapf.
+The Python extension supports source code formatting using either [autopep8](https://pypi.org/project/autopep8/) (the default), [black](https://github.com/ambv/black), or [yapf](https://yapf.now.sh/).
 
 ### General formatting settings
 


### PR DESCRIPTION
VSCode docs are wonderful for being link-rich, so I added some links to the different python formatting styles available in the official python extension