### PR TITLE
replace text with argument

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -333,7 +333,7 @@ To create the named local volume, follow these steps:
 
     RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \
             /home/$USERNAME/.vscode-server-insiders/extensions \
-        && chown -R user-name-goes-here \
+        && chown -R $USERNAME \
             /home/$USERNAME/.vscode-server/extensions \
             /home/$USERNAME/.vscode-server-insiders/extensions
     ```


### PR DESCRIPTION
in the "Avoiding extension reinstalls on container rebuild" section's snippet I changed user-name-goes-here to the $USERNAME argument in the command chown -R