### PR TITLE
Fix syntax highlighting issues coming from docs

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -101,7 +101,9 @@ If your extension is not functioning as expected, it may be running in the wrong
 If the **Developer: Show Running Extensions** command shows that a UI extension is incorrectly being treated as a workspace extension or vice versa, try setting the `extensionKind` property in your extension's [`package.json`](/api/get-started/extension-anatomy#extension-manifest):
 
 ```json
-"extensionKind": "ui"
+{
+    "extensionKind": "ui"
+}
 ```
 
 - `"extensionKind": "ui"` — Forces the extension to be a UI extension that is always run on the user's local machine.
@@ -110,9 +112,11 @@ If the **Developer: Show Running Extensions** command shows that a UI extension 
 You can also quickly **test** the effect of changing an extension's kind with the `remote.extensionKind` [setting](/docs/getstarted/settings). This setting is a map of extension IDs to extension kinds. For example, if you wish to force the [Azure Cosmos DB](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-cosmosdb) extension to be a UI extension (instead of its Workspace default) and the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) to be a workspace extension (instead of its UI default), you would set:
 
 ```json
-"remote.extensionKind": {
-    "ms-azuretools.vscode-cosmosdb": "ui",
-    "msjsdiag.debugger-for-chrome": "workspace"
+{
+  "remote.extensionKind": {
+      "ms-azuretools.vscode-cosmosdb": "ui",
+      "msjsdiag.debugger-for-chrome": "workspace"
+  }
 }
 ```
 
@@ -129,8 +133,10 @@ If you are persisting simple key-value pairs, you can store workspace specific o
 These APIs were added in VS Code 1.31. To use them, start by updating your `engines.vscode` value in `package.json`:
 
 ```json
-"engines": {
-    "vscode": "^1.31.0"
+{
+    "engines": {
+        "vscode": "^1.31.0"
+    }
 }
 ```
 

--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -39,22 +39,24 @@ Contribute configuration keys that will be exposed to the user. The user will be
 ### Configuration example
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "configuration": {
-        "title": "TypeScript",
-        "properties": {
-            "typescript.useCodeSnippetsOnMethodSuggest": {
-                "type": "boolean",
-                "default": false,
-                "description": "Complete functions with their parameter signature."
-            },
-            "typescript.tsdk": {
-                "type": ["string", "null"],
-                "default": null,
-                "description": "Specifies the folder path containing the tsserver and lib*.d.ts files to use."
-            }
+      "title": "TypeScript",
+      "properties": {
+        "typescript.useCodeSnippetsOnMethodSuggest": {
+          "type": "boolean",
+          "default": false,
+          "description": "Complete functions with their parameter signature."
+        },
+        "typescript.tsdk": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Specifies the folder path containing the tsserver and lib*.d.ts files to use."
         }
+      }
     }
+  }
 }
 ```
 
@@ -73,9 +75,10 @@ Your configuration entry is used both to provide intellisense when editing your 
 The `title` 1️⃣️ is the main heading that will be used for your configuration section. Normally you will only have one section for your extension.
 
 ```json
