### PR TITLE
replaced iframe with link

### DIFF
--- a/docs/introvideos/quicktour.md
+++ b/docs/introvideos/quicktour.md
@@ -13,7 +13,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 This tutorial gives you an overview of the core features of Visual Studio Code, including IntelliSense, debugging, Git version control integration, and more. You'll see these features as we add an endpoint to a JavaScript web app using [Express web framework](https://expressjs.com/).
 
-<iframe src="https://www.youtube.com/embed/pI1skOo2yjk?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[JavaScript Quick Tour Video](https://www.youtube.com/embed/pI1skOo2yjk?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 


### PR DESCRIPTION
Replaced the iframe with a link to the JavaScript Quick Tour YouTube video in docs/introvideos/quicktour.md. Because it isn't possible to embed videos in markdown, I thought I'd convert it to a link to the video.