### PR TITLE
Fixes in section "Avoiding extension reinstalls on container rebuild"

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -333,9 +333,9 @@ To create the named local volume, follow these steps:
 
     RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \
             /home/$USERNAME/.vscode-server-insiders/extensions \
-        && chown -R user-name-goes-here \
-            /home/$USERNAME/.vscode-server/extensions \
-            /home/$USERNAME/.vscode-server-insiders/extensions
+        && chown -R $USERNAME \
+            /home/$USERNAME/.vscode-server \
+            /home/$USERNAME/.vscode-server-insiders
     ```
 
 2. Next, we'll configure a named volume mount for `~/.vscode-server/extensions` and `~/.vscode-server-insiders/extensions` in the container. The configuration will depend on whether you specify an image, Dockerfile, or Docker Compose file in your `devcontainer.json` file.


### PR DESCRIPTION
The Dockerfile snippet in the section "Changed Avoiding extension reinstalls on container rebuild" was creating the ".vscode" directory as root and giving to the local user the rights only on the subdirectory "extensions".
When vscode is then run in the container it tries to create the some directories (e.g. ".vscode/bin"), but it fails because the local user has no rights on the ".vscode" directory