### PR TITLE
Fix broken link to Customizing IntelliSense, assertEquals -> assertEqual

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -23,7 +23,7 @@ Also see [Linting](/docs/python/linting.md).
 
 Autocomplete and IntelliSense are provided for all files within the current working folder and for Python packages that are installed in standard locations. To customize the behavior of the analysis engine, see the [code analysis settings](settings-reference.md#code-analysis-settings) and [autocomplete settings](settings-reference.md#autocomplete-settings).
 
-You can also customize the general behavior of autocomplete and IntelliSense, even to disable these features entirely. See [Customizing IntelliSense](intellisense.md#_customizing-intellisense).
+You can also customize the general behavior of autocomplete and IntelliSense, even to disable these features entirely. See [Customizing IntelliSense](/docs/editor/intellisense#customizing-intellisense).
 
 <video id="python-code-completion-video" src="https://az754404.vo.msecnd.net/public/python-intellisense.mp4" poster="/images/python_python-intellisense-placeholder.png" autoplay loop controls muted></video>
 

--- a/docs/python/unit-testing.md
+++ b/docs/python/unit-testing.md
@@ -50,10 +50,10 @@ The following steps give you a quick walkthrough of working with tests in VS Cod
 
     class Test_TestIncrementDecrement(unittest.TestCase):
         def test_increment(self):
-            self.assertEquals(inc_dec.increment(3), 4)
+            self.assertEqual(inc_dec.increment(3), 4)
 
         def test_decrement(self):
-            self.assertEquals(inc_dec.decrement(3), 4)
+            self.assertEqual(inc_dec.decrement(3), 4)
 
     if __name__ == '__main__':
         unittest.main()
@@ -77,10 +77,10 @@ The following steps give you a quick walkthrough of working with tests in VS Cod
 
     ![Test results in the Python Test Log output panel](images/unit-testing/python-test-log-output.png)
 
-1. To more closely analyze a test, set a breakpoint on first the line in the `test_decrement` function, that reads `self.assertEquals(inc_dec.decrement(3), 4)`. Then select the **Debug Test** adornment above that function. VS Code starts the debugger and pauses at the breakpoint. In this case, you can use the **Debug Console** panel to enter `inc_dec.decrement(3)` and see the actual result is 2 and that the expected result of 4 is incorrect. Stop the debugger and correct that line of code:
+1. To more closely analyze a test, set a breakpoint on first the line in the `test_decrement` function, that reads `self.assertEqual(inc_dec.decrement(3), 4)`. Then select the **Debug Test** adornment above that function. VS Code starts the debugger and pauses at the breakpoint. In this case, you can use the **Debug Console** panel to enter `inc_dec.decrement(3)` and see the actual result is 2 and that the expected result of 4 is incorrect. Stop the debugger and correct that line of code:
 
     ```python
-    self.assertEquals(inc_dec.decrement(3), 2)
+    self.assertEqual(inc_dec.decrement(3), 2)
     ```
 
 1. Save the file and run the test again to see that it passes.


### PR DESCRIPTION
On website build published at https://code.visualstudio.com/docs/python/editing
The previous link in "Customizing IntelliSense." is broken:
> https://code.visualstudio.com/docs/python/intellisense#__customizing-intellisense
> responds with "Sorry! We seem to be having technical issues"