### PR TITLE
update wording with new behavior

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -249,7 +249,7 @@ If you are using X forwarding to use VS Code remotely, you will need to use the 
 
 The custom title bar and menus were enabled by default on Linux for several months. The custom title bar has been a success on Windows, but the customer response on Linux suggests otherwise. Based on feedback, we have decided to make this setting opt-in on Linux and leave the native title bar as the default.
 
-The custom title bar provides many benefits including great theming support and better accessibility through keyboard navigation and screen readers. Unfortunately, these benefits do not translate as well to the Linux platform. Linux has a variety of desktop environments and window managers that can make the VS Code theming look foreign to users. For users needing the accessibility improvements, we enable the custom title bar when running in accessibility mode when a screen reader is detected. You can still manually set the title bar with the **Window: Title Bar Style** (`window.titleBarStyle`) setting.
+The custom title bar provides many benefits including great theming support and better accessibility through keyboard navigation and screen readers. Unfortunately, these benefits do not translate as well to the Linux platform. Linux has a variety of desktop environments and window managers that can make the VS Code theming look foreign to users. For users needing the accessibility improvements, we recommend enabling the custom title bar when running in accessibility mode using a screen reader. You can still manually set the title bar with the **Window: Title Bar Style** (`window.titleBarStyle`) setting.
 
 ### Broken cursor in editor with display scaling enabled
 


### PR DESCRIPTION
pivoting to only recommend the custom setting when accessibility mode is enabled to avoid a tight coupling of settings