### PR TITLE
minor rpm-based command corrections

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -73,7 +73,7 @@ sudo sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.m
 Then update the package cache and install the package using `dnf` (Fedora 22 and above):
 
 ```bash
-dnf check-update
+sudo dnf check-update
 sudo dnf install code
 ```
 
@@ -242,10 +242,10 @@ This error can appear during installation and is typically caused by the package
 sudo apt-get update
 
 # For .rpm (Fedora 21 and below)
-sudo yum update
+sudo yum check-update
 
 # For .rpm (Fedora 22 and above)
-sudo dnf update
+sudo dnf check-update
 ```
 
 ### The code bin command does not bring the window to the foreground on Ubuntu


### PR DESCRIPTION
- prefer `sudo dnf check-update` over `dnf check-update`, no need to create cache as user since `root` is installing
    - couldn't actually find docs on this, but in my experience if I do `dnf check-update` I have to re-download the same updated lists as `root`.  Since all other commands here are as `sudo` it seems to be OK to encourage this, even if it doesn't actually make a difference.
- `dnf` / `yum` command to update lists is `check-update`, not `update`