### PR TITLE
Add "statusBarItem.prominentForeground" to theme color docs

### DIFF
--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -452,6 +452,7 @@ The Status Bar is shown in the bottom of the workbench.
 - `statusBar.noFolderBorder`: Status Bar border color separating the Status Bar and editor when no folder is opened.
 - `statusBarItem.activeBackground`: Status Bar item background color when clicking.
 - `statusBarItem.hoverBackground`: Status Bar item background color when hovering.
+- `statusBarItem.prominentForeground`: Status Bar prominent items foreground color.
 - `statusBarItem.prominentBackground`: Status Bar prominent items background color. Prominent items stand out from other Status Bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example.
 - `statusBarItem.prominentHoverBackground`: Status Bar prominent items background color when hovering. Prominent items stand out from other Status Bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example.
 


### PR DESCRIPTION
We will be introducing a new color theme token, `statusBarItem.prominentForeground` and this is to update the docs to reflect this new color.

**Note:** this should only be merged _AFTER_ 1.33 is released since this will only be available in 1.34

FYI @aeschli 