### PR TITLE
SSH Updates, Clarification on extensionKind

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -17,7 +17,7 @@ This article summarizes what extension authors need to know about VS Code Remote
 
 In order to make working with Remote Development or VS Online as transparent as possible to users, VS Code distinguishes two kinds of extensions:
 
-- **UI Extensions**: These extensions contribute to the VS Code user interface and are always run on the user's local machine. In the case of VS Online's browser-based editor, they may even run in the browser itself. UI Extensions cannot directly access files in the workspace, or run scripts/tools installed in that workspace or on the machine. Example UI Extensions include: themes, snippets, language grammars, and keymaps.
+- **UI Extensions**: These extensions contribute to the VS Code user interface and are always run on the user's local machine. UI Extensions cannot directly access files in the remote workspace, or run scripts/tools installed in that workspace or on the machine. Example UI Extensions include: themes, snippets, language grammars, and keymaps.
 
 - **Workspace Extensions**: These extensions are run on the same machine as where the workspace is located. When in a local workspace, Workspace Extensions run on the local machine. When in a remote workspace or when using VS Online, Workspace Extensions run on the remote machine / environment. Workspace Extensions can access files in the workspace to provide rich, multi-file language services, debugger support, or perform complex operations on multiple files in the workspace (either directly or by invoking scripts/tools). While Workspace Extensions do not focus on modifying the UI, they can contribute explorers, views, and other UI elements as well.
 
@@ -145,15 +145,15 @@ As of VS Code 1.40, this value is an array:
 
 ```json
 {
-    "extensionKind": ["ui"]
+    "extensionKind": ["ui", "workspace"]
 }
 ```
 
 Prior releases only allowed an extension to specify one location as a string. Extensions can now specify more than one.
 
-- `"extensionKind": ["ui"]` — Indicates the extension requires access to local capabilities and therefore can only run in the VS Code client.
-- `"extensionKind": ["workspace"]` — Indicates the extension requires access to workspace contents and therefore will run in VS Code Server when connected to a remote workspace or VS Online.
-- `"extensionKind": ["ui", "workspace"]` — Indicates the extension can run in either location, but will default to the VS Code client.
+- `"extensionKind": ["workspace"]` — Indicates the extension requires access to workspace contents and therefore will run in VS Code Server when connected to a remote workspace or VS Online. Most extensions fall into this category.
+- `"extensionKind": ["ui", "workspace"]` — Indicates the extension **prefers** to run as a UI extension, but does not have any hard requirements on local assets, devices, or capabilities. When using VS Code, the extension will run in VS Code's local extension host. When using VS Online's browser-based editor, it will run in the remote extension host instead (as no local extension host is available). The old  `"ui"`  value (as a string) maps to this type for backwards compatibility, but is considered deprecated.
+- `"extensionKind": ["ui"]` — Indicates the extension **must** run as a UI extension because it requires access to local assets, devices, or capabilities. Therefore, it can only run in VS Code's local extension host and will not work in VS Online's browser-based editor (as there is no local extension host available).
 
 You can also quickly **test** the effect of changing an extension's kind with the `remote.extensionKind` [setting](/docs/getstarted/settings). This setting is a map of extension IDs to extension kinds. For example, if you wish to force the [Azure Cosmos DB](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-cosmosdb) extension to be a UI extension (instead of its Workspace default) and the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) to be a workspace extension (instead of its UI default), you would set:
 

