### PR TITLE
Syntax highlighting uses Oniguruma regular expressions

### DIFF
--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -20,7 +20,7 @@ This document only discusses the first part: breaking text into tokens and scope
 
 ## TextMate grammars
 
-VS Code uses [TextMate grammars][tm-grammars] to break text into a list of tokens. TextMate grammars are a structured collection of [ruby regular expressions](https://macromates.com/manual/en/regular_expressions) and are typically written as a plist or json. You can find a good introduction to TextMate grammars [here](https://www.apeth.com/nonblog/stories/textmatebundle.html), and you can take a look at existing TextMate grammars to learn more about how they work.
+VS Code uses [TextMate grammars][tm-grammars] to break text into a list of tokens. TextMate grammars are a structured collection of [Oniguruma regular expressions](https://macromates.com/manual/en/regular_expressions) and are typically written as a plist or JSON. You can find a good introduction to TextMate grammars [here](https://www.apeth.com/nonblog/stories/textmatebundle.html), and you can take a look at existing TextMate grammars to learn more about how they work.
 
 ### Tokens and scopes
 


### PR DESCRIPTION
Ruby uses Onigma, a fork of Oniguruma, for regular expressions since version 2.0. So it’s no longer accurate to say TextMate uses _Ruby_ regular expressions.

VS Code uses Oniguruma to [implement](https://github.com/Microsoft/vscode-textmate/blob/bd860d3d87b37343cc61239e5e90d813c1b3595d/package.json#L30) grammars.