### PR TITLE
Fix TypeScript formatter option name

### DIFF
--- a/release-notes/v1_39.md
+++ b/release-notes/v1_39.md
@@ -267,7 +267,7 @@ These include:
 
 * Syntax highlighting of optional chaining and nullish coalescing in JavaScript and TypeScript files.
 * Completion support for optional chaining.
-* Control over semicolons with the new `javascript.format.insertSpaceAfterSemicolonInForStatements` and `typescript.format.insertSpaceAfterSemicolonInForStatements` settings.
+* Control over semicolons with the new `javascript.format.semicolons` and `typescript.format.semicolons` settings.
 
 You can easily try all these new TypeScript 3.7 features today by installing the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next). Please share feedback and let us know if you run into any bugs with the TypeScript 3.7 beta!
 


### PR DESCRIPTION
Not sure if there’s any point in changing old release notes, but I mostly just wanted to bring this patch to someone’s attention since there’s a chance this section will get copied forward to the October release notes when TypeScript 3.7 stable is bundled with VS Code. /cc @mjbvz thanks!