### PR TITLE
Update link in cpp.md

### DIFF
--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -144,7 +144,7 @@ Cygwin/MinGW debugging on Windows supports both attach and launch debugging scen
 
 To learn more, see [Configuring launch.json for C/C++ debugging](https://github.com/Microsoft/vscode-cpptools/blob/master/launch.md).
 
-If you are debugging with GDB on Windows, see [Windows Debugging with GDB](#windows-debugging-with-gdb).
+If you are debugging with GDB on Windows, see [Windows Debugging with MinGW64](/docs/cpp/config-mingw.md).
 
 ### Conditional Breakpoints
 


### PR DESCRIPTION
The link for `Windows Debugging with GDB` points to the same header that the link is in. This is not helpful for users who are trying to figure out how to setup GDB on Windows. Redirecting to /docs/cpp/config-mingw.md instead.