### PR TITLE
Update volume target path

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -348,7 +348,7 @@ To create the named local volume, follow these steps:
     "mounts": [
         "source=unique-vol-name-here,target=/root/.vscode-server/extensions,type=volume",
         // And/or for VS Code Insiders
-        "source=unique-vol-name-here-insiders,target=/.vscode-server-insiders/extensions,type=volume",
+        "source=unique-vol-name-here-insiders,target=/root/.vscode-server-insiders/extensions,type=volume",
     ]
     ```
 


### PR DESCRIPTION
The "Avoiding extension reinstalls on container rebuild" section provides directions on how to create volume mounts to hold the remote VS Code server and extensions. In one of the steps, the volume mount target for VS Code Insiders is shown without the home prefix. Anyone using VS Code Insiders who blindly copies this configuration will end up mounting the volume to the wrong path.

This PR updates the volume mount to include the home directory in the target path.