### PR TITLE
Update python-tutorial.md

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -79,6 +79,8 @@ From within VS Code, select a Python 3 interpreter by opening the **Command Pale
 
 The command presents a list of available interpreters that VS Code can find automatically, including virtual environments. If you don't see the desired interpreter, see [Configuring Python environments](/docs/python/environments.md).
 
+> **Note**: When using an Anaconda distribution, the correct interpreter should have the suffix `('base':conda)`, eg. `Python 3.7.3 64-bit ('base':conda)`.
+
 Selecting an interpreter sets the `python.pythonPath` value in your workspace settings to the path of the interpreter. To see the setting, select **File** > **Preferences** > **Settings** (**Code** > **Preferences** > **Settings** on macOS), then select the **Workspace Settings** tab.
 
 > **Note**: If you select an interpreter without a workspace folder open, VS Code sets `python.pythonPath` in your user settings instead, which sets the default interpreter for VS Code in general. The user setting makes sure you always have a default interpreter for Python projects. The workspace settings lets you override the user setting.


### PR DESCRIPTION
Added note to select the correct interpreter when running in an Anaconda environment. Only tested on VSCode 1.37.0 on MacOSX High Sierra.