### PR TITLE
Add note on how to persist bash history

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -72,6 +72,28 @@ Next, depending on what you reference in `devcontainer.json`:
 
 If you've already built the container and connected to it, run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up the change. Otherwise run **Remote-Containers: Open Folder in Container...** to connect to the container.
 
+## Persist `bash` history between runs
+
+This change allows your command history from the container to be persisted between sessions. 
+
+Add the following mount path to your `devcontainer.json` file. This volume will be used to store the command history from the container. 
+
+     ```json
+          "runArgs": [
+               // Keep command history 
+               "-v", "projectname-bashhistory:/root/commandhistory",
+          ],
+      ```
+ 
+ Next update the `Dockerfile` so that each time a command is used in `bash` the history is updated and stored in the new mount added to the `devcontainer.json` file. 
+ 
+      ```Dockerfile
+      RUN echo "export PROMPT_COMMAND='history -a'" >> "/root/.bashrc" \
+          && echo "export HISTFILE=/root/commandhistory/.bash_history" >> "/root/.bashrc"
+      ```
+
+> Note: If you are mapping the user of the dev container you'll need to update the references to `root` in the above scripts to the users home directory. 
+
 ## Adding another local file mount
 
 You can add a volume bound to any local folder using by following the appropriate steps below based on what you reference in `devcontainer.json`:


### PR DESCRIPTION

This is a quick edit to show users how to persist bash history between dev container sessions.