### PR TITLE
Update containers-advanced.md

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -126,7 +126,7 @@ services:
     volumes:
        # Or wherever you've mounted your source code
       - .:/workspace
-      - try-node-node_modules: /workspace/node_modules
+      - try-node-node_modules:/workspace/node_modules
 
 volumes:
   - try-node-node_modules:

--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -126,7 +126,7 @@ services:
     volumes:
        # Or wherever you've mounted your source code
       - .:/workspace
-      - your-service-name-here-node_modules: /workspace/node_modules
+      - try-node-node_modules: /workspace/node_modules
 
 volumes:
   - try-node-node_modules:


### PR DESCRIPTION
Changed referenced named volume to `try-node-node_modules` as this is the only declared volume. And this name is used in the proceeding example.