### PR TITLE
Use apt-key for gpg key management

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -25,8 +25,7 @@ Installing the .deb package will automatically install the apt repository and si
 The repository and key can also be installed manually with the following script:
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-sudo install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
+curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 


### PR DESCRIPTION
Please use apt-key instead of install gpg repo key manually.

Cheers