### PR TITLE
Distinguish Ipython and Ipython Notebook

### DIFF
--- a/docs/python/jupyter-support.md
+++ b/docs/python/jupyter-support.md
@@ -11,7 +11,7 @@ MetaSocialImage: images/tutorial/social.png
 
 # Working with Jupyter Notebooks in Visual Studio Code
 
-[Jupyter](http://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a *notebook*.
+[Jupyter](http://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython Notebook) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a *notebook*.
 
 To work with Jupyter notebooks, you must activate an Anaconda environment in VS Code, or another Python environment in which you've installed the [Jupyter package](https://pypi.org/project/jupyter/). To select an environment, use the **Python: Select Interpreter** command from the Command Palette (`kb(workbench.action.showCommands)`).
 


### PR DESCRIPTION
Changed IPython to IPython Notebook. I realise that it's a minor typo in terms of changes, but it's an important distinction to make as IPython is an on-going project on its own.