### PR TITLE
Provide workaround for Origin change error in APT

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -37,6 +37,15 @@ sudo apt-get install apt-transport-https
 sudo apt-get update
 sudo apt-get install code # or code-insiders
 ```
+If you receive an error similar to the following:
+> E: Repository 'http://dl.google.com/linux/chrome/deb stable Release' changed its 'Origin' value from 'Google, Inc.' to 'Google LLC'
+> N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
+
+Use `apt` instead of `apt-get` and you will be prompted to accept the origin change
+```bash
+sudo apt update
+```
+
 
 ### RHEL, Fedora and CentOS based distributions
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -37,15 +37,6 @@ sudo apt-get install apt-transport-https
 sudo apt-get update
 sudo apt-get install code # or code-insiders
 ```
-If you receive an error similar to the following:
-> E: Repository 'http://dl.google.com/linux/chrome/deb stable Release' changed its 'Origin' value from 'Google, Inc.' to 'Google LLC'
-> N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
-
-Use `apt` instead of `apt-get` and you will be prompted to accept the origin change
-```bash
-sudo apt update
-```
-
 
 ### RHEL, Fedora and CentOS based distributions
 
@@ -256,3 +247,15 @@ There are two possible workarounds for this:
 
 Information on this issue can be tracked in issue [62593](https://github.com/Microsoft/vscode/issues/62593).
 
+### Repository changed its origin value
+
+If you receive an error similar to the following:
+
+> E: Repository '...' changed its 'Origin' value from '...' to '...'
+> N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
+
+Use `apt` instead of `apt-get` and you will be prompted to accept the origin change:
+
+```bash
+sudo apt update
+```


### PR DESCRIPTION
The following error is produced using the `apt-get update` command in the instructions:
```bash
E: Repository 'http://dl.google.com/linux/chrome/deb stable Release' changed its 'Origin' value from 'Google, Inc.' to 'Google LLC'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```
APT will provide the user a prompt to accept the change, but only if using `apt update`, _not_ with `apt-get update`.

This change adds instructions to the user for if the error appears. It doesn't change the existing command from `apt-get update` to `apt update` due to being unsure if it could be a breaking change for older Debian-based distros.