### PR TITLE
Remove link to broken extension

### DIFF
--- a/api/references/extension-manifest.md
+++ b/api/references/extension-manifest.md
@@ -153,8 +153,6 @@ Set a `category` for your extension. Extensions in the same `category` are group
 }
 ```
 
-> **Tip:** The [Extension Manifest Editor](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.extension-manifest-editor) extension lets you preview how your extension `README.md` and `package.json` metadata will look when published to the Marketplace.
-
 ### Approved Badges
 
 Due to security concerns, we only allow badges from trusted services.


### PR DESCRIPTION
The Extension Manifest Editor extension has been broken for a while (see https://github.com/microsoft/extension-manifest-editor/issues/20).