### PR TITLE
PowerShell chokes on $REMOTEHOST

### DIFF
--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -46,7 +46,7 @@ To set up SSH key based authentication for your remote host:
     ```powershell
     $REMOTEHOST="your-user-name-on-host@host-fqdn-or-ip-goes-here"
 
-    scp "$env:USERPROFILE\.ssh\id_rsa.pub" "$REMOTEHOST:~/tmp.pub"
+    scp "$env:USERPROFILE\.ssh\id_rsa.pub" "${REMOTEHOST}:~/tmp.pub"
     ssh "$REMOTEHOST" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat ~/tmp.pub >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && rm -f ~/tmp.pub"
     ```
 
@@ -90,7 +90,7 @@ While using a single SSH key across all your SSH hosts can be convenient, if any
     ```powershell
     $REMOTEHOST="name-of-ssh-host-here"
 
-    scp "$env:USERPROFILE\.ssh\id_rsa-remote-ssh.pub" "$REMOTEHOST:~/tmp.pub"
+    scp "$env:USERPROFILE\.ssh\id_rsa-remote-ssh.pub" "${REMOTEHOST}:~/tmp.pub"
     ssh "$REMOTEHOST" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat ~/tmp.pub >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && rm -f ~/tmp.pub"
     ```
 


### PR DESCRIPTION
The following error occurs when running the provided commands in PowerShell:

![](https://i.imgur.com/j4OeDR8.png)

Adding braces around the variable name as suggested by PowerShell fixes this.

Running on Windows 10 1903 (OS Build 18362.418)