### PR TITLE
Fix a few typos in the editor docs

### DIFF
--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -266,7 +266,7 @@ You can change the location by launching VS Code with the `--extensions-dir <dir
 
 ### Whenever I try to install any extension, I get a connect ETIMEDOUT error
 
-You may see this error if your machine is going through a proxy server to access the Internet.  See the [Proxy server support](/docs/setup/network.md#proxy-server-support) section in SETUP topic for details.
+You may see this error if your machine is going through a proxy server to access the Internet.  See the [Proxy server support](/docs/setup/network.md#proxy-server-support) section in the setup topic for details.
 
 ### Can I download an extension directly from the Marketplace?
 

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -23,7 +23,7 @@ To open the terminal:
 
 ## Managing Multiple Terminals
 
-You can create multiple terminals open to different locations and easily navigate between them. Terminal instances can be added by hitting the plus icon on the top-right of the **TERMINAL** panel or by triggering the `kb(workbench.action.terminal.new)` command. This creates another entry in the dropdown list that can be used to switch between them.
+You can create multiple terminals open to different locations and easily navigate between them. Terminal instances can be added by clicking the plus icon on the top-right of the **TERMINAL** panel or by triggering the `kb(workbench.action.terminal.new)` command. This creates another entry in the dropdown list that can be used to switch between them.
 
 ![Multiple Terminals](images/integrated-terminal/terminal-multiple-instances.png)
 
@@ -208,7 +208,7 @@ There are also extensions available that give more options such as [Terminal Her
 
 ## Changing how the terminal is rendered
 
-By default, the integrated terminal will render using multiple `<canvas>` elements which is better tuned than the DOM for rendering interactive text that changes often. However, Electron/Chromium are slower rendering to canvas on some environment and so VS Code also provides a fallback DOM-renderer experience. VS Code will try to detect slow performance and give you the option to change via a notification. You can also change the rendering directly by setting `terminal.integrated.rendererType` in your user or workspace [settings](/docs/getstarted/settings.md).
+By default, the integrated terminal will render using multiple `<canvas>` elements which is better tuned than the DOM for rendering interactive text that changes often. However, Electron/Chromium are slower rendering to canvas on some environments and so VS Code also provides a fallback DOM-renderer experience. VS Code will try to detect slow performance and give you the option to change via a notification. You can also change the rendering directly by setting `terminal.integrated.rendererType` in your user or workspace [settings](/docs/getstarted/settings.md).
 
 ```js
 {

--- a/docs/editor/portable.md
+++ b/docs/editor/portable.md
@@ -46,7 +46,7 @@ On **macOS**, you need to place the data folder as a sibling of the application 
 
 Portable Mode won't work if your application is in [quarantine](https://apple.stackexchange.com/a/104875), which happens by default if you just downloaded Code. Make sure you remove the quarantine attribute, if Portable Mode doesn't seem to work:
 
-```
+```bash
 xattr -dr com.apple.quarantine Visual\ Studio\ Code.app
 ```
 

--- a/docs/editor/refactoring.md
+++ b/docs/editor/refactoring.md
@@ -25,7 +25,7 @@ If you'd just like to see refactorings without Quick Fixes, you can use the **Re
 
 >**Note:** If you prefer to not see the Code Action lightbulb in your editor, you can disable lightbulbs with the `editor.lightbulb.enable` [setting](/docs/getstarted/settings.md). You can still open Quick Fixes through **Quick Fix** command and `kb(editor.action.quickFix)` keyboard shortcut.
 
-## Refactoring
+## Refactoring Actions
 
 ### Extract Method
 


### PR DESCRIPTION
This PR fixes a few typos in the editor section of the docs.