-"configuration": {
-    "title": "GitMagic",
-    ...
+{
+  "configuration": {
+    "title": "GitMagic"
+  }
 }
 ```
 
@@ -96,7 +99,7 @@ In the Settings UI, your configuration key will be used to namespace and constru
 
 Entries will be grouped according to the hierarchy established in your keys. So for example, these entries
 
-```json
+```
 gitMagic.blame.dateFormat
 gitMagic.blame.format
 gitMagic.blame.heatMap.enabled
@@ -125,21 +128,20 @@ Schema](https://json-schema.org/understanding-json-schema/reference/index.html).
 Your `description` 3️⃣ appears after the title and before the input field, except for booleans, where the description is used as the label for the checkbox. 6️⃣
 
 ```json
-"gitMagic.blame.heatmap.enabled": {
-    "description": "Specifies whether to provide a heatmap indicator in the gutter blame annotations",
-    ...
+{
+  "gitMagic.blame.heatmap.enabled": {
+    "description": "Specifies whether to provide a heatmap indicator in the gutter blame annotations"
+  }
 }
-
 ```
 
 If you use `markdownDescription` instead of `description`, your setting description will be rendered as Markdown in the settings UI.
 
 ```json
-"gitMagic.blame.dateFormat": {
-    "markdownDescription": "Specifies how to format absolute dates (e.g. using the `${date}` token)
-        in gutter blame annotations. See the [Moment.js docs](https://momentjs.com/docs/#/displaying/format/)
-        for valid formats",
-    ...
+{
+  "gitMagic.blame.dateFormat": {
+    "markdownDescription": "Specifies how to format absolute dates (e.g. using the `${date}` token) in gutter blame annotations. See the [Moment.js docs](https://momentjs.com/docs/#/displaying/format/) for valid formats"
+  }
 }
 ```
 
@@ -148,20 +150,24 @@ If you use `markdownDescription` instead of `description`, your setting descript
 Entries of type `number` 4️⃣ , `string` 5️⃣ , `boolean` 6️⃣ can be edited directly in the Settings UI.
 
 ```json
-"gitMagic.views.pageItemLimit": {
+{
+  "gitMagic.views.pageItemLimit": {
     "type": "number",
     "default": 20,
-    "markdownDescription": "Specifies the number of items to show in each page when paginating a view list. Use 0 to specify no limit",
+    "markdownDescription": "Specifies the number of items to show in each page when paginating a view list. Use 0 to specify no limit"
+  }
 }
 ```
 
 For `boolean` entries, the `description` (or `markdownDescription`) will be used as the label for the checkbox.
 
 ```json
-"gitMagic.blame.compact": {
+{
+  "gitMagic.blame.compact": {
     "type": "boolean",
-    "description": "Specifies whether to compact (deduplicate) matching adjacent gutter blame annotations",
-},
+    "description": "Specifies whether to compact (deduplicate) matching adjacent gutter blame annotations"
+  }
+}
 ```
 
 Other types, such as `object` and `array`, aren't exposed directly in the settings UI, and can only be modified by editing the JSON directly. Instead of controls for editing them, users will see a link to `Edit in settings.json` as shown in the screenshot above. 8️⃣
@@ -175,18 +181,17 @@ If you provide an array of items under the `enum` 7️⃣ property, the settings
 You can also provide an `enumDescriptions` property, which provides descriptive text rendered at the bottom of the dropdown:
 
 ```json
-"gitMagic.blame.heatmap.location": {
+{
+  "gitMagic.blame.heatmap.location": {
     "type": "string",
     "default": "right",
-    "enum": [
-        "left",
-        "right"
-    ],
+    "enum": ["left", "right"],
     "enumDescriptions": [
-        "Adds a heatmap indicator on the left edge of the gutter blame annotations",
-        "Adds a heatmap indicator on the right edge of the gutter blame annotations"
-    ],
-},
+      "Adds a heatmap indicator on the left edge of the gutter blame annotations",
+      "Adds a heatmap indicator on the right edge of the gutter blame annotations"
+    ]
+  }
+}
 ```
 
 **Other JSON Schema properties**
@@ -217,24 +222,26 @@ Configuration scopes determine when a setting is available to the user through t
 Below are example configuration scopes from the built-in Git extension:
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "configuration": {
-        "title": "Git",
-        "properties": {
-            "git.alwaysSignOff": {
-                "type": "boolean",
-                "scope": "resource",
-                "default": false,
-                "description": "%config.alwaysSignOff%"
-            },
-            "git.ignoredRepositories": {
-                "type": "array",
-                "default": [],
-                "scope": "window",
-                "description": "%config.ignoredRepositories%"
-            },
+      "title": "Git",
+      "properties": {
+        "git.alwaysSignOff": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "%config.alwaysSignOff%"
+        },
+        "git.ignoredRepositories": {
+          "type": "array",
+          "default": [],
+          "scope": "window",
+          "description": "%config.ignoredRepositories%"
         }
+      }
     }
+  }
 }
 ```
 
@@ -249,13 +256,15 @@ The following example contributes default editor configurations for the `markdow
 ### Configuration default example
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "configurationDefaults": {
-        "[markdown]": {
-            "editor.wordWrap": "on",
-            "editor.quickSuggestions": false
-        }
+      "[markdown]": {
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": false
+      }
     }
+  }
 }
 ```
 
@@ -273,12 +282,16 @@ hand, shows disabled items but doesn't show the category label.
 ### command example
 
 ```json
-"contributes": {
-    "commands": [{
+{
+  "contributes": {
+    "commands": [
+      {
         "command": "extension.sayHello",
         "title": "Hello World",
         "category": "Hello"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -324,15 +337,19 @@ In addition to a title, commands can also define icons which VS Code will show i
 ### menu example
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "menus": {
-        "editor/title": [{
-            "when": "resourceLangId == markdown",
-            "command": "markdown.showPreview",
-            "alt": "markdown.showPreviewToSide",
-            "group": "navigation"
-        }]
+      "editor/title": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "markdown.showPreview",
+          "alt": "markdown.showPreviewToSide",
+          "group": "navigation"
+        }
+      ]
     }
+  }
 }
 ```
 
@@ -345,15 +362,21 @@ When registering commands in `package.json`, they will automatically be shown in
 The snippet below makes the 'Hello World' command only visible in the **Command Palette** when something is selected in the editor:
 
 ```json
-"commands": [{
-    "command": "extension.sayHello",
-    "title": "Hello World"
-}],
-"menus": {
-    "commandPalette": [{
+{
+  "commands": [
+    {
+      "command": "extension.sayHello",
+      "title": "Hello World"
+    }
+  ],
+  "menus": {
+    "commandPalette": [
+      {
         "command": "extension.sayHello",
         "when": "editorHasSelection"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -397,11 +420,15 @@ The **editor title menu** has these default groups:
 The order inside a group depends on the title or an order-attribute. The group-local order of a menu item is specified by appending `@<number>` to the group identifier as shown below:
 
 ```json
-"editor/title": [{
-    "when": "editorHasSelection",
-    "command": "extension.Command",
-    "group": "myGroup@1"
-}]
+{
+  "editor/title": [
+    {
+      "when": "editorHasSelection",
+      "command": "extension.Command",
+      "group": "myGroup@1"
+    }
+  ]
+}
 ```
 
 ## contributes.keybindings
@@ -419,13 +446,17 @@ Contributing a key binding will cause the Default Keyboard Shortcuts to display 
 Defining that `kbstyle(Ctrl+F1)` under Windows and Linux and `kbstyle(Cmd+F1)` under macOS trigger the `"extension.sayHello"` command:
 
 ```json
-"contributes": {
-    "keybindings": [{
+{
+  "contributes": {
+    "keybindings": [
+      {
         "command": "extension.sayHello",
         "key": "ctrl+f1",
         "mac": "cmd+f1",
         "when": "editorTextFocus"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -445,16 +476,19 @@ The main effects of `contributes.languages` are:
 ### language example
 
 ```json
-...
-"contributes": {
-    "languages": [{
+{
+  "contributes": {
+    "languages": [
+      {
         "id": "python",
-        "extensions": [ ".py" ],
-        "aliases": [ "Python", "py" ],
-        "filenames": [ ... ],
+        "extensions": [".py"],
+        "aliases": ["Python", "py"],
+        "filenames": [],
         "firstLine": "^#!/.*\\bpython[0-9.-]*\\b",
         "configuration": "./language-configuration.json"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -473,18 +507,22 @@ Contribute a debugger to VS Code. A debugger contribution has the following prop
 - `languages` those languages for which the debug extension could be considered the "default debugger".
 - `adapterExecutableCommand` the command ID where the debug adapters executable path and arguments are dynamically calculated. The command returns a structure with this format:
 
-  ```json
-  command: "<executable>",
-  args: [ "<argument1>", "<argument2>", ... ]
-  ```
+```json
+{
+  "command": "<executable>",
+  "args": ["<argument1>", "<argument2>", "<argumentsn...>"]
+}
+```
 
-  The attribute `command` must be either an absolute path to an executable or a name of executable looked up via the PATH environment variable. The special value `node` will be mapped to VS Code's built-in node runtime without being looked up on the PATH.
+The attribute `command` must be either an absolute path to an executable or a name of executable looked up via the PATH environment variable. The special value `node` will be mapped to VS Code's built-in node runtime without being looked up on the PATH.
 
 ### debugger example
 
 ```json
-"contributes": {
-    "debuggers": [{
+{
+  "contributes": {
+    "debuggers": [
+      {
         "type": "node",
         "label": "Node Debug",
 
@@ -494,41 +532,45 @@ Contribute a debugger to VS Code. A debugger contribution has the following prop
         "languages": ["javascript", "typescript", "javascriptreact", "typescriptreact"],
 
         "configurationAttributes": {
-            "launch": {
-                "required": [ "program" ],
-                "properties": {
-                    "program": {
-                        "type": "string",
-                        "description": "The program to debug."
-                    }
-                }
+          "launch": {
+            "required": ["program"],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "The program to debug."
+              }
             }
+          }
         },
 
-        "initialConfigurations": [{
+        "initialConfigurations": [
+          {
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
             "program": "${workspaceFolder}/app.js"
-        }],
+          }
+        ],
 
         "configurationSnippets": [
-            {
-                "label": "Node.js: Attach Configuration",
-                "description": "A new configuration for attaching to a running node program.",
-                "body": {
-                    "type": "node",
-                    "request": "attach",
-                    "name": "${2:Attach to Port}",
-                    "port": 9229
-                }
+          {
+            "label": "Node.js: Attach Configuration",
+            "description": "A new configuration for attaching to a running node program.",
+            "body": {
+              "type": "node",
+              "request": "attach",
+              "name": "${2:Attach to Port}",
+              "port": 9229
             }
+          }
         ],
 
         "variables": {
-            "PickProcess": "extension.node-debug.pickNodeProcess"
+          "PickProcess": "extension.node-debug.pickNodeProcess"
         }
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -539,15 +581,17 @@ For a full walkthrough on how to integrate a `debugger`, go to [Debugger Extensi
 Usually a debugger extension will also have a `contributes.breakpoints` entry where the extension lists the language file types for which setting breakpoints will be enabled.
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "breakpoints": [
-        {
-            "language": "javascript"
-        },
-        {
-            "language": "javascriptreact"
-        }
+      {
+        "language": "javascript"
+      },
+      {
+        "language": "javascriptreact"
+      }
     ]
+  }
 }
 ```
 
@@ -560,16 +604,19 @@ Contribute a TextMate grammar to a language. You must provide the `language` thi
 ### grammar example
 
 ```json
-"contributes": {
-    "grammars": [{
+{
+  "contributes": {
+    "grammars": [
+      {
         "language": "markdown",
         "scopeName": "text.html.markdown",
         "path": "./syntaxes/markdown.tmLanguage.json",
         "embeddedLanguages": {
-            "meta.embedded.block.frontmatter": "yaml",
-            ...
+          "meta.embedded.block.frontmatter": "yaml"
         }
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -584,12 +631,16 @@ Contribute a TextMate theme to VS Code. You must specify a label, whether the th
 ### theme example
 
 ```json
-"contributes": {
-    "themes": [{
+{
+  "contributes": {
+    "themes": [
+      {
         "label": "Monokai",
         "uiTheme": "vs-dark",
         "path": "./themes/Monokai.tmTheme"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -604,11 +655,15 @@ Contribute snippets for a specific language. The `language` attribute is the [la
 The example below shows adding snippets for the Go language.
 
 ```json
-"contributes": {
-    "snippets": [{
+{
+  "contributes": {
+    "snippets": [
+      {
         "language": "go",
         "path": "./snippets/go.json"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -617,11 +672,15 @@ The example below shows adding snippets for the Go language.
 Contribute a validation schema for a specific type of `json` file. The `url` value can be either a local path to a schema file included in the extension or a remote server URL such as a [json schema store](http://schemastore.org/json).
 
 ```json
-"contributes": {
-    "jsonValidation": [{
+{
+  "contributes": {
+    "jsonValidation": [
+      {
         "fileMatch": ".jshintrc",
         "url": "http://json.schemastore.org/jshintrc"
-    }]
+      }
+    ]
+  }
 }
 ```
 
@@ -638,16 +697,18 @@ Contribute a view to VS Code. You must specify an identifier and name for the vi
 When the user opens the view, VS Code will then emit an activationEvent `onView:${viewId}` (`onView:nodeDependencies` for the example below). You can also control the visibility of the view by providing the `when` context value.
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "views": {
-        "explorer": [
-            {
-                "id": "nodeDependencies",
-                "name": "Node Dependencies",
-                "when": "workspaceHasPackageJSON"
-            }
-        ]
+      "explorer": [
+        {
+          "id": "nodeDependencies",
+          "name": "Node Dependencies",
+          "when": "workspaceHasPackageJSON"
+        }
+      ]
     }
+  }
 }
 ```
 
@@ -660,28 +721,30 @@ Extension writers should create a [TreeView](/api/references/vscode-api#TreeView
 Contribute a view container into which [Custom views](#contributes.views) can be contributed. You must specify an identifier, title, and an icon for the view container. At present, you can contribute them to the Activity Bar (`activitybar`) only. Below example shows how the `Package Explorer` view container is contributed to the Activity Bar and how views are contributed to it.
 
 ```json
-"contributes": {
-        "viewsContainers": {
-            "activitybar": [
-                {
-                    "id": "package-explorer",
-                    "title": "Package Explorer",
-                    "icon": "resources/package-explorer.svg"
-                }
-            ]
-        },
-        "views": {
-            "package-explorer": [
-                {
-                    "id": "package-dependencies",
-                    "name": "Dependencies"
-                },
-                {
-                    "id": "package-outline",
-                    "name": "Outline"
-                }
-            ]
+{
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "package-explorer",
+          "title": "Package Explorer",
+          "icon": "resources/package-explorer.svg"
         }
+      ]
+    },
+    "views": {
+      "package-explorer": [
+        {
+          "id": "package-dependencies",
+          "name": "Dependencies"
+        },
+        {
+          "id": "package-outline",
+          "name": "Outline"
+        }
+      ]
+    }
+  }
 }
 ```
 
@@ -705,22 +768,24 @@ Contribute a view container into which [Custom views](#contributes.views) can be
 Contribute problem matcher patterns. These contributions work in both the output panel runner and in the terminal runner. Below is an example to contribute a problem matcher for the gcc compiler in an extension:
 
 ```json
-"contributes": {
+{
+  "contributes": {
     "problemMatchers": [
-        {
-            "name": "gcc",
-            "owner": "cpp",
-            "fileLocation": ["relative", "${workspaceFolder}"],
-            "pattern": {
-                "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
-                "file": 1,
-                "line": 2,
-                "column": 3,
-                "severity": 4,
-                "message": 5
-            }
+      {
+        "name": "gcc",
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
         }
+      }
     ]
+  }
 }
 ```
 
@@ -751,24 +816,24 @@ Contributes named problem patterns that can be used in problem matchers (see abo
 Contributes and defines an object literal structure that allows to uniquely identify a contributed task in the system. A task definition has at minimum a `type` property but it usually defines additional properties. For example a task definition for a task representing a script in a package.json file looks like this:
 
 ```json
-"taskDefinitions": [
+{
+  "taskDefinitions": [
     {
-        "type": "npm",
-        "required": [
-            "script"
-        ],
-        "properties": {
-            "script": {
-                "type": "string",
-                "description": "The script to execute"
-            },
-            "path": {
-                "type": "string",
-                "description": "The path to the package.json file. If omitted the package.json in the root of the workspace folder is used."
-            }
+      "type": "npm",
+      "required": ["script"],
+      "properties": {
+        "script": {
+          "type": "string",
+          "description": "The script to execute"
+        },
+        "path": {
+          "type": "string",
+          "description": "The path to the package.json file. If omitted the package.json in the root of the workspace folder is used."
         }
+      }
     }
-]
+  ]
+}
 ```
 
 The task definition is defined using JSON schema syntax for the `required` and `properties` property. The `type` property defines the task type. If the above example:
@@ -788,16 +853,20 @@ let task = new vscode.Task({ type: 'npm', script: 'test' }, ....);
 Contributes new themable colors. These colors can be used by the extension in editor decorators and in the status bar. Once defined, users can customize the color in the `workspace.colorCustomization` setting and user themes can set the color value.
 
 ```json
-"contributes": {
-  "colors": [{
-      "id": "superstatus.error",
-      "description": "Color for error message in the status bar.",
-      "defaults": {
+{
+  "contributes": {
+    "colors": [
+      {
+        "id": "superstatus.error",
+        "description": "Color for error message in the status bar.",
+        "defaults": {
           "dark": "errorForeground",
           "light": "errorForeground",
           "highContrast": "#010203"
+        }
       }
-  }]
+    ]
+  }
 }
 ```
 
@@ -808,12 +877,14 @@ Color default values can be defined for light, dark and high contrast theme and 
 Contributes [TypeScript server plugins](https://github.com/Microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin) that augment VS Code's JavaScript and TypeScript support:
 
 ```json
-"contributes": {
-   "typescriptServerPlugins": [
+{
+  "contributes": {
+    "typescriptServerPlugins": [
       {
         "name": "typescript-styled-plugin"
       }
     ]
+  }
 }
 ```
 
@@ -834,17 +905,19 @@ TypeScript server plugins are loaded for all JavaScript and TypeScript files whe
 Contributes resource label formatters that specify how to display URIs everywhere in the workbench. For example here's how an extension could contribute a formatter for URIs with scheme `remotehub`:
 
 ```json
-"contributes": {
-   "resourceLabelFormatters": [
-        {
-            "scheme": "remotehub",
-            "formatting": {
-                "label": "${path}",
-                "separator": "/",
-                "workspaceSuffix": "GitHub"
-            }
+{
+  "contributes": {
+    "resourceLabelFormatters": [
+      {
+        "scheme": "remotehub",
+        "formatting": {
+          "label": "${path}",
+          "separator": "/",
+          "workspaceSuffix": "GitHub"
         }
+      }
     ]
+  }
 }
 ```
 

--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -29,7 +29,7 @@ Install the following:
    * Open a terminal and navigate to the folder in which you'd like to create the app.
    * Enter the following command in the command shell:
 
-   ```console
+   ```cmd
      dotnet new console
    ```
 
@@ -40,7 +40,7 @@ Install the following:
 
 3. Run the app by entering the following command in the command shell:
 
-   ```console
+   ```cmd
     dotnet run
    ```
 

--- a/docs/nodejs/working-with-javascript.md
+++ b/docs/nodejs/working-with-javascript.md
@@ -34,19 +34,23 @@ Automatic type acquisition requires [npmjs](https://www.npmjs.com), the Node.js 
 Type declaration files are automatically downloaded and managed by Visual Studio Code for packages listed in your project's `package.json` or that you import into a JavaScript file.
 
 ```json
+{
     "dependencies": {
         "lodash": "^4.17.0"
     }
+}
 ```
 
 You can alternately explicitly list packages to acquire type declaration files for in a [`jsconfig.json`](#_javascript-projects-jsconfigjson).
 
 ```json
+{
     "typeAcquisition": {
         "include": [
             "jquery"
         ]
     }
+}
 ```
 
 Most common JavaScript libraries ship with declaration files or have type declaration files available. You can search for a library's type declaration file package using the [TypeSearch](https://microsoft.github.io/TypeSearch) site.
@@ -64,7 +68,9 @@ If you have npm installed but still see a warning message, you can explicitly te
 For example, on Windows, you would add a path like this to your `settings.json` file:
 
 ```json
+{
   "typescript.npm": "C:\\Program Files\\nodejs\\npm.cmd"
+}
 ```
 
 ## JavaScript projects (jsconfig.json)

--- a/docs/python/tutorial-azure-functions.md
+++ b/docs/python/tutorial-azure-functions.md
@@ -369,7 +369,7 @@ After your first deployment, you can make changes to your code, such as adding a
 
 1. Start the debugger by pressing F5 or selecting the **Debug** > **Start Debugging** menu command. The **Output** window should now show both endpoints in your project:
 
-    ```output
+    ```
     Http Functions:
 
             DigitsOfPi: [GET] http://localhost:7071/api/DigitsOfPi

--- a/docs/python/tutorial-create-containers.md
+++ b/docs/python/tutorial-create-containers.md
@@ -205,7 +205,7 @@ The following steps summarize the configuration used in the [python-sample-vscod
 
 > **Note**: When building a Docker image on Windows, you typically see the message below, which is why the Dockerfile shown here includes the two `chmod` commands. If need to make other files writable, add the appropriate `chmod` commands to your Dockerfile.
 >
-> ```output
+> ```
 > SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
 > ```
 

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -102,7 +102,7 @@ To create a minimal Django app, then, it's necessary to first create the Django 
 
 1. To verify the Django project, make sure your virtual environment is activated, then start Django's development server using the command `python manage.py runserver`. The server runs on the default port 8000, and you see output like the following output in the terminal window:
 
-    ```output
+    ```
     Performing system checks...
 
     System check identified no issues (0 silenced).

--- a/release-notes/July_2016.md
+++ b/release-notes/July_2016.md
@@ -40,13 +40,17 @@ Note that quick suggestions and `kbstyle(Tab)` completion might interfere becaus
 Either disable quick suggestions:
 
 ```json
-    "editor.quickSuggestions": false
+{
+  "editor.quickSuggestions": false
+}
 ```
 
 or remove snippets from the suggest widget:
 
 ```json
-    "editor.snippetSuggestions": "none"
+{
+  "editor.snippetSuggestions": "none"
+}
 ```
 
 ## Workbench

--- a/release-notes/June_2016.md
+++ b/release-notes/June_2016.md
@@ -348,22 +348,26 @@ It works in two steps:
 A menu item is defined for a menu location like `editor/context` and must at least specify the `command` to run. To avoid overly cluttered menus, a menu item should also specify a condition under which it shows. Last, an alternative command and a group into which the item is sorted can be defined. Groups are visually separated and there is a special group called _navigation_ which is the most prominent.
 
 ```json
-"commands": [{
-    "command": "markdown.showPreview",
-    "title": "Open Preview",
-    "icon": {
+{
+  "commands": [
+    {
+      "command": "markdown.showPreview",
+      "title": "Open Preview",
+      "icon": {
         "light": "./media/Preview.svg",
         "dark": "./media/Preview_inverse.svg"
+      }
     }
-}],
-"menus": {
+  ],
+  "menus": {
     "explorer/context": [
-        {
-            "when": "resourceLangId == markdown",
-            "command": "markdown.showPreview",
-            "group": "navigation"
-        }
+      {
+        "when": "resourceLangId == markdown",
+        "command": "markdown.showPreview",
+        "group": "navigation"
+      }
     ]
+  }
 }
 ```
 

--- a/release-notes/v1_17.md
+++ b/release-notes/v1_17.md
@@ -458,16 +458,18 @@ interface CompletionContext {
 Extensions can now contribute commands to the touch bar on macOS. A new menu identifier `touchBar` was added for this purpose:
 
 ```json
-"contributes": {
-  "menus": {
-    "touchBar": [
-      {
-        "command": "markdown.showPreview",
-        "when": "editorLangId == markdown",
-        "group": "navigation"
-      }
-    ]
-   }
+{
+  "contributes": {
+    "menus": {
+      "touchBar": [
+        {
+          "command": "markdown.showPreview",
+          "when": "editorLangId == markdown",
+          "group": "navigation"
+        }
+      ]
+     }
+  }
 }
 ```
 


### PR DESCRIPTION
- `json`: It must begin and ends with paren. Otherwise it's invalid JSON and syntax highlighting would fail.
- `console`: It should be `cmd` instead.
- `output`: There's no such language.