### PR TITLE
Line 26 re-arrangement

### DIFF
--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -23,7 +23,7 @@ Below are the most popular language extensions in the [Marketplace](https://mark
 
 ## IntelliSense features
 
-VS Code IntelliSense features are powered by a language service. A language service provides intelligent code completions based on language semantics and an analysis of your source code. If a language service knows possible completions, the IntelliSense suggestions will pop up as you type. If you continue typing characters, the list of members (variables, methods, etc.) is filtered to include only members containing your typed characters. Pressing `kbstyle(Tab)` or `kbstyle(Enter)` will insert the selected member.
+VS Code IntelliSense features are powered by a language service. A language service provides intelligent code completions based on language semantics and an analysis of your source code. If a language service knows possible completions, the IntelliSense suggestions will pop up as you type. If you continue typing characters, the list of members (variables, methods, etc.) is filtered to only include members containing your typed characters. Pressing `kbstyle(Tab)` or `kbstyle(Enter)` will insert the selected member.
 
 You can trigger IntelliSense in any editor window by typing `kb(editor.action.triggerSuggest)` or by typing a trigger character (such as the dot character (`kbstyle(.)`) in JavaScript).
 


### PR DESCRIPTION
It would be better to re-arrange line  26 in following manner:
If you continue typing characters, the list of members is filtered to only include members containing the typed characters. 
One other option that can be used goes like this:
If you continue typing characters, the list of members is filtered to include only the members containing the typed characters.