### PR TITLE
Standardize casing of Node.js

### DIFF
--- a/docs/extensionAPI/vscode-api.md
+++ b/docs/extensionAPI/vscode-api.md
@@ -1813,7 +1813,7 @@ of the folder that has been opened. There is no workspace when just a file but n
 folder has been opened.</p>
 <p>The workspace offers support for <a href="#workspace.createFileSystemWatcher">listening</a> to fs
 events and for <a href="#workspace.findFiles">finding</a> files. Both perform well and run <em>outside</em>
-the editor-process so that they should be always used instead of nodejs-equivalents.</p>
+the editor-process so that they should be always used instead of Node.js-equivalents.</p>
 </div>
 
 #### Variables

--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -1778,7 +1778,7 @@ Below are the Visual Studio Code default settings and their values. You can also
 
 // Node Debug
 
-  // Automatically attach node debugger when node.js was launched in debug mode from integrated terminal.
+  // Automatically attach node debugger when Node.js was launched in debug mode from integrated terminal.
   //  - disabled: Auto attach is disabled and not shown in status bar.
   //  - on: Auto attach is active.
   //  - off: Auto attach is inactive.

--- a/docs/introvideos/debugging.md
+++ b/docs/introvideos/debugging.md
@@ -12,7 +12,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 
 Debugging is a core feature of Visual Studio Code. In this tutorial, we will show you how to configure and use debugging basics. We will walk you through how you get started with Node.js debugging in VS Code.
 
-> **Tip:** To use the debugging features demonstrated in this video for Node.js, you will need to first install [nodejs](https://nodejs.org/en/).
+> **Tip:** To use the debugging features demonstrated in this video for Node.js, you will need to first install [Node.js](https://nodejs.org/en/).
 
 <iframe src="https://www.youtube.com/embed/2oFKNL7vYV8?rel=0&amp;disablekb=0&amp;modestbranding=1&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -149,7 +149,7 @@ This is a simple introduction to compiling Markdown in VS Code.
 
 Things you'll need:
 
-* [node](https://nodejs.org)
+* [Node.js](https://nodejs.org)
 * [markdown-it](https://www.npmjs.com/package/markdown-it)
 * [tasks.json](/docs/editor/tasks.md)
 

--- a/docs/nodejs/debugging-recipes.md
+++ b/docs/nodejs/debugging-recipes.md
@@ -57,9 +57,9 @@ This recipe shows how to run and debug a VS Code Node.js project written in Type
 
 - [Debugging Node.js with TypeScript in Docker](https://github.com/Microsoft/vscode-recipes/tree/master/Docker-TypeScript)
 
-## MERN - Mongo, Express, React and NodeJS
+## MERN - Mongo, Express, React and Node.js
 
-This recipe shows how to run and debug a MERN (Mongo, Express, React and NodeJS) based project in VS Code.
+This recipe shows how to run and debug a MERN (Mongo, Express, React and Node.js) based project in VS Code.
 
 ![MERN logos](images/recipes/mern.png)
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -32,7 +32,7 @@ Currently these protocols are supported by specific version ranges of the follow
 Runtime   | 'Legacy' Protocol | 'Inspector' Protocol
 ----------|-------------------|----------
 io.js     | all               | no
-node.js   | < 8.x             | >= 6.3 (Windows: >= 6.9)
+Node.js   | < 8.x             | >= 6.3 (Windows: >= 6.9)
 Electron  | < 1.7.4           | >= 1.7.4
 Chakra    | all               | not yet
 
@@ -90,13 +90,13 @@ These attributes are only available for launch configurations of request type `l
 
 This attribute is only available for launch configurations of request type `attach`:
 
-* `processId` - the debugger tries to attach to this process after having sent a USR1 signal. With this setting, the debugger can attach to an already running process that was not started in debug mode. When using the `processId` attribute the debug port is determined automatically based on the node.js version (and the used protocol) and cannot be configured explicitly. So don't specify a `port` attribute.
+* `processId` - the debugger tries to attach to this process after having sent a USR1 signal. With this setting, the debugger can attach to an already running process that was not started in debug mode. When using the `processId` attribute the debug port is determined automatically based on the Node.js version (and the used protocol) and cannot be configured explicitly. So don't specify a `port` attribute.
 
 ### Launch configurations for common scenarios
 
 You can use IntelliSense to add launch configuration snippets for commonly used Node.js debugging scenarios to a `launch.json` file.
 
-![Launch configuration snippets for node.js](images/nodejs-debugging/launch-snippets.png)
+![Launch configuration snippets for Node.js](images/nodejs-debugging/launch-snippets.png)
 
 Here is the list of all snippets:
 
@@ -109,7 +109,7 @@ Here is the list of all snippets:
 - **Mocha Tests**: Debug mocha tests in a `test` folder of your project. Make sure that your project has 'mocha' installed in its `node_modules` folder.
 - **Yeoman generator**: Debug a yeoman generator. The snippet asks you to specify the name of the generator. Make sure that your project has 'yo' installed in its `node_modules` folder and that your generated project has been installed for debugging by running `npm link` in the project folder.
 - **Gulp task**: Debug a gulp task. Make sure that your project has 'gulp' installed in its `node_modules` folder.
-- **Electron Main**: Debug the main node.js process of an Electron application. The snippet assumes that the Electron executable has been installed inside the `node_modules/.bin` directory of the workspace.
+- **Electron Main**: Debug the main Node.js process of an Electron application. The snippet assumes that the Electron executable has been installed inside the `node_modules/.bin` directory of the workspace.
 
 ### Node console
 


### PR DESCRIPTION
According to the Node.js trademark policy, Node.js should be capatalized as such. I updated everything except release notes.

"You may only use Node.js wordmarks in their full form and properly capitalized (e.g. “Node.js”)."
Page 3: https://nodejs.org/static/documents/trademark-policy.pdf

Related to 38d94c9.