### PR TITLE
Updated mac.md for command palette shortcut

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -21,7 +21,7 @@ MetaDescription: Get Visual Studio Code up and running on Mac (macOS).
 You can also run VS Code from the terminal by typing 'code' after adding it to the path:
 
 - Launch VS Code.
-- Open the **Command Palette** (`kbstyle(F1)`) and type 'shell command' to find the **Shell Command: Install 'code' command in PATH** command.
+- Open the **Command Palette** (`kbstyle(⇧⌘P)`) and type 'shell command' to find the **Shell Command: Install 'code' command in PATH** command.
 
 ![macOS shell commands](images/mac/shell-command.png)
 


### PR DESCRIPTION
Updated mac.md to show the correct keyboard MacOS shortcut to open the Command Palette.  Origin document had **F1** as the keyboard shortcut. The shortcut should have been **⇧⌘P**.