### PR TITLE
Documentation to make it easier to connect to Hyper-V hosts

### DIFF
--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -82,6 +82,13 @@ Host example-remote-linux-machine-with-identity-file
 
 The second example uses an alternate location for your SSH key if you want to use more than one. See [tips and tricks](/docs/remote/troubleshooting.md#improving-your-security-with-a-dedicated-key) for details. You can also set the `"remote.SSH.configFile"` property in `settings.json` if you want to use a different config file than those listed.
 
+If your remote host is inside a **Hyper-V** environment, the easiest way to connect to your host is via the `.mshome.net` domain name. This is because Hyper-V tends to assign new IP addresses when the computer is restarted or is woken up from sleep. To connect, take not of then **hostname** of your host and then connect it at `<hostname>.mshome.net`. The corresponding config file will look like so:
+```text
+Host example-remote-linux-machine
+    User your-user-name-here
+    HostName remote-host-hostname.mshome.net
+```
+
 ## Managing extensions
 
 VS Code runs extensions in one of two places: locally on the UI / client side, or remotely on the SSH host. While extensions that affect the VS Code UI, like themes and snippets, are installed locally, most extensions will reside on the SSH host. This ensures you have smooth experience and allows you to install any needed extensions for a given workspace on an SSH host from your local machine. This way, you can pick up exactly where you left off, from a different machine complete with your extensions.


### PR DESCRIPTION
Hyper-V tends to assign new IP addresses when the computer is restarted or is woken up from sleep. This details how to use `mshome.net` to make it easier to connect to Hyper-V hosts.