### PR TITLE
Updating hello - httptrigger-java

### DIFF
--- a/docs/java/java-azurefunctions.md
+++ b/docs/java/java-azurefunctions.md
@@ -171,7 +171,7 @@ After signing in, click **Deploy to Function App** button, select the folder of 
 Once the function is deployed, test the function app running on Azure using curl:
 
 ```bash
-curl -w '\n' https://fabrikam-function-20170920120101928.azurewebsites.net/api/hello -d AzureFunctions
+curl -w '\n' https://fabrikam-function-20170920120101928.azurewebsites.net/api/httptrigger-java -d AzureFunctions
 ```
 
 You should see:


### PR DESCRIPTION
In the example of running Func after deploying to Azure the code snippet says to call api/hello, but the code that the maven artefact creates creates httptrigger-java

Either the instructions need updating, as per this PR, or, the instructions need to change to tell the reader to change the Function name before deploying.