### PR TITLE
Correct window.restoreWindows default setting

### DIFF
--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -359,8 +359,7 @@ If configured to be `default`, we will make the best guess about reusing a windo
 
 Note: There can still be cases where this setting is ignored (for example, when using the `-new-window` or `-reuse-window` command-line option).
 
-The `window.restoreWindows` setting tells VS Code how to restore the opened windows of your previous session. By default, VS Code will
-reopen the last opened window you worked on (setting: `one`). Change this setting to `none` to never reopen any windows and always start with an empty VS Code instance. Change it to `all` to restore all windows you worked on during your previous session or `folders` to only restore windows that had folders opened.
+The `window.restoreWindows` setting tells VS Code how to restore the opened windows of your previous session. By default, VS Code will restore all windows you worked on during your previous session (setting: `all`). Change this setting to `none` to never reopen any windows and always start with an empty VS Code instance. Change it to `one` to reopen the last opened window you worked on or `folders` to only restore windows that had folders opened.
 
 ## Next steps
 


### PR DESCRIPTION
In VS Code 1.42.1 the default setting for window.restoreWindows is 'all' and not like mentioned 'one'