### PR TITLE
Fixed WSL Guide Shell Settings

### DIFF
--- a/docs/cpp/config-wsl.md
+++ b/docs/cpp/config-wsl.md
@@ -133,6 +133,14 @@ Next, create a `tasks.json` file to tell VS Code how to build (compile) the prog
    ```json
     {
         "version": "2.0.0",
+        "windows": {
+            "options": {
+                "shell": {
+                    "executable": "c:\\windows\\sysnative\\bash.exe",
+                    "args": ["-c"]
+                }
+            }
+        },
         "tasks": [
             {
                 "label": "build hello world on WSL",


### PR DESCRIPTION
Without the settings added, VSCode will choose whatever the default shell is, in many cases PowerShell (see #2553 ). This fixes that issue, and makes the shell for the workgroup *Bash* instead of *PowerShell*.