### PR TITLE
Make APIs plural.

### DIFF
--- a/api/get-started/extension-anatomy.md
+++ b/api/get-started/extension-anatomy.md
@@ -21,7 +21,7 @@ Understanding these three concepts is crucial to writing extensions in VS Code:
 
 - [**Activation Events**](/api/references/activation-events): events upon which your extension becomes active.
 - [**Contribution Points**](/api/references/contribution-points): static declarations that you make in the `package.json` [Extension Manifest](#extension-manifest) to extend VS Code.
-- [**VS Code API**](/api/references/vscode-api): a set of JavaScript API that you can invoke in your extension code.
+- [**VS Code API**](/api/references/vscode-api): a set of JavaScript APIs that you can invoke in your extension code.
 
 In general, your extension would use a combination of Contribution Points and VS Code API to extend VS Code's functionality. The [Extension Capabilities Overview](/api/extension-capabilities/overview) topic helps you find the right Contribution Point and VS Code API for your extension.
 


### PR DESCRIPTION
I know this is a trivial change but I just noticed it in passing. Please feel free to ignore if incorrect.