### PR TITLE
Update editing.md

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -84,7 +84,7 @@ On first use of the **Python: Run Selection/Line in Python Terminal** command, V
 
 Formatting makes code easier to read by human beings by applying specific rules and conventions for line spacing, indents, spacing around operators, and so on (see an example on the [autopep8](https://pypi.org/project/autopep8/) page). Formatting doesn't affect the functionality of the code itself. ([Linting](/docs/python/linting.md), on the other hand, analyzes code for common syntactical, stylistic, and functional errors as well as unconventional programming practices that can lead to errors. Although there is a little overlap between formatting and linting, the two capabilities are complementary.)
 
-The Python extension supports source code formatting using either [autopep8](https://pypi.org/project/autopep8/) (the default), [black](https://github.com/ambv/black), or [yapf](https://github.com/google/yapf).
+The Python extension supports source code formatting using either [autopep8](https://pypi.org/project/autopep8/) (the default), [black](https://github.com/python/black), or [yapf](https://github.com/google/yapf).
 
 ### General formatting settings
 


### PR DESCRIPTION
`black` is now owned by the @python organization on GitHub. Update link accordingly in-case the redirect dies for... some reason. 