### PR TITLE
Update developer guide to recommend not using base Electron or VS Code modules w/o a fallback

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -359,6 +359,26 @@ To solve this problem:
 
 You can find the "modules" version VS Code uses by going to **Help > Developer Tools** and typing `process.versions.modules` in the console. However, to make sure native modules work seamlessly in different Node.js environments, you may want to compile the native modules against all possible Node.js "modules" versions and platforms you want support (Electron Node.js, official Node.js Windows/Darwin/Linux, all versions). The [node-tree-sitter](https://github.com/tree-sitter/node-tree-sitter/releases/tag/v0.14.0) module is a good example of a module that does this well.
 
+## Avoid using Electron modules
+
+While it can be convenient to rely on built-in Electron or VS Code modules not exposed by the extension API, it's important to note that VS Code Server runs a standard (non-Electron) version of Node.js. These modules will be missing when running remotely with a few exception cases [like `keytar`](#persisting-secrets) where specific code in place to make them work. You should use base Node.js modules or modules in your extension VSIX to avoid these problems.
+
+If you absolutely have to use an Electron module, be sure you've got code in place to use a fallback if it is missing. For example, this code will use the Electron `original-fs` node module if found and fall back to the base Node.js `fs` module not.
+
+```typescript
+function requireWithFallback(electronModule: string, nodeModule: string) {
+    try {
+        return require(electronModule);
+    }
+    catch (err) { }
+    return require(nodeModule);
+}
+
+const fs = requireWithFallback('original-fs', 'fs');
+```
+
+Try to avoid these situations whenever possible.
+
 ## Known issues
 
 There are a few extension problems that could be resolved with some added functionality for Workspace Extensions. The following table is a list of known issues under consideration:

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -663,6 +663,12 @@ Native modules bundled with (or dynamically acquired for) a VS Code extension mu
 
 Resolution: Extensions need to be modified to solve this problem. They will need to include (or dynamically acquire) both sets of binaries (Electron and standard Node.js) for the "modules" version in Node.js that VS Code ships and then check to see if `context.executionContext === vscode.ExtensionExecutionContext.Remote` in their activation function to set up the correct binaries. See the [extension guide](/api/advanced-topics/remote-extensions#using-native-node.js-modules) for details.
 
+#### Extensions fail due to missing modules
+
+Extensions that rely on Electron or VS Code base modules (not exposed by the extension API) without providing a fallback can fail when running remotely. You may see errors in the Developer Tools window like `original-fs` not being found.
+
+Resolution: Remove the dependency on an Electron module or provide a fallback. See the [extension guide](/api/advanced-topics/remote-extensions#avoid-using-electron-modules) for details.
+
 ### Cannot access / transfer remote workspace files to local machines
 
 Extensions that open workspace files in external applications may encounter errors because the external application cannot directly access the remote files.


### PR DESCRIPTION
Developer guidance due to https://github.com/microsoft/vscode-remote-release/issues/188