### PR TITLE
update line or block comments, honoring the current language v:1.30.1

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -133,6 +133,11 @@ For inserting the current date and time:
 * `CURRENT_SECOND` The current second
 
 
+For inserting line or block comments, honoring the current language:
+* `BLOCK_COMMENT_START ` output: in PHP `/*` or in HTML `<!--` and ...
+* `BLOCK_COMMENT_END ` output: in PHP `*/` or in HTML `-->` and ...
+
+
 ### Variable transforms
 
 Transformations allow you to modify the value of a variable before it is inserted. The definition of a transformation consists of three parts:


### PR DESCRIPTION
snippet variables that insert line or block comments, honoring the current language. Use BLOCK_COMMENT_START and BLOCK_COMMENT_END for block comments and LINE_COMMENT otherwise.
v : 1.30.1