### PR TITLE
Standardize on casing of npm

### DIFF
--- a/docs/extensionAPI/api-debugging.md
+++ b/docs/extensionAPI/api-debugging.md
@@ -75,9 +75,9 @@ Please note that accessing breakpoints initially returns an empty array but trig
 You can find the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol) specification expressed as a [JSON schema](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/debugProtocol.json) or as a (generated) [TypeScript definition](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts) file in the
 [`vscode-debugadapter-node`](https://github.com/Microsoft/vscode-debugadapter-node) repository.
 Both files show the detailed structure of the individual protocol requests, responses and events.
-The protocol is also available as the NPM module [`vscode-debugprotocol`](https://www.npmjs.com/package/vscode-debugprotocol).
+The protocol is also available as the npm module [`vscode-debugprotocol`](https://www.npmjs.com/package/vscode-debugprotocol).
 
-We have implemented client libraries for the Debug Adapter Protocol in TypeScript and C#, but only the JavaScript/TypeScript client library is already available as an NPM module [`vscode-debugadapter-node`](https://github.com/Microsoft/vscode-debugadapter-node). You can find the C# client library in the [Mono Debug](https://github.com/Microsoft/vscode-mono-debug/blob/master/src/DebugSession.cs) repository.
+We have implemented client libraries for the Debug Adapter Protocol in TypeScript and C#, but only the JavaScript/TypeScript client library is already available as an npm module [`vscode-debugadapter-node`](https://github.com/Microsoft/vscode-debugadapter-node). You can find the C# client library in the [Mono Debug](https://github.com/Microsoft/vscode-mono-debug/blob/master/src/DebugSession.cs) repository.
 
 The following debugger extension projects can serve as examples for how to implement debug adapters:
 

--- a/docs/extensions/example-debuggers.md
+++ b/docs/extensions/example-debuggers.md
@@ -72,7 +72,7 @@ What's in the package?
 * `package.json` is the manifest for the mock-debug extension:
   - it lists the contributions of the mock-debug extension,
   - the `compile` and `watch` scripts are used to transpile the TypeScript source into the `out` folder and watch for subsequent source modifications,
-  - the dependencies `vscode-debugprotocol`, `vscode-debugadapter`, and `vscode-debugadapter-testsupport` are NPM modules that simplify the development of node-based debug adapters.
+  - the dependencies `vscode-debugprotocol`, `vscode-debugadapter`, and `vscode-debugadapter-testsupport` are npm modules that simplify the development of node-based debug adapters.
 * `src/mockRuntime.ts` is a 'mock' runtime with a simple debug API.
 * the code that 'adapts' the runtime to the debug adapter protocol lives in `src/mockDebug.ts`. Here you find the handlers for the various requests of the debug adapter protocol.
 * since the implementation of debug extension lives in the debug adapter, there is no need to have extension code at all (i.e. code that runs in the extension host process). However, Mock Debug has a small `src/extension.ts` because it illustrates what can be done in the extension code of a debug extension.

--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -1207,7 +1207,7 @@ Below are the Visual Studio Code default settings and their values. You can also
   // Enable/disable automatic closing of JSX tags. Requires using TypeScript 3.0 or newer in the workspace.
   "typescript.autoClosingTags": true,
 
-  // Check if NPM is installed for Automatic Type Acquisition.
+  // Check if npm is installed for Automatic Type Acquisition.
   "typescript.check.npmIsInstalled": true,
 
   // Disables automatic type acquisition.
@@ -1267,7 +1267,7 @@ Below are the Visual Studio Code default settings and their values. You can also
   // Sets the locale used to report JavaScript and TypeScript errors. Requires using TypeScript 2.6.0 or newer in the workspace. Default of `null` uses VS Code's locale.
   "typescript.locale": null,
 
-  // Specifies the path to the NPM executable used for Automatic Type Acquisition. Requires using TypeScript 2.3.4 or newer in the workspace.
+  // Specifies the path to the npm executable used for Automatic Type Acquisition. Requires using TypeScript 2.3.4 or newer in the workspace.
   "typescript.npm": null,
 
   // Preferred path style for auto imports.
@@ -1902,7 +1902,7 @@ Below are the Visual Studio Code default settings and their values. You can also
   // Controls whether force pushing uses the safer force-with-lease variant.
   "git.useForcePushWithLease": true,
 
-// Npm
+// npm
 
   // Controls whether npm scripts should be automatically detected.
   "npm.autoDetect": "on",

--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -107,7 +107,7 @@ VS Code can integrate with Sass and Less transpilers through our integrated [tas
 
 For this walkthrough, let's use either the [node-sass](https://www.npmjs.com/package/node-sass) or [less](https://www.npmjs.com/package/less) Node.js module.
 
->**Note:** If you don't have [Node.js](https://nodejs.org) and the [NPM](https://www.npmjs.com/) package manager already installed, you'll need to do so for this walkthrough. [Install Node.js for your platform](https://nodejs.org/en/download/). The Node Package Manager (NPM) is included in the Node.js distribution. You'll need to open a new terminal (command prompt) for `npm` to be on your PATH.
+>**Note:** If you don't have [Node.js](https://nodejs.org) and the [npm](https://www.npmjs.com/) package manager already installed, you'll need to do so for this walkthrough. [Install Node.js for your platform](https://nodejs.org/en/download/). The Node Package Manager (npm) is included in the Node.js distribution. You'll need to open a new terminal (command prompt) for `npm` to be on your PATH.
 
 ```bash
 npm install -g node-sass less

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -55,7 +55,7 @@ If you are using Visual Studio Code 1.8+, you can alternately explicitly list pa
 
 Now when you `require` or `import` **lodash**, VS Code will use the automatically downloaded type declaration files for the library to provide rich Intellisense. Most common JavaScript libraries have type declaration files available. You can search for a library's type declaration file package using the [TypeSearch](https://microsoft.github.io/TypeSearch) site.
 
-### Fixing NPM not installed warning for Automatic Type Acquisition
+### Fixing npm not installed warning for Automatic Type Acquisition
 
 [Automatic Type Acquisition](/docs/languages/javascript.md#automatic-type-acquisition) (ATA) uses [npm](https://www.npmjs.com), the Node.js package manager, to install and manage Type Declaration (typings) files. To ensure that Automatic Type Acquisition works properly, first ensure that you have npm installed on your machine.
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -101,7 +101,7 @@ You can use IntelliSense to add launch configuration snippets for commonly used 
 Here is the list of all snippets:
 
 - **Launch Program**: Launch a Node.js program in debug mode.
-- **Launch via NPM**: Launch a Node.js program through an npm 'debug' script. If you have defined an npm debug script in your package.json, you can use this directly from your launch configuration. Make sure that the debug port used in the npm script, corresponds to the port specified in the snippet.
+- **Launch via npm**: Launch a Node.js program through an npm 'debug' script. If you have defined an npm debug script in your package.json, you can use this directly from your launch configuration. Make sure that the debug port used in the npm script, corresponds to the port specified in the snippet.
 - **Attach**: Attach to the debug port of a locally running Node.js program. Make sure that the Node.js program to debug has been started in debug mode and the debug port used is the same as the one specified in the snippet.
 - **Attach to Remote Program**: Attach to the debug port of a Node.js program running on the host specified by the `address` attribute. Make sure that the Node.js program to debug has been started in debug mode and the debug port used is the same as the one specified in the snippet. To help VS Code mapping source files between your workspace and the filesystem of the remote host, make sure to specify correct paths for the `localRoot`and `remoteRoot` attributes.
 - **Attach by Process ID**: Open the process picker to select a node or gulp process for debugging. With this launch configuration you can even attach to a node or gulp process that was not started in debug mode.
@@ -137,7 +137,7 @@ the corresponding launch configuration would look like this:
 
 ```json
 {
-    "name": "Launch via NPM",
+    "name": "Launch via npm",
     "type": "node",
     "request": "launch",
     "cwd": "${workspaceFolder}",

--- a/docs/nodejs/nodejs-tutorial.md
+++ b/docs/nodejs/nodejs-tutorial.md
@@ -10,7 +10,7 @@ MetaSocialImage: images/nodejs/runtimes_node.png
 ---
 # Node.js tutorial in Visual Studio Code
 
-[Node.js](https://nodejs.org/) is a platform for building fast and scalable server applications using JavaScript. Node.js is the runtime and [NPM](https://www.npmjs.com/) is the Package Manager for Node.js modules.
+[Node.js](https://nodejs.org/) is a platform for building fast and scalable server applications using JavaScript. Node.js is the runtime and [npm](https://www.npmjs.com/) is the Package Manager for Node.js modules.
 
 Visual Studio Code has support for the JavaScript and TypeScript languages out-of-the-box as well as Node.js debugging. However, to run a Node.js application, you will need to install the Node.js runtime on your machine.
 
@@ -103,7 +103,7 @@ Now that you've seen VS Code in action with "Hello World", the next section show
 
 ## An Express application
 
-[Express](https://expressjs.com/) is a very popular application framework for building and running Node.js applications. You can scaffold (create) a new Express application using the Express Generator tool. The Express Generator is shipped as an NPM module and installed by using the NPM command line tool `npm`.
+[Express](https://expressjs.com/) is a very popular application framework for building and running Node.js applications. You can scaffold (create) a new Express application using the Express Generator tool. The Express Generator is shipped as an npm module and installed by using the npm command line tool `npm`.
 
 >**Tip:** To test that you've got `npm` correctly installed on your computer, type `npm --help` from a terminal and you should see the usage documentation.
 
@@ -121,7 +121,7 @@ We can now scaffold a new Express application called `myExpressApp` by running:
 express myExpressApp
 ```
 
-This creates a new folder called `myExpressApp` with the contents of your application.  To install all of the application's dependencies (again shipped as NPM modules), go to the new folder and execute `npm install`:
+This creates a new folder called `myExpressApp` with the contents of your application.  To install all of the application's dependencies (again shipped as npm modules), go to the new folder and execute `npm install`:
 
 ```bash
 cd myExpressApp

--- a/docs/setup/additional-components.md
+++ b/docs/setup/additional-components.md
@@ -18,7 +18,7 @@ If you are used to working with larger, monolithic development tools (IDEs), you
 Here are a few commonly installed components:
 
 - [Git](https://git-scm.com/download) - VS Code has built-in support for source code control using Git but requires Git to be installed separately.
-- [Node.js (includes NPM)](https://nodejs.org/) - A platform and runtime for building and running JavaScript applications.
+- [Node.js (includes npm)](https://nodejs.org/) - A platform and runtime for building and running JavaScript applications.
 - [TypeScript](https://www.typescriptlang.org) - The TypeScript compiler, `tsc`, for transpiling TypeScript to JavaScript.
 
 You'll find the components above mentioned often in our documentation and walkthroughs.
@@ -41,9 +41,9 @@ Visual Studio Code integrates with existing tool chains.  We think the following
 - [Express](https://expressjs.com/) - An application framework for Node.js applications using the **Jade** template engine.
 - [Gulp](https://gulpjs.com/) - A streaming task runner system which integrates easily with VS Code tasks.
 - [Mocha](https://mochajs.org/) - A JavaScript test framework that runs on Node.js.
-- [Yarn](https://yarnpkg.com/) - A dependency manager and alternative to NPM.
+- [Yarn](https://yarnpkg.com/) - A dependency manager and alternative to npm.
 
->**Note:** Most of these tools require Node.js and the NPM package manager to install and use.
+>**Note:** Most of these tools require Node.js and the npm package manager to install and use.
 
 ## Next Steps
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -111,7 +111,7 @@ VS Code ships monthly and you can see when a new release is available by checkin
 
 ## Node.js
 
-Node.js is a popular platform and runtime for easily building and running JavaScript applications. It also includes [NPM](https://www.npmjs.com/), a Package Manager for Node.js modules. You'll see Node.js and NPM mentioned frequently in our documentation and some optional VS Code tooling requires Node.js (for example, the VS Code [extension generator](/docs/extensions/yocode.md)).
+Node.js is a popular platform and runtime for easily building and running JavaScript applications. It also includes [npm](https://www.npmjs.com/), a Package Manager for Node.js modules. You'll see Node.js and npm mentioned frequently in our documentation and some optional VS Code tooling requires Node.js (for example, the VS Code [extension generator](/docs/extensions/yocode.md)).
 
 If you'd like to install Node.js on Linux, see [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager) to find the Node.js package and installation instructions tailored to your Linux distribution. You can also install and support multi version of Node.js by using the [Node Version Manager](https://github.com/creationix/nvm).
 

--- a/docs/setup/setup-overview.md
+++ b/docs/setup/setup-overview.md
@@ -74,7 +74,7 @@ VS Code is a small download (< 100 MB) and has a disk footprint of less than 200
 
 ### How do I create and run a new project?
 
-VS Code doesn't include a traditional **File** > **New Project** dialog or pre-installed project templates. You'll need to add [additional components](/docs/setup/additional-components.md) and scaffolders depending on your development interests. With scaffolding tools like [Yeoman](http://yeoman.io/) and the multitude of modules available through the [NPM](https://www.npmjs.com/) package manager, you're sure to find appropriate templates and tools to create your projects.
+VS Code doesn't include a traditional **File** > **New Project** dialog or pre-installed project templates. You'll need to add [additional components](/docs/setup/additional-components.md) and scaffolders depending on your development interests. With scaffolding tools like [Yeoman](http://yeoman.io/) and the multitude of modules available through the [npm](https://www.npmjs.com/) package manager, you're sure to find appropriate templates and tools to create your projects.
 
 ### How do I know which version I'm running?
 

--- a/tutorials/nodejs-deployment/express.md
+++ b/tutorials/nodejs-deployment/express.md
@@ -16,7 +16,7 @@ In this step, you will create a very simple Node.js application that can be depl
 
 ## Install the Express Generator
 
-[Express](https://www.expressjs.com) is a very popular framework for building and running Node.js applications. You can scaffold (create) a new Express application using the [Express Generator](https://expressjs.com/en/starter/generator.html) tool. The Express Generator is shipped as an NPM module and installed by using the NPM command line tool `npm`.
+[Express](https://www.expressjs.com) is a very popular framework for building and running Node.js applications. You can scaffold (create) a new Express application using the [Express Generator](https://expressjs.com/en/starter/generator.html) tool. The Express Generator is shipped as an npm module and installed by using the npm command line tool `npm`.
 
 ```bash
 $ npm install -g express-generator


### PR DESCRIPTION
Per the npm team, npm should always be lowercase. I updated all
references in docs and tutorials, I left the blogs and release notes
alone.

See this blog post for more references on using npm vs NPM or Npm:
https://css-tricks.com/start-sentence-npm/