### PR TITLE
Fix GitHub typo in document files.

### DIFF
--- a/api/references/extension-manifest.md
+++ b/api/references/extension-manifest.md
@@ -201,7 +201,7 @@ We allow badges from the following URL prefixes:
 - www.bithound.io
 - www.versioneye.com
 
-If you have other badges you would like to use, please open a Github [issue](https://github.com/Microsoft/vscode/issues) and we're happy to take a look.
+If you have other badges you would like to use, please open a GitHub [issue](https://github.com/Microsoft/vscode/issues) and we're happy to take a look.
 
 ## Combining Extension Contributions
 

--- a/blogs/2017/08/07/emmet-2.0.md
+++ b/blogs/2017/08/07/emmet-2.0.md
@@ -82,7 +82,7 @@ There are a few other changes that we have documented in the new Emmet [page](/d
 
 I want to thank [Sergey Chikuyonok](https://github.com/sergeche) for his amazing work on modularizing Emmet and helping us bring these improvements to VS Code.
 
-Thanks also goes to everyone who used the new Emmet in VS Code when it was in preview and provided great feedback through GitHub issues. The discussions in Github issues were very helpful in getting to the current user experience.
+Thanks also goes to everyone who used the new Emmet in VS Code when it was in preview and provided great feedback through GitHub issues. The discussions in GitHub issues were very helpful in getting to the current user experience.
 
 Special thanks to [Steve Lombardi](https://github.com/smlombardi), [Jens Hausdorf](https://github.com/jens1o), [Vladimir Sizikov](https://github.com/vvs), [Niichie](https://github.com/Niichie), [Thomas Klepzig](https://github.com/tklepzig) and many more who used the VS Code Insiders builds to test my bug fixes and feature additions.
 

--- a/release-notes/v1_15.md
+++ b/release-notes/v1_15.md
@@ -303,7 +303,7 @@ Extensions can contribute CSS to customize the look or layout of the Markdown pr
 
 ![Changing the Markdown preview style](images/1_15/markdown-api-styles.png)
 
-The [VS Code Github Style extension](https://github.com/mjbvz/vscode-github-markdown-preview-style) is a good example that demonstrates using a stylesheet to make the Markdown preview look like Github's rendered Markdown.
+The [VS Code GitHub Style extension](https://github.com/mjbvz/vscode-github-markdown-preview-style) is a good example that demonstrates using a stylesheet to make the Markdown preview look like GitHub's rendered Markdown.
 
 **Markdown it plugins**
 


### PR DESCRIPTION
```shell
~/.g/g/m/vscode-docs(patch-1)> git grep 'Github' | wc -l
       0
```