### PR TITLE
Update tslint-eslint-migration.md

### DIFF
--- a/api/advanced-topics/tslint-eslint-migration.md
+++ b/api/advanced-topics/tslint-eslint-migration.md
@@ -22,7 +22,6 @@ The command above adds ESLint, adds a parser that makes ESLint understand TypeSc
 Now, to make the actual migration simpler, install the [tslint-to-eslint-config](https://github.com/typescript-eslint/tslint-to-eslint-config) utility. This tool will take your TSLint configuration and create the "closest" ESLint configuration from it.
 
 ```bash
-npm install -g tslint-to-eslint-config
 npx tslint-to-eslint-config
 ```
 
@@ -54,7 +53,7 @@ To integrate ESLint with Visual Studio Code, do the following:
 
 ## TSLint: Removal
 
-Congratulations. You should now have a working ESLint setup and it's time to clean up. You can remove the `tslint-to-eslint-config` utility as it was only used for the migration and not for subsequent runs.
+Congratulations. You should now have a working ESLint setup and it's time to clean up. 
 
 The removal of TSLint depends on your project, but usually these are the steps:
 


### PR DESCRIPTION
If you're using npx you don't need to install anything globally, it'll download it on demand if it's not located on the system, which is helpful since we don't want this package hanging around once it's done.