### PR TITLE
Update bundling-extension.md

### DIFF
--- a/api/working-with-extensions/bundling-extension.md
+++ b/api/working-with-extensions/bundling-extension.md
@@ -89,7 +89,7 @@ Merge these entries into the `scripts` section in `package.json`:
 "scripts": {
   "vscode:prepublish": "webpack --mode production",
   "compile": "webpack --mode none",
-  "watch": "webpack --mode none --watch",
+  "watch": "webpack --mode development",
   "test-compile": "tsc -p ./",
 },
 ```


### PR DESCRIPTION
Do not use "--watch" option in watch script. Vscode can not catch compiled status correctly. It will cause the dev environment can't wake up.