### PR TITLE
Document workbench.action.quickInputBack

### DIFF
--- a/docs/customization/keyboard-shortcuts.md
+++ b/docs/customization/keyboard-shortcuts.md
@@ -112,6 +112,7 @@ Key|Command
 `kb(editor.action.marker.prevInFiles)`|Go to previous error or warning
 `kb(workbench.action.openpreviousRecentlyUsedEditorInGroup)`|Navigate editor group history
 `kb(workbench.action.navigateBack)`|Go back
+`kb(workbench.action.quickInputBack)`|Go back to previous step, when in the QuickInput UI
 `kb(workbench.action.navigateForward)`|Go forward
 `kb(editor.action.toggleTabFocusMode)`|Toggle Tab moves focus
 


### PR DESCRIPTION
Issue #1760 asks about what this command does, so I looked into it and documented it in the keyboard shortcuts md file. Seems appropriate since I installed a fresh copy of VSCode, and there was a default keybinding for this command.

Comments welcome.