### PR TITLE
Urgent: VULGAR Contributor name REMOVED

### DIFF
--- a/release-notes/v1_31.md
+++ b/release-notes/v1_31.md
@@ -968,7 +968,7 @@ Here is a snapshot of [contributors](https://microsoftl10n.github.io/VSCode/). F
 * **Japanese:** nh,Masakazu TENMYO, 裕子 知念.
 * **Korean:** SeungJin Jeong.
 * **Norwegian:** Stephan Eriksen.
-* **Polish:** grzegorz m, chujcie toobchodzi, Jakub Jedryszek.
+* **Polish:** grzegorz m, Jakub Jedryszek.
 * **Portuguese (Brazil):** Bruno Talanski, Alan Willian, Letticia Nicoli, Alessandro Fragnani, Cynthia Zanoni.
 * **Portuguese(Portugal):** Vitor Barbosa.
 * **Spanish:** Engel Aguilar, José María Aguilar, julian3xl, Alvaro Enrique Ruano, Ing. Sergio Uziel Tovar Lemus, Mario Mendieta.


### PR DESCRIPTION
I have removed one contributor to Polish language because the name is vulgar (2 people suggested it, including from our Subsidiary)