### PR TITLE
add dotnet core razor to language identifiers

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -98,6 +98,7 @@ Pug | `jade`
 Python | `python`
 R | `r`
 Razor (cshtml) | `razor`
+Razor .Net Core | `aspnetcorerazor`
 Ruby | `ruby`
 Rust | `rust`
 SCSS | `scss` (syntax using curly brackets), `sass` (indented syntax)


### PR DESCRIPTION
I stumbled across this while trying to enable emmet for cshtml files for .Net Core razor. Thought I would add it to the list in case it helps anyone else.