### PR TITLE
Fixed typo "by instead of but"

### DIFF
--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -210,7 +210,7 @@ npm install gulp gulp-sass gulp-less
 
 > **Note:** `gulp-sass` and `gulp-less` are Gulp plug-ins for the `node-sass` and `lessc` modules we were using before. There are many other Gulp Sass and Less plug-ins you can use, as well as plug-ins for Grunt.
 
-You can test that your gulp installation was successful but typing `gulp -v`. You should see a version displayed for both the global (CLI) and local installations.
+You can test that your gulp installation was successful by typing `gulp -v`. You should see a version displayed for both the global (CLI) and local installations.
 
 ### Step 2: Create a simple Gulp task
 


### PR DESCRIPTION
Fixed a typo error in the line "You can test that your gulp installation was successful by typing `gulp -v`."