### PR TITLE
docs: Add "icon" property to the "command" example

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -289,7 +289,11 @@ hand, shows disabled items but doesn't show the category label.
       {
         "command": "extension.sayHello",
         "title": "Hello World",
-        "category": "Hello"
+        "category": "Hello",
+        "icon": {
+          "light": "path/to/light/icon.svg",
+          "dark": "path/to/dark/icon.svg"
+        }
       }
     ]
   }


### PR DESCRIPTION
I was thinking that command's icon can be only string, therefor can't support light/dark mode.
I was happy to find out (by other resources) that it does possible.
A short example was save me some time 😀