### PR TITLE
fixed broken image path in tutorials section

### DIFF
--- a/tutorials/static-website/create-app.md
+++ b/tutorials/static-website/create-app.md
@@ -49,7 +49,7 @@ npm start
 
 Now, open your browser and navigate to [http://localhost:3000](http://localhost:3000), where you should see something like this:
 
-![Running React App](images/static-website/local-app.png)
+![Running React App](../images/static-website/local-app.png)
 
 You are now ready to deploy your app!
 


### PR DESCRIPTION
Inside *tutorials/static-website/create-app.md* the image path was broken and looked like this first image.

With this commit, I have fixed the path and now the image is visible in the document as shown in the second image.

**Current state**
<img width="842" alt="screen shot 2018-10-14 at 9 05 08 pm" src="https://user-images.githubusercontent.com/11405622/46920936-6bf5ad00-cff5-11e8-8f1d-ccf7d6936e1a.png">

**After the fix**


<img width="962" alt="screen shot 2018-10-14 at 9 04 41 pm" src="https://user-images.githubusercontent.com/11405622/46920937-6c8e4380-cff5-11e8-9edc-edfc27d00505.png">

 