### PR TITLE
updated documentation to securely add gpg key to system

### DIFF
--- a/docs/java/java-azurefunctions.md
+++ b/docs/java/java-azurefunctions.md
@@ -104,8 +104,7 @@ brew install azure-functions-core-tools
 1. Register the Microsoft Product key as trusted.
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 ```
 
 2. Add source

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -48,8 +48,7 @@ Installing the .deb package will automatically install the apt repository and si
 The repository and key can also be installed manually with the following script:
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -o root -g root -m 644 packages.microsoft.gpg /usr/share/keyrings/
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 


### PR DESCRIPTION
Small change to documentation on how to add the trusted key into the system's keyring securely. 