### PR TITLE
Recommend to always use strict host key checking

### DIFF
--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -134,6 +134,24 @@ If you do see that message, follow these steps to update your SSH server's [sshd
 3. Restart the SSH server (on Ubuntu, run `sudo systemctl restart sshd`).
 4. Retry.
 
+**Always use strict host key checking**
+
+If the target host key changes and you are using StrictHostKeyChecking=no, the ssh connection will still be made but TCP forwarding will be disabled, regardless of server configuration. Ensuring StrictHostKeyChecking=yes for the destination host will prevent a successful connection, ensuring there is no timeout in the ssh tunnel setup.
+
+example:
+```text
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+It is also possible that a host key has just been changed.
+The fingerprint for the ECDSA key sent by the remote host is
+...
+Port forwarding is disabled to avoid man-in-the-middle attacks.
+Connected to SSH Host - Please do not close this terminal
+```
+
 **Set the ProxyCommand parameter in your SSH config file**
 
 If you are behind a proxy and are unable to connect to your SSH host, you may need to use the `ProxyCommand` parameter for your host in a **local** [SSH config file](https://linux.die.net/man/5/ssh_config). You can [read this article](https://www.cyberciti.biz/faq/linux-unix-ssh-proxycommand-passing-through-one-host-gateway-server/) for an example of its use.


### PR DESCRIPTION
I've searched for a long time before finding the cause of my timout at "Waiting for ssh tunnel to be ready". So I thought I'd share here. Not sure if this is a bug or something the users should be aware of. It would be nice if vscode intercept that use case where the  target host key has changed (ie.: "Port forwarding is disabled to avoid man-in-the-middle attacks." warning). Let me know if a enhancement request would be a better way to go here.
Also, as an addition to what I put here, it would be nice to provide an external guide on how to properly add trusted host key. I didn't include one as I don't know if :
1- you already have one somewhere that I'm not aware of
2- what is your policy for external link in the documentation

Thanks for considering this!