### PR TITLE
Add some plurals to command reference

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -27,13 +27,13 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 - _query_ - Search string
 - _(returns)_ - A promise that resolves to an array of SymbolInformation and DocumentSymbol instances.
 
-`vscode.executeDefinitionProvider` - Execute all definition provider.
+`vscode.executeDefinitionProvider` - Execute all definition providers.
 
 - _uri_ - Uri of a text document
 - _position_ - Position of a symbol
 - _(returns)_ - A promise that resolves to an array of Location instances.
 
-`vscode.executeDeclarationProvider` - Execute all declaration provider.
+`vscode.executeDeclarationProvider` - Execute all declaration providers.
 
 - _uri_ - Uri of a text document
 - _position_ - Position of a symbol
@@ -51,7 +51,7 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 - _position_ - Position of a symbol
 - _(returns)_ - A promise that resolves to an array of Location instances.
 
-`vscode.executeHoverProvider` - Execute all hover provider.
+`vscode.executeHoverProvider` - Execute all hover providers.
 
 - _uri_ - Uri of a text document
 - _position_ - Position of a symbol


### PR DESCRIPTION
There also might be other places where "all" and plurality is called for (i.e. other commands that return arrays), but without knowing whether that means multiple providers are called or a single provider with multiple values is returned I didn't want to be presumptuous and get it wrong.