### PR TITLE
Fix broken image links in tutorials

### DIFF
--- a/tutorials/app-service-extension/create-app.md
+++ b/tutorials/app-service-extension/create-app.md
@@ -51,7 +51,7 @@ $ npm start
 
 Now, open your browser and navigate to [http://localhost:3000](http://localhost:3000), where you should see something like this:
 
-![Running Express Application](images/nodejs-deployment/express.png)
+![Running Express Application](../images/nodejs-deployment/express.png)
 
 Next, open your application folder in VS Code and get ready to deploy it to Azure.
 
@@ -61,4 +61,5 @@ $ code .
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/app-service-extension/deploy-app">I created the Node.js application</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'create-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/app-service-extension/deploy-app">I created the Node.js application</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'create-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/app-service-extension/deploy-app.md
+++ b/tutorials/app-service-extension/deploy-app.md
@@ -14,7 +14,7 @@ In this step, you deploy your Node.js website using VS Code and the Azure App Se
 
 In the **AZURE APP SERVICE** explorer, click the blue up arrow icon to deploy your app to Azure.
 
-![Deploy to Web App](images/app-service-extension/deploy.png)
+![Deploy to Web App](../images/app-service-extension/deploy.png)
 
 > **Tip:** You can also deploy from the **Command Palette** (`kb(workbench.action.showCommands)`) by typing 'deploy to web app' and running the **Azure App Service: Deploy to Web App** command.
 
@@ -32,11 +32,11 @@ In the **AZURE APP SERVICE** explorer, click the blue up arrow icon to deploy yo
 
   Click **Yes** when prompted to update your configuration to run `npm install` on the target server. Your app is then deployed.
 
-  ![Configured deployment](images/app-service-extension/server-build.png)
+  ![Configured deployment](../images/app-service-extension/server-build.png)
 
 Once the deployment starts, you're prompted to update your workspace so that all subsequent deploys automatically target the same App Service Web App. Choose **Yes** to ensure your changes are deployed to the correct app.
 
-![Configured deployment](images/app-service-extension/save-configuration.png)
+![Configured deployment](../images/app-service-extension/save-configuration.png)
 
 > **Tip:** Be sure that your application is listening on the port provided by the PORT environment variable: `process.env.PORT`.
 
@@ -54,4 +54,5 @@ You can deploy changes to this app by using the same process and choosing the ex
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/app-service-extension/tailing-logs">My site is on Azure</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/app-service-extension/tailing-logs">My site is on Azure</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/app-service-extension/getting-started.md
+++ b/tutorials/app-service-extension/getting-started.md
@@ -26,7 +26,7 @@ The Azure App Service extension is used to create, manage, and deploy Linux Web 
 
 Once the extension is installed, log into your Azure account - in the Activity Bar, click on the Azure logo to show the **AZURE APP SERVICE** explorer. Click **Sign in to Azure...** and follow the instructions.
 
-![sign in to Azure](images/app-service-extension/sign-in.png)
+![sign in to Azure](../images/app-service-extension/sign-in.png)
 
 ## Troubleshooting
 
@@ -47,5 +47,5 @@ In VS Code, you should see your Azure email address in the Status Bar and your s
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/app-service-extension/create-app">I've installed the Azure Extension</a>
+<a class="tutorial-next-btn" href="/tutorials/app-service-extension/create-app">I've installed the Azure Extension</a>  
 <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/app-service-extension/tailing-logs.md
+++ b/tutorials/app-service-extension/tailing-logs.md
@@ -14,9 +14,9 @@ Find the app in the **AZURE APP SERVICE** explorer, right-click the app, and cho
 
 When prompted, choose to enable logging and restart the application. Once the app is restarted, the VS Code output window opens with a connection to the log stream.
 
-![View Streaming Logs](images/app-service-extension/view-logs.png)
+![View Streaming Logs](../images/app-service-extension/view-logs.png)
 
-![Enable Logging and Restart](images/app-service-extension/enable-restart.png)
+![Enable Logging and Restart](../images/app-service-extension/enable-restart.png)
 
 After a few seconds, you will see a message indicating that you are connected to the log-streaming service.
 
@@ -58,4 +58,5 @@ The [Azure for Node.js](https://docs.microsoft.com/en-us/nodejs/azure/?view=azur
 
 ----
 
-<a class="tutorial-next-btn" href="/docs">I'm Done!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/docs">I'm Done!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azureappservice', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/docker-extension/containerize-app.md
+++ b/tutorials/docker-extension/containerize-app.md
@@ -36,7 +36,7 @@ This tutorial uses the Azure Container Registry so for my example:
 
 `fiveisprime.azurecr.io/myexpressapp:latest`
 
-![tag docker image](images/docker-extension/tag-image.png)
+![tag docker image](../images/docker-extension/tag-image.png)
 
 If you are using Docker Hub, use your Docker Hub username, for example:
 
@@ -46,16 +46,17 @@ Once completed, the Terminal panel will open and the Docker command will be exec
 
 Once built, the image will show up in the **DOCKER** explorer under **Images**.
 
-![Docker Image](images/docker-extension/image-list.png)
+![Docker Image](../images/docker-extension/image-list.png)
 
 ## Push the image to a registry
 
 Open the **Command Palette** (`kb(workbench.action.showCommands)`) and run **Docker: Push** and choose the image you just built to push the image to the registry. This will also execute the Docker command in the Terminal panel to show the status of the operation. Once completed, expand the **Images** node in the Docker extension explorer to see your image.
 
-![Image in ACR](images/docker-extension/image-in-acr.png)
+![Image in ACR](../images/docker-extension/image-in-acr.png)
 
 Next, you'll deploy your image to Azure.
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/docker-extension/deploy-container">I've created an image for my application</a> <a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'containerize-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/docker-extension/deploy-container">I've created an image for my application</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'containerize-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/docker-extension/create-registry.md
+++ b/tutorials/docker-extension/create-registry.md
@@ -24,9 +24,9 @@ Docker Hub is Docker's own hosted registry that provides a free way of sharing i
 
 Ensure that the registry endpoint that you just setup is visible under **Registries** in the **DOCKER** explorer.
 
-![Registries](images/docker-extension/registries.png)
+![Registries](../images/docker-extension/registries.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/docker-extension/containerize-app">I've Created a Registry</a>
+<a class="tutorial-next-btn" href="/tutorials/docker-extension/containerize-app">I've Created a Registry</a>  
 <a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/docker-extension/deploy-container.md
+++ b/tutorials/docker-extension/deploy-container.md
@@ -14,13 +14,13 @@ Now that you have your app image built and pushed to a registry, you can deploy 
 
 Find the image under the **Registries** node in the **DOCKER** explorer, right click the `:latest` tag and choose **Deploy Image to Azure App Service**.
 
-![Deploy From the Explorer](images/docker-extension/deploy-menu.png)
+![Deploy From the Explorer](../images/docker-extension/deploy-menu.png)
 
 From here follow the prompts. Set up a Resource Group in `West US` and App Service Plan. For this tutorial, use 'myResourceGroup' and 'myPlan' for the Resource Group and plan names then give your app a **unique** name.
 
 Once created, your app is accessible via http://**unique-name**.azurewebsites.net. In this example, I called it `myExpressApp4321`.
 
-![Create and Deploy](images/docker-extension/create.gif)
+![Create and Deploy](../images/docker-extension/create.gif)
 
 A **Resource Group** is essentially a named collection of all our application's resources in Azure. For example, a Resource Group can contain a reference to a website, a database, and an Azure Function.
 
@@ -32,4 +32,5 @@ The Output panel will open during deployment to indicate the status of the opera
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/docker-extension/tailing-logs">My site is on Azure</a> <a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/docker-extension/tailing-logs">My site is on Azure</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/docker-extension/getting-started.md
+++ b/tutorials/docker-extension/getting-started.md
@@ -30,7 +30,7 @@ The Azure App Service extension is used to create, manage, and deploy Linux Web 
 
 Once the extensions are installed, log into your Azure account - in the Activity Bar, click on the Azure logo to show the **AZURE APP SERVICE** explorer. Click **Sign in to Azure...** and follow the instructions.
 
-![sign in to Azure](images/app-service-extension/sign-in.png)
+![sign in to Azure](../images/app-service-extension/sign-in.png)
 
 ## Prerequisite Check
 
@@ -47,5 +47,5 @@ Docker Version 17.12.0-ce, build c97c6d6
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/docker-extension/create-registry">I've installed the Docker Extension</a>
+<a class="tutorial-next-btn" href="/tutorials/docker-extension/create-registry">I've installed the Docker Extension</a>  
 <a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/docker-extension/tailing-logs.md
+++ b/tutorials/docker-extension/tailing-logs.md
@@ -14,9 +14,9 @@ Find the app in the **AZURE APP SERVICE** explorer, right-click the app, and cho
 
 When prompted, choose to enable logging and restart the application. Once the app is restarted, the VS Code Output panel opens with a connection to the log stream.
 
-![View Streaming Logs](images/app-service-extension/view-logs.png)
+![View Streaming Logs](../images/app-service-extension/view-logs.png)
 
-![Enable Logging and Restart](images/app-service-extension/enable-restart.png)
+![Enable Logging and Restart](../images/app-service-extension/enable-restart.png)
 
 After a few seconds, you will see a message indicating that you are connected to the log-streaming service.
 
@@ -57,4 +57,5 @@ The [Azure for Node.js](https://docs.microsoft.com/en-us/nodejs/azure/?view=azur
 
 ----
 
-<a class="tutorial-next-btn" href="/docs">I'm Done!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/docs">I'm Done!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('docker-extension', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/functions-extension/create-app.md
+++ b/tutorials/functions-extension/create-app.md
@@ -12,11 +12,11 @@ First, create a local Azure Functions application. An Azure Functions app can co
 
 In VS Code, expand the **AZURE FUNCTIONS** explorer and click the **Create Project** icon.
 
-![Create Local App](images/functions-extension/create-function-app-project.png)
+![Create Local App](../images/functions-extension/create-function-app-project.png)
 
 Choose an empty directory for the app then select JavaScript for the language of your Functions App.
 
-![Select Language](images/functions-extension/create-function-app-project-language.png)
+![Select Language](../images/functions-extension/create-function-app-project-language.png)
 
 VS Code will reload and your new local Functions app will be loaded into your workspace.
 
@@ -24,4 +24,5 @@ Next, add an HTTP trigger Function to your app.
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/functions-extension/create-function">I created the Functions App</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'create-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/functions-extension/create-function">I created the Functions App</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'create-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/functions-extension/create-function.md
+++ b/tutorials/functions-extension/create-function.md
@@ -12,21 +12,22 @@ Next, create a Function that handles HTTP requests.
 
 From the **AZURE FUNCTIONS** explorer, click the **Create Function** icon.
 
-![Create Function](images/functions-extension/create-function.png)
+![Create Function](../images/functions-extension/create-function.png)
 
 Select the directory you currently have open - it's the default option so press `kbstyle(Enter)`. When prompted, choose HTTP trigger, use the default name of `HttpTriggerJS`, and choose **Anonymous** authentication.
 
-![Choose Template](images/functions-extension/create-function-choose-template.png)
+![Choose Template](../images/functions-extension/create-function-choose-template.png)
 
-![Choose Authentication](images/functions-extension/create-function-anonymous-auth.png)
+![Choose Authentication](../images/functions-extension/create-function-anonymous-auth.png)
 
 Upon completion, a new directory is created within your Function app named `HttpTriggerJS` that includes `index.js`and `functions.json` files. The `index.js` file contains the source code that responds to the HTTP request and `functions.json` contains the [binding configuration](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings) for the HTTP trigger.
 
-![Completed Project](images/functions-extension/functions-vscode-intro.png)
+![Completed Project](../images/functions-extension/functions-vscode-intro.png)
 
 Next, run your app locally to verify everything is working.
 
 ---
 
-<a class="tutorial-next-btn" href="/tutorials/functions-extension/run-app">I created the Functions App</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'create-function')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/functions-extension/run-app">I created the Functions App</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'create-function')" href="javascript:void(0)">I ran into an issue</a>
 

--- a/tutorials/functions-extension/deploy-app.md
+++ b/tutorials/functions-extension/deploy-app.md
@@ -10,7 +10,7 @@ DateApproved: 2/9/2018
 
 In the **AZURE FUNCTIONS** explorer, click the blue up arrow icon to deploy your app to Azure Functions.
 
-![Deploy to Functions](images/functions-extension/function-app-publish-project.png)
+![Deploy to Functions](../images/functions-extension/function-app-publish-project.png)
 
 > **Tip:** You can also deploy from the **Command Palette** (`kb(workbench.action.showCommands)`) by typing 'deploy to function app' and running the **Azure Functions: Deploy to Function App** command.
 
@@ -30,13 +30,13 @@ The Output panel shows the Azure resources that were created in your subscriptio
 
 > **Tip:** A storage account is not required for HTTP trigger functions, other function triggers (e.g. Storage) do, however, require a storage account.
 
-![Deploy to Functions](images/functions-extension/function-create-output.png)
+![Deploy to Functions](../images/functions-extension/function-create-output.png)
 
 ## Browse the website
 
 The Output panel will open during deployment to indicate the status of the operation. Once completed, find the app that you just created in the **AZURE FUNCTIONS** explorer, expand the **Functions** node to expose the HttpTriggerJS function, then right-click and choose **Copy Function Url**. Paste the URL into your browser along add the `?name=Matt` query parameter and press `kbstyle(Enter)` to see the response.
 
-![Deploy to Functions](images/functions-extension/functions-test-remote-browser.png)
+![Deploy to Functions](../images/functions-extension/functions-test-remote-browser.png)
 
 ## Updating the App
 
@@ -61,4 +61,5 @@ Or get them all by installing the
 
 ----
 
-<a class="tutorial-next-btn" href="/docs">I'm Done!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/docs">I'm Done!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'deploy-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/functions-extension/getting-started.md
+++ b/tutorials/functions-extension/getting-started.md
@@ -44,7 +44,7 @@ The Azure Functions extension is used to create, manage, and deploy Functions Ap
 Once the extension is installed, log into your Azure account - in the Activity Bar, click on the Azure logo to show the **Azure Functions** explorer. Click **Sign in to Azure...** and follow the instructions.
 
 
-![sign in to Azure](images/functions-extension/sign-in.png)
+![sign in to Azure](../images/functions-extension/sign-in.png)
 
 ## Prerequisite check
 
@@ -74,5 +74,5 @@ Function Runtime Version: 2.0.11415.0
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/functions-extension/create-app">I've installed the Azure Extension</a>
+<a class="tutorial-next-btn" href="/tutorials/functions-extension/create-app">I've installed the Azure Extension</a>  
 <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/functions-extension/run-app.md
+++ b/tutorials/functions-extension/run-app.md
@@ -12,16 +12,17 @@ Upon creating the Function application, the necessary VS Code launch configurati
 
 Press `F5` to launch the debugger. Output from the Functions Core tools is displayed in the VS Code Integrate Terminal panel. Once the host has started up, the local URL for your Function is written out. `Ctrl+Click` (`Cmd+Click` on macOS) the URL to open it in your browser.
 
-![Functions Launch](images/functions-extension/functions-vscode-f5.png)
+![Functions Launch](../images/functions-extension/functions-vscode-f5.png)
 
 The default HTTP template parses a `name` query parameter to customize the response, add `?name=<yourname>` to the URL in your browser to see the response output correctly.
 
 > **TIP:** You can also set and hit breakpoints when running locally to test any changes.
 
-![Hello Matt](images/functions-extension/functions-test-local-browser.png)
+![Hello Matt](../images/functions-extension/functions-test-local-browser.png)
 
 After verifying that the app runs locally, it's time to publish it to Azure Functions.
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/functions-extension/deploy-app">I created the Functions App</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'run-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/functions-extension/deploy-app">I created the Functions App</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-azurefunctions', 'run-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/create-website.md
+++ b/tutorials/nodejs-deployment/create-website.md
@@ -72,8 +72,9 @@ $ az webapp browse --name myExpressApp-chrisdias
 
 You should see something like this:
 
-![Empty Azure Website](images/nodejs-deployment/emptyazuresite.png)
+![Empty Azure Website](../images/nodejs-deployment/emptyazuresite.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/deploy-website">My site is running</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'create-website')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/deploy-website">My site is running</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'create-website')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/deploy-website.md
+++ b/tutorials/nodejs-deployment/deploy-website.md
@@ -70,7 +70,7 @@ You'll be prompted for the password you provided above. You should then see a se
 
 Browse to the site again and you should see your Express site hosted in Azure!
 
-![Express Site Hosted in Azure](images/nodejs-deployment/expressinazure.png)
+![Express Site Hosted in Azure](../images/nodejs-deployment/expressinazure.png)
 
 > Are you seeing the error `Object #<eventemitter> has no method 'hrtime'`? If so, you probably need to set the node runtime version on the site. The following command will tell the site to use node version `6.9.1`. If your site requires a different or later version of node, specify the **full** semantic version `major.minor.patch`.
 
@@ -80,4 +80,5 @@ $ az webapp config appsettings set --name myExpressApp-chrisdias --settings WEBS
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/tailing-logs">My site is on Azure</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'deploy-website')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/tailing-logs">My site is on Azure</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'deploy-website')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/express.md
+++ b/tutorials/nodejs-deployment/express.md
@@ -52,8 +52,9 @@ $ npm start
 
 Now, open your browser and navigate to [http://localhost:3000](http://localhost:3000), where you should see something like this:
 
-![Running Express Application](images/nodejs-deployment/express.png)
+![Running Express Application](../images/nodejs-deployment/express.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/create-website">I created the Node.js application</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'express')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/create-website">I created the Node.js application</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'express')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/extensions.md
+++ b/tutorials/nodejs-deployment/extensions.md
@@ -28,17 +28,17 @@ You can browse and install extensions from within VS Code. Bring up the **Extens
 
 Enter `Azure` in the search box and press `kbstyle(Enter)` to query the Marketplace. You'll see a number of Azure related extensions.
 
-![Search for Extensions](images/nodejs-deployment/searchforextension.png)
+![Search for Extensions](../images/nodejs-deployment/searchforextension.png)
 
 ## Install the MS SQL Extension
 
 Scroll to find the **mssql** extension and click on it to review the README. Click the **Install** button to download and install the extension. You'll be prompted to restart VS Code to load the extension.
 
-![SQL Extension](images/nodejs-deployment/sqlextension.png)
+![SQL Extension](../images/nodejs-deployment/sqlextension.png)
 
 Open the **Command Palette** (`kb(workbench.action.showCommands)`) and type in `sql` to search for the newly added commands which will let you connect to a SQL Server, run queries, and more!
 
-![SQL Commands](images/nodejs-deployment/sqlcommands.png)
+![SQL Commands](../images/nodejs-deployment/sqlcommands.png)
 
 ## Learn More at [docs.microsoft.com](https://docs.microsoft.com)
 
@@ -50,4 +50,5 @@ Congratulations, you've successfully completed this walkthrough!
 
 ----
 
-<a class="tutorial-next-btn" href="/docs">I'm Done!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'extensions')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/docs">I'm Done!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'extensions')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/getting-started.md
+++ b/tutorials/nodejs-deployment/getting-started.md
@@ -59,4 +59,5 @@ git version 2.6.4
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/express">I've installed the Azure CLI</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/express">I've installed the Azure CLI</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/publishing-changes.md
+++ b/tutorials/nodejs-deployment/publishing-changes.md
@@ -16,11 +16,11 @@ In this step, you will make changes to your application, commit them to the loca
 
 Open the `myExpressApp` folder in Visual Studio Code.
 
-![Open VS Code](images/nodejs-deployment/openvscode.png)
+![Open VS Code](../images/nodejs-deployment/openvscode.png)
 
 Open `views/index.pug` and change line 5 to say something fun such as 'VS Code Rocks!!' and then save the file (`kb(workbench.action.files.save)`).
 
-![Edit pug file](images/nodejs-deployment/editpugfile.png)
+![Edit pug file](../images/nodejs-deployment/editpugfile.png)
 
 > Pro Tip: Turn on "AutoSave" from the **File** > **AutoSave** menu!
 
@@ -28,22 +28,23 @@ Open `views/index.pug` and change line 5 to say something fun such as 'VS Code R
 
 Open the **Source Control** view (`kb(workbench.view.scm)`), enter a commit message, and press `kbstyle(Ctrl+Enter)` to commit the change (`kbstyle(Cmd+Enter)` on macOS).
 
-![Commit Changes](images/nodejs-deployment/commitchanges.png)
+![Commit Changes](../images/nodejs-deployment/commitchanges.png)
 
 ## Publish Changes to Website
 
 Click on the **Source Control** overflow menu (**...**) and choose **Publish**.
 
-![Publish Menu](images/nodejs-deployment/publishmenu.png)
+![Publish Menu](../images/nodejs-deployment/publishmenu.png)
 
 You will be prompted for a Remote to publish to, choose `Azure`.
 
-![Choose Azure](images/nodejs-deployment/chooseazure.png)
+![Choose Azure](../images/nodejs-deployment/chooseazure.png)
 
 Your changes will then be deployed to the Website. Refresh your application and you should see the changes.
 
-![Published Changes](images/nodejs-deployment/vscoderocks.png)
+![Published Changes](../images/nodejs-deployment/vscoderocks.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/extensions">I can see my changes!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'publishing-changes')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/extensions">I can see my changes!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'publishing-changes')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/nodejs-deployment/tailing-logs.md
+++ b/tutorials/nodejs-deployment/tailing-logs.md
@@ -34,4 +34,5 @@ GET / 304 0.490 ms - -
 
 ----
 
- <a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/publishing-changes">I can see my logs</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>
+ <a class="tutorial-next-btn" href="/tutorials/nodejs-deployment/publishing-changes">I can see my logs</a>  
+ <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment', 'tailing-logs')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/static-website/code-change.md
+++ b/tutorials/static-website/code-change.md
@@ -28,8 +28,9 @@ Run `npm run build` locally then right-click your updated `build` directory and 
 
 Once your deployment is complete, revisit your storage endpoint (`https://<storage-account-name>.z4.web.core.windows.net/`) and you should see the following!
 
-![Import build](images/static-website/updated-azure-app.png)
+![Import build](../images/static-website/updated-azure-app.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/docs">I'm done!</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'code-change')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/docs">I'm done!</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'code-change')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/static-website/create-app.md
+++ b/tutorials/static-website/create-app.md
@@ -49,10 +49,11 @@ npm start
 
 Now, open your browser and navigate to [http://localhost:3000](http://localhost:3000), where you should see something like this:
 
-![Running React App](images/static-website/local-app.png)
+![Running React App](../images/static-website/local-app.png)
 
 You are now ready to deploy your app!
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/static-website/create-storage">I created the React application</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'create-app')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/static-website/create-storage">I created the React application</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'create-app')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/static-website/create-storage.md
+++ b/tutorials/static-website/create-storage.md
@@ -20,11 +20,11 @@ In this section, we will setup our Azure Storage account and blob container.
 
    > **Note**: If you don't see **Storage accounts**, select **All services** from the top of the menu, find it in the full list, and star it to dock it in your menu bar.
 
-   ![Sign into Storage Explorer](images/static-website/storage/1-portal-select-storage.png)
+   ![Sign into Storage Explorer](../images/static-website/storage/1-portal-select-storage.png)
 
 3. Click either **+ Add** or **Create Storage Accounts** to create a new account.
 
-   ![Create new storage account](images/static-website/storage/2-portal-new-storage.png)
+   ![Create new storage account](../images/static-website/storage/2-portal-new-storage.png)
 
 4. Fill in a **Name** for your storage account and the **Resource group**.
 
@@ -34,7 +34,7 @@ In this section, we will setup our Azure Storage account and blob container.
 
    Static website hosting is only available for accounts using GPv2.
 
-   ![Add name and Resource Group](images/static-website/storage/3-portal-config-storage.png)
+   ![Add name and Resource Group](../images/static-website/storage/3-portal-config-storage.png)
 
 6. When you're ready, click **Create** and wait for the account to be created.
 
@@ -48,7 +48,7 @@ In this section, we will setup our Azure Storage account and blob container.
 
   > **Note**: Be sure to include the name of your index document.
 
-   ![Confirm container](images/static-website/storage/8-portal-config-static-site.png)
+   ![Confirm container](../images/static-website/storage/8-portal-config-static-site.png)
 
 ## Your site URL
 

--- a/tutorials/static-website/deploy-website.md
+++ b/tutorials/static-website/deploy-website.md
@@ -14,18 +14,19 @@ In the **AZURE STORAGE** explorer, expand your subscription and find the Azure S
 
 1. Open your application code in VS Code, right-click on your **build** directory, and choose **Deploy to Static Website...**.
 
-    ![Deploy to Static Website](images/static-website/deploy-build.png)
+    ![Deploy to Static Website](../images/static-website/deploy-build.png)
 
 1. Choose your Subscription and the Storage Account that you just created. When completed, you can click into the portal to copy your website URL (primary endpoint).
 
-    ![Deployment Complete](images/static-website/deployment-complete.png)
+    ![Deployment Complete](../images/static-website/deployment-complete.png)
 
 ## Browse your website
 
 Visit the URL to see your app running on Azure.
 
-![App running in Azure](images/static-website/azure-app.png)
+![App running in Azure](../images/static-website/azure-app.png)
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/static-website/code-change">My site is on Azure</a> <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'deploy-explorer')" href="javascript:void(0)">I ran into an issue</a>
+<a class="tutorial-next-btn" href="/tutorials/static-website/code-change">My site is on Azure</a>  
+<a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'deploy-explorer')" href="javascript:void(0)">I ran into an issue</a>

--- a/tutorials/static-website/getting-started.md
+++ b/tutorials/static-website/getting-started.md
@@ -41,7 +41,7 @@ The [Azure Storage](https://marketplace.visualstudio.com/items?itemName=ms-azure
 
 Once the extension is installed, log into your Azure account - in the Activity Bar, click on the Azure logo to show the **AZURE STORAGE** explorer. Click **Sign in to Azure...** and follow the instructions.
 
-![sign in to Azure](images/static-website/sign-in.png)
+![sign in to Azure](../images/static-website/sign-in.png)
 
 ## Prerequisite check
 
@@ -62,5 +62,5 @@ to ensure that both Node.js and npm are installed.
 
 ----
 
-<a class="tutorial-next-btn" href="/tutorials/static-website/create-app">I've installed the prerequisites</a>
+<a class="tutorial-next-btn" href="/tutorials/static-website/create-app">I've installed the prerequisites</a>  
 <a class="tutorial-feedback-btn" onclick="reportIssue('node-deployment-staticwebsite', 'getting-started')" href="javascript:void(0)">I ran into an issue</a>


### PR DESCRIPTION
Looks like the images were all moved to a common folder, rather than in the specific tutorials. I am viewing these tutorials on Github directly, I don't know how this would effect to the publishing site. 

There was also no line break on the links at the bottom of each page. This may be due to a [VS Code bug](https://github.com/Microsoft/vscode/issues/39928) as I was experiencing it too while editing the files.