### PR TITLE
Modify hello_there in views.py same as app.py

### DIFF
--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -609,7 +609,7 @@ Throughout this Flask tutorial, all the app code is contained in a single `app.p
 
     @app.route("/hello/")
     @app.route("/hello/<name>")
-    def hello_there(name):
+    def hello_there(name = None):
         return render_template(
             "hello_there.html",
             name=name,


### PR DESCRIPTION
Modify the hello_there function in views.py to have the name parameter default to None as seen in app.py.  This restores the message returrned when navigating to /hello