### PR TITLE
Replace apt-get with apt

### DIFF
--- a/docs/java/java-azurefunctions.md
+++ b/docs/java/java-azurefunctions.md
@@ -114,7 +114,7 @@ sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 
 ```bash
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
-sudo apt-get update
+sudo apt update
 ```
 
 3. Install

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -40,7 +40,7 @@ To create a virtual environment, use the following command, where "env" is the n
 
 ```bash
 # macOS/Linux
-# You may need to run sudo apt-get install python3-venv first
+# You may need to run sudo apt install python3-venv first
 python3 -m venv env
 
 # Windows

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -252,7 +252,7 @@ sudo python3 -m pip install matplotlib
 py -3 -m pip install matplotlib
 
 # Linux (Debian)
-sudo apt-get install python3-tk
+sudo apt install python3-tk
 python -m pip install matplotlib
 ```
 

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -41,7 +41,7 @@ In this section you create a virtual environment in which Django is installed. U
 
     ```bash
     # macOS/Linux
-    sudo apt-get install python3-venv    # If needed
+    sudo apt install python3-venv    # If needed
     python3 -m venv env
 
     # Windows

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -44,7 +44,7 @@ In this section you create a virtual environment in which Flask is installed. Us
 
     ```bash
     # macOS/Linux
-    sudo apt-get install python3-venv    # If needed
+    sudo apt install python3-venv    # If needed
     python3 -m venv env
 
     # Windows

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -17,7 +17,7 @@ The easiest way to install Visual Studio Code for Debian/Ubuntu based distributi
 
 ```bash
 sudo dpkg -i <file>.deb
-sudo apt-get install -f # Install dependencies
+sudo apt install -f # Install dependencies
 ```
 
 Installing the .deb package will automatically install the apt repository and signing key to enable auto-updating using the regular system mechanism. Note that 32-bit and .tar.gz binaries are also available on the [download page](/Download).
@@ -33,9 +33,9 @@ sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode s
 Then update the package cache and install the package using:
 
 ```bash
-sudo apt-get install apt-transport-https
-sudo apt-get update
-sudo apt-get install code # or code-insiders
+sudo apt install apt-transport-https
+sudo apt update
+sudo apt install code # or code-insiders
 ```
 
 ### RHEL, Fedora and CentOS based distributions
@@ -158,7 +158,7 @@ If you see an error when deleting files from the VS Code Explorer on the Debian 
 Run these commands to solve this issue:
 
 ```bash
-sudo apt-get install gvfs-bin
+sudo apt install gvfs-bin
 ```
 
 ### "Visual Studio Code is unable to watch for file changes in this large workspace" (error ENOSPC)
@@ -203,7 +203,7 @@ This error can appear during installation and is typically caused by the package
 
 ```bash
 # For .deb
-sudo apt-get update
+sudo apt update
 
 # For .rpm (Fedora 21 and below)
 sudo yum update
@@ -218,8 +218,8 @@ Running 'code .' on Ubuntu when VS Code is already open in the current directory
 
 ```bash
 # Install
-sudo apt-get update
-sudo apt-get install compizconfig-settings-manager
+sudo apt update
+sudo apt install compizconfig-settings-manager
 
 # Run
 ccsm

--- a/docs/supporting/errors.md
+++ b/docs/supporting/errors.md
@@ -18,7 +18,7 @@ On Linux, the VS Code Node.js debugger requires the [gnome-terminal](https://hel
 
 There are two options for solving this problem:
 
-* Install the gnome-terminal by running the command `sudo apt-get install gnome-terminal` (or the equivalent of your Linux distribution).
+* Install the gnome-terminal by running the command `sudo apt install gnome-terminal` (or the equivalent of your Linux distribution).
 * Manually launch your program in debug mode by passing a `--inspect` or `--inspect-brk` option to Node.js and then attach the VS Code debugger to port 9229 on 'localhost'.
 
 ## 20003


### PR DESCRIPTION
This is perhaps a controversial change, but I believe it to be a positive one. Debian and Ubuntu have both moved to using `apt` rather than `apt-get` as the primary interface for their package manager as of a few years ago, as it contains numerous improvements to usability and consolidates a few other commands into one. This should only affect fairly old versions of the distributions - Ubuntu switched over to it in 16.04 (two LTS releases ago), for example, and 14.04 is only a few months away from EOL.