### PR TITLE
Correct jupyter-support-py.md reference to IPython

### DIFF
--- a/docs/python/jupyter-support-py.md
+++ b/docs/python/jupyter-support-py.md
@@ -11,7 +11,7 @@ MetaSocialImage: images/tutorial/social.png
 
 # Working with the Python Interactive window
 
-[Jupyter](http://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a **notebook**. Visual Studio Code supports working with [Jupyter Notebooks natively](/docs/python/jupyter-support.md), as well as through Python code files. This topic covers the support offered through Python code files and demonstrates how to:
+[Jupyter](http://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython Notebook) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a **notebook**. Visual Studio Code supports working with [Jupyter Notebooks natively](/docs/python/jupyter-support.md), as well as through Python code files. This topic covers the support offered through Python code files and demonstrates how to:
 
 - Work with Jupyter-like code cells
 - Run code in the Python Interactive Window


### PR DESCRIPTION
Jupyter was previously known as IPython Notebook, not IPython. (IPython is the kernel that underlies both old and new notebooks.) See, for example, https://ipython.org/notebook.html