### PR TITLE
Added variable WORKSPACE_NAME to userdefinedsnippets.md

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -117,6 +117,7 @@ The following variables can be used:
 * `TM_DIRECTORY` The directory of the current document
 * `TM_FILEPATH` The full file path of the current document
 * `CLIPBOARD` The contents of your clipboard
+* `WORKSPACE_NAME` The name of the opened workspace or folder
 
 For inserting the current date and time:
 


### PR DESCRIPTION
Add the variable WORKSPACE_NAME to [User Defined Snippets documentation](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables). This variable was added in the [1.33 update (March 2019)](https://code.visualstudio.com/updates/v1_33#_snippet-variable-workspacename).