### PR TITLE
Use a more solid getNodeModule for keytar

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -238,22 +238,28 @@ Visual Studio Code does not provide a secret persistence mechanism itself, but m
 For example:
 
 ```typescript
-import * as vscode from 'vscode';
+import { env } from 'vscode';
+import * as keytarType from 'keytar';
 
-function getCoreNodeModule(moduleName) {
-    try {
-        return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
-    }
-    catch (err) { }
-    try {
-        return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
-    }
-    catch (err) { }
-    return undefined;
+declare const __webpack_require__: typeof require;
+declare const __non_webpack_require__: typeof require;
+function getNodeModule<T>(moduleName: string): T | undefined {
+	const r = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
+	try {
+		return r(`${env.appRoot}/node_modules.asar/${moduleName}`);
+	} catch (err) {
+		// Not in ASAR.
+	}
+	try {
+		return r(`${env.appRoot}/node_modules/${moduleName}`);
+	} catch (err) {
+		// Not available.
+	}
+	return undefined;
 }
 
 // Use it
-const keytar = getCoreNodeModule('keytar');
+const keytar = getNodeModule<typeof keytarType>('keytar');
 await keytar.setPassword('my-service-name','my-account','iamal337d00d');
 const password = await keytar.getPassword('my-service-name','my-account');
 ```


### PR DESCRIPTION
The previous code for getNodeModule works fine in a development environment, but will fail loading the Node module in production. The function should be changed as indicated. That code is coming from the vscode-azureaccount repo.