### PR TITLE
explain the setting required for convert to async

### DIFF
--- a/release-notes/v1_28.md
+++ b/release-notes/v1_28.md
@@ -305,6 +305,8 @@ The new **Convert to async function** suggestion for JavaScript and TypeScript r
 
 ![Converting a promise chain to an async function](images/1_28/ts-convert-to-async.gif)
 
+> Note that this feature requires that the setting `javascript.validate.enable` is set to true.
+
 ### New settings for JS/TS suggestions
 
 We've cleaned up the settings names for JavaScript and TypeScript suggestions, and added a few additional settings that provide finer grained control:


### PR DESCRIPTION
> Note that this feature requires that the setting `javascript.validate.enable` is set to true.