### PR TITLE
terminal all → terminate all

### DIFF
--- a/release-notes/v1_34.md
+++ b/release-notes/v1_34.md
@@ -41,7 +41,7 @@ We have introduced the setting `debug.showSubSessionsInToolBar` which controls w
 
 ### Terminate all tasks
 
-The **Tasks: Terminate Task** command has a new option to terminal all tasks if there are multiple tasks running. If this is an action you do often, you can create a keyboard shortcut for the command with the `terminateAll` argument.
+The **Tasks: Terminate Task** command has a new option to terminate all tasks if there are multiple tasks running. If this is an action you do often, you can create a keyboard shortcut for the command with the `terminateAll` argument.
 
 ```json
 {


### PR DESCRIPTION
I believe this is a typo