### PR TITLE
Update Tips and Tricks page with new screenshots/GIFs.

### DIFF
--- a/docs/getstarted/images/tips-and-tricks/mdiff-switch-to-inline.png
+++ b/docs/getstarted/images/tips-and-tricks/mdiff-switch-to-inline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2bd992e25a2710e8d19523d655df4215c5f2d1e0a8d25ee8521cc3b0fb17b30
+size 369938

--- a/docs/getstarted/images/tips-and-tricks/mgutter_icons.gif
+++ b/docs/getstarted/images/tips-and-tricks/mgutter_icons.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0df6816cb00541d3e3793e182de8594d816e2ee8ef883047c4803d26e682e24b
+size 20111283

--- a/docs/getstarted/images/tips-and-tricks/msee-changes.gif
+++ b/docs/getstarted/images/tips-and-tricks/msee-changes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44646d01e76302ce471cf93cb8fda1e8d47ff88561070792aa7f80e69fd07c91
+size 17810009

--- a/docs/getstarted/images/tips-and-tricks/mstage-unstage.gif
+++ b/docs/getstarted/images/tips-and-tricks/mstage-unstage.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5bf04e2cab90c98f28f186ceb11cfcb176505d53759dbc709a5e0748e06642
+size 27764435

--- a/docs/getstarted/images/tips-and-tricks/mswitch-branch.gif
+++ b/docs/getstarted/images/tips-and-tricks/mswitch-branch.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bbb5beec124bfeeef41f322462ce8b80ac78fc9edbbd53b5d4dda545ad6b120
+size 21674098

--- a/docs/getstarted/images/tips-and-tricks/mswitch-to-inline.gif
+++ b/docs/getstarted/images/tips-and-tricks/mswitch-to-inline.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:840f7623e1e7b267f60f64a3fb07317ea0d5f523fefb4ad7fec6872da389a7a2
+size 10890322

--- a/docs/getstarted/images/tips-and-tricks/mundo-last-commit.gif
+++ b/docs/getstarted/images/tips-and-tricks/mundo-last-commit.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d38d46721ccaed1d751bd70b4befa4df08007149a302917de5d29e35c528b76
+size 6999766

--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -731,21 +731,19 @@ Git integration comes with VS Code "out-of-the-box". You can install other SCM p
 
 ### Diffs
 
-From the **Source Control** view, select the file to diff.
+From the **Source Control** view, select a file to open the diff.
 
-![git icon](images/tips-and-tricks/source-control-icon.png)
+![git diff from source control](images/tips-and-tricks/msee-changes.gif)
 
-**Side by side**
+Alternatively, click the **Open Changes** button in the top right corner to diff the current open file.
 
-Default is side by side diff.
+**Views**
 
-![git diff side by side](images/tips-and-tricks/git_side_by_side.png)
+The default view for diffs is the **side by side view**.
 
-**Inline view**
+Toggle **inline view** by clicking the **More Actions** (...) button in the top right and selecting **Toggle Inline View**.
 
-Toggle inline view by clicking the **More Actions** (...) button in the top right and selecting **Switch to Inline View**.
-
-![git inline](images/tips-and-tricks/git_inline.png)
+![git switch to inline diff](images/tips-and-tricks/mdiff-switch-to-inline.png)
 
 If you prefer the inline view, you can set `"diffEditor.renderSideBySide": false`.
 
@@ -764,15 +762,17 @@ You can make edits directly in the pending changes of the diff view.
 
 Easily switch between Git branches via the Status Bar.
 
-![switch branches](images/tips-and-tricks/switch_branches.gif)
+![switch branches](images/tips-and-tricks/mswitch-branch.gif)
 
 ### Staging
 
-**Stage all**
+**Stage file changes**
 
 Hover over the number of files and click the plus button.
 
-![git stage all](images/tips-and-tricks/git_stage_all.gif)
+Click the minus button to unstage changes.
+
+![git stage all](images/tips-and-tricks/mstage-unstage.gif)
 
 **Stage selected**
 
@@ -780,7 +780,9 @@ Stage a portion of a file by selecting that file (using the arrows) and then cho
 
 ### Undo last commit
 
-![undo last commit](images/tips-and-tricks/undo_last_commit.gif)
+Click the (...) button and then select **Undo Last Commit** to undo the previous commit. The changes are added to the Staged Changes section.
+
+![undo last commit](images/tips-and-tricks/mundo-last-commit.gif)
 
 ### See Git output
 
@@ -792,7 +794,7 @@ Use the **Toggle Output** command (`kb(workbench.action.output.toggleOutput)`) a
 
 View diff decorations in editor. See [documentation](/docs/editor/versioncontrol.md#gutter-indicators) for more details.
 
-![git gutter indicators](images/tips-and-tricks/editingevolved_gutter.png)
+![git gutter indicators](images/tips-and-tricks/mgutter_icons.gif)
 
 ### Resolve merge conflicts
 
@@ -801,7 +803,15 @@ During a merge, go to the **Source Control** view (`kb(workbench.view.scm)`) and
 ### Set VS Code as default merge tool
 
 ```bash
-git config --global merge.tool code
+git config --global merge.tool vscode
+git config --global mergetool.vscode.cmd 'code --wait $MERGED'
+```
+
+### Set VS Code as default diff tool
+
+```bash
+git config --global diff.tool vscode
+git config --global difftool.vscode.cmd 'code --wait --diff $LOCAL $REMOTE'
 ```
 
 ## Debugging


### PR DESCRIPTION
This is needed because a lot of the icons in the images were still using old icons.

Also improve the instructions for using VS Code as a git merge and diff tool.