### PR TITLE
linux.md: update apt deb install instructions

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -17,6 +17,10 @@ The easiest way to install Visual Studio Code for Debian/Ubuntu based distributi
 
 ```bash
 sudo apt install ./<file>.deb
+
+# If you're on an older Linux distribution you will need to run this instead
+# sudo dpkg -i <file>.deb
+# sudo apt-get install -f # Install dependencies
 ```
 
 Installing the .deb package will automatically install the apt repository and signing key to enable auto-updating using the system's package manager. Note that 32-bit and .tar.gz binaries are also available on the [download page](/Download).

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -16,8 +16,7 @@ MetaDescription: Get Visual Studio Code up and running on Linux.
 The easiest way to install Visual Studio Code for Debian/Ubuntu based distributions is to download and install the [.deb package (64-bit)](https://go.microsoft.com/fwlink/?LinkID=760868), either through the graphical software center if it's available, or through the command line with:
 
 ```bash
-sudo dpkg -i <file>.deb
-sudo apt-get install -f # Install dependencies
+sudo apt install ./<file>.deb
 ```
 
 Installing the .deb package will automatically install the apt repository and signing key to enable auto-updating using the system's package manager. Note that 32-bit and .tar.gz binaries are also available on the [download page](/Download).


### PR DESCRIPTION
The more recent versions of apt support installing deb packages directly without the dpkg -i && apt-get install -f trick. This should work on Ubuntu 14.04 and later and on the current Debian stable.