### PR TITLE
Replace outdated git cheat sheet url

### DIFF
--- a/docs/editor/versioncontrol.md
+++ b/docs/editor/versioncontrol.md
@@ -31,7 +31,7 @@ If you would like to install an additional SCM provider, you can search on the *
 
 VS Code ships with a Git source control manager (SCM) extension. Most of the source control UI and work flows are common across other SCM extensions so reading about the Git support will help you understand how to use another provider.
 
->**Note:** If you are new to Git, the [git-scm](https://git-scm.com/documentation) website is a good place to start with a popular online [book](https://git-scm.com/book), Getting Started [videos](https://git-scm.com/video/what-is-git) and [cheat sheets](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf). The VS Code documentation assumes you are already familiar with Git.
+>**Note:** If you are new to Git, the [git-scm](https://git-scm.com/documentation) website is a good place to start with a popular online [book](https://git-scm.com/book), Getting Started [videos](https://git-scm.com/video/what-is-git) and [cheat sheets](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf). The VS Code documentation assumes you are already familiar with Git.
 
 ![Git overview](images/versioncontrol/overview.png)
 


### PR DESCRIPTION
Hey,
Current url returns:
```
Error
Failed to load PDF document.
```

There is a simple url update.