### PR TITLE
Correct cmd command for matplotlib pkg installment

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -278,7 +278,7 @@ A best practice among Python developers is to avoid installing packages into a g
    python3 -m pip install matplotlib
 
    # Windows (may require elevation)
-   python -m pip install matplotlib
+   py -m pip install matplotlib
 
    # Linux (Debian)
    apt-get install python3-tk


### PR DESCRIPTION
Using the integrated terminal within vscode, the cmd ` python -m pip install matplotlib` generated the following error

```
python : The term 'python' is not recognized as the name of a cmdlet, function, script file, 
or operable program. Check the spelling of the name, or if a path was included, verify that 
the path is correct and try again.
At line:1 char:1
+ python -m pip install matplotlib
+ ~~~~~~
    + CategoryInfo          : ObjectNotFound: (python:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

but the command `py -m pip install matplotlib` work as expected.