### PR TITLE
Fix capitalization of taskDefinitions link

### DIFF
--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -643,7 +643,7 @@ The task definition is defined using JSON schema syntax for the `required` and `
 * `"required": [ "script" ]` defines that `script` attributes as mandatory. The `path` property is optional.
 * `"properties"` : { ... }` defines the additional properties and their types.
 
-When the extension actual creates a Task it needs to pass a `TaskDefinition` that conforms to the task definition contributed in the package.json file. For the `npm` example a task creation for the test script inside a package.json file looks like this:
+When the extension actually creates a Task, it needs to pass a `TaskDefinition` that conforms to the task definition contributed in the package.json file. For the `npm` example a task creation for the test script inside a package.json file looks like this:
 
 ```ts
 let task = new vscode.Task({ type: 'npm', script: 'test' }, ....);

--- a/docs/extensionAPI/extension-points.md
+++ b/docs/extensionAPI/extension-points.md
@@ -26,7 +26,7 @@ This document covers the various Visual Studio Code contribution points that are
 * [`viewsContainers`](/docs/extensionAPI/extension-points.md#contributesviewscontainers)
 * [`problemMatchers`](/docs/extensionAPI/extension-points.md#contributesproblemmatchers)
 * [`problemPatterns`](/docs/extensionAPI/extension-points.md#contributesproblempatterns)
-* [`taskDefinitions`](/docs/extensionAPI/extension-points.md#contributestaskDefinitions)
+* [`taskDefinitions`](/docs/extensionAPI/extension-points.md#contributestaskdefinitions)
 * [`colors`](/docs/extensionAPI/extension-points.md#contributescolors)
 
 ## contributes.configuration


### PR DESCRIPTION
This broke the link on code.visualstudio.com.