### PR TITLE
Add logging info for the debugger

### DIFF
--- a/docs/cpp/enable-logging-cpp.md
+++ b/docs/cpp/enable-logging-cpp.md
@@ -31,9 +31,11 @@ To turn on full logging for the lanugage server, follow these steps:
 ## Enable logging for the debug adapter
 Enabling logging for the debug adapter will show communication information between VS Code and our extension and between our extension and the debug adapter.
 
+Logging configuration for the debug adapter is configured in `launch.json`.
+
 ### Logging for `MI` debuggers
 
-The logging block with its defaults is as follows:
+The logging block for `MI` debuggers with its default configuration in `launch.json` is as follows:
 
 ```
 "logging": {
@@ -53,7 +55,7 @@ The logging between CppTools and the debugger is called `engineLogging`. When us
 
 ### Logging for `Visual C++` debugger
 
-The logging block with its defaults is as follows:
+The logging block for `Visual C++` debugger with its default configuration in `launch.json` is as follows:
 
 ```
 "logging": { 

--- a/docs/cpp/enable-logging-cpp.md
+++ b/docs/cpp/enable-logging-cpp.md
@@ -8,9 +8,9 @@ DateApproved: 07/25/2019
 MetaDescription: How to enable logging in the Visual Studio Code C/C++ extension
 ---
 # C/C++ extension logging
-Logging information is available for the language server and debugger. If you are experiencing a problem that we are unable to diagnose based on information in your issue report, we might ask you to enable logging and send us your logs.
+Logging information is available for the language server and the debug adapter. If you are experiencing a problem that we are unable to diagnose based on information in your issue report, we might ask you to enable logging and send us your logs.
 
-Logging information is delivered directly to the Output window in Visual Studio Code.
+Logging information is delivered directly to the Output window for the language server and to the debugConsole window for the debug adapter.
 
 ## Enable logging for the language server
 
@@ -28,8 +28,8 @@ To turn on full logging for the lanugage server, follow these steps:
 
    ![Log filter selector](images/cpp/log-filter-selector.png)
 
-## Enable logging for the debugger
-Enabling logging for the debugger will show communication information between VS Code and our extension and between our extension and the debugger.
+## Enable logging for the debug adapter
+Enabling logging for the debug adapter will show communication information between VS Code and our extension and between our extension and the debug adapter.
 
 ### Logging for `MI` debuggers
 

--- a/docs/cpp/enable-logging-cpp.md
+++ b/docs/cpp/enable-logging-cpp.md
@@ -8,14 +8,13 @@ DateApproved: 07/25/2019
 MetaDescription: How to enable logging in the Visual Studio Code C/C++ extension
 ---
 # C/C++ extension logging
-
-If you are experiencing a problem that we are unable to diagnose based on information in your issue report, we might ask you to enable logging and send us your logs.
+Logging information is available for the language server and debugger. If you are experiencing a problem that we are unable to diagnose based on information in your issue report, we might ask you to enable logging and send us your logs.
 
 Logging information is delivered directly to the Output window in Visual Studio Code.
 
-## Enable logging
+## Enable logging for the language server
 
-To turn on full logging for an issue report, follow these steps:
+To turn on full logging for the lanugage server, follow these steps:
 
 1. Open the **Command Palette** and choose **Preferences: Workspace settings**.
 1. Search for "logging" in the search box.
@@ -28,3 +27,38 @@ To turn on full logging for an issue report, follow these steps:
 1. Select the "C/C++" option in the log filter selector:
 
    ![Log filter selector](images/cpp/log-filter-selector.png)
+
+## Enable logging for the debugger
+Enabling logging for the debugger will show communication information between VS Code and our extension and between our extension and the debugger.
+
+### Logging for `MI` debuggers
+
+The logging block with its defaults is as follows:
+
+```
+"logging": {
+    "trace": false,
+    "traceResponse": false,
+    "engineLogging": false
+}
+```
+
+#### VS Code and the CppTools extension
+
+The logging here is called `trace` logging and can be enabled by setting `trace` and `traceResponse` to `true` in the logging block inside `launch.json`. This will help diagnose issues related to VS Code's communication to our extension and our responses.
+
+#### CppTools extension and the debugger
+
+The logging between CppTools and the debugger is called `engineLogging`. When using an `MI` debugger such as `gdb` or `lldb`, this will show the request, response and events using the `mi` interpreter. This logging will help us determine whether the debugger is receiving the right commands and generating the correct responses.
+
+### Logging for `Visual C++` debugger
+
+The logging block with its defaults is as follows:
+
+```
+"logging": { 
+    "engineLogging": false
+}
+```
+
+The `Visual C++` debugger logging will show only the communication to and from VS Code as all communication to the debugger is done internally to the process and is not visible through logging.


### PR DESCRIPTION
Add logging info for the debugger.
Content from https://github.com/microsoft/vscode-cpptools/blob/master/Documentation/FAQs.md#how-to-enable-logging