### PR TITLE
undocument `resourceIsFile` keybinding context (it was removed in v1.26)

### DIFF
--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -246,7 +246,6 @@ resourceScheme | True when the resource Uri scheme matches. Example: `"resourceS
 resourceFilename | True when the Explorer or editor filename matches. Example: `"resourceFilename == gulpfile.js"`
 resourceExtname | True when the Explorer or editor filename extension matches. Example: `"resourceExtname == .js"`
 resourceLangId | True when the Explorer or editor title [language Id](/docs/languages/identifiers.md) matches. Example: `"resourceLangId == markdown"`
-resourceIsFile | True if resource is a file.
 **Explorer contexts** |
 explorerViewletVisible | True if Explorer view is visible.
 explorerViewletFocus | True if Explorer view has keyboard focus.


### PR DESCRIPTION
I've removed the documentation for the unsupported `resourceIsFile` keybinding context.

Support was removed in [VS Code version 1.26](https://code.visualstudio.com/updates/v1_26#_notable-changes) (via [#48725](https://github.com/Microsoft/vscode/issues/48275)).
