### PR TITLE
Fix letter casing for default clang-format config

### DIFF
--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -41,7 +41,7 @@ The Visual Studio clang-format style is not yet an official clang-format style b
 ```json
 UseTab: (VS Code current setting)
 IndentWidth: (VS Code current setting)
-BreakBeforeBraces: AllMan
+BreakBeforeBraces: Allman
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
 ColumnLimit: 0


### PR DESCRIPTION
The default clang-format configuration given in the docs includes `BreakBeforeBraces: AllMan`, which is cased incorrectly and causes clang-format 6.0 to fail when used in an actual `.clang-format` file. The correct case is `Allman` with a lowercase m.