### PR TITLE
Correct base template path generated by snippet.

### DIFF
--- a/docs/python/images/django-tutorial/code-snippet-inserted.png
+++ b/docs/python/images/django-tutorial/code-snippet-inserted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44456d1a707194bb7073aab362bbc4abb4ecc06971e239063f8b12f1ebcdad7a
-size 2521
+oid sha256:7318fa5dab76c88bd3a416f6faab7691da3dfbe944f887ce08b36653cca6d677
+size 5469


### PR DESCRIPTION
![Old](https://media.githubusercontent.com/media/Microsoft/vscode-docs/master/docs/python/images/django-tutorial/code-snippet-inserted.png)

versus

![New](https://media.githubusercontent.com/media/chrzhang/vscode-docs/master/docs/python/images/django-tutorial/code-snippet-inserted.png)