### PR TITLE
Update config-clang-mac.md

### DIFF
--- a/docs/cpp/config-clang-mac.md
+++ b/docs/cpp/config-clang-mac.md
@@ -55,7 +55,7 @@ The **code .** command opens VS Code in the current working directory, which bec
 ## Configure the compiler path
 
 1. Press `kb(workbench.action.showCommands)` to open the Command Palette. Start typing "C/C++" and then choose **Edit Configurations** from the list of suggestions. VS Code creates a file called `c_cpp_properties.json` and populates it with some default settings.
-1. Find the `compilerPath` setting and paste in the path to the `bin` folder. For Clang, this is typically `usr/bin/clang/`.
+1. Find the `compilerPath` setting and paste in the path to the `bin` folder. For Clang, this is typically `/usr/bin/clang`.
 
 The `compilerPath` setting is the most important setting in your configuration. The extension uses it to infer the path to system header files, which it needs for IntelliSense support. There is no need to specify it explicitly in the `includePath` setting unless you have additional or non-standard paths in your code base. In fact, we recommend that you delete the setting entirely if you don't need it.
 
@@ -89,7 +89,7 @@ Your complete `c_cpp_properties.json` file should look like this:
 
 ## Create a build task
 
-Next, we need to create a `tasks.json` file to tell VS Code how to build (compile) the program. This task will invoke the g++ compiler on WSL to create an executable file based on the source code.
+Next, we need to create a `tasks.json` file to tell VS Code how to build (compile) the program. This task will invoke the clang++ compiler to create an executable file based on the source code.
 
 1. From the main menu, choose **View > Command Palette** and then type "task" and choose **Tasks: Add a default build task** then choose **Others**. VS Code creates a minimal `tasks.json` file and opens it in the editor.
 1. Go ahead and replace the entire file contents with the following code snippet:


### PR DESCRIPTION
clang is at `/usr/bin/clang`, not at `usr/bin/clang/`. And since this is about macOS, there's no WSL.