### PR TITLE
Add instructions for getting IntelliSense on PowerShell ps1xml files

### DIFF
--- a/docs/languages/powershell.md
+++ b/docs/languages/powershell.md
@@ -172,3 +172,34 @@ CodeLens function reference support shows the number of times a function is refe
 ## Extension FAQ page
 
 Check out the FAQ page on the [PowerShell extensions Wiki](https://github.com/PowerShell/vscode-powershell/wiki/FAQ)
+
+## Types.ps1xml and Format.ps1xml files
+
+You can get IntelliSense features when authoring `Types.ps1xml` and `Format.ps1xml` files by installing the [XML extension by RedHat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml).
+After installing, add this configuration to your user settings:
+
+```json
+"xml.fileAssociations": [
+  {
+    "systemId": "https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Format.xsd",
+    "pattern": "**/*.Format.ps1xml"
+  },
+  {
+    "systemId": "https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Types.xsd",
+    "pattern": "**/*.Types.ps1xml"
+  }
+]
+```
+
+This tells the XML extension to use the official XML schemas from the PowerShell repository for all `.ps1xml` files.
+This enables the following features in `ps1xml` files:
+
+- Syntax error reporting
+- Schema validation
+- Tag and attribute completion
+- Auto-close tags
+- Symbol highlighting
+- Document folding
+- Document symbols and outline
+- Renaming support
+- Document Formatting

--- a/docs/languages/powershell.md
+++ b/docs/languages/powershell.md
@@ -175,7 +175,8 @@ Check out the FAQ page on the [PowerShell extensions Wiki](https://github.com/Po
 
 ## Types.ps1xml and Format.ps1xml files
 
-You can get IntelliSense features when authoring `Types.ps1xml` and `Format.ps1xml` files by installing the [XML extension by RedHat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml).
+`ps1xml` files are PowerShell's way to extend the type system and define output formatting. For more information on these files, please refer to the official PowerShell documentation on [`Types.ps1xml`](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_types.ps1xml?view=powershell-6) and [`Format.ps1xml`](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_format.ps1xml?view=powershell-6).
+You can get IntelliSense features when authoring `ps1xml` files by installing the [XML extension by RedHat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml).
 After installing, add this configuration to your user settings:
 
 ```json


### PR DESCRIPTION
`ps1xml` files are PowerShell's way to extend the type system and define output formatting. It's possible to get awesome autocompletion, validation etc for them, but it's not obvious how to. This PR adds documentation for that. Since the schema of these files is quite complex, this makes a night and day difference in editing experience.

![screenshot](https://user-images.githubusercontent.com/10532611/45297479-cdfa5880-b505-11e8-88d4-20cf464532f8.png)