### PR TITLE
Update .NET Core download link

### DIFF
--- a/docs/other/dotnet.md
+++ b/docs/other/dotnet.md
@@ -19,7 +19,7 @@ MetaTags:
 
 Install the following:
 
-- [.NET Core](https://microsoft.com/net/core).
+- [.NET Core](https://dotnet.microsoft.com/download).
 - The [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) from the VS Code Marketplace.
 
 ## Create a "Hello World" app


### PR DESCRIPTION
Updating to the main .NET download page. The current link lands folks in a tutorial to build a hello world app with .NET Core CLI. We've heard from customers (via the Feedback button on the .NET site) that this is confusing.

The target page will automatically detect OS and show the correct downloads.