### PR TITLE
Information about the NVDA screen reader add-on

### DIFF
--- a/docs/editor/accessibility.md
+++ b/docs/editor/accessibility.md
@@ -62,6 +62,8 @@ Read-only files never trap the `kbstyle(Tab)` key. The **Integrated Terminal** p
 
 VS Code supports screen readers in the editor using a strategy based on paging the text. We have tested using the [NVDA screen reader](https://www.nvaccess.org), but we expect all screen readers to benefit from this support.
 
+There is a community developed [NVDA add-on for VS Code](https://github.com/pawelurbanski/nvda-for-vs-code), that works with improvements added in VS Code Insider edition 1.33, which should become a part of the stable 1.33 release. The README file of the add-on provides more information. There is also a **settings.json** file provided with settings that are useful when woring with a screen reader. 
+
 > When using NVDA on Windows, we recommend to update to NVDA 2017.3 or higher. NVDA 2017.3 increases NVDA's timeout for receiving a caret move event from 30ms to 100ms. This version is the first one [where the built-in timeout is increased from 30ms to 100ms](https://github.com/nvaccess/nvda/pull/7201).
 
 The **Go to Next/Previous Error or Warning** actions (`kb(editor.action.marker.nextInFiles)` and `kb(editor.action.marker.prevInFiles)`) allow screen readers to announce the error or warning messages.


### PR DESCRIPTION
Contains a paragraph in the screen reader section that points to the NVDA add-on I created. It is related to fixes added in the 1.33 insider edition.
The add-on enhances the following use cases:
* Reading the item completed from the intelisense code completion without reading back the entire line of code,
* Fixes losing focus when coding in the editor and using the escape key to leave the intelisense suggestion popup,
* Provides a settings.json file that can be useful when working with a screen reader.

The add-on with a redme file can be found here: https://github.com/pawelurbanski/nvda-for-vs-code

@jrieken - this pull request for the documentation makes our fixes complete, and makes working with VS Code much better.