### PR TITLE
docs: variables-reference.md include settings.json

### DIFF
--- a/docs/editor/variables-reference.md
+++ b/docs/editor/variables-reference.md
@@ -9,7 +9,7 @@ MetaDescription: Visual Studio Code variable substitution reference
 ---
 # Variables Reference
 
-Visual Studio Code supports variable substitution in [Debugging](/docs/editor/debugging.md) and [Task](/docs/editor/tasks.md) configuration files. Variable substitution is supported inside key and value strings in `launch.json` and `tasks.json` files using **${variableName}** syntax.
+Visual Studio Code supports variable substitution in [Settings](/docs/getstarted/settings.md), [Debugging](/docs/editor/debugging.md) and [Task](/docs/editor/tasks.md) configuration files. Variable substitution is supported inside key and value strings in `settings.json`, `launch.json` and `tasks.json` files using **${variableName}** syntax.
 
 ## Predefined variables
 


### PR DESCRIPTION
-  make it clear that besides `launch.json` and `tasks.json`, variable substitution is also available in `settings.json`