### PR TITLE
Remove Multiple Spaces in Languages Docs

### DIFF
--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -10,7 +10,7 @@ MetaSocialImage: images/csharp/languages_csharp.png
 ---
 # Working with C&#35;
 
-The C# support in Visual Studio Code is optimized for cross-platform .NET Core development (see [working with .NET Core and VS Code](/docs/other/dotnet.md) for another relevant article).  Our focus with VS Code is to be a great editor for cross-platform C# development.
+The C# support in Visual Studio Code is optimized for cross-platform .NET Core development (see [working with .NET Core and VS Code](/docs/other/dotnet.md) for another relevant article). Our focus with VS Code is to be a great editor for cross-platform C# development.
 
 ![C# language within VS Code](images/csharp/c_sharp_hero.png)
 
@@ -23,7 +23,7 @@ For detailed instructions on:
 
 >**Note:** [VS Code has limited support for debugging applications running on the Desktop .NET Framework.](https://github.com/OmniSharp/omnisharp-vscode/wiki/Desktop-.NET-Framework)
 
-Due to this focus, many standard C# project types are not recognized by VS Code.  An example of a non-supported project type is an ASP.NET MVC Application (though ASP.NET Core is supported).  In these cases, if you want to have a lightweight tool to edit a file - VS Code has you covered.  If you want the best possible experience for those projects and development on Windows in general, we recommend you use [Visual Studio Community](https://visualstudio.microsoft.com/vs/community).
+Due to this focus, many standard C# project types are not recognized by VS Code. An example of a non-supported project type is an ASP.NET MVC Application (though ASP.NET Core is supported). In these cases, if you want to have a lightweight tool to edit a file - VS Code has you covered. If you want the best possible experience for those projects and development on Windows in general, we recommend you use [Visual Studio Community](https://visualstudio.microsoft.com/vs/community).
 
 ## Installing C&#35; support
 
@@ -39,13 +39,13 @@ In addition to the [Microsoft C# extension](https://marketplace.visualstudio.com
 
 ## Roslyn and OmniSharp
 
-Visual Studio Code uses the power of [Roslyn](https://github.com/dotnet/roslyn) and [OmniSharp](https://www.omnisharp.net) to offer an enhanced C# experience.  We offer support for:
+Visual Studio Code uses the power of [Roslyn](https://github.com/dotnet/roslyn) and [OmniSharp](https://www.omnisharp.net) to offer an enhanced C# experience. We offer support for:
 
 * .NET Core projects
 * MSBuild projects
 * C# scripts (CSX)
 
-On startup the best matching projects are loaded automatically but you can also choose your projects manually.  The status bar will show what projects have been loaded and also allows you to select a different set of projects. To do so, click on the status bar projects item and select *Change projects…*.  In the image below a single project has been picked up:
+On startup the best matching projects are loaded automatically but you can also choose your projects manually. The status bar will show what projects have been loaded and also allows you to select a different set of projects. To do so, click on the status bar projects item and select *Change projects…*. In the image below a single project has been picked up:
 
 ![Select Project](images/csharp/selectproject.png)
 
@@ -79,7 +79,7 @@ We have several built-in snippets included in VS Code that will come up as you t
 
 ![Snippets](images/csharp/snippet.png)
 
->**Tip:** You can add in your own User Defined Snippets for C#.  Take a look at [User Defined Snippets](/docs/editor/userdefinedsnippets.md) to find out how.
+>**Tip:** You can add in your own User Defined Snippets for C#. Take a look at [User Defined Snippets](/docs/editor/userdefinedsnippets.md) to find out how.
 
 ## Search for Symbols
 
@@ -89,7 +89,7 @@ There are also features outside the editor. One is the ability to search for sym
 
 ## CodeLens
 
-Another cool feature is the ability to see the number of references to a method directly above the method. Click on the reference info to see the references in the Peek view.  This reference information updates as you type.
+Another cool feature is the ability to see the number of references to a method directly above the method. Click on the reference info to see the references in the Peek view. This reference information updates as you type.
 
 >**Note:** Methods defined in `object`, such as `equals` and `hashCode` do not get reference information due to performance reasons.
 
@@ -99,13 +99,13 @@ Another cool feature is the ability to see the number of references to a method 
 
 ## Find References/Peek Definition
 
-You can click on the references of an object to find the locations of its use in place without losing context.  This same experience works in reverse where you can Peek the definition of an object and see it inline without leaving your location.
+You can click on the references of an object to find the locations of its use in place without losing context. This same experience works in reverse where you can Peek the definition of an object and see it inline without leaving your location.
 
 ![Peek](images/csharp/peek.png)
 
 ## Quick Fixes / Suggestions
 
-There are some basic quick fixes supported in VS Code.  You will see a lightbulb and clicking on it, or pressing `kb(editor.action.quickFix)` provides you with a simple list of fixes/suggestions.
+There are some basic quick fixes supported in VS Code. You will see a lightbulb and clicking on it, or pressing `kb(editor.action.quickFix)` provides you with a simple list of fixes/suggestions.
 
 ![Quick fix](images/csharp/lightbulb.png)
 
@@ -123,15 +123,15 @@ Read on to find out about:
 
 ### My Project won't load
 
-VS Code only supports a limited set of project types (primarily .NET Core).  For full .NET project support, we suggest you use [Visual Studio Community](https://visualstudio.microsoft.com/vs/community).
+VS Code only supports a limited set of project types (primarily .NET Core). For full .NET project support, we suggest you use [Visual Studio Community](https://visualstudio.microsoft.com/vs/community).
 
 ### IntelliSense is not working
 
-This is typically as a result of the current project type not being supported.  You can see an indication in the OmniSharp flame in the bottom left hand side of the status bar.
+This is typically as a result of the current project type not being supported. You can see an indication in the OmniSharp flame in the bottom left hand side of the status bar.
 
 ### How do I build/run my project?
 
-VS Code supports tasks for build and natively understand the output of MSBuild, CSC, XBuild.  Find out more in the [Tasks](/docs/editor/tasks.md) documentation.
+VS Code supports tasks for build and natively understand the output of MSBuild, CSC, XBuild. Find out more in the [Tasks](/docs/editor/tasks.md) documentation.
 
 ### I'm missing required assets to build and debug C# in VS Code. My debugger says "No Configuration"
 

--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -9,7 +9,7 @@ MetaDescription: Find out how Visual Studio Code can support your CSS, SCSS and 
 ---
 # CSS, SCSS and Less
 
-Visual Studio Code has built-in support for editing style sheets in CSS `.css`, SCSS `.scss` and Less `.less`.  In addition, you can install an extension for greater functionality.
+Visual Studio Code has built-in support for editing style sheets in CSS `.css`, SCSS `.scss` and Less `.less`. In addition, you can install an extension for greater functionality.
 
 <div class="marketplace-extensions-css-curated"></div>
 
@@ -33,7 +33,7 @@ Clicking on a color preview will launch the integrated color picker which suppor
 
 ![Color picker in CSS](images/css/css-color-picker.png)
 
-> **Tip:** You can  trigger between different color modes by clicking on the color string at the top of the picker.
+> **Tip:** You can trigger between different color modes by clicking on the color string at the top of the picker.
 
 You can hide VS Code's color previews by setting the following [setting](/docs/getstarted/settings.md):
 
@@ -100,7 +100,7 @@ There is jump to definition for `@import` and `url()` links in CSS, SCSS and Les
 
 ## Transpiling Sass and Less into CSS
 
-VS Code can integrate with Sass and Less transpilers through our integrated [task runner](/docs/editor/tasks.md).  We can use this to transpile `.scss` or `.less` files into `.css` files.  Let's walk through transpiling a simple Sass/Less file.
+VS Code can integrate with Sass and Less transpilers through our integrated [task runner](/docs/editor/tasks.md). We can use this to transpile `.scss` or `.less` files into `.css` files. Let's walk through transpiling a simple Sass/Less file.
 
 ### Step 1: Install a Sass or Less transpiler
 
@@ -114,7 +114,7 @@ npm install -g node-sass less
 
 ### Step 2: Create a simple Sass or Less file
 
-Open VS Code on an empty folder and create a `styles.scss` or `styles.less` file.  Place the following code in that file:
+Open VS Code on an empty folder and create a `styles.scss` or `styles.less` file. Place the following code in that file:
 
 ```scss
 $padding: 6px;
@@ -138,13 +138,13 @@ nav {
 
 For the Less version of the above file, just change `$padding` to `@padding`.
 
->**Note:** This is a very simple example, which is why the source code is almost identical between both file types.  In more advanced scenarios, the syntaxes and constructs will be much different.
+>**Note:** This is a very simple example, which is why the source code is almost identical between both file types. In more advanced scenarios, the syntaxes and constructs will be much different.
 
 ### Step 3: Create tasks.json
 
-The next step is to set up the task configuration.  To do this, run **Tasks** > **Configure Tasks** and click **Create tasks.json file from templates**. In the selection dialog that shows up, select **Others**.
+The next step is to set up the task configuration. To do this, run **Tasks** > **Configure Tasks** and click **Create tasks.json file from templates**. In the selection dialog that shows up, select **Others**.
 
-This will create a sample `tasks.json` file in the workspace `.vscode` folder.  The initial version of file has an example to run an arbitrary command. We will modify that configuration for transpiling Sass/Less instead:
+This will create a sample `tasks.json` file in the workspace `.vscode` folder. The initial version of file has an example to run an arbitrary command. We will modify that configuration for transpiling Sass/Less instead:
 
 ```json
 // Sass configuration
@@ -182,7 +182,7 @@ This will create a sample `tasks.json` file in the workspace `.vscode` folder.  
 
 ### Step 4: Run the Build Task
 
-As this is the only command in the file, you can execute it by pressing `kb(workbench.action.tasks.build)` (**Run Build Task**).  The sample Sass/Less file should not have any compile problems, so by running the task all that happens is a corresponding `styles.css` file is created.
+As this is the only command in the file, you can execute it by pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). The sample Sass/Less file should not have any compile problems, so by running the task all that happens is a corresponding `styles.css` file is created.
 
 Since in more complex environments there can be more than one build task we prompt you to pick the task to execute after pressing `kb(workbench.action.tasks.build)` (**Run Build Task**). In addition, we allow you to scan the output for compile problems (errors and warnings). Depending on the compiler, select an appropriate entry in the list to scan the tool output for errors and warnings. If you don't want to scan the output, select **Never scan the build output** from the presented list.
 
@@ -194,11 +194,11 @@ If you want to make the task the default build task to run execute **Configure D
 
 ## Automating Sass/Less compilation
 
-Let's take things a little further and automate Sass/Less compilation with VS Code.  We can do so with the same task runner integration as before, but with a few modifications.
+Let's take things a little further and automate Sass/Less compilation with VS Code. We can do so with the same task runner integration as before, but with a few modifications.
 
 ### Step 1: Install Gulp and some plug-ins
 
-We will use [Gulp](https://gulpjs.com/) to create a task that will automate Sass/Less compilation.  We will also use the [gulp-sass](https://www.npmjs.com/package/gulp-sass) plug-in to make things a little easier.  The Less plug-in is [gulp-less](https://www.npmjs.com/package/gulp-less).
+We will use [Gulp](https://gulpjs.com/) to create a task that will automate Sass/Less compilation. We will also use the [gulp-sass](https://www.npmjs.com/package/gulp-sass) plug-in to make things a little easier. The Less plug-in is [gulp-less](https://www.npmjs.com/package/gulp-less).
 
 We need to install gulp both globally (`-g` switch) and locally:
 
@@ -207,7 +207,7 @@ npm install -g gulp
 npm install gulp gulp-sass gulp-less
 ```
 
-> **Note:** `gulp-sass` and `gulp-less` are Gulp plug-ins for the `node-sass` and `lessc` modules we were using before.  There are many other Gulp Sass and Less plug-ins you can use, as well as plug-ins for Grunt.
+> **Note:** `gulp-sass` and `gulp-less` are Gulp plug-ins for the `node-sass` and `lessc` modules we were using before. There are many other Gulp Sass and Less plug-ins you can use, as well as plug-ins for Grunt.
 
 You can test that your gulp installation was successful but typing `gulp -v`. You should see a version displayed for both the global (CLI) and local installations.
 
@@ -258,7 +258,7 @@ What is happening here?
 1. Our `default` gulp task first runs the `sass` or `less` task once when it starts up.
 2. It then watches for changes to any SCSS/Less file at the root of our workspace, for example the current folder open in VS Code.
 3. It takes the set of SCSS/Less files that have changed and runs them through our respective compiler, for example `gulp-sass`, `gulp-less`.
-4. We now have a set of CSS files, each named respectively after their original SCSS/Less file.  We then put these files in the same directory.
+4. We now have a set of CSS files, each named respectively after their original SCSS/Less file. We then put these files in the same directory.
 
 ### Step 3: Run the gulp default task
 
@@ -289,14 +289,14 @@ Set a setting to `warning` or `error` if you want to enable lint checking, use `
 Id|Description|Default
 ---|------------|----
 validate | Enables or disables all validations | true
-compatibleVendorPrefixes | When using a property with a vendor-specific prefix (for example `-webkit-transition`), make sure to also include all other vendor-specific properties eg. `-moz-transition`, `-ms-transition` and `-o-transition` | ignore
-vendorPrefix | When using a property with a vendor-specific prefix for example `-webkit-transition`, make sure to also include the standard property if it exists eg. `transition` | warning
+compatibleVendorPrefixes | When using a property with a vendor-specific prefix (for example `-webkit-transition`), make sure to also include all other vendor-specific properties e.g. `-moz-transition`, `-ms-transition` and `-o-transition` | ignore
+vendorPrefix | When using a property with a vendor-specific prefix for example `-webkit-transition`, make sure to also include the standard property if it exists e.g. `transition` | warning
 duplicateProperties | Warn about duplicate properties in the same ruleset | ignore
 emptyRules | Warn about empty rulesets | warning
 importStatement | Warn about using an `import` statement as import statements are loaded sequentially which has a negative impact on web page performance | ignore
 boxModel | Do not use `width` or `height` when using `padding` or `border` | ignore
 universalSelector | Warn when using the universal selector `*` as it is known to be slow and should be avoided | ignore
-zeroUnits | Warn when having zero with a unit e.g. `0em` as zero does not need a unit.  | ignore
+zeroUnits | Warn when having zero with a unit e.g. `0em` as zero does not need a unit. | ignore
 fontFaceProperties | Warn when using `@font-face` rule without defining a `src` and `font-family` property | warning
 hexColorLength | Warn when using hex numbers that don't consist of three or six hex numbers | error
 argumentsInColorFunction | Warn when an invalid number of parameters in color functions e.g. `rgb` | error

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -13,7 +13,7 @@ Visual Studio Code provides basic support for HTML programming out of the box. T
 
 ## IntelliSense
 
-As you type in HTML, we offer suggestions via HTML IntelliSense.  In the image below, you can see a suggested HTML element closure `</div>` as well as a context specific list of suggested elements.
+As you type in HTML, we offer suggestions via HTML IntelliSense. In the image below, you can see a suggested HTML element closure `</div>` as well as a context specific list of suggested elements.
 
 ![HTML IntelliSense](images/html/htmlintellisense.png)
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -65,7 +65,7 @@ npm is installed with the Node.js runtime, which is available for download from 
 
 If you have npm installed but still see a warning message, you can explicitly tell VS Code where npm is installed with the `typescript.npm` [setting](/docs/getstarted/settings.md). This should be set to the full path of the npm executable on your machine, and this does not have to match the version of npm you are using to manage packages in your workspace. `typescript.npm` requires TypeScript 2.3.4+.
 
-For example on Windows, you would add a path like this to your `settings.json` file:
+For example, on Windows, you would add a path like this to your `settings.json` file:
 
 ```json
   "typescript.npm": "C:\\Program Files\\nodejs\\npm.cmd"
@@ -227,7 +227,7 @@ VS Code provides several formatting settings for JavaScript. They can all be fou
 
 A [linter](https://en.wikipedia.org/wiki/Lint_%28software%29) is a tool that provides warnings for suspicious looking code. VS Code supports linters through [extensions](/docs/editor/extension-gallery.md). Linters provide warnings, errors, and light bulb actions.
 
-VS Code provides support for JavaScript linters, including [ESLint](https://eslint.org/), [JSHint](http://jshint.com/) and [StandardJS](https://standardjs.com/).  If enabled, the JavaScript code is validated as you type and you can navigate to reported problems and fix them inside VS Code.
+VS Code provides support for JavaScript linters, including [ESLint](https://eslint.org/), [JSHint](http://jshint.com/) and [StandardJS](https://standardjs.com/). If enabled, the JavaScript code is validated as you type and you can navigate to reported problems and fix them inside VS Code.
 
  ![linter warning](images/javascript/eslint_warning.png)
 

--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -9,13 +9,13 @@ MetaDescription: Edit JSON files in Visual Studio Code
 ---
 # Editing JSON with Visual Studio Code
 
-JSON is a data format that is common in configuration files like `package.json` or `project.json`. We also use it extensively in Visual Studio Code for our configuration files.  When opening a file that ends with `.json`, VS Code provides features out of the box to make it simpler to write or modify the file's content.
+JSON is a data format that is common in configuration files like `package.json` or `project.json`. We also use it extensively in Visual Studio Code for our configuration files. When opening a file that ends with `.json`, VS Code provides features out of the box to make it simpler to write or modify the file's content.
 
 ![JSON within VS Code](images/json/json_hero.png)
 
 ## IntelliSense & Validation
 
-For properties and values, both for JSON data with and without a schema, we offer up suggestions as you type with IntelliSense. You can also manually see suggestions with the **Trigger Suggestions** command (`kb(editor.action.triggerSuggest)`).  We also perform structural and value verification based on an associated JSON schema giving you red squiggles.
+For properties and values, both for JSON data with and without a schema, we offer up suggestions as you type with IntelliSense. You can also manually see suggestions with the **Trigger Suggestions** command (`kb(editor.action.triggerSuggest)`). We also perform structural and value verification based on an associated JSON schema giving you red squiggles.
 
 ![IntelliSense](images/json/intellisense.png)
 

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -118,11 +118,11 @@ Disables additional security in the preview window. This allows script execution
 
 There are several built-in Markdown snippets included in VS Code - press `kb(editor.action.triggerSuggest)` (Trigger Suggest) and you get a context specific list of suggestions.
 
->**Tip:** You can add in your own User Defined Snippets for Markdown.  Take a look at [User Defined Snippets](/docs/editor/userdefinedsnippets.md) to find out how.
+>**Tip:** You can add in your own User Defined Snippets for Markdown. Take a look at [User Defined Snippets](/docs/editor/userdefinedsnippets.md) to find out how.
 
 ## Compiling Markdown into HTML
 
-VS Code integrates with Markdown compilers through the integrated [task runner](/docs/editor/tasks.md).  We can use this to compile `.md` files into `.html` files.  Let's walk through compiling a simple Markdown document.
+VS Code integrates with Markdown compilers through the integrated [task runner](/docs/editor/tasks.md). We can use this to compile `.md` files into `.html` files. Let's walk through compiling a simple Markdown document.
 
 ### Step 1: Install a Markdown compiler
 
@@ -132,7 +132,7 @@ For this walkthrough, we use the popular [Node.js](https://nodejs.org) module, [
 npm install -g markdown-it
 ```
 
-> **Note:** There are many Markdown compilers to choose from beyond **markdown-it**.  Pick the one that best suits your needs and environment.
+> **Note:** There are many Markdown compilers to choose from beyond **markdown-it**. Pick the one that best suits your needs and environment.
 
 ### Step 2: Create a simple MD file
 
@@ -160,7 +160,7 @@ Things you'll need:
 
 ### Step 3: Create tasks.json
 
-The next step is to set up the task configuration file `tasks.json`.  To do this, run **Tasks** > **Configure Tasks** and click **Create tasks.json file from templates**. VS Code then presents a list of possible `tasks.json` templates to choose from. Select **Others** since we want to run an external command.
+The next step is to set up the task configuration file `tasks.json`. To do this, run **Tasks** > **Configure Tasks** and click **Create tasks.json file from templates**. VS Code then presents a list of possible `tasks.json` templates to choose from. Select **Others** since we want to run an external command.
 
 This generates a `tasks.json` file in your workspace `.vscode` folder with the following content:
 
@@ -197,7 +197,7 @@ To use **markdown-it** to compile the Markdown file, change the contents as foll
 }
 ```
 
-> **Tip:** While the sample is there to help with common configuration settings, IntelliSense is available for the `tasks.json` file as well to help you along.  Use `kb(editor.action.triggerSuggest)` to see the available settings.
+> **Tip:** While the sample is there to help with common configuration settings, IntelliSense is available for the `tasks.json` file as well to help you along. Use `kb(editor.action.triggerSuggest)` to see the available settings.
 
 ### Step 4: Run the Build Task
 
@@ -229,7 +229,7 @@ If you want to make the **Compile Markdown** task the default build task to run 
 
 ## Automating Markdown compilation
 
-Let's take things a little further and automate Markdown compilation with VS Code.  We can do so with the same task runner integration as before, but with a few modifications.
+Let's take things a little further and automate Markdown compilation with VS Code. We can do so with the same task runner integration as before, but with a few modifications.
 
 ### Step 1: Install Gulp and some plug-ins
 
@@ -242,7 +242,7 @@ npm install -g gulp
 npm install gulp gulp-markdown-it
 ```
 
-> **Note:** gulp-markdown-it is a Gulp plug-in for the **markdown-it** module we were using before.  There are many other Gulp Markdown plug-ins you can use, as well as plug-ins for Grunt.
+> **Note:** gulp-markdown-it is a Gulp plug-in for the **markdown-it** module we were using before. There are many other Gulp Markdown plug-ins you can use, as well as plug-ins for Grunt.
 
 You can test that your gulp installation was successful but typing `gulp -v`. You should see a version displayed for both the global (CLI) and local installations.
 
@@ -273,7 +273,7 @@ What is happening here?
 
 1. We are watching for changes to any Markdown file in our workspace, i.e. the current folder open in VS Code.
 2. We take the set of Markdown files that have changed, and run them through our Markdown compiler, i.e. `gulp-markdown-it`.
-3. We now have a set of HTML files, each named respectively after their original Markdown file.  We then put these files in the same directory.
+3. We now have a set of HTML files, each named respectively after their original Markdown file. We then put these files in the same directory.
 
 ### Step 3: Run the gulp default Task
 
@@ -322,4 +322,4 @@ No, VS Code targets the [CommonMark](http://commonmark.org) Markdown specificati
 
 ### In the walkthrough above, I didn't find the Configure Task command in the Command Palette?
 
-You may have opened a file in VS Code rather than a folder.  You can open a folder by either selecting the folder with **File** > **Open Folder...** or navigating to the folder and typing 'code .' at the command line.
+You may have opened a file in VS Code rather than a folder. You can open a folder by either selecting the folder with **File** > **Open Folder...** or navigating to the folder and typing 'code .' at the command line.

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -26,7 +26,7 @@ Go to the [Marketplace](https://marketplace.visualstudio.com/vscode) or use our 
 On this website, we have a number of topics outlining several of the common languages supported by VS Code. These include: [C++](/docs/languages/cpp.md) - [C&#35;](/docs/languages/csharp.md) - [CSS](/docs/languages/css.md) - [Dockerfile](/docs/azure/docker.md) - [Go](/docs/languages/go.md) - [HTML](/docs/languages/html.md) - [Java](/docs/languages/java.md) - [JavaScript](/docs/languages/javascript.md) - [JSON](/docs/languages/json.md) - [Less](/docs/languages/css.md) -
 [Markdown](/docs/languages/markdown.md) - [PHP](/docs/languages/php.md) - [PowerShell](/docs/languages/powershell.md) - [Python](/docs/languages/python.md) - [SCSS](/docs/languages/css.md) - [T-SQL](/docs/languages/tsql.md) - [TypeScript](/docs/languages/typescript.md).
 
-Click on any linked item to get an overview of how to use VS Code in the context of that language.  Most language extensions also contain a summary of their core features in their README.
+Click on any linked item to get an overview of how to use VS Code in the context of that language. Most language extensions also contain a summary of their core features in their README.
 
 ## Language features in VS Code
 
@@ -41,7 +41,7 @@ The richness of support varies across the different languages and their extensio
 
 ## Changing the language for the selected file
 
-In VS Code, we default the language support for a file based on its filename extension.  However, at times you may wish to change language modes, to do this click on the language indicator - which is located on the right hand of the Status Bar.  This will bring up the **Select Language Mode** drop-down where you can select another language for the current file.
+In VS Code, we default the language support for a file based on its filename extension. However, at times you may wish to change language modes, to do this click on the language indicator - which is located on the right hand of the Status Bar. This will bring up the **Select Language Mode** drop-down where you can select another language for the current file.
 
 ![Language Selector](images/overview/languageselect.png)
 

--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -13,7 +13,7 @@ Visual Studio Code is a great editor for PHP development. You get features like 
 
 ## PHP extensions
 
-There are many PHP language extensions available on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode) and more are being created.  You can search for PHP extensions from within VS Code in the **Extensions** view (`kb(workbench.view.extensions)`) then filter the extensions drop-down list by typing `php`.
+There are many PHP language extensions available on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode) and more are being created. You can search for PHP extensions from within VS Code in the **Extensions** view (`kb(workbench.view.extensions)`) then filter the extensions drop-down list by typing `php`.
 
 <div class="marketplace-extensions-php"></div>
 
@@ -25,7 +25,7 @@ There are many PHP language extensions available on the [VS Code Marketplace](ht
 
 ## Snippets
 
-Visual Studio Code includes a set of common snippets for PHP.  To access these, hit `kb(editor.action.triggerSuggest)` to get a context-specific list.
+Visual Studio Code includes a set of common snippets for PHP. To access these, hit `kb(editor.action.triggerSuggest)` to get a context-specific list.
 
 ![PHP Snippets](images/php/php-snippets.png)
 
@@ -63,7 +63,7 @@ To set the PHP executable path, open your **User or Workspace Settings** and add
 
 ## Debugging
 
-PHP debugging with **XDebug** is supported through a [PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug).  Follow the extension's instructions for configuring **XDebug** to work with VS Code.
+PHP debugging with **XDebug** is supported through a [PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug). Follow the extension's instructions for configuring **XDebug** to work with VS Code.
 
 ## Next Steps
 

--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -45,7 +45,7 @@ VS Code's TypeScript support can operate in two different modes:
 
 ## tsconfig.json
 
-Typically the first step in any new TypeScript project is to add in a `tsconfig.json` file.  This defines the TypeScript [project settings](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) such as the compiler options and the files that should be included. To do this, open up the folder where you want to store your source and add in a new file named `tsconfig.json`.  Once in this file, IntelliSense (`kb(editor.action.triggerSuggest)`) will help you along the way.
+Typically the first step in any new TypeScript project is to add in a `tsconfig.json` file. This defines the TypeScript [project settings](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) such as the compiler options and the files that should be included. To do this, open up the folder where you want to store your source and add in a new file named `tsconfig.json`. Once in this file, IntelliSense (`kb(editor.action.triggerSuggest)`) will help you along the way.
 
 ![jsconfig.json IntelliSense](images/typescript/jsconfigintellisense.png)
 
@@ -80,7 +80,7 @@ You can disable this behavior by setting: `"typescript.reportStyleChecksAsWarnin
 
 ## Transpiling TypeScript into JavaScript
 
-VS Code integrates with `tsc` through our integrated [task runner](/docs/editor/tasks.md).  We can use this to transpile `.ts` files into `.js` files.  Another benefit of using VS Code tasks is that you get integrated error and warning detection displayed in the [Problems](/docs/editor/editingevolved.md#errors-warnings) panel. Let's walk through transpiling a simple TypeScript Hello World program.
+VS Code integrates with `tsc` through our integrated [task runner](/docs/editor/tasks.md). We can use this to transpile `.ts` files into `.js` files. Another benefit of using VS Code tasks is that you get integrated error and warning detection displayed in the [Problems](/docs/editor/editingevolved.md#errors-warnings) panel. Let's walk through transpiling a simple TypeScript Hello World program.
 
 >**Tip:** If you don't have the TypeScript compiler installed, you can [get it here](https://www.typescriptlang.org/).
 
@@ -148,7 +148,7 @@ The example TypeScript file did not have any compile problems, so by running the
 
 ### Step 4: Reviewing build issues
 
-Unfortunately, most builds don't go that smoothly and the result is often some additional information.  For instance, if there was a simple error in our TypeScript file, we may get the following output from `tsc`:
+Unfortunately, most builds don't go that smoothly and the result is often some additional information. For instance, if there was a simple error in our TypeScript file, we may get the following output from `tsc`:
 
     HelloWorld.ts(3,17): error TS2339: Property 'logg' does not exist on type 'Console'.
 


### PR DESCRIPTION
Greetings, 

I've removed multiple spaces from the language files, also fixed a [typo](https://github.com/Microsoft/vscode-docs/commit/1947da826fd81db5f80a2d7125467d470a4a1d5e#diff-96f708142354de732fffafacadd12b75R292).