### PR TITLE
Video Markdown Fix in .md Files in docs/introvideos

### DIFF
--- a/docs/introvideos/basics.md
+++ b/docs/introvideos/basics.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 In this tutorial, we walk you through setting up Visual Studio Code and give an overview of the basic features.
 
-<iframe src="https://www.youtube.com/embed/Sdg0ef2PpBw?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/Sdg0ef2PpBw/0.jpg)](https://www.youtube.com/embed/Sdg0ef2PpBw?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/codeediting.md
+++ b/docs/introvideos/codeediting.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 In this Visual Studio Code tutorial, we cover source code editing, including the features outlined below. After viewing this overview, read on in the [Learn More](/docs/introvideos/codeediting.md#learn-more) section to see more features.
 
-<iframe src="https://www.youtube.com/embed/rsatrlBEFFA?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/rsatrlBEFFA/0.jpg)](https://www.youtube.com/embed/rsatrlBEFFA?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/configure.md
+++ b/docs/introvideos/configure.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 In this tutorial, we show you how to personalize Visual Studio Code.
 
-<iframe src="https://www.youtube.com/embed/4wVF4w_53hs?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/4wVF4w_53hs/0.jpg)](https://www.youtube.com/embed/4wVF4w_53hs?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/debugging.md
+++ b/docs/introvideos/debugging.md
@@ -14,7 +14,7 @@ Debugging is a core feature of Visual Studio Code. In this tutorial, we will sho
 
 > **Tip:** To use the debugging features demonstrated in this video for Node.js, you will need to first install [nodejs](https://nodejs.org/en/).
 
-<iframe src="https://www.youtube.com/embed/2oFKNL7vYV8?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/2oFKNL7vYV8/0.jpg)](https://www.youtube.com/embed/2oFKNL7vYV8?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/extend.md
+++ b/docs/introvideos/extend.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 Use Visual Studio Code extensions to add new features, themes and more. In this tutorial, we will show you how to find extensions, install the ones you like, and disable extensions you don't want to use all the time.
 
-<iframe src="https://www.youtube.com/embed/Fed01v3yYNE?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/Fed01v3yYNE/0.jpg)](https://www.youtube.com/embed/Fed01v3yYNE?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/intellisense.md
+++ b/docs/introvideos/intellisense.md
@@ -14,7 +14,7 @@ In this tutorial, we show you how to set up IntelliSense for a JavaScript projec
 
 > Note: For IntelliSense with other programming languages, consult the language extension's README. You can learn more about language support [here](/docs/languages/overview.md).
 
-<iframe src="https://www.youtube.com/embed/lSPHucggmLo?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/lSPHucggmLo/0.jpg)](https://www.youtube.com/embed/lSPHucggmLo?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/quicktour.md
+++ b/docs/introvideos/quicktour.md
@@ -13,7 +13,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 This tutorial gives you an overview of the core features of Visual Studio Code, including IntelliSense, debugging, Git version control integration, and more. You'll see these features as we add an endpoint to a JavaScript web app using [Express web framework](https://expressjs.com/).
 
-<iframe src="https://www.youtube.com/embed/pI1skOo2yjk?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/pI1skOo2yjk/0.jpg)](https://www.youtube.com/embed/pI1skOo2yjk?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/introvideos/versioncontrol.md
+++ b/docs/introvideos/versioncontrol.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 In this tutorial, we will learn how to use the basics of Git version control in Visual Studio Code.
 
-<iframe src="https://www.youtube.com/embed/AKNYgP0yEOY?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+[![Click to Watch](http://img.youtube.com/vi/AKNYgP0yEOY/0.jpg)](https://www.youtube.com/embed/AKNYgP0yEOY?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0)
 
 ## Outline
 

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -59,7 +59,7 @@ Additionally, double clicking an element in the Markdown preview will automatica
 
 The Outline view is a separate section in the bottom of the File Explorer. When expanded, it will show the symbol tree of the currently active editor. For Markdown files, the symbol tree is the Markdown file's header hierarchy.
 
-![Markdown Outline view](images/markdown/markdown-outline-view.png)
+![Markdown Outline view](images/Markdown/markdown-outline-view.png)
 
 The Outline view is a great way to review your document's header structure and outline.
 


### PR DESCRIPTION
For all .md files in "docs/introvideos", I fixed the markdown for embedding videos because "iFrame" didn't compile correctly.

Screenshot before change:

<img width="965" alt="screen shot 2018-10-23 at 4 10 01 pm" src="https://user-images.githubusercontent.com/22715360/47388618-a986c400-d6e0-11e8-9200-7a179ffaf277.png">

Screenshot after change:

<img width="851" alt="screen shot 2018-10-23 at 4 27 00 pm" src="https://user-images.githubusercontent.com/22715360/47388642-b4415900-d6e0-11e8-8c7b-d08ca443c713.png">

 