### PR TITLE
Fix illegal regex in language configuration guide

### DIFF
--- a/api/language-extensions/language-configuration-guide.md
+++ b/api/language-extensions/language-configuration-guide.md
@@ -60,7 +60,7 @@ Here is a [Language Configuration Sample](https://github.com/Microsoft/vscode-ex
 	},
 	"wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
 	"indentationRules": {
-		"increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
+		"increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*))$",
 		"decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*\/)?\\s*[\\}\\]].*$"
 	}
 }
@@ -201,7 +201,7 @@ In VS Code, there are three kinds of folding:
 ```json
 {
 	"indentationRules": {
-		"increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
+		"increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*))$",
 		"decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*\/)?\\s*[\\)\\}\\]].*$"
 	}
 }


### PR DESCRIPTION
This regex was missing a closing parenthesis at the very end. Discovered by pasting it into https://debuggex.com. Confirmed by testing the pattern `if (true) {` against this regex.