### PR TITLE
Update python-tutorial.md

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -255,7 +255,7 @@ plt.show()                   # Display the plot
 
 > **Tip**: If you enter the above code by hand, you may find that auto-completions change the names after the `as` keywords when you press `kbstyle(Enter)` at the end of a line. To avoid this, type a space, then `kbstyle(Enter)`.
 
-Next, try running the file in the debugger using the "Python: Current file" configuration as described in the last section. (If you still have `"stopOnEntry": true` in that configuration, you need to select the run command again to continue.)
+Next, try running the file in the debugger using the "Python: Current file" configuration as described in the last section.
 
 Unless you're using an Anaconda distribution or have previously installed the `matplotlib` package, you should see the message, "ModuleNotFoundError: No module named 'matplotlib'". Such a message indicates that the required package isn't available in your system.
 


### PR DESCRIPTION
removed an additional reference to 'stoponentry' since we no longer reference this in our getting started tutorial.