--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -97,8 +97,6 @@ You can use one of the following solutions to resolve this problem:
 
 * **Remote - Containers only**: Forward the [Docker socket and install the Docker CLI](https://aka.ms/vscode-remote/samples/docker-in-docker) (only) in the container.
 
-* Use the [`extensionKind` property](#advanced-forcing-an-extension-to-run-locally--remotely) to force the extension to be `ui`. However, this will prevent some commands from working.
-
 ### What Linux packages or libraries need to be installed on a host to use Remote Development?
 
 Remote Development requires kernel >= 3.10, glibc >=2.17, and libstdc++ >= 3.4.18. Recent x86_64 glibc-based distributions have the best support, but exact requirements can vary by distribution.

--- a/docs/remote/images/ssh/ssh-command-input.png
+++ b/docs/remote/images/ssh/ssh-command-input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cd1c27efd349ebb1cec891986bec212409391ed436b7a53208a82d192ead56d
+size 34316

--- a/docs/remote/images/ssh/ssh-explorer-add-new.png
+++ b/docs/remote/images/ssh/ssh-explorer-add-new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d82b48a56ff1d19d624c78471816fe6851b2d66c20ab51844b9a100425f976
+size 74701

--- a/docs/remote/images/ssh/ssh-explorer-connect.png
+++ b/docs/remote/images/ssh/ssh-explorer-connect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49a0ff40bf8ab5e178e965f0c1c704864ca62366a3ff6301c17df223b56e575c
+size 76131

--- a/docs/remote/images/ssh/ssh-explorer-forward-port.png
+++ b/docs/remote/images/ssh/ssh-explorer-forward-port.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:143fe1748c2fef7f1b64f711a4d39dfb4f23908d2a896a1ef593e3126a5c8d5d
+size 81044

--- a/docs/remote/images/ssh/ssh-explorer-open-folder.png
+++ b/docs/remote/images/ssh/ssh-explorer-open-folder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f872a45b14e5d0ae56ac9c7af22a547b2a2591d6cd4eb512e41f33aa476b054
+size 83784

--- a/docs/remote/images/ssh/ssh-host-input.png
+++ b/docs/remote/images/ssh/ssh-host-input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1fab78919d389b89b13507d544369c4551e3425c8706e04d361d1235a55b4c2
+size 29522

--- a/docs/remote/images/ssh/ssh-open-folder.png
+++ b/docs/remote/images/ssh/ssh-open-folder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef70668b9284f61136664d8eaff2cc62e892a5d5d3773b44af3af0cb3a48f62c
+size 36942

--- a/docs/remote/images/ssh/ssh-statusbar.png
+++ b/docs/remote/images/ssh/ssh-statusbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78e3ac28a6f08afb680a63f4878f8c08bc5418851a24469e521f9020ff6643d9
+size 17018

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -49,52 +49,80 @@ To get started, you need to:
 
 ### Connect to a remote host
 
-Visual Studio Code uses [SSH configuration files](https://linux.die.net/man/5/ssh_config) and requires [SSH key based authentication](https://www.ssh.com/ssh/public-key-authentication) to connect to your host. If you do not have a host yet, you can create a [Linux VM on Azure](https://docs.microsoft.com/azure/virtual-machines/linux/quick-create-portal?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json) or [setup an SSH host on an existing machine](/docs/remote/troubleshooting.md#installing-a-supported-ssh-server).
+In this quick start, we'll cover how to connect to a SSH host with minimal setup. [In the next section](#remember-hosts-and-advanced-settings), we'll cover how you can configure VS Code to remember hosts you connect to frequently along with any advanced settings.
+
+If you do not have a host yet, you can [setup an SSH host on an existing machine](/docs/remote/troubleshooting.md#installing-a-supported-ssh-server) or create a [Linux VM on Azure](https://docs.microsoft.com/azure/virtual-machines/linux/quick-create-portal?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
 > **Note:** When using ARMv7l / ARMv8l `glibc` SSH hosts, some extensions may not work due to x86 compiled native code inside the extension. Experimental ARMv8l (AArch64) is available in [VS Code Insiders](https://code.visualstudio.com/insiders/) only. See [system requirements](#system-requirements) for supported hosts.
 
 To get started, follow these steps:
 
-1. First, **configure key based authentication** on the host you plan to connect to by adding your local public SSH key to `~/.ssh/authorized_keys` on the host. If you are new to SSH or are running into trouble, see [Configuring key based authentication](/docs/remote/troubleshooting.md#configuring-key-based-authentication) for additional information on setting this up. If you followed the Azure VM tutorial, you can skip this step.
+1. **[Optional]** While password-based authentication is supported, we recommend setting up **key based authentication** on the host you plan to connect to by adding your local public SSH key to `~/.ssh/authorized_keys` on the host. See the [Tips and Tricks](/docs/remote/troubleshooting.md#configuring-key-based-authentication) article for details.
 
-    > **Note:** PuTTY for Windows is not a [supported client](/docs/remote/troubleshooting.md#installing-a-supported-ssh-client), but you can [convert your PuTTYGen keys](/docs/remote/troubleshooting.md#reusing-a-key-generated-in-puttygen).
+    > **Tip:** PuTTY for Windows is not a [supported client](/docs/remote/troubleshooting.md#installing-a-supported-ssh-client), but you can [convert your PuTTYGen keys](/docs/remote/troubleshooting.md#reusing-a-key-generated-in-puttygen).
 
-2. Run **Remote-SSH: Connect to Host...** from the Command Palette (`kbstyle(F1)`) and enter the host and your user on the host in the input box as follows: `user@hostname`.
+2. Select **Remote-SSH: Connect to Host...** from the Command Palette (`kbstyle(F1)`) and enter the host and your user on the host in the input box as follows: `user@hostname`.
 
     ![Illustration of user@host input box](images/ssh/ssh-user@box.png)
 
-    > **Note:** If you see errors about bad SSH file permissions when connecting, see [Fixing SSH file permission errors](/docs/remote/troubleshooting.md#fixing-ssh-file-permission-errors) for details on the correct settings.
-
 3. After a moment, VS Code will connect to the SSH server and set itself up. VS Code will keep you up-to-date using a progress notification and you can see a detailed log in the `Remote - SSH` output channel.
 
-    > **Note:** If your connection is hanging, you may need to enable TCP forwarding or respond to a server prompt. See [Tips and Tricks](/docs/remote/troubleshooting.md#troubleshooting-hanging-or-failing-connections) for details.
+    > **Tip:** If you see errors about bad SSH file permissions when connecting, see [fixing SSH file permission errors](/docs/remote/troubleshooting.md#fixing-ssh-file-permission-errors). If your connection is hanging, you may need to enable TCP forwarding or respond to a server prompt. See [Tips and Tricks](/docs/remote/troubleshooting.md#troubleshooting-hanging-or-failing-connections) for details.
 
 4. After you are connected, you'll be in an empty window. You can then open a folder or workspace on the remote machine using **File > Open...** or **File > Open Workspace...**
 
-5. After a moment, the folder or workspace you selected will open. Install **any extensions** you want to use on this host from the Extensions view.
+    ![File > Open on a remote SSH host](images/ssh/ssh-open-folder.png)
+
+5. The window will reload and the folder or workspace you selected will open. If you have multiple VS Code windows open, you can refer to the status bar to see which one is connected to the host.
+
+    ![SSH status bar item](images/ssh/ssh-statusbar.png)
+
+    Clicking on this same status bar item at any time will show you a set of quick actions you can select from while you are connected.
+
+From here, [install any extensions](#managing-extensions) you want to use when connected to the host and  start editing!
 
 ### Disconnect from a remote host
 
 To close the connection when you finish editing files on the remote host, choose **File > Close Remote Connection** to disconnect from the host. The default configuration does not include a keyboard shortcut for this command. You can also simply exit VS Code to close the remote connection.
 
-### Remembering hosts you connect to frequently
+### Remember hosts and advanced settings
 
-If you have a few hosts you use frequently, you can add them to an SSH config file so they automatically appear in the host dropdown. Run **Remote-SSH: Open Configuration File...** and add the host to the file using the [SSH config file format](https://linux.die.net/man/5/ssh_config).
+If you have a set of hosts you use frequently or you need to connect to a host using some additional options, you can add them to a local file that follows the [SSH config file format](http://man7.org/linux/man-pages/man5/ssh_config.5.html).
 
-For example, here are two example hosts:
+To make setup easy, the extension can guide you through adding a host without having to hand edit this file.
+
+Start by selecting **Remote-SSH: Add New SSH Host...** from the Command Palette (`kbstyle(F1)`) or clicking on the "Add New" icon in the SSH **Remote Explorer** in the Activity Bar.
+
+![Remote Explorer add new item](images/ssh/ssh-explorer-add-new.png)
+
+You'll then be asked to enter the SSH connection information. You can either enter a host name:
+
+![Remote Explorer add new item](images/ssh/ssh-host-input.png)
+
+Or a the a full `ssh` command you would use to connect to the host from the command line:
+
+![Remote Explorer add new item](images/ssh/ssh-command-input.png)
+
+Finally, you'll be asked to pick a config file to use. You can also set the `"remote.SSH.configFile"` property in `settings.json` if you want to use a different config file than those listed. The extension takes care of the rest!
+
+For example, entering `ssh -i ~/.ssh/id_rsa-remote-ssh yourname@remotehost.yourcompany.com` in the input box would generate this entry:
 
 ```text
-Host example-remote-linux-machine
-    User your-user-name-here
-    HostName host-fqdn-or-ip-goes-here
-
-Host example-remote-linux-machine-with-identity-file
-    User your-user-name-on-host
+Host remotehost.yourcompany.com
+    User remotehost.yourcompany.com`
     HostName another-host-fqdn-or-ip-goes-here
     IdentityFile ~/.ssh/id_rsa-remote-ssh
 ```
 
-The second example uses an alternate location for your SSH key if you want to use more than one. See [Tips and Tricks](/docs/remote/troubleshooting.md#improving-your-security-with-a-dedicated-key) for details. You can also set the `"remote.SSH.configFile"` property in `settings.json` if you want to use a different config file than those listed.
+See [Tips and Tricks](/docs/remote/troubleshooting.md#improving-your-security-with-a-dedicated-key) for details on generating the key shown here. Regardless, you can manually edit this file with anything the [SSH config file format](http://man7.org/linux/man-pages/man5/ssh_config.5.html) supports, so this is just one example.
+
+From this point forward, the host will appear in the list of hosts when you select **Remote-SSH: Connect to Host...** from the Command Palette (`kbstyle(F1)`) or in the SSH section of the **Remote Explorer**.
+
+![Input box for a SSH command](images/ssh/ssh-explorer-connect.png)
+
+The **Remote Explorer** allows you to both open a new empty window on the remote host or directly open a folder you previously opened. Simply expand the host and click on the "Open Folder" icon next to the folder you want to open on the host.
+
+![Remote Explorer open folder](images/ssh/ssh-explorer-open-folder.png)
 
 ## Managing extensions
 
@@ -148,15 +176,21 @@ Sometimes when developing, you may need to access a port on a remote machine tha
 
 ### Temporarily forwarding a port
 
-If you want to **temporarily forward** a new port for the duration of the session, run the **Remote-SSH: Forward Port from Active Host...** command when connected to an active SSH host.
+Once you are connected to a host, if you want to **temporarily forward** a new port for the duration of the session, select **Remote-SSH: Forward Port from Active Host...** from the Command Palette (`kbstyle(F1)`) or click on the "Forward New Port" icon in the **Remote Explorer** after selecting it from the Activity Bar.
+
+![Remote explorer forward port button](images/ssh/ssh-explorer-forward-port.png)
+
+You'll then be asked to enter the port you would like to forward and you can give it a name.
 
 ![Forward port input](images/ssh/forward-port-ssh.png)
 
-After entering a port number, a notification will tell you the localhost port you should use to access the remote port. For example, if you forwarded an HTTP server listening on port 3000, the notification may tell you that it was mapped to port 4123 on localhost. You can then connect to this remote HTTP server using http://localhost:4123.
+A notification will tell you the localhost port you should use to access the remote port. For example, if you forwarded an HTTP server listening on port 3000, the notification may tell you that it was mapped to port 4123 on localhost since 3000 was already in use. You can then connect to this remote HTTP server using http://localhost:4123.
+
+This same information is available in the Forwarded Ports section of the Remote Explorer if you need to access it later.
 
 ### Always forwarding a port
 
-If you have ports that you **always want to forward**, you can use the `LocalForward` directive in the same SSH config file you created above in the [Remembering hosts](#remembering-hosts-you-connect-to-frequently) section above.
+If you have ports that you **always want to forward**, you can use the `LocalForward` directive in the same SSH config file you use to [remember hosts and advanced settings](#remember-hosts-and-advanced-settings).
 
 For example, if you wanted to forward ports 3000 and 27017, you could update the file as follows:
 


### PR DESCRIPTION
This PR addresses two things:

1. As a part of https://github.com/microsoft/vscode-remote-release/issues/1776, I noticed the comment `(By the way, I think the "requires SSH key based authentication" part is outdated.)` and realized that this entire doc hadn't been updated since we got the Remote Explorer updated (since SSH had an explorer to begin with and didn't seem necessary). We also drove strongly to key-based auth given limitations and  I've seen some comments about how hard even the basics are. So, I ended up revising the content to break the getting started into two:

    * A simple, really basic "connect" path.

    * More meat around the SSH config file and the explorer for advanced setup.

2. Clarifies the array form of extensionKind per https://github.com/microsoft/vscode-remote-release/issues/1787#issuecomment-551514386