### PR TITLE
Remove outdated note about IntelliSense for ES7

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -345,7 +345,7 @@ Yes, you can. You can see this working using JavaScript source maps in the [Node
 
 Some users want to use syntax constructs like the proposed pipeline (`|>`) operator. However, these are currently not supported by VS Code's JavaScript language service and are flagged as errors. For users who still want to use these future features, we provide the `javascript.validate.enable` [setting](/docs/getstarted/settings.md).
 
-With `javascript.validate.enable: false`, you disable all built-in syntax checking. If you do this, we recommend that you use a linter like [ESLint](https://eslint.org) to validate your source code. Since VS Code's JavaScript support doesn't understand ES7 constructs, features like IntelliSense might not be fully accurate.
+With `javascript.validate.enable: false`, you disable all built-in syntax checking. If you do this, we recommend that you use a linter like [ESLint](https://eslint.org) to validate your source code.
 
 ### Can I use other JavaScript tools like Flow?
 


### PR DESCRIPTION
This note about IntelliSense not implementing ES7 seems to be a outdated. Newer features like `String.prototype.trimStart` and `trimEnd` from ES2019 already work.

Note: My assumption here is that older features must be complete if later ones are. Please decline this PR if actually some ES7 features are not yet present even though ES2019 is already supported.