### PR TITLE
Containers advanced topics and misc cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto eol=lf
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text

--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -1,0 +1,413 @@
+---
+Order: 6
+Area: remote
+TOCTitle: Advanced Containers
+PageTitle: Advanced Container Configuration
+ContentId: f180ac25-1d59-47ec-bad2-3ccbf214bbd8
+MetaDescription: Advanced setup for using the VS Code Remote - Containers extension
+DateApproved: 5/15/2019
+---
+# Advanced Container Configuration
+
+❗ **Note:** The **[Remote Development extensions](https://aka.ms/vscode-remote/download)** require **[Visual Studio Code Insiders](https://code.visualstudio.com/insiders)**.
+
+---
+
+This article includes advanced setup scenarios for the [Visual Studio Code Remote - Containers](https://aka.ms/vscode-remote/download/containers) extension. See the [Developing inside a Container](containers.md) article for additional information.
+
+## Adding another volume mount
+
+You can add a volume mount to any local folder using these steps:
+
+1. Configure the volume mount:
+
+   - When an **image** or **Dockerfile** is referenced in `devcontainer.json`, add the following to the `runArgs` property in this same file:
+
+        ```json
+        "runArgs": ["-v","/local/source/path/goes/here:/target/path/in/container/goes/here"]
+        ```
+
+   - When a **Docker Compose** file is referenced, add the following to your `docker-compose.yml`:
+
+        ```json
+        volumes:
+          - /local/source/path/goes/here:/target/path/in/container/goes/here
+        ```
+
+2. If you've already built the container and connected to it, run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up the change.
+
+## Adding a non-root user to your dev container
+
+Many images run as a root user by default. However, some provide one or more non-root users, that you can optionally use instead. If your image or Dockerfile provides a non-root user (but still defaults to root), you can opt into using it in one of two ways:
+
+- When referencing an **image** or **Dockerfile**, add the following to your `devcontainer.json`:
+
+    ```json
+    "runArgs": ["-u", "user-name-goes-here"]
+    ```
+
+- If you are using **Docker Compose**, add the following to your service in `docker-compose.yml`:
+
+    ```yaml
+    user: user-name-goes-here
+    ```
+
+For images that only provide a root user, you can automatically create a non-root user by using a Dockerfile. For example, this snippet will create a user called `user-name-goes-here`, give it the ability to use `sudo`, and set it as the default:
+
+```Dockerfile
+ARG USERNAME=user-name-goes-here
+RUN useradd -m $USERNAME
+ENV HOME /home/$USERNAME
+
+# [Optional] Add sudo support
+RUN apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+
+# ** Anything else you want to do like clean up goes here **
+
+# Set the default user
+USER $USERNAME
+```
+
+## Using Docker or Kubernetes from a container
+
+While you can build, deploy, and debug your application inside a dev container, you may also need to test it by running it inside a set of production-like containers. Fortunately, by installing the needed Docker or Kubernetes CLIs, you can build and deploy your app's container images from inside your dev container.
+
+Once the needed CLIs are in place, you can also work with the appropriate container cluster using the [Docker](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker) extension if you force it to run as a Workspace extension or the [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension.
+
+See the following examples dev containers for additional information:
+
+* [Docker-in-Docker](https://aka.ms/vscode-remote/samples/docker-in-docker) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
+
+* [Docker-in-Docker Compose](https://aka.ms/vscode-remote/samples/docker-in-docker-compose) - Variation of Docker-in-Docker for situations where you are using Docker Compose instead of a single Dockerfile.
+
+* [Kubernetes-Helm](https://aka.ms/vscode-remote/samples/kubernetes-helm) - Includes the Docker CLI, kubectl, and Helm and illustrates how you can use them from inside a dev container to access a local Minikube or Docker provided Kubernetes cluster.
+
+## Connecting to multiple containers at once
+
+Currently you can only connect to one container per VS Code window. However, you can spin up multiple VS Code windows [attach to them](#attaching-to-running-containers).
+
+If you'd prefer to use `devcontainer.json` instead and are using Docker Compose, you can setup separate  `.devcontainer` folders for each service in your source tree that point to a common `docker-compose.yml`.
+
+To see how this works, consider this extremely simplified source tree:
+
+```text
+📁container1-src
+     📄.devcontainer.json
+     📄hello.go
+📁container2-src
+     📄.devcontainer.json
+     📄hello.js
+📄docker-compose.yml
+```
+
+Next, assume the `docker-compose.yml` in the root is as follows:
+
+```yml
+version: '3'
+services:
+  container-1:
+    image: ubuntu:bionic
+    volumes:
+      - ./container-1-src:/workspace
+      - ~/.gitconfig:/root/.gitconfig
+    command: sleep infinity
+    links:
+      - container-2
+
+  container-2:
+    image: ubuntu:bionic
+    volumes:
+      - ./container-2-src:/workspace
+      - ~/.gitconfig:/root/.gitconfig
+    command: sleep infinity
+```
+
+You can then set up `container1-src/.devcontainer.json` for Go development as follows:
+
+```json
+{
+    "name": "Container 1",
+    "dockerComposeFile": ["../docker-compose.yml"],
+    "service": "container-1",
+    "workspaceFolder": "/workspace",
+    "extensions": ["ms-vscode.Go"],
+    "shutdownAction": "none"
+}
+```
+
+Next, you can `container2-src/.devcontainer.json` for Node.js development as follows:
+
+```json
+{
+    "name": "Container 2",
+    "dockerComposeFile": ["../docker-compose.yml"],
+    "service": "container-2",
+    "workspaceFolder": "/workspace",
+    "extensions": ["dbaeumer.vscode-eslint"],
+    "shutdownAction": "none"
+}
+```
+
+The `"shutdownAction":"none"` in the `devcontainer.json` files is optional, but will leave the containers running when VS Code closes -- which prevents you from accidentally shutting down both containers by closing one window.
+
+To connect to both:
+1. <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container1-src` folder.
+2. VS Code will then start up both containers, connect this window to service `container-1`, and install the Go extension.
+3. Next, start up a new window using **File > New Window**.
+4. In the new Window, <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container2-src` folder.
+5. Since the services is already running, VS Code will then connect to `container-2` and install the ESLint extension.
+
+You can now interact with both containers at once from separate windows.
+
+## Using SSH to connect to a remote Docker host
+
+Occasionally you may want to use the Remote - Containers extension to develop inside a container that sits on remote server. While we are looking at ways to optimize this experience, this section will outline how you can achieve this today by attaching to a remote container or using Docker Compose.
+
+### Accessing Docker Remotely
+
+If you have a remote [Docker Machine](https://docs.docker.com/machine/overview/) running on a remote server, you can work with it from your local machine using the Docker CLI by specifying [environment variables like `DOCKER_HOST`, `DOCKER_CERT_PATH`, `DOCKER_TLS_VERIFY`](https://docs.docker.com/machine/reference/env/) on your local machine to connect to a public TCP port. However, this port is often not exposed publicly since it can have leave the machine vulnerable if not secured properly. (For example, installing Docker CE / Desktop does not open up a port by default.)
+
+A more secure way is to use a SSH tunnel to access the Docker socket as needed. If you have an [OpenSSH compatible SSH client](/docs/remote/troubleshooting.md#installing-a-supported-ssh-client) installed, you can run the following commands in a local terminal / command prompt to start up VS Code so that it connects to the remote SSH host. Replace `user@hostname` with the appropriate remote user and hostname / IP for your server and ensure `code-insiders` is in your path.
+
+On **macOS or Linux**:
+
+```bash
+export DOCKER_HOST=localhost:23750
+code-insiders
+ssh -NL localhost:23750:/var/run/docker.sock user@hostname
+```
+
+On **Windows**:
+
+```bat
+SET DOCKER_HOST=localhost:23750
+code-insiders
+ssh -NL localhost:23750:/var/run/docker.sock user@hostname
+```
+
+Note that you may need to [enable `AllowStreamLocalForwarding` in your SSH server's sshd config](https://www.ssh.com/ssh/tunneling/example) for this to work.
+
+At this point, you can [attach to any running container](#attaching-to-running-containers) on the remote host from inside the VS Code instance that was started.
+
+Once you are done, press `kbstyle(Ctrl+C)` in the terminal / command prompt to close the tunnel. The environment variables that were set are not global, so you can just bounce VS Code to start working with your local Docker install instead.
+
+### Using devcontainer.json to work with a remote dev container
+
+Docker does **not** support mounting (binding) your local filesystem into a remote container. Even if it did, this would result in very poor performance. As a result, the best practice is store your source code on the remote machine. There are a few different ways to do this, but the simplest is to **create your remote dev container first**, and then **clone your source code into it**.
+
+In this section we'll walk you through how to convert a local `devcontainer.json` into a remote one. Just follow these steps:
+
+1. Follow the steps above to start up VS Code pointing to the right Docker host.
+2. Create and open an empty folder in VS Code
+3. Run **Remote-Containers: Add Container Configuration File...** from the command palette (`kbstyle(F1)`).
+4. Pick a starting point for your remote container from the list that appears.
+5. What you do next will depend on whether you picked a definition that uses a Dockerfile or Docker Compose.
+
+    **Dockerfile**
+
+    Add a `docker-compose.remote.yml` file into the `.devcontainer` folder with the following contents:
+
+    ```yml
+    version: '3'
+    services:
+      dev-container:
+        build:
+          context: .
+          dockerfile: Dockerfile
+
+        volumes:
+            - ssh-workspace:/ssh-workspace
+
+        command: sleep infinity
+
+      # [Optional] Required for ptrace-based debuggers like C++, Go, and Rust
+      cap_add:
+        - SYS_PTRACE
+      security_opt:
+        - seccomp:unconfined
+
+    volumes:
+      ssh-workspace:
+    ```
+
+    Then alter `.devcontainer/devcontainer.json` as follows:
+
+    ```json
+    {
+        "name": "Your name goes here",
+        "dockerComposeFile": "docker-compose.remote.yml",
+        "service": "dev-container",
+        "workspaceFolder": "/ssh-workspace",
+    }
+    ```
+
+    **Docker Compose**
+
+    Add a `docker-compose.remote.yml` file into the `.devcontainer` folder with the following contents. Replace `SERVICE-NAME-GOES-HERE` with the value of the `service` property in `devcontainer.json`.
+
+    ```yml
+    version: '3'
+    services:
+      SERVICE-NAME-GOES-HERE:
+        volumes:
+            - ssh-workspace:/ssh-workspace
+
+    volumes:
+      ssh-workspace:
+    ```
+
+    Then alter two properties in `.devcontainer/devcontainer.json` as follows:
+
+    ```json
+    "dockerComposeFile": [
+        "docker-compose.yml",
+        "docker-compose.remote.yml"
+    ],
+    "workspaceFolder": "/ssh-workspace"
+    ```
+
+6. Run **Remote-Containers: Reopen Folder in Container** from the command palette (`kbstyle(F1)`).
+
+7. Use ``kbstyle(Ctrl+Shift+`)`` to open a terminal inside the container. You can run `git clone` from here to pull down your source code. You can then use **File > Open... / Open Folder...** to open the cloned repository.
+
+Next time you want to connect to this same container, simply run **Remote-Containers: Open Folder in Container...** and select the same local folder in a VS Code window with `DOCKER_HOST` set.
+
+### [Optional] Using the remote filesystem (bind mount) instead of a volume
+
+The model above uses a Docker volume to persist the source code. While this will prevent the source code from being deleted when you rebuild, you can also use the remote filesystem instead (assuming you have access). The advantage of this model is that you can clone or interact with the source code from **another terminal window** using SSH. This can also be useful if you've **already got source code on-disk** that you want to open in a container.
+
+Just change the `volumes` section to point to the absolute file path on the remote filesystem where the source code should be kept.
+
+```yml
+version: '3'
+services:
+    dev-container:
+      # ...
+      volumes:
+        - /absolute/path/on/remote/machine/for/source/code:/ssh-workspace
+```
+
+### [Optional] Making the remote source code available locally
+
+If you store your code in the remote filesystem instead of inside a Docker volume, there are two ways you can access this source code locally:
+
+1. [Mount the remote filesystem using SSHFS](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host).
+2. [Sync files the remote host to your local machine using `rsync`](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-code).
+
+SSHFS is the more convenient option and does not require any sync'ing, but note that that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. Rsync is a better option if you need to use these types of tools since it will copy the entire contents of a folder on remote host to your local machine.
+
+### [Optional] Storing your remote devcontainer.json files on the server
+
+Finally, you can combine the techniques above to store your `.devcontainer` files on the remote server. This allows you to connect to it from any machine and spin up a remote dev container without having any files locally. Imagine you had the following folder tree on the remote machine:
+
+```text
+📁 /home/your-user-name
+    📁 repos
+        📁 your-repository-here
+            📁 .devcontainer
+            📁 .remote
+                📁 .devcontainer
+```
+
+If you put your remote focused dev container settings described above in `~/repos/your-repository-here/.remote` you can open the remote dev container from this folder using a SSHFS mount. Just follow these steps:
+
+1. [Set up SSHFS on your system](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host).
+
+2. Run the following commands replacing `user@hostname` with your remote user and hostname / IP and `repos/your-repository-here/.remote` with the actual path (relative to your home folder) of your remote dev container definition on the host.
+
+    On **macOS or Linux**, run the following in a local terminal:
+
+    ```bash
+    export USER_AT_HOST=user@hostname
+    export REMOTE_CFG_PATH="repos/your-repository-here/.remote"
+
+    # Mount the remote filesystem
+    mkdir -p "$HOME/sshfs/$USER_AT_HOST"
+    sshfs "$USER_AT_HOST:" "$HOME/sshfs/$USER_AT_HOST" -ovolname="$USER_AT_HOST" -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C
+
+    # Start VS Code and forward the docker port.
+    export DOCKER_HOST=localhost:23750
+    code-insiders "$HOME/sshfs/$USER_AT_HOST/$REMOTE_CFG_PATH"
+    ssh -NL localhost:23750:/var/run/docker.sock $USER_AT_HOST
+    ```
+
+    On **Windows** run the following in a command prompt:
+
+    ```bat
+    SET USER_AT_HOST=user@hostname
+    SET REMOTE_CFG_PATH="repos/your-repository-here/.remote"
+
+    REM Mount the remote filesystem
+    net use /PERSISTENT:NO X: \\sshfs\%USER_AT_HOST%
+
+    REM Start VS Code and forward the docker port
+    SET DOCKER_HOST=localhost:23750
+    code-insiders "X:\%REMOTE_CFG_PATH%"
+    ssh -NL localhost:23750:/var/run/docker.sock %USER_AT_HOST%
+    ```
+
+3. Once the VS Code window opens, run **Remote-Containers: Reopen Folder in Container** from the command palette (`kbstyle(F1)`).
+
+## Reducing Dockerfile build warnings
+
+The following are some tips for eliminating warnings that may be appearing in your Dockerfile builds.
+
+### debconf: delaying package configuration, since apt-utils is not installed
+
+This error can typically be safely ignored and is tricky to get rid of completely. However, you can reduce it to one message in stdout when installing the needed package by adding the following to your Dockerfile:
+
+```Dockerfile
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+## YOUR DOCKERFILE CONTENT GOES HERE
+
+ENV DEBIAN_FRONTEND=dialog
+```
+
+### Warning: apt-key output should not be parsed (stdout is not a terminal)
+
+This non-critical warning tells you not to parse the output of `apt-key`, so as long as your script doesn't, there's no problem. You can safely ignore it.
+
+This occurs in Dockerfiles because the `apt-key` command is not running from a terminal. Unfortunately, this error cannot be eliminated completely, but can be hidden unless the `apt-key` command returns a non-zero exit code (indicating a failure).
+
+For example:
+
+```Dockerfile
+# (OUT=$(apt-key add - 2>&1) || echo $OUT) will only print the output with non-zero exit code is hit
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+```
+
+You can also set the `APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE` environment variable to suppress the warning, but it looks a bit scary so be sure to add comments in your Dockerfile if you use it:
+
+```Dockerfile
+# Suppress an apt-key warning about standard out not being a terminal. Its use in this script is safe.
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+```
+
+### Information messages appearing in red
+
+Some CLIs output certain information (like debug details) to standard error instead of standard out. These will appear in red in VS Code's terminal and output logs.
+
+If the messages are harmless, you can simply pipe the output of the command from standard error to standard out instead. Simply append `2>&1` to the end of the command.
+
+For example:
+
+```Dockerfile
+RUN apt-get -y install --no-install-recommends apt-utils 2>&1
+```
+
+If the command fails, it will still stop the build but you will not see red messages that make you think something may be wrong if it succeeds.
+
+## Questions or feedback
+
+* See [Tips and Tricks](/docs/remote/troubleshooting.md#containers-tips) or the [FAQ](/docs/remote/faq.md).
+* Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
+* Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
+* Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+* Contribute to [our documentation](https://github.com/Microsoft/vscode-docs) or [VS Code itself](https://github.com/Microsoft/vscode).
+* See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -72,11 +72,11 @@ USER $USERNAME
 
 ## Using Docker or Kubernetes from a container
 
-While you can build, deploy, and debug your application inside a dev container, you may also need to test it by running it inside a set of production-like containers. Fortunately, by installing the needed Docker or Kubernetes CLIs, you can build and deploy your app's container images from inside your dev container.
+While you can build, deploy, and debug your application inside a dev container, you may also need to test it by running it inside a set of production-like containers. Fortunately, by installing the needed Docker or Kubernetes CLIs and mounting your local Docker socket, you can build and deploy your app's container images from inside your dev container.
 
 Once the needed CLIs are in place, you can also work with the appropriate container cluster using the [Docker](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker) extension if you force it to run as a Workspace extension or the [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension.
 
-See the following examples dev containers for additional information:
+See the following example dev containers definitions for additional information on a specific scenairo:
 
 * [Docker-in-Docker](https://aka.ms/vscode-remote/samples/docker-in-docker) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
 
@@ -86,9 +86,9 @@ See the following examples dev containers for additional information:
 
 ## Connecting to multiple containers at once
 
-Currently you can only connect to one container per VS Code window. However, you can spin up multiple VS Code windows [attach to them](#attaching-to-running-containers).
+Currently you can only connect to one container per VS Code window. However, you can spin up multiple VS Code windows to [attach to them](#attaching-to-running-containers).
 
-If you'd prefer to use `devcontainer.json` instead and are using Docker Compose, you can setup separate  `.devcontainer` folders for each service in your source tree that point to a common `docker-compose.yml`.
+If you'd prefer to use `devcontainer.json` instead and are using Docker Compose, you can setup separate  `devcontainer.json` files for each service in your source tree that point to a common `docker-compose.yml`.
 
 To see how this works, consider this extremely simplified source tree:
 
@@ -156,7 +156,7 @@ To connect to both:
 1. <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container1-src` folder.
 2. VS Code will then start up both containers, connect this window to service `container-1`, and install the Go extension.
 3. Next, start up a new window using **File > New Window**.
-4. In the new Window, <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container2-src` folder.
+4. In the new window, <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container2-src` folder.
 5. Since the services is already running, VS Code will then connect to `container-2` and install the ESLint extension.
 
 You can now interact with both containers at once from separate windows.
@@ -167,7 +167,7 @@ Occasionally you may want to use the Remote - Containers extension to develop in
 
 ### Accessing Docker Remotely
 
-If you have a remote [Docker Machine](https://docs.docker.com/machine/overview/) running on a remote server, you can work with it from your local machine using the Docker CLI by specifying [environment variables like `DOCKER_HOST`, `DOCKER_CERT_PATH`, `DOCKER_TLS_VERIFY`](https://docs.docker.com/machine/reference/env/) on your local machine to connect to a public TCP port. However, this port is often not exposed publicly since it can have leave the machine vulnerable if not secured properly. (For example, installing Docker CE / Desktop does not open up a port by default.)
+If you have a remote [Docker Machine](https://docs.docker.com/machine/overview/) running on a remote server, you can work with it from your local machine using the Docker CLI by specifying [environment variables like `DOCKER_HOST`, `DOCKER_CERT_PATH`, `DOCKER_TLS_VERIFY`](https://docs.docker.com/machine/reference/env/). However, this port is often not exposed publicly since it can have leave the machine vulnerable if not secured properly. (For example, installing Docker CE / Desktop does not open up a port by default.)
 
 A more secure way is to use a SSH tunnel to access the Docker socket as needed. If you have an [OpenSSH compatible SSH client](/docs/remote/troubleshooting.md#installing-a-supported-ssh-client) installed, you can run the following commands in a local terminal / command prompt to start up VS Code so that it connects to the remote SSH host. Replace `user@hostname` with the appropriate remote user and hostname / IP for your server and ensure `code-insiders` is in your path.
 
@@ -189,7 +189,7 @@ ssh -NL localhost:23750:/var/run/docker.sock user@hostname
 
 Note that you may need to [enable `AllowStreamLocalForwarding` in your SSH server's sshd config](https://www.ssh.com/ssh/tunneling/example) for this to work.
 
-At this point, you can [attach to any running container](#attaching-to-running-containers) on the remote host from inside the VS Code instance that was started.
+At this point, you can [attach to any running container](/docs/remote/containers.md#attaching-to-running-containers) on the remote host from inside the VS Code instance that was started.
 
 Once you are done, press `kbstyle(Ctrl+C)` in the terminal / command prompt to close the tunnel. The environment variables that were set are not global, so you can just bounce VS Code to start working with your local Docker install instead.
 
@@ -200,7 +200,7 @@ Docker does **not** support mounting (binding) your local filesystem into a remo
 In this section we'll walk you through how to convert a local `devcontainer.json` into a remote one. Just follow these steps:
 
 1. Follow the steps above to start up VS Code pointing to the right Docker host.
-2. Create and open an empty folder in VS Code
+2. Create and open an empty folder in VS Code.
 3. Run **Remote-Containers: Add Container Configuration File...** from the command palette (`kbstyle(F1)`).
 4. Pick a starting point for your remote container from the list that appears.
 5. What you do next will depend on whether you picked a definition that uses a Dockerfile or Docker Compose.
@@ -291,16 +291,16 @@ services:
 
 ### [Optional] Making the remote source code available locally
 
-If you store your code in the remote filesystem instead of inside a Docker volume, there are two ways you can access this source code locally:
+If you store your code on the remote host's filesystem instead of inside a Docker volume, there are two ways you can the files locally:
 
 1. [Mount the remote filesystem using SSHFS](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host).
-2. [Sync files the remote host to your local machine using `rsync`](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-code).
+2. [Sync files from the remote host to your local machine using `rsync`](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-code).
 
 SSHFS is the more convenient option and does not require any sync'ing, but note that that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. Rsync is a better option if you need to use these types of tools since it will copy the entire contents of a folder on remote host to your local machine.
 
 ### [Optional] Storing your remote devcontainer.json files on the server
 
-Finally, you can combine the techniques above to store your `.devcontainer` files on the remote server. This allows you to connect to it from any machine and spin up a remote dev container without having any files locally. Imagine you had the following folder tree on the remote machine:
+Finally, you can combine the techniques above to store your `devcontainer.json` files on the remote server. This allows you to connect to it from any machine and spin up a remote dev container without having any files locally. Imagine you had the following folder tree on the remote machine:
 
 ```text
 📁 /home/your-user-name
@@ -393,7 +393,7 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 
 Some CLIs output certain information (like debug details) to standard error instead of standard out. These will appear in red in VS Code's terminal and output logs.
 
-If the messages are harmless, you can simply pipe the output of the command from standard error to standard out instead. Simply append `2>&1` to the end of the command.
+If the messages are harmless, you can simply pipe the output of the command from standard error to standard out instead by appending `2>&1` to the end of the command.
 
 For example:
 
@@ -401,7 +401,7 @@ For example:
 RUN apt-get -y install --no-install-recommends apt-utils 2>&1
 ```
 
-If the command fails, it will still stop the build but you will not see red messages that make you think something may be wrong if it succeeds.
+If the command fails, you will still be able to see the errors, they just won't be in red.
 
 ## Questions or feedback
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -708,7 +708,7 @@ If you have a remote [Docker Machine](https://docs.docker.com/machine/overview/)
 
 A more secure way is to use a SSH tunnel to access the Docker socket as needed. If you have an [OpenSSH compatible SSH client](/docs/remote/troubleshooting.md#installing-a-supported-ssh-client) installed, you can run the following commands in a local terminal / command prompt to start up VS Code so that it connects to the remote SSH host. Replace `user@hostname` with the appropriate remote user and hostname / IP for your server and ensure `code-insiders` is in your path.
 
-On **macOS / Linux**:
+On **macOS or Linux**:
 
 ```bash
 export DOCKER_HOST=localhost:23750
@@ -821,43 +821,23 @@ Just change the `volumes` section to point to the absolute file path on the remo
 version: '3'
 services:
     dev-container:
-    # ...
-    volumes:
+      # ...
+      volumes:
         - /absolute/path/on/remote/machine/for/source/code:/ssh-workspace
 ```
 
 **[Optional] Making the remote source code available locally**
 
-If you store your code in the remote filesystem instead of inside a Docker volume, you can also access the remote code from your local machine using [SSHFS](https://en.wikipedia.org/wiki/SSHFS). You can install SSHFS locally as follows:
+If you store your code in the remote filesystem instead of inside a Docker volume, there are two ways you can access this source code locally:
 
-- macOS using [Homebrew](https://brew.sh/): `brew install sshfs`
-- Linux using the native package manager. For Debian/Ubuntu: `sudo apt-get install sshfs`
-- Windows using [Chocolaty](https://chocolatey.org/): `choco install sshfs`
+1. [Mount the remote filesystem using SSHFS](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host).
+2. [Sync files the remote host to your local machine using `rsync`](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-code).
 
-To mount the remote filesystem on **macOS or Linux**, run the following from a local terminal replacing `user@hostname` with the remote user and hostname / IP:
-
-```bash
-export USER_AT_HOST=user@hostname
-
-mkdir -p "$HOME/sshfs/$USER_AT_HOST"
-sshfs "$USER_AT_HOST:" "$HOME/sshfs/$USER_AT_HOST" -ovolname="$USER_AT_HOST" -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C
-```
-
-While this command is active, the remote machine will be available at `~/sshfs`.
-
-On **Windows**, run the following from the command prompt replacing `user@hostname` with the remote user and hostname / IP:
-
-```bat
-net use /PERSISTENT:NO X: \\sshfs\user@hostname
-```
-
-The remote machine will be available at `X:\`. You can disconnect from it by right-clicking on the drive in the File Explorer and clicking Disconnect.
-
-Note that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. However, can also sync files from your remote SSH host to your local machine [using `rsync`](https://rsync.samba.org/) if you would prefer to use a broader set of tools. See [Tips and Tricks](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-codey) for details on setting this up.
+SSHFS is the more convenient option and does not require any sync'ing, but note that that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. Rsync is a better option if you need to use these types of tools since it will copy the entire contents of a folder on remote host to your local machine.
 
 **[Optional] Storing your remote devcontainer.json files on the server**
 
-Finally, you can combine the techniques above to store your remote connection `.devcontainer` files on the remote server. This allows you to connect to it from any machine and spin up a remote dev container. Imagine you had the following folder tree on the remote machine:
+Finally, you can combine the techniques above to store your `.devcontainer` files on the remote server. This allows you to connect to it from any machine and spin up a remote dev container without having any files locally. Imagine you had the following folder tree on the remote machine:
 
 ```text
 📁 /home/your-user-name
@@ -868,34 +848,44 @@ Finally, you can combine the techniques above to store your remote connection `.
                 📁 .devcontainer
 ```
 
-If you put your remote focused dev container settings described above in `~/repos/your-repository-here/.remote` you can open the remote dev container from this folder using a local mount.
+If you put your remote focused dev container settings described above in `~/repos/your-repository-here/.remote` you can open the remote dev container from this folder using a SSHFS mount. Just follow these steps:
 
-On **Linux/macOS**:
+1. [Set up SSHFS on your system](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host).
 
-```bash
-export USER_AT_HOST=user@hostname
-export REMOTE_CFG_PATH="repos/your-repository-here/.remote"
+2. Run the following commands replacing `user@hostname` with your remote user and hostname / IP and `repos/your-repository-here/.remote` with the actual path (relative to your home folder) of your remote dev container definition on the host.
 
-mkdir -p "$HOME/sshfs/$USER_AT_HOST"
-sshfs "$USER_AT_HOST:" "$HOME/sshfs/$USER_AT_HOST" -ovolname="$USER_AT_HOST" -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C
-export DOCKER_HOST=localhost:23750
-code-insiders "$HOME/sshfs/$USER_AT_HOST/$REMOTE_CFG_PATH"
-ssh -NL localhost:23750:/var/run/docker.sock $USER_AT_HOST
-```
+    On **macOS or Linux**, run the following in a local terminal:
 
-On **Windows**:
+    ```bash
+    export USER_AT_HOST=user@hostname
+    export REMOTE_CFG_PATH="repos/your-repository-here/.remote"
 
-```bat
-SET USER_AT_HOST=user@hostname
-SET REMOTE_CFG_PATH="repos\your-repository-here\.remote"
+    # Mount the remote filesystem
+    mkdir -p "$HOME/sshfs/$USER_AT_HOST"
+    sshfs "$USER_AT_HOST:" "$HOME/sshfs/$USER_AT_HOST" -ovolname="$USER_AT_HOST" -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C
 
-net use /PERSISTENT:NO X: \\sshfs\%USER_AT_HOST%
-SET DOCKER_HOST=localhost:23750
-code-insiders "X:\%REMOTE_CFG_PATH%"
-ssh -NL localhost:23750:/var/run/docker.sock %USER_AT_HOST%
-```
+    # Start VS Code and forward the docker port.
+    export DOCKER_HOST=localhost:23750
+    code-insiders "$HOME/sshfs/$USER_AT_HOST/$REMOTE_CFG_PATH"
+    ssh -NL localhost:23750:/var/run/docker.sock $USER_AT_HOST
+    ```
 
-Once VS Code appears with the folder, run **Remote-Containers: Reopen Folder in Container** from the command palette.
+    On **Windows** run the following in a command prompt:
+
+    ```bat
+    SET USER_AT_HOST=user@hostname
+    SET REMOTE_CFG_PATH="repos/your-repository-here/.remote"
+
+    REM Mount the remote filesystem
+    net use /PERSISTENT:NO X: \\sshfs\%USER_AT_HOST%
+
+    REM Start VS Code and forward the docker port
+    SET DOCKER_HOST=localhost:23750
+    code-insiders "X:\%REMOTE_CFG_PATH%"
+    ssh -NL localhost:23750:/var/run/docker.sock %USER_AT_HOST%
+    ```
+
+3. Once the VS Code window opens, run **Remote-Containers: Reopen Folder in Container** from the command palette (`kbstyle(F1)`).
 
 ## devcontainer.json  reference
 
@@ -975,6 +965,14 @@ If you see "W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates
 
 Some extensions rely on libraries not found in the certain Docker images. See [above](#installing-additional-software-in-the-sandbox) for help resolving the problem.
 
+### Can I connect to multiple containers at once?
+
+A VS Code window can only connect to one window currently, but you can open a new window and [attach](#attaching-to-running-containers) to an already running container or [use a common Docker Compose file with multiple `devcontainer.json` files](#connecting-to-multiple-containers-at-once) to automate the process a bit more.
+
+### Can I work with containers on a remote host?
+
+With some manual configuration, yes. You can attach to a container running on a remote host or create specialized `devcontainer.json` and `Docker Compose` file designed to work with your remote host. See [Using SSH to connect to a remote Docker host](#using-ssh-to-connect-to-a-remote-docker-host) for details.
+
 ### How can I build or deploy container images into my local Docker / Kubernetes install when working inside a container?
 
 You can build images and deploy containers by forwarding the Docker socket and installing the Docker CLI (and kubectl for Kubernetes) in the container. See the [Docker-in-Docker](https://aka.ms/vscode-remote/samples/docker-in-docker), [Docker-in-Docker Compose](https://aka.ms/vscode-remote/samples/docker-in-docker-compose), and [Kubernetes-Helm](https://aka.ms/vscode-remote/samples/kubernetes-helm) dev container definitions for details.
@@ -986,6 +984,17 @@ The VS Code Server requires outbound HTTPS (port 443) connectivity to `update.co
 ### As an extension author, what do I need to do to make sure my extension works?
 
 The VS Code extension API hides most of the implementation details of running remotely so many extensions will just work inside dev containers without any modification. However, we recommend that you test your extension in a dev container to be sure that all of its functionality works as expected. See the article on [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for details.
+
+### What other resources are there that can help answer my question?
+
+The following articles may help answer your question:
+* [Remote - Containers Tips and Tricks](/docs/remote/troubleshooting.md#containers-tips)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
+* [Docker Compose file reference](https://docs.docker.com/compose/compose-file/)
+* [Docker Desktop for Windows troubleshooting guide](https://docs.docker.com/docker-for-windows/troubleshoot) and [FAQ](https://docs.docker.com/docker-for-windows/faqs/)
+* [Docker Desktop for Mac troubleshooting guide](https://docs.docker.com/docker-for-mac/troubleshoot) and [FAQ](https://docs.docker.com/docker-for-mac/faqs/)
+* [Docker Support Resources](https://success.docker.com/article/best-support-resources)
+
 
 ## Questions or feedback
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -35,7 +35,7 @@ To get started, follow these steps:
 
     2. Right-click on the Docker taskbar item and update **Settings / Preferences > Shared Drives / File Sharing** with any source code locations you want to open in a container. If you run into trouble, see [Docker Desktop for Windows tips](/docs/remote/troubleshooting.md#docker-desktop-for-windows-tips) on avoiding common problems with sharing.
 
-    3. **Windows**: Consider disabling automatic line ending conversion for Git on the **Windows side** by using a command prompt to run: `git config --global core.autocrlf false` If left enabled, this setting can cause files that you have not edited to appear modified due to line ending differences. See [tips and tricks](/docs/remote/troubleshooting.md#resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files) for details.
+    3. **Windows**: Consider adding a `.gitattributes` file or disabling automatic line ending conversion for Git on the **Windows side** by using a command prompt to run: `git config --global core.autocrlf false` If left enabled, this setting can cause files that you have not edited to appear modified due to line ending differences. See [tips and tricks](/docs/remote/troubleshooting.md#resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files) for details.
 
     **Linux**:
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -609,13 +609,12 @@ The following are dev container definitions that use Docker Compose:
 
 See the [Advanced Container Configuration](/docs/remote/containers-advanced.md) article for information on the following topics:
 
-- [Adding another volume mount](/docs/remote/containers-advanced.md#adding-another-volume-mount)
-- [Adding a non-root user to your dev container](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container)
-- [Using Docker or Kubernetes from inside a container](/docs/remote/containers-advanced.md#using-docker-or-kubernetes-from-a-container)
-- [Connecting to multiple containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once)
-- [Using SSH to connect to a remote Docker host](/docs/remote/containers-advanced.md#using-ssh-to-connect-to-a-remote-docker-host)
-- [Reducing Dockerfile build warnings](/docs/remote/containers-advanced.md#reducing-dockerfile-build-warnings)
-
+* [Adding another volume mount](/docs/remote/containers-advanced.md#adding-another-volume-mount)
+* [Adding a non-root user to your dev container](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container)
+* [Using Docker or Kubernetes from inside a container](/docs/remote/containers-advanced.md#using-docker-or-kubernetes-from-a-container)
+* [Connecting to multiple containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once)
+* [Using SSH to connect to a remote Docker host](/docs/remote/containers-advanced.md#using-ssh-to-connect-to-a-remote-docker-host)
+* [Reducing Dockerfile build warnings](/docs/remote/containers-advanced.md#reducing-dockerfile-build-warnings)
 
 ## devcontainer.json  reference
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -325,7 +325,7 @@ COPY settings.vscode.json /root/.vscode-remote/data/Machine/settings.json
 
 There are a few different ways VS Code Remote - Containers can be used to develop an application inside a fully containerized environment. In general, there are two primary scenarios that drive interest in this development style:
 
-* [Stand-Alone Dev Sandboxes](#working-with-a-developer-sandbox): You may not be deploying your application into a containerized environment but still want to isolate your build and runtime environment from your local OS or develop in an environment that is more representative of production. For example, you may be running code on your local macOS or Windows machine that will ultimately be deployed to a Linux VM or server.
+* [Stand-Alone Dev Sandboxes](#working-with-a-developer-sandbox): You may not be deploying your application into a containerized environment but still want to isolate your build and runtime environment from your local OS or develop in an environment that is more representative of production. For example, you may be running code on your local macOS or Windows machine that will ultimately be deployed to a Linux VM or server. You can reference an existing [image](#using-an-existing-container-image) or a [Dockerfile](#using-a-dockerfile) for this purpose.
 
 * **Container Deployed Applications**: You deploy your application into one or more containers and would like to work locally in the containerized environment. VS Code currently supports working with container-based applications defined in a number of ways:
 
@@ -366,9 +366,27 @@ For example:
 }
 ```
 
-See the [devcontainer.json reference](#devcontainerjson-reference) for information on other available properties such as the `appPort` and `extensions` list.
+See the [devcontainer.json reference](#devcontainerjson-reference) for information on other available properties such as the `appPort`, `runArgs`, and `extensions` list.
 
-To open the folder in the container, run the **Remote-Containers: Open Folder in Container** or **Remote: Reopen Folder in Container** command from the Command Palette (`kbstyle(F1)`). Once the container has been created, the **local filesystem will be automatically mapped** into the container and you can start working with it from VS Code.
+To open the folder in the container, run the **Remote-Containers: Open Folder in Container** or **Remote: Reopen Folder in Container** command from the Command Palette (`kbstyle(F1)`).
+
+Once the container has been created, the **local filesystem will be automatically mapped** into the container and you can start working with it from VS Code. You can also add additional local mount points to give your container access to other locations. The example below mounts your home / user profile folder into the container using the `runArgs` property and local environment variables:
+
+```json
+{
+    "name": "My Project",
+    "image": "microsoft/dotnet:sdk",
+    "appPort": 8090,
+    "extensions": [
+        "ms-vscode.csharp"
+    ],
+    "runArgs": [
+        "-v", "${env:HOME}${env:USERPROFILE}:/host-home-folder"
+    ]
+}
+```
+
+After making edits, you can run the **Remote-Containers: Rebuild Container** command cause the updated settings to take effect.
 
 ### Installing additional software in the sandbox
 
@@ -395,9 +413,9 @@ To create a customized sandbox or application in a single container, you can use
 
 > **Note:** Alpine Linux and Windows based containers are not currently supported.
 
-You may want to install other tools such as Git inside the container, which you can easily [do manually](#installing-additional-software-in-the-sandbox). However, you can also create a custom `Dockerfile` specifically for development that includes these dependencies. The [vscode-dev-containers repository](https://github.com/Microsoft/vscode-dev-containers) contains examples you can use as a starting point.
+You may want to install other tools such as Git inside the container, which you can easily [do manually](#installing-additional-software-in-the-sandbox). However, you can also create a custom Dockerfile specifically for development that includes these dependencies. The [vscode-dev-containers repository](https://github.com/Microsoft/vscode-dev-containers) contains examples you can use as a starting point.
 
-You can use the `dockerFile` property in `.devcontainer/devcontainer.json` to configure VS Code for use with your `Dockerfile`.
+You can use the `dockerFile` property in `.devcontainer/devcontainer.json` to specify the path to a custom `Dockerfile` and take advantage of all the same properties available in the `image` case.
 
 For example:
 
@@ -413,7 +431,7 @@ For example:
 }
 ```
 
-See the [devcontainer.json reference](#devcontainerjson-reference) for information on other available properties such as `appPort`, the `extensions` list, and `postCreateCommand`.
+See the [devcontainer.json reference](#devcontainerjson-reference) for information on other available properties such as `appPort`, `runArgs`, the `extensions` list, and `postCreateCommand`.
 
 The example below uses `runArgs` to change the security policy to enable the ptrace system call for a Go development container:
 
@@ -586,6 +604,8 @@ The following are dev container definitions that use Docker Compose:
 * [Python & PostgreSQL](https://aka.ms/vscode-remote/samples/python-postgresl) -  A Python container that connects to PostGreSQL in a different container.
 
 * [Docker-in-Docker Compose](https://aka.ms/vscode-remote/samples/docker-in-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
+
+## Advanced Configuration
 
 ### Using Docker or Kubernetes from a container
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -625,7 +625,7 @@ See the following examples dev containers for additional information:
 
 Currently you can only connect to one container per VS Code window. However, you can spin up multiple VS Code windows [attach to them](#attaching-to-running-containers).
 
-If you'd prefer to use `devcontainer.json` instead and are using Docker Compose, you can setup separate  `.devcontainer` folders for each service in your source tree that point to a common `docker-compose.yml`. VS Code will actually attach to running containers if they are already up when you open a folder in a container which allows this approach to work.
+If you'd prefer to use `devcontainer.json` instead and are using Docker Compose, you can setup separate  `.devcontainer` folders for each service in your source tree that point to a common `docker-compose.yml`.
 
 To see how this works, consider this extremely simplified source tree:
 
@@ -687,16 +687,16 @@ Next, you can `container2-src/.devcontainer.json` for Node.js development as fol
 }
 ```
 
-The `"shutdownAction":"none"` in the `devcontainer.json` files will leave the containers running even if you close the two VS Code windows -- which prevents you from accidentally shutting down both containers (and thus both windows stop working) by closing one.  This part is optional.
-
+The `"shutdownAction":"none"` in the `devcontainer.json` files is optional, but will leave the containers running when VS Code closes -- which prevents you from accidentally shutting down both containers by closing one window.
 
 To connect to both:
 1. <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container1-src` folder.
 2. VS Code will then start up both containers, connect this window to service `container-1`, and install the Go extension.
-3. Next, **File > New Window**
+3. Next, start up a new window using **File > New Window**.
 4. In the new Window, <kbd>F1</kbd> > **Remote-Containers: Open Folder in Container...** and select the `container2-src` folder.
-5. VS Code will then connect to the already running `container-2` and install the ESLint extension.
+5. Since the services is already running, VS Code will then connect to `container-2` and install the ESLint extension.
 
+You can now interact with both containers at once from separate windows.
 
 ### Using SSH to connect to a remote Docker host
 
@@ -853,7 +853,7 @@ net use /PERSISTENT:NO X: \\sshfs\user@hostname
 
 The remote machine will be available at `X:\`. You can disconnect from it by right-clicking on the drive in the File Explorer and clicking Disconnect.
 
-Note that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. You can also sync files from your remote SSH host to your local machine [using `rsync`](https://rsync.samba.org/) if you would prefer to use a broader set of tools. See [Accessing your remote source code locally](/docs/remote/troubleshooting.md#accessing-your-remote-source-code-locally) for details on setting this up.
+Note that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. However, can also sync files from your remote SSH host to your local machine [using `rsync`](https://rsync.samba.org/) if you would prefer to use a broader set of tools. See [Tips and Tricks](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-codey) for details on setting this up.
 
 **[Optional] Storing your remote devcontainer.json files on the server**
 

--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -1,5 +1,5 @@
 ---
-Order: 6
+Order: 7
 Area: remote
 TOCTitle: FAQ
 PageTitle: Visual Studio Code Remote Development Frequently Asked Questions

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -220,6 +220,10 @@ Most Linux distributions will not require additional dependency installation ste
 
 The VS Code Server requires outbound HTTPS (port 443) connectivity to `update.code.visualstudio.com` and `marketplace.visualstudio.com`. All other communication between the server and the VS Code client is accomplished through an authenticated, secure, SSH tunnel.
 
+### Can I use local tools on source code sitting on the remote SSH host?
+
+Yes. Typically this is done [using SSHFS](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host) or by [using `rsync`](/docs/remote/troubleshooting.md#using-rsync-to-maintain-a-local-copy-of-your-source-code) to get a copy of the files on your local machine. SSHFS mounts the remote filesystem is ideal for scenarios where you need to edit individual files or browse the source tree and requires no sync step to use. However, it is not ideal for using something like a source control tool that bulk manages files. In this case, the `rsync` approach is better since you get a complete copy of the remote source code on your local machine. See [Tips and Tricks](/docs/remote/troubleshooting.md#using-sshfs-to-access-files-on-your-remote-host) for details.
+
 ### Can I use VS Code when I only have SFTP/FTP filesystem access to my remote host (no shell access)?
 
 Some cloud platforms only provide remote filesystem access for developers rather than direct shell access. VS Code Remote Development was not designed with this use case in mind since it negates the performance and user experience benefits.

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -57,7 +57,7 @@ To get started, follow these steps:
 
 3. After a moment, VS Code will connect to the SSH server and set itself up. VS Code will keep you up to date using a progress notification and you can see a detailed log in the `Remote - SSH` output channel.
 
-    > **Note:** If your connection is hanging, you may need to enable TCP forwarding or respond to a server prompt. See [tips and tricks](/docs/remote/troubleshooting.md#troubleshooting-hanging-connections) for details.
+    > **Note:** If your connection is hanging, you may need to enable TCP forwarding or respond to a server prompt. See [tips and tricks](/docs/remote/troubleshooting.md#troubleshooting-hanging-or-failing-connections) for details.
 
 4. After you are connected, you'll be in an empty window. You can then open a folder or workspace on the remote machine using **File > Open...** or **File > Open Workspace...**
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -521,73 +521,6 @@ If you see an error from Docker reporting that you are out of disk space, you ca
 1. Open a **local** terminal/command prompt (or use a local window in VS Code).
 2. Type `docker system prune --all`.
 
-### Adding another volume mount
-
-You can add a volume mount to any local folder using these steps:
-
-1. Configure the volume mount:
-
-   - When an **image** or **Dockerfile** is referenced in `devcontainer.json`, add the following to the `runArgs` property in this same file:
-
-        ```json
-        "runArgs": ["-v","/local/source/path/goes/here:/target/path/in/container/goes/here"]
-        ```
-
-   - When a **Docker Compose** file is referenced, add the following to your `docker-compose.yml`:
-
-        ```json
-        volumes:
-          - /local/source/path/goes/here:/target/path/in/container/goes/here
-        ```
-
-2. If you've already built the container and connected to it, run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up the change.
-
-### Adding a non-root user to your dev container
-
-Many images run as a root user by default. However, some provide one or more non-root users, that you can optionally use instead. If your image or Dockerfile provides a non-root user (but still defaults to root), you can opt into using it in one of two ways:
-
-- When referencing an **image** or **Dockerfile**, add the following to your `devcontainer.json`:
-
-    ```json
-    "runArgs": ["-u", "user-name-goes-here"]
-    ```
-
-- If you are using **Docker Compose**, add the following to your service in `docker-compose.yml`:
-
-    ```yaml
-    user: user-name-goes-here
-    ```
-
-For images that only provide a root user, you can automatically create a non-root user by using a Dockerfile. For example, this snippet will create a user called `user-name-goes-here`, give it the ability to use `sudo`, and set it as the default:
-
-```Dockerfile
-ARG USERNAME=user-name-goes-here
-RUN useradd -m $USERNAME
-ENV HOME /home/$USERNAME
-
-# [Optional] Add sudo support
-RUN apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
-    chmod 0440 /etc/sudoers.d/$USERNAME
-
-# ** Anything else you want to do like clean up goes here **
-
-# [Optional] Set the default user
-USER $USERNAME
-```
-
-### Using Docker or Kubernetes from a container
-
-See the [main Containers article](/docs/remote/containers.md#using-docker-or-kubernetes-from-a-container) for details on this topic.
-
-### Connecting to multiple containers at once
-
-See the [main Containers article](/docs/remote/containers.md#connecting-to-multiple-containers-at-once) for details on this topic.
-
-### Using SSH to connect to a remote Docker host
-
-See the [main Containers article](/docs/remote/containers.md#using-ssh-to-connect-to-a-remote-docker-host) for details on this topic.
-
 ### Resolving Dockerfile build failures for images using Debian 8
 
 When building containers that use images based on Debian 8/Jessie — such as older versions of the `node:8` image — you may encounter the following error:
@@ -612,11 +545,7 @@ There are two ways to resolve this error:
     RUN cat /etc/*-release | grep -q jessie && printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
     ```
 
-### Other common Docker related errors and issues
-
-This section explains how to work around common issues related to using Docker.
-
-### Sign in errors to Docker Hub when an email is use
+### Resolving Docker Hub sign in errors when an email is used
 
 The Docker CLI only supports using your Docker ID, so using your email to sign in can cause problems. See Docker issue [#935](https://github.com/docker/hub-feedback/issues/935#issuecomment-300361781) for details.
 
@@ -626,40 +555,16 @@ As a workaround, use your Docker ID to sign into Docker rather than your email.
 
 There is [known issue with Docker for Mac](https://github.com/docker/for-mac/issues/1759) that can drive high CPU spikes. In particular, high CPU usage occurring when watching files and building. If you see high CPU usage for `com.docker.hyperkit` in Activity Monitor while very little is going on in your dev container, you are likely hitting this issue. Follow the [Docker issue](https://github.com/docker/for-mac/issues/1759) for updates and fixes.
 
-### debconf: delaying package configuration, since apt-utils is not installed
+### Advanced container configuration tips
 
-This error can typically be safely ignored and is tricky to get rid of completely. However, you can reduce it to one message in stdout when installing the needed package by adding the following to your Dockerfile:
+See the [Advanced Container Configuration](/docs/remote/containers-advanced.md) article for information on the following advanced configuration topics:
 
-```Dockerfile
-# Configure apt
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
-
-## YOUR DOCKERFILE CONTENT GOES HERE
-
-ENV DEBIAN_FRONTEND=dialog
-```
-
-### Warning: apt-key output should not be parsed (stdout is not a terminal)
-
-This non-critical warning tells you not to parse the output of `apt-key`, so as long as your script doesn't, there's no problem. You can safely ignore it.
-
-This occurs in Dockerfiles because the `apt-key` command is not running from a terminal. Unfortunately, this error cannot be eliminated completely, but can be hidden unless the `apt-key` command returns a non-zero exit code (indicating a failure).
-
-For example:
-
-```Dockerfile
-# (OUT=$(apt-key add - 2>&1) || echo $OUT) will only print the output with non-zero exit code is hit
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-```
-
-You can also set the `APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE` environment variable to suppress the warning, but it looks a bit scary so be sure to add comments in your Dockerfile if you use it:
-
-```Dockerfile
-# Suppress an apt-key warning about standard out not being a terminal. Its use in this script is safe.
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
-```
+- [Adding another volume mount](/docs/remote/containers-advanced.md#adding-another-volume-mount)
+- [Adding a non-root user to your dev container](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container)
+- [Using Docker or Kubernetes from inside a container](/docs/remote/containers-advanced.md#using-docker-or-kubernetes-from-a-container)
+- [Connecting to multiple containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once)
+- [Using SSH to connect to a remote Docker host](/docs/remote/containers-advanced.md#using-ssh-to-connect-to-a-remote-docker-host)
+- [Reducing Dockerfile build warnings](/docs/remote/containers-advanced.md#reducing-dockerfile-build-warnings)
 
 ## WSL tips
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -310,7 +310,7 @@ Either use an SSH key without a passphrase, clone using HTTPS, or run `git push`
 
 ### Using SSHFS to access files on your remote host
 
-[SSHFS](https://en.wikipedia.org/wiki/SSHFS) provides a secure remote filesystem access protocol that builds up from SFTP. It provides advantages over something like a CIFS / Samba share in that all that is required is SSH access to the machine which can give you local access to your remote project files.
+[SSHFS](https://en.wikipedia.org/wiki/SSHFS) is a secure remote filesystem access protocol that builds up from SFTP. It provides advantages over something like a CIFS / Samba share in that all that is required is SSH access to the machine.
 
 You can install SSHFS locally as follows:
 
@@ -333,7 +333,7 @@ read -n 1 -p "Press any key to unmount the remote filesystem..."
 umount "$HOME/sshfs/$USER_AT_HOST"
 ```
 
-This will make your home folder on the remote machine available under at `~/sshfs` until you press a key.
+This will make your home folder on the remote machine available under the `~/sshfs` folder until you press a key.
 
 On **Windows** you should add a `.gitattributes` file to your project to **force consistent line endings** between Linux and Windows to avoid unexpected issues due to CRLF/LF differences between the two operating systems. [See below](#resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) for details.
 
@@ -367,9 +367,9 @@ Or using **WSL from a command prompt on Windows**:
 wsl rsync -rlptzv --progress --delete --exclude=.git "user@hostname:/remote/source/code/path" "$(wslpath -a '%CD%')"
 ```
 
-You can re-run this command each time you want to access the files and only updates will be transferred. The `.git` folder is intentionally excluded both for performance reasons and so you can use local Git tools without worrying about the state on the remote host.
+You can re-run this command each time you want to get the latest copy of your files and only updates will be transferred. The `.git` folder is intentionally excluded both for performance reasons and so you can use local Git tools without worrying about the state on the remote host.
 
-To push content, you simply reverse the source and target parameters in the command. However, **on Windows** you should add a `.gitattributes` file to your project to **force consistent line endings** before doing so. [See below](#resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) for details.
+To push content, simply reverse the source and target parameters in the command. However, **on Windows** you should add a `.gitattributes` file to your project to **force consistent line endings** before doing so. [See below](#resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) for details.
 
 ```bash
 rsync -rlptzv --progress --delete --exclude=.git . "user@hostname:/remote/source/code/path"

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -328,21 +328,6 @@ net use /PERSISTENT:NO X: \\sshfs\user@hostname
 
 The remote machine will be available at `X:\`. You can disconnect from it by right-clicking on the drive in the File Explorer and clicking Disconnect.
 
-You can also use **WSL from a command prompt** as follows:
-
-```bat
-SET USER_AT_HOST=user@hostname
-
-mkdir "%USERPROFILE%/sshfs/%USER_AT_HOST%"
-wsl sshfs "%USER_AT_HOST%:" "$(wslpath -a '%USERPROFILE%/sshfs/%USER_AT_HOST%')" -ovolname='%USER_AT_HOST%' -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C"
-
-REM Wait for a key press, then disconnect
-pause
-wsl umount "$(wslpath -a '%USERPROFILE%/sshfs/%USER_AT_HOST%')"
-```
-
-This will make the folder available under a `sshfs` folder in your user directory from Windows until you press a key.
-
 Note that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems. However, can also sync files from your remote SSH host to your local machine [using `rsync`](https://rsync.samba.org/) if you would prefer to use a broader set of tools. See [below](#using-rsync-to-maintain-a-local-copy-of-your-source-codde) for details.
 
 ### Using rsync to maintain a local copy of your source code
@@ -370,7 +355,6 @@ To push content, you simply reverse the source and target parameters in the comm
 ```bash
 rsync -rlptzv --progress --delete --exclude=.git . "user@hostname:/remote/source/code/path"
 ```
-
 
 ## Container tips
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -388,23 +388,9 @@ To change Docker's drive and folder sharing settings:
 
 ### Resolving Git line ending issues in containers (resulting in many modified files)
 
-Since Windows and Linux use different default line endings, you may see files that appear modified but seem to have no differences aside from the line endings. To prevent this from happening, you can disable automatic line ending conversion and optionally add a `.gitattributes` file to your folder.
+Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line ending conversion using a `.gitattributes` file or globally on the Windows side.
 
-First run:
-
-```bash
-git config --global core.autocrlf false
-```
-
-This will disable automated conversation. If you would prefer to still always upload Unix-style line endings (LF), you can use the `input` option instead.
-
-```bash
-git config --global core.autocrlf input
-```
-
-Next, you can prevent others from facing this issue, regardless of their setting, by adding or modifying a  `.gitattributes` file in your repository.
-
-For example, the `.gitattributes` settings below will force everything to be LF, except for Windows batch files that require CRLF:
+Typically adding or modifying a  `.gitattributes` file in your repository is the most reliable way to solve this problem. Committing this file to source control will help others and allows you to vary behaviors by repository as appropriate. For example, adding the following to `.gitattributes` file to the root of your repository will force everything to be LF, except for Windows batch files that require CRLF:
 
 ```yaml
 * text=auto eol=lf
@@ -412,7 +398,19 @@ For example, the `.gitattributes` settings below will force everything to be LF,
 *.{bat,[bB][aA][tT]} text eol=crlf
 ```
 
-You can add other file types in your repository that require CRLF to this same file.
+Note that this works in **Git v2.10+**, so if you are running into problems, be sure you've got a recent Git client installed. You can add other file types in your repository that require CRLF to this same file.
+
+If you'd prefer to disable line ending conversation entirely, run:
+
+```bash
+git config --global core.autocrlf false
+```
+
+If you would prefer to still always upload Unix-style line endings (LF), you can use the `input` option instead.
+
+```bash
+git config --global core.autocrlf input
+```
 
 Finally, reclone the repository so these settings take effect.
 
@@ -558,6 +556,17 @@ RUN apt-get install -y sudo \
 # [Optional] Set the default user
 USER $USERNAME
 ```
+### Using Docker or Kubernetes from a container
+
+See the [main Containers article](/docs/remote/containers.md#using-docker-or-kubernetes-from-a-container) for details on this topic.
+
+### Connecting to multiple containers at once
+
+See the [main Containers article](/docs/remote/containers.md#connecting-to-multiple-containers-at-once) for details on this topic.
+
+### Using SSH to connect to a remote Docker host
+
+See the [main Containers article](/docs/remote/containers.md#using-ssh-to-connect-to-a-remote-docker-host) for details on this topic.
 
 ### Resolving Dockerfile build failures for images using Debian 8
 
@@ -565,13 +574,9 @@ When building containers that use images based on Debian 8/Jessie — such as ol
 
 ```text
 ...
-Get:5 http://security.debian.org jessie/updates/main amd64 Packages [825 kB]
-Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
-Fetched 10.1 MB in 6s (1458 kB/s)
 W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
 E: Some index files failed to download. They have been ignored, or old ones used instead.
-The command '/bin/sh -c apt-get update     && apt-get -y install --no-install-recommends apt-utils 2>&1' returned a non-zero code: 100
-Failed: Building an image from the Dockerfile.
+...
 ```
 
 This is a [well known issue](https://github.com/debuerreotype/docker-debian-artifacts/issues/66) caused by the Debian 8 being "archived". More recent versions of images typically resolve this problem, often by upgrading to Debian 9/Stretch.
@@ -684,8 +689,11 @@ If the VS Code Insiders install path is missing, edit your `.bashrc`, add the fo
 ```bash
 WINDOWS_USERNAME="Your Username"
 VSCODE_PATH="/mnt/c/Users/${WINDOWS_USERNAME}/AppData/Local/Programs/Microsoft VS Code Insiders/bin"
-# Use this path if you installed the System Installer version of VS Code Insiders
+# or...
 # VSCODE_PATH="/mnt/c/Program Files/Microsoft VS Code Insiders/bin"
+# or...
+# VSCODE_PATH="/mnt/c/Program Files (x86)/Microsoft VS Code Insiders/bin"
+
 export PATH=$PATH:/mnt/c/Windows/System32:${VSCODE_PATH}
 ```
 
@@ -697,23 +705,9 @@ Some extensions rely on libraries not found in the vanilla install of certain WS
 
 ### Resolving Git line ending issues in WSL (resulting in many modified files)
 
-Since Windows and Linux use different default line endings, you may see files that appear modified but seem to have no differences aside from the line endings. To prevent this from happening, you can disable automatic line ending conversion and optionally add a `.gitattributes` file to your folder.
+Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line ending conversion using a `.gitattributes` file or globally on the Windows side.
 
-First run:
-
-```bash
-git config --global core.autocrlf false
-```
-
-This will disable automated conversation. If you would prefer to still always upload Unix-style line endings (LF), you can use the `input` option instead.
-
-```bash
-git config --global core.autocrlf input
-```
-
-Next, you can prevent others from facing this issue, regardless of their setting, by adding or modifying a  `.gitattributes` file in your repository.
-
-For example, the `.gitattributes` settings below will force everything to be LF, except for Windows batch files that require CRLF:
+Typically adding or modifying a  `.gitattributes` file in your repository is the most reliable way to solve this problem. Committing this file to source control will help others and allows you to vary behaviors by repository as appropriate. For example, adding the following to `.gitattributes` file to the root of your repository will force everything to be LF, except for Windows batch files that require CRLF:
 
 ```yaml
 * text=auto eol=lf
@@ -721,7 +715,19 @@ For example, the `.gitattributes` settings below will force everything to be LF,
 *.{bat,[bB][aA][tT]} text eol=crlf
 ```
 
-You can add other file types in your repository that require CRLF to this same file.
+Note that this works in **Git v2.10+**, so if you are running into problems, be sure you've got a recent Git client installed. You can add other file types in your repository that require CRLF to this same file.
+
+If you'd prefer to disable line ending conversation entirely, run:
+
+```bash
+git config --global core.autocrlf false
+```
+
+If you would prefer to still always upload Unix-style line endings (LF), you can use the `input` option instead.
+
+```bash
+git config --global core.autocrlf input
+```
 
 Finally, reclone the repository so these settings take effect.
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -291,6 +291,49 @@ If you clone a Git repository using SSH and your SSH key has a passphrase, VS Co
 
 Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
 
+### Using SSHFS to access files on your remote host
+
+[SSHFS](https://en.wikipedia.org/wiki/SSHFS) provides a secure remote filesystem access protocol that builds up from SFTP. It provides advantages over something like a CIFS / Samba share in that all that is required is SSH access to the machine which can give you local access to your remote project files.
+
+You can install SSHFS locally as follows:
+
+- macOS using [Homebrew](https://brew.sh/): `brew install sshfs`
+- Linux using the native package manager. For Debian/Ubuntu: `sudo apt-get install sshfs`
+- Windows using [Chocolaty](https://chocolatey.org/): `choco install sshfs`
+
+To mount the remote filesystem on **macOS or Linux**, run the following from a local terminal replacing `user@hostname` with the remote user and hostname / IP:
+
+```bash
+export USER_AT_HOST=user@hostname
+
+mkdir -p "$HOME/sshfs/$USER_AT_HOST"
+sshfs "$USER_AT_HOST:" "$HOME/sshfs/$USER_AT_HOST" -ovolname="$USER_AT_HOST" -p 22  -o workaround=nonodelay -o transform_symlinks -o idmap=user  -C
+```
+
+While this command is active, the remote machine will be available at `~/sshfs`.
+
+On **Windows**, run the following from the command prompt replacing `user@hostname` with the remote user and hostname / IP:
+
+```bat
+net use /PERSISTENT:NO X: \\sshfs\user@hostname
+```
+
+The remote machine will be available at `X:\`. You can disconnect from it by right-clicking on the drive in the File Explorer and clicking Disconnect.
+
+Note that performance will be significantly slower than working through VS Code, so this is best used for small edits, uploading content, etc. Using something like a local source control tool in this way will be very slow and can cause unforseen problems.
+
+### Using rsync to maintain a local copy of your source code
+
+An alternative to [using SSHFS to access remote files](#using-sshfs-to-access-files-on-your-remote-host) is to [use `rsync`](https://rsync.samba.org/) to copy the entire contents of a folder on remote host to your local machine. This is primarily something to consider if you really need to use multi-file or performance intensive local tools.
+
+The `rsync` command is available out of box on macOS and can be installed using Linux package managers (e.g. `sudo apt-get install rsync` on Debian/Ubuntu). For Windows, you'll need to either use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) or [Cygwin](https://www.cygwin.com/) to access the command.
+
+To use the command, navigate to the folder you want to store the sync'd contents and run the following replacing `user@hostname`  with the remote user and hostname / IP and `/remote/source/code/path` with the remote source code location.
+
+```bash
+rsync -rlptzv --progress --delete --exclude=.git user@hostname:/remote/source/code/path .
+```
+
 ## Container tips
 
 ### Docker Desktop for Windows tips

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -115,7 +115,7 @@ If you used PuTTYGen to set up SSH public key authentication for the host you ar
         IdentityFile C:\path\to\your\exported\private\keyfile
     ```
 
-### Troubleshooting hanging connections
+### Troubleshooting hanging or failing connections
 
 If you are running into problems with VS Code hanging while trying to connect (and potentially timing out), there are a few things you can do to try to resolve the issue.
 

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -37,7 +37,7 @@ To get started you need to:
 
 3. Install the [Remote Development](https://aka.ms/vscode-remote/download/extension) extension pack.
 
-4. Consider disabling automatic line ending conversion for Git on the **Windows side** by using a command prompt to run: `git config --global core.autocrlf false` If left enabled, this setting can cause files that you have not edited to appear modified due to line ending differences. See [tips and tricks](/docs/remote/troubleshooting.md#resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) for details.
+4. Consider adding a `.gitattributes` file or disabling automatic line ending conversion for Git on the **Windows side** by using a command prompt to run: `git config --global core.autocrlf false` If left enabled, this setting can cause files that you have not edited to appear modified due to line ending differences. See [tips and tricks](/docs/remote/troubleshooting.md#resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files) for details.
 
 ### Open a folder in WSL
 


### PR DESCRIPTION
This PR:
1. Adds an "Advanced configuration" section in the main containers article that now includes:
    - Docker-in-Docker/Kubernetes (existed before)
    - Connecting to multiple containers at once (new)
    - Using SSH to connect to a remote Docker host (new)
2. Adds tips and tricks topics on:
   - Setting up a SSHFS mount. (Referenced in "Using SSH to connect to a remote Docker host")
   - Using rsync to move content to/from a remote host.  (Referenced in "Using SSH to connect to a remote Docker host")
   - Two more SSH tips given commonly raised issues.
   - Other cleanup

I could see the "Advanced configuration" section becoming a separate article or breaking up troubleshooting into separate articles per-extension that then includes advanced configuration.  However, I held off on making those changes.