### PR TITLE
Update python/debugging.md debugOptions

### DIFF
--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -4,7 +4,7 @@ Area: python
 TOCTitle: Debugging
 ContentId: 3d9e6bcf-eae8-4c94-b857-89225b5c4ab5
 PageTitle: Debugging configurations for Python apps in Visual Studio Code
-DateApproved: 01/17/2019
+DateApproved: 04/24/2019
 MetaDescription: Details on configuring the Visual Studio Code debugger for different Python applications.
 MetaSocialImage: images/tutorial/social.png
 ---
@@ -180,9 +180,13 @@ As an example, say `${workspaceFolder}` contains a `py_code` folder containing `
 
 ### `redirectOutput`
 
-When omitted (the default) or set to `true`, causes the debugger to print all output from the program into the VS Code debug output window. If omitted, all program output is not displayed in the debugger output window.
+When omitted or set to `True` (the default), causes the debugger to print all output from the program into the VS Code debug output window. If omitted, all program output is not displayed in the debugger output window.
 
 This option is typically omitted when using `"console": "integratedTerminal"` or `"console": "externalTerminal"` because there's no need to duplicate the output in the debug console.
+
+### `justMyCode`
+
+When omitted or set to `True` (the default), restricts debugging to user-written code only. Set to `False` to also enable debugging of standard library functions.
 
 ### `django`
 

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -162,7 +162,7 @@ Specifies how program output is displayed.
 
 | Value | Where output is displayed |
 |--- | --- |
-| `"none"` | VS Code debug console |
+| `"internalConsole"` | VS Code debug console |
 | `"integratedTerminal"` (default) | [VS Code Integrated Terminal](/docs/editor/integrated-terminal.md) |
 | `"externalTerminal"` | Separate console window |
 

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -179,18 +179,22 @@ As an example, say `${workspaceFolder}` contains a `py_code` folder containing `
 | `${workspaceFolder}/data` | `salaries.csv` |
 
 ### `redirectOutput`
-When omitted (the default) or set to `true` causes the debugger to print all output from the program into the VS Code debug output window. If this setting is omitted, all program output is not displayed in the debugger output window.
+
+When omitted (the default) or set to `true`, causes the debugger to print all output from the program into the VS Code debug output window. If omitted, all program output is not displayed in the debugger output window.
 
 This option is typically omitted when using `"console": "integratedTerminal"` or `"console": "externalTerminal"` because there's no need to duplicate the output in the debug console.
 
 ### `django`
-If set to `True`, activates debugging features specific to the Django web framework.
+
+When set to `True`, activates debugging features specific to the Django web framework.
 
 ### `sudo`
-If set to `True` and used with `"console": "externalTerminal"`, allows for debugging apps that require elevation. Using an external console is necessary to capture the password.  
+
+When set to `True` and used with `"console": "externalTerminal"`, allows for debugging apps that require elevation. Using an external console is necessary to capture the password.  
 
 ### `pyramid`
-If set to `True`, ensures that a Pyramid app is launched with [the necessary `pserve` command](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/startup.html?highlight=pserve).
+
+When set to `True`, ensures that a Pyramid app is launched with [the necessary `pserve` command](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/startup.html?highlight=pserve).
 
 ### `env`
 
@@ -365,7 +369,7 @@ The configuration drop-down provides a variety of different options for general 
 
 Specific steps are also needed for remote debugging and Google App Engine. For details on debugging unit tests (including nosetest), see [Unit testing](/docs/python/unit-testing.md).
 
-To debug an app that requires administrator privileges, use `"console": "externalTerminal"` and include "Sudo" in `debugOptions`.
+To debug an app that requires administrator privileges, use `"console": "externalTerminal"` and `"sudo": "True"`.
 
 ### Flask debugging
 

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -183,9 +183,6 @@ When omitted (the default) or set to `true` causes the debugger to print all out
 
 This option is typically omitted when using `"console": "integratedTerminal"` or `"console": "externalTerminal"` because there's no need to duplicate the output in the debug console.
 
-### `debugStdLib`
-If set to `True`, activates debugging features specific to the Django web framework.
-
 ### `django`
 If set to `True`, activates debugging features specific to the Django web framework.
 

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -178,17 +178,22 @@ As an example, say `${workspaceFolder}` contains a `py_code` folder containing `
 | `${workspaceFolder}/py_code` | `../data/salaries.csv` |
 | `${workspaceFolder}/data` | `salaries.csv` |
 
-### `debugOptions`
+### `redirectOutput`
+When omitted (the default) or set to `true` causes the debugger to print all output from the program into the VS Code debug output window. If this setting is omitted, all program output is not displayed in the debugger output window.
 
-An array of additional options:
+This option is typically omitted when using `"console": "integratedTerminal"` or `"console": "externalTerminal"` because there's no need to duplicate the output in the debug console.
 
-| Option | Description |
-| --- | --- |
-| `"RedirectOutput"` (default) | Causes the debugger to print all output from the program into the VS Code debug output window. If this setting is omitted, all program output is not displayed in the debugger output window. This option is typically omitted when using `"console": "integratedTerminal"` or `"console": "externalTerminal"` because there's no need to duplicate the output in the debug console. |
-| `"DebugStdLib"` | Enabled debugging of standard library functions. |
-| `"Django"` | Activates debugging features specific to the Django web framework. |
-| `"Sudo"` | When used with `"console": "externalTerminal"`, allows for debugging apps that require elevation. Using an external console is necessary to capture the password. |
-| `"Pyramid"` | When set to true, ensures that a Pyramid app is launched with [the necessary `pserve` command](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/startup.html?highlight=pserve). |
+### `debugStdLib`
+If set to `True`, activates debugging features specific to the Django web framework.
+
+### `django`
+If set to `True`, activates debugging features specific to the Django web framework.
+
+### `sudo`
+If set to `True` and used with `"console": "externalTerminal"`, allows for debugging apps that require elevation. Using an external console is necessary to capture the password.  
+
+### `pyramid`
+If set to `True`, ensures that a Pyramid app is launched with [the necessary `pserve` command](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/startup.html?highlight=pserve).
 
 ### `env`
 


### PR DESCRIPTION
The changes to `debugOptions` in https://github.com/Microsoft/vscode-python/issues/1326 (which are reflected in the behaviour of my install of VS Code so I assume have been incorporated into the main debugger) do not appear to be reflected in the documentation.  This was causing me some problems.

So have updated the file to reflect them.