### PR TITLE
Remove 'half-width kana' from 1.39 release note

### DIFF
--- a/release-notes/v1_39.md
+++ b/release-notes/v1_39.md
@@ -45,7 +45,7 @@ Auto completion's details can now be selected and copy-pasted.
 
 ![Selectable completion details](./images/1_39/selectable-completion-details.gif)
 
-### Half-width Japanese kana on Windows
+### Updated Japanese UI font on Windows
 
 On Windows, we have switched the Japanese UI typeface from `Meiryo` to `Yu Gothic UI` and `Meiryo UI`.
 


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode/pull/79735

I believe we will (and should) keep using full-width kana. Just updating CSS will not make katakana half-width. ["Half-width kana"](https://en.wikipedia.org/wiki/Half-width_kana#Encoding) normally refers to special katakana characters that are assigned [different Unicode code points](https://en.wikipedia.org/wiki/Halfwidth_and_Fullwidth_Forms_(Unicode_block)). Fonts like Meiryo UI have **full**-width katakana that are narrower than average.