### PR TITLE
Fix incorrect indentation in an example

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -953,15 +953,15 @@ While the `postCreateCommand` property allows you to install additional tools in
 
 ```yaml
 version: '3'
-  services:
-    your-service-name-here:
-       build:
-         context: .
-         # Location is relative to folder containing this compose file
-         dockerfile: Dockerfile
-       volumes:
-         - .:/workspace:cached
-       command: /bin/sh -c "while sleep 1000; do :; done"
+services:
+  your-service-name-here:
+      build:
+        context: .
+        # Location is relative to folder containing this compose file
+        dockerfile: Dockerfile
+      volumes:
+        - .:/workspace:cached
+      command: /bin/sh -c "while sleep 1000; do :; done"
 ```
 
 ### Docker Compose dev container definitions


### PR DESCRIPTION
In `docker-compose.yml`, `version` and `services` nodes must be on the same level.