### PR TITLE
Update and clarify snippet files part of the snippet user guide

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -1,13 +1,13 @@
 ---
 Order: 12
 Area: editor
-TOCTitle: Creating snippets
+TOCTitle: Snippets
 ContentId: 79CD9B45-97FF-48B1-8DD5-2555F56206A6
-PageTitle: Creating your own snippets in Visual Studio Code
+PageTitle: Snippets in Visual Studio Code
 DateApproved: 7/3/2019
 MetaDescription: It is easy to add code snippets to Visual Studio Code both for your own use or to share with others on the public Extension Marketplace. TextMate .tmSnippets files are supported.
 ---
-# Creating your own snippets
+# Snippets in Visual Studio Code
 
 Code snippets are templates that make it easier to enter repeating code patterns, such as loops or conditional-statements.
 
@@ -17,7 +17,7 @@ The snippet syntax follows the [TextMate snippet syntax](https://manual.macromat
 
 ![ajax snippet](images/userdefinedsnippets/ajax-snippet.gif)
 
-## Add snippets from the Marketplace
+## Install snippets from the Marketplace
 
 Many [extensions](/docs/editor/extension-gallery.md) on the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode) include snippets.  If you find one you want to use, install it and restart VS Code and the new snippet will be available (see [Extension Marketplace](/docs/editor/extension-gallery.md#browse-and-install-extensions) for more instructions on installing an extension).
 
@@ -27,7 +27,7 @@ Below are some popular extensions which include snippets in their language suppo
 
 > **Tip**: The extensions shown above are dynamically queried. Click on an extension tile above to read the description and reviews to decide which extension is best for you. See more in the [Marketplace](https://marketplace.visualstudio.com/vscode).
 
-## Creating your own snippets
+## Create your own snippets
 
 You can define your own snippets, either global snippets or snippets for a specific language. To open up a snippet file for editing, select **User Snippets** under **File** > **Preferences** (**Code** > **Preferences** on macOS) and select the language (by [language identifier](/docs/languages/identifiers.md)) for which the snippets should appear or create a new global snippet (**New Global Snippets file**).
 

--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -101,7 +101,84 @@ Most user-defined snippets are scoped to the user's settings, rather than define
 
 ## Snippet schema
 
-<!-- TODO Write section "Snippet schema". Open with an approximate schema defined like https://code.visualstudio.com/docs/editor/tasks-appendix -->
+The following JSON Schema informally describes the base structure of a snippets file:
+
+```json
+{
+  "title": "SnippetsFile",
+  "type": "object",
+  "patternProperties": {
+    "\\.*": {
+      "$ref": "Snippet"
+    }
+  },
+  "additionalProperties": false,
+  "minProperties": 0,
+  "$comment": "Every property is a snippet: the value is its definition and the key is its name."
+}
+```
+
+The following interfaces describe the structure of a single snippet definition.
+
+```typescript
+/**
+ * A single VS Code snippet definition. Valid in any snippet file.
+ */
+interface Snippet {
+
+    /**
+     * The one-or-more word(s) by which suggestions, Intellisense, and/or
+     * completions trigger on a prefix substring match with any of them. At
+     * least one word must be provided, but may be the empty string.
+     *
+     * A word may be separator-delimited. A word may not autocomplete properly
+     * if it contains whitespace. Substring prefix matching of "words part"s is
+     * supported for snippet prefixes (e.g. user input "fe" can substring prefix
+     * match "for-each").
+     */
+    prefix: string | string[];
+
+    /**
+     * The one-or-more line(s) that the snippet inserts. At least one line must
+     * be provided, but may be the empty string.
+     *
+     * Multiple lines will be joined at insertion time with a context-aware line
+     * separator. Similarly, embedded indentation will be formatted at insertion
+     * time with a context-aware indentation character(s).
+     *
+     * Supports most TextMate snippet syntax, e.g. tabstops, transforms, etc.
+     */
+    body: string | string[];
+
+    /**
+     * The optional natural-language description of the snippet for Intellisense.
+     *
+     * If provided, then the description and the (unexpanded) snippet body are
+     * displayed in any Intellisense detail view. Otherwise, the raw name of the
+     * snippet and the body are displayed. (the snippet is name is its key in
+     * the snippet file)
+     */
+    description?: string;
+}
+
+/**
+ * A single VS Code snippet definition. Only valid in global snippets files.
+ */
+interface GlobalSnippet extends Snippet {
+
+    /**
+     * The optional comma-delimited list of one or more language identifiers
+     * by which to scope this global snippet. E.g. "javascript,typescript".
+     *
+     * If exactly one language identifier is provided, then this global snippet
+     * is equivalent to a language snippet. If more than one language identifier
+     * is provided, then this snippet is accessible from all-and-only the
+     * specified languages. If no value is set, then this snippet is globally
+     * accessible from all languages.
+     */
+    scope?: string;
+}
+```
 
 ## Snippet syntax
 


### PR DESCRIPTION
High-level summary of changes:

- Fix #2855 "Missing documentation for the 'snippet prefix arrays' feature"
- Fix #2450 "Not mentioned project level snippets"
- Standardize document title and first couple headers for clarity's sake
- Split--and then lightly extend--the subsection "Creating your own snippets" to improve SoC/SRP per section.
- Separate, reflow, and add detail to the cursory snippets files documentation with a new section that better addresses the language-vs-global and user-vs-project -scoping of snippets files.
- Add a new section "Snippet schema" that explicitly and declaratively provides the structure of a snippets file and snippet definition. (this was not something that existed before, outside of implicit and only-cursorily-documented VS Code intellisense)