### PR TITLE
`env-file` doesn't work in docker-compose

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -57,7 +57,7 @@ Next, depending on what you reference in `devcontainer.json`:
 * **Dockerfile or image**: Edit `devcontainer.json` and add a path to the `.env` file relative to the location of `devcontainer.json`:
 
     ```json
-    "runArgs": ["--env-file","devcontainer.env"]
+    "runArgs": ["--env_file","devcontainer.env"]
     ```
 
 * **Docker Compose:** Edit `docker-compose.yml` and add a path to the `.env` file relative to the Docker Compose file:
@@ -66,7 +66,7 @@ Next, depending on what you reference in `devcontainer.json`:
     version: '3'
     services:
       your-service-name-here:
-        env-file: devcontainer.env
+        env_file: devcontainer.env
         # ...
   ```
 


### PR DESCRIPTION
I tested it from documentation and it was failing with:

```sh
docker-compose -f /XYZ/.devcontainer/docker-compose.yml config --services
ERROR: The Compose file '/XYZ/.devcontainer/docker-compose.yml' is invalid because:
Unsupported config option for services.remote_dev: 'env-file'
```
In docker-compose doc https://docs.docker.com/compose/environment-variables/#the-env_file-configuration-option, it's `env_file` and not `env-file`