### PR TITLE
Update the install command for functions tools.

### DIFF
--- a/tutorials/functions-extension/getting-started.md
+++ b/tutorials/functions-extension/getting-started.md
@@ -26,7 +26,7 @@ $ brew install azure-functions-core-tools
 **On Windows**, install using [npm](https://npmjs.com).
 
 ```bash
-$ npm install -g azure-functions-core-tools@2
+$ npm install -g azure-functions-core-tools
 ```
 
 **On Linux**, follow the instructions in the Azure Functions Core Tools [GitHub repository](https://github.com/Azure/azure-functions-core-tools#linux).


### PR DESCRIPTION
The tag for version 2 has been removed so this installation command is
failing for users coming to the tutorial.