### PR TITLE
Fixed typos in PHP documentation

### DIFF
--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -9,11 +9,11 @@ MetaDescription: Learn about Visual Studio Code editor features (syntax highligh
 ---
 # PHP in Visual Studio Code
 
-Visual Studio Code is a great editor for PHP development. You get features like syntax highlighting and bracket matching, IntelliSense (code completion), and snippets out of the box and you can add more functionality through community created VS Code [extensions](/docs/editor/extension-gallery.md).
+Visual Studio Code is a great editor for PHP development. You get features like syntax highlighting and bracket matching, IntelliSense (code completion), and snippets out of the box and you can add more functionality through community-created VS Code [extensions](/docs/editor/extension-gallery.md).
 
 ## PHP extensions
 
-There are many PHP language extensions available on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode) and more are being created.  You can search for PHP extensions from within VS Code in the **Extensions** view (`kb(workbench.view.extensions)`) then filter the extensions drop down list by typing `php`.
+There are many PHP language extensions available on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode) and more are being created.  You can search for PHP extensions from within VS Code in the **Extensions** view (`kb(workbench.view.extensions)`) then filter the extensions drop-down list by typing `php`.
 
 <div class="marketplace-extensions-php"></div>
 
@@ -25,7 +25,7 @@ There are many PHP language extensions available on the [VS Code Marketplace](ht
 
 ## Snippets
 
-Visual Studio Code includes a set of common snippets for PHP.  To access these, hit `kb(editor.action.triggerSuggest)` to get a context specific list.
+Visual Studio Code includes a set of common snippets for PHP.  To access these, hit `kb(editor.action.triggerSuggest)` to get a context-specific list.
 
 ![PHP Snippets](images/php/php-snippets.png)
 


### PR DESCRIPTION
- [hyphenation rule regarding adjectives](https://www.grammarbook.com/punctuation/hyphens.asp)
- [dropdown or drop-down](https://www.merriam-webster.com/dictionary/drop-down)