### PR TITLE
Grammar fix

### DIFF
--- a/api/extension-capabilities/overview.md
+++ b/api/extension-capabilities/overview.md
@@ -116,6 +116,6 @@ There are certain restrictions we impose upon extensions. Here are the restricti
 
 ### No DOM Access
 
-Extensions have no access to the DOM of VS Code UI. You **cannot** write an extension that applies custom CSS to VS Code or adds a HTML element to VS Code UI.
+Extensions have no access to the DOM of VS Code UI. You **cannot** write an extension that applies custom CSS to VS Code or adds an HTML element to VS Code UI.
 
 At VS Code, we're continually trying to optimize use of the underlying web technologies to deliver an always available, highly responsive editor and we will continue to tune our use of the DOM as these technologies and our product evolve. To ensure that extensions cannot interfere with the stability and performance of VS Code, and that we can continue to improve the DOM of VS Code without breaking existing extensions, we run extensions in an [Extension Host](/api/advanced-topics/extension-host) process and prevent direct access to the DOM.


### PR DESCRIPTION
`a HTML element` should be `an HTML element`.