### PR TITLE
Add remote highlights to 1.38 release notes

### DIFF
--- a/release-notes/v1_38.md
+++ b/release-notes/v1_38.md
@@ -298,15 +298,24 @@ This milestone we continued working on improvements to the [GitHub Pull Requests
 
 ### Remote Development (Preview)
 
-Work has continued on the [Remote Development](https://aka.ms/vscode-remote/download/extension) extensions, which allow you to use a container, remote machine, or the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl) (WSL) as a full-featured development environment. You can learn about new extension features and bug fixes in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/tree/master/remote-release-notes/v1_38.md).
-
-You can also read a recent blog post describing [Tips and Tricks for Linux development with WSL and Visual Studio Code](https://devblogs.microsoft.com/commandline/tips-and-tricks-for-linux-development-with-wsl-and-visual-studio-code/).
+Work has continued on the [Remote Development](https://aka.ms/vscode-remote/download/extension) extensions, which allow you to use a container, remote machine, or the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
 To help get you started with the Remote Development extensions, there are three step-by-step tutorials:
 
 * [Containers](https://code.visualstudio.com/remote-tutorials/containers/getting-started) - Run Visual Studio Code in a Docker Container.
 * [Remote via SSH](https://code.visualstudio.com/remote-tutorials/ssh/getting-started) - Connect to remote and virtual machines with Visual Studio Code via SSH.
 * [Working in WSL](https://code.visualstudio.com/remote-tutorials/wsl/getting-started) - Run Visual Studio Code in Windows Subsystem for Linux.
+
+You can also read a recent blog post describing [Tips and Tricks for Linux development with WSL and Visual Studio Code](https://devblogs.microsoft.com/commandline/tips-and-tricks-for-linux-development-with-wsl-and-visual-studio-code/).
+
+Feature highlights in 1.38 include:
+
+* VS Code stable preview support for Alpine Linux Containers, Alpine WSL distributions, and ARMv7l / AArch32 SSH hosts.
+* VS Code Insiders experimental support for ARMv8l / AArch64 SSH hosts.
+* A number of improvements to Remote - Containers including a new container explorer!
+
+You can learn about new extension features and bug fixes in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/tree/master/remote-release-notes/v1_38.md).
+
 
 ## Extension authoring
 


### PR DESCRIPTION
As an experiment, I'd like to add a short list of 1.38 highlights to the remote section of the core VS Code release notes.  Its presence here seems to drive more uptake than their presence in the release notes.