### PR TITLE
Fixing space  of 1.39 release localization contributors.

### DIFF
--- a/release-notes/v1_39.md
+++ b/release-notes/v1_39.md
@@ -710,3 +710,4 @@ Here is a snapshot of [contributors](https://microsoftl10n.github.io/VSCode/). F
 <!-- In-product release notes styles.  Do not modify without also modifying regex in gulpfile.common.js -->
 <a id="scroll-to-top" role="button" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>
+


### PR DESCRIPTION
fix for comment https://github.com/microsoft/vscode-docs/commit/b3869b845ea3835e8d13a1db84e6278e3aab95d9#commitcomment-35400567
I can see space present though.
![image](https://user-images.githubusercontent.com/18324209/66371972-1e601600-e9a5-11e9-803f-82fac57455e9.png)
