### PR TITLE
Remove reload after extension install description

### DIFF
--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -118,7 +118,7 @@ Open the Extensions view (`kb(workbench.view.extensions)`) and type 'chrome` in 
 
 ![debugger for chrome](images/reactjs/debugger-for-chrome.png)
 
-Press the **Install** button for **Debugger for Chrome**. The button will change to **Installing** then, after completing the installation, it will change to **Reload**. Press **Reload** to restart VS Code and activate the extension.
+Press the **Install** button for **Debugger for Chrome**.
 
 ### Set a breakpoint
 


### PR DESCRIPTION
Reloading vscode after installing the chrome debugger isn't needed anymore