### PR TITLE
Remove unused import

### DIFF
--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -137,7 +137,6 @@ To create a minimal Django app, then, it's necessary to first create the Django 
 
     ```python
     from django.http import HttpResponse
-    from django.shortcuts import render
 
     def home(request):
         return HttpResponse("Hello, Django!")


### PR DESCRIPTION
Under the section **Create A Django app**. We `import render` which is unnecessary. And under section **Use a template to render a page** we ask the user to add `import render` which is incorrect with the code state in section **Use a template to render a page** if we don't remove the `import render` in section **Create A Django app**. 

I hope it makes sense. 