### PR TITLE
Setup: add Arch Linux installation information

### DIFF
--- a/docs/editor/portable.md
+++ b/docs/editor/portable.md
@@ -9,13 +9,13 @@ MetaDescription: Visual Studio Code supports a Portable Mode.
 ---
 # Portable Mode
 
-Visual Studio Code supports [Portable Mode](https://en.wikipedia.org/wiki/Portable_application). This mode enables all data created and maintained by VS Code to live near itself, so it can be moved around across environments. 
+Visual Studio Code supports [Portable Mode](https://en.wikipedia.org/wiki/Portable_application). This mode enables all data created and maintained by VS Code to live near itself, so it can be moved around across environments.
 
-This mode also provides a way to set the installation folder location for VS Code extension, useful for **Windows** corporate environments that prevent extensions from being installed in the AppData folder.
+This mode also provides a way to set the installation folder location for VS Code extension, useful for corporate environments that prevent extensions from being installed in the Windows AppData folder.
 
-Portable Mode is supported on the ZIP download for Windows and Linux, as well as the regular Application download for macOS.
+Portable mode is supported on the ZIP download for Windows and Linux, as well as the regular Application download for macOS.
 
-> **Note:** Do not attempt to configure portable mode on a **Windows installation**. Portable mode is only supported on the ZIP archive, and will not auto update.
+> **Note:** Do not attempt to configure portable mode on a **Windows installation**. Portable mode is only supported on the Windows ZIP archive. Note as well that the Windows ZIP archive does not support auto update.
 
 ## Enable Portable Mode
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -83,6 +83,18 @@ sudo zypper install code
 
 There is a community maintained Arch User Repository (AUR) [package for VS Code](https://aur.archlinux.org/packages/visual-studio-code-bin).
 
+First clone the packe with git and cd into the installation folder:
+
+```bash
+git clone https://aur.archlinux.org/visual-studio-code-bin.git
+cd visual-studio-code-bin
+```
+
+Then install the package (including needed dependencies) with makepkg:
+```bash
+sudo makepkg -si PKGBUILD
+```
+
 ### Nix package for NixOS (or any Linux distribution using Nix package manager)
 
 There is a community maintained [Nix package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/default.nix) in the nixpkgs repository. In order to install it using Nix, set `allowUnfree` option to true in your `config.nix` and execute:


### PR DESCRIPTION
As suggested: Adding a Link to the AUR package installation wiki site instead of detailed instlalation instructions. 