### PR TITLE
Fix typo in FoldingRange section

### DIFF
--- a/api/references/vscode-api.md
+++ b/api/references/vscode-api.md
@@ -7511,7 +7511,7 @@ a symbolic links, in that use <code>FileType.File | FileType.SymbolicLink</code>
 
 
 
-<div class="comment"><p>A line based folding range. To be valid, start and end line must a zero or larger and smaller than the number of lines in the document.
+<div class="comment"><p>A line based folding range. To be valid, start and end line must be bigger than zero and smaller than the number of lines in the document.
 Invalid ranges will be ignored.</p>
 </div>
 


### PR DESCRIPTION
I think the initial idea was for it to read: "line must be zero or larger", switched it to "line must be bigger than zero"