### PR TITLE
Limit the validity of the signing key to packages.microsoft.com

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -46,9 +46,9 @@ Installing the .deb package will automatically install the apt repository and si
 The repository and key can also be installed manually with the following script:
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-sudo install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
-sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+sudo install -o root -g root -m 644 packages.microsoft.gpg /usr/share/keyrings/
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 
 Then update the package cache and install the package using:


### PR DESCRIPTION
Before this change the key has been trusted for all possible repositories.
Moving it to /usr/share/keyrings/, the conventional location, prevents that.

The 'signed-by' links location with its particular, authoritative key(s).

To prevent any name clashings, it's a good practice to not use an
organizations name here (except the key or keyring is really meant to cover
the entire org, like GNU's) and go with with a descriptive one,
or one obvious to where it will be used.