### PR TITLE
fix: Update gallerycdn -> gallery

### DIFF
--- a/docs/setup/network.md
+++ b/docs/setup/network.md
@@ -22,7 +22,7 @@ If you are behind a firewall that needs to allow specific domains used by VS Cod
 * `go.microsoft.com`
 * `vscode.blob.core.windows.net`
 * `marketplace.visualstudio.com`
-* `*.gallerycdn.vsassets.io`
+* `*.gallery.vsassets.io`
 * `rink.hockeyapp.net`
 * `vscode.search.windows.net`
 * `raw.githubusercontent.com`


### PR DESCRIPTION
Troubleshooting update install issues and found the URL being called was docsmsft.gallery.vsassets.io