### PR TITLE
Fixed image path inside all the files tutorials/static-website

### DIFF
--- a/tutorials/static-website/code-change.md
+++ b/tutorials/static-website/code-change.md
@@ -28,7 +28,7 @@ Run `npm run build` locally then right-click your updated `build` directory and 
 
 Once your deployment is complete, revisit your storage endpoint (`https://<storage-account-name>.z4.web.core.windows.net/`) and you should see the following!
 
-![Import build](images/static-website/updated-azure-app.png)
+![Import build](../images/static-website/updated-azure-app.png)
 
 ----
 

--- a/tutorials/static-website/create-app.md
+++ b/tutorials/static-website/create-app.md
@@ -49,7 +49,7 @@ npm start
 
 Now, open your browser and navigate to [http://localhost:3000](http://localhost:3000), where you should see something like this:
 
-![Running React App](images/static-website/local-app.png)
+![Running React App](../images/static-website/local-app.png)
 
 You are now ready to deploy your app!
 

--- a/tutorials/static-website/create-storage.md
+++ b/tutorials/static-website/create-storage.md
@@ -34,7 +34,7 @@ In this section, we will setup our Azure Storage account and blob container.
 
    Static website hosting is only available for accounts using GPv2.
 
-   ![Add name and Resource Group](images/static-website/storage/3-portal-config-storage.png)
+   ![Add name and Resource Group](../images/static-website/storage/3-portal-config-storage.png)
 
 6. When you're ready, click **Create** and wait for the account to be created.
 
@@ -48,7 +48,7 @@ In this section, we will setup our Azure Storage account and blob container.
 
   > **Note**: Be sure to include the name of your index document.
 
-   ![Confirm container](images/static-website/storage/8-portal-config-static-site.png)
+   ![Confirm container](../images/static-website/storage/8-portal-config-static-site.png)
 
 ## Your site URL
 

--- a/tutorials/static-website/deploy-website.md
+++ b/tutorials/static-website/deploy-website.md
@@ -14,17 +14,17 @@ In the **AZURE STORAGE** explorer, expand your subscription and find the Azure S
 
 1. Open your application code in VS Code, right-click on your **build** directory, and choose **Deploy to Static Website...**.
 
-    ![Deploy to Static Website](images/static-website/deploy-build.png)
+    ![Deploy to Static Website](../images/static-website/deploy-build.png)
 
 1. Choose your Subscription and the Storage Account that you just created. When completed, you can click into the portal to copy your website URL (primary endpoint).
 
-    ![Deployment Complete](images/static-website/deployment-complete.png)
+    ![Deployment Complete](../images/static-website/deployment-complete.png)
 
 ## Browse your website
 
 Visit the URL to see your app running on Azure.
 
-![App running in Azure](images/static-website/azure-app.png)
+![App running in Azure](../images/static-website/azure-app.png)
 
 ----
 

--- a/tutorials/static-website/getting-started.md
+++ b/tutorials/static-website/getting-started.md
@@ -41,7 +41,7 @@ The [Azure Storage](https://marketplace.visualstudio.com/items?itemName=ms-azure
 
 Once the extension is installed, log into your Azure account - in the Activity Bar, click on the Azure logo to show the **AZURE STORAGE** explorer. Click **Sign in to Azure...** and follow the instructions.
 
-![sign in to Azure](images/static-website/sign-in.png)
+![sign in to Azure](../images/static-website/sign-in.png)
 
 ## Prerequisite check
 


### PR DESCRIPTION
All the files inside  [_tutorials/static-website_](https://github.com/Microsoft/vscode-docs/tree/master/tutorials/static-website) have broken image paths. 
- code-change.md
- create-storage.md
- deploy-website.md
- getting-started.md
- create-app.md

With this PR, I have fixed the image paths in each file, now they are visible again. To see that in action I am attaching the before and after of create-app.md. 

Same is true for all the above-mentioned files.

**Current state**
<img width="842" alt="screen shot 2018-10-14 at 9 05 08 pm" src="https://user-images.githubusercontent.com/11405622/46920936-6bf5ad00-cff5-11e8-8f1d-ccf7d6936e1a.png">

**After the fix**


<img width="962" alt="screen shot 2018-10-14 at 9 04 41 pm" src="https://user-images.githubusercontent.com/11405622/46920937-6c8e4380-cff5-11e8-9edc-edfc27d00505.png">