### PR TITLE
Fix incoherence in Virtual Documents guide

### DIFF
--- a/api/extension-guides/virtual-documents.md
+++ b/api/extension-guides/virtual-documents.md
@@ -51,7 +51,7 @@ With this we have a fully functional text document content provider. The next se
 
 ### Update Virtual Documents
 
-Depending on the scenario virtual documents might change. To support that, providers can implement a `onDidChange`-event. It must be fired for an uri and the editor will then ask for the new contents - assuming the document is still in use.
+Depending on the scenario virtual documents might change. To support that, providers can implement a `onDidChange`-event.
 
 The `vscode.Event`-type defines the contract for eventing in VS Code. The easiest way to implement an event is `vscode.EventEmitter`, like so:
 
@@ -65,11 +65,13 @@ const myProvider = class implements vscode.TextDocumentContentProvider {
 };
 ```
 
-That's all what's needed to make VS code listen for changes of virtual document. The next section will add an editor action that uses the event emitter.
+The event emitter has a `fire` method which is can be used to notify VS Code when a change has happened in a document. The document which has changed is identified by its uri given as argument to the `fire` method. The provider will then be called again to provide the updated content, assuming the document is still open.
+
+That's all what's needed to make VS Code listen for changes of virtual document. To see a more complex example making use of this feature, look at: https://github.com/Microsoft/vscode-extension-samples/blob/master/contentprovider-sample/README.md
 
 ### Add Editor Commands
 
-To illustrate above change-event and to get more cowsay, an editor action is needed that reverses what the cow just said. First we need a command that does that:
+Editor actions can be added which only interact with documents provided by an associated content provider. This is a sample command that reverses what the cow just said:
 
 ```ts
 // register a command that updates the current cowsay


### PR DESCRIPTION
The virtual documents guide talks about event emitters and introduces an example which is supposed to use them but actually doesn't. 
The text has been updated to reflect what the code really does, and the mention of the event emitter feature is now accompanied by a link to a relevant example.

Fixes #3183 