### PR TITLE
docs: don't use PS stdout redirection doing UTF-16

### DIFF
--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -151,6 +151,13 @@ To control which Pylint messages are shown, add the following contents to an opt
 
 You can easily generate an options file using Pylint itself:
 
+```bash
+# Using an *nix shell or cmd on Windows
+pylint --generate-rcfile > .pylintrc
+```
+
+For PowerShell you have to explictly specify a UTF-8 output encoding:
+
 ```ps
 pylint --generate-rcfile | Out-File -Encoding utf8 .pylintrc
 ```

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -151,7 +151,7 @@ To control which Pylint messages are shown, add the following contents to an opt
 
 You can easily generate an options file using Pylint itself:
 
-```bash
+```ps
 pylint --generate-rcfile | Out-File -Encoding utf8 .pylintrc
 ```
 

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -152,7 +152,7 @@ To control which Pylint messages are shown, add the following contents to an opt
 You can easily generate an options file using Pylint itself:
 
 ```bash
-pylint --generate-rcfile > .pylintrc
+pylint --generate-rcfile | Out-File -Encoding utf8 .pylintrc
 ```
 
 The generated file contains sections for all the Pylint options, along with documentation in the comments.


### PR DESCRIPTION
If you do `pylint pylint --generate-rcfile >.pylintrc` in PowerShell,
then this file gets written in UTF-16. This in turn is not accepted by
`pylint`, which will throw the following error upon *any* execution:
  """
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position
    0: invalid start byte
  """
See also https://stackoverflow.com/q/52418511/603003.


Also when executing "linting" in VSCode, VSCode just does nothing. After fixing the encoding, linting works from within VSCode and from shell via `pylint`.