### PR TITLE
semantic tokenization doc

### DIFF
--- a/api/extension-capabilities/theming.md
+++ b/api/extension-capabilities/theming.md
@@ -21,7 +21,8 @@ In Visual Studio Code, there are two types of themes:
 As you can see in the illustration, Color Theme defines colors for UI components as well as for highlighting in the editor:
 
 - The `colors` mapping that controls colors for UI Components.
-- The `tokenColors` and the `semanticTokenColors` mappings as well as the `semanticHighlighting` setting define the color and styles for the syntax and semantic highlighting in the editor. The [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
+- The `tokenColors` define the color and styles for highlighting in the editor. The [Syntax Highlight Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
+- The `semanticTokenColors` mappings as well as the `semanticHighlighting` setting allow to enhance the highlighting in the editor. The [Semantic Highlight Guide](/api/language-extensions/semantic-highlight-guide) explains the APIs related to that.
 
 We have a [Color Theme Guide](/api/extension-guides/color-theme) and a [Color Theme Sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/theme-sample) that illustrates how to create a theme.
 

--- a/api/extension-capabilities/theming.md
+++ b/api/extension-capabilities/theming.md
@@ -18,10 +18,10 @@ In Visual Studio Code, there are two types of themes:
 
 ![color-theme](images/theming/color-theme.png)
 
-As you can see in the illustration, Color Theme defines two mappings:
+As you can see in the illustration, Color Theme defines colos for UI components as well as for highlighting in the editor:
 
 - The `colors` mapping that controls colors for UI Components.
-- The `tokenColors` mapping that controls colors for each source code token (your source code is broken into tokens by a [grammar](/api/language-extensions/syntax-highlight-guide)).
+- The `tokenColors`and the `semanticTokenColors` mappings as well as the `semanticHighlighting` setting define the color and styles for the syntax and semantic highlighting in the editor. The [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
 
 We have a [Color Theme Guide](/api/extension-guides/color-theme) and a [Color Theme Sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/theme-sample) that illustrates how to create a theme.
 

--- a/api/extension-capabilities/theming.md
+++ b/api/extension-capabilities/theming.md
@@ -18,7 +18,7 @@ In Visual Studio Code, there are two types of themes:
 
 ![color-theme](images/theming/color-theme.png)
 
-As you can see in the illustration, Color Theme defines colos for UI components as well as for highlighting in the editor:
+As you can see in the illustration, Color Theme defines colors for UI components as well as for highlighting in the editor:
 
 - The `colors` mapping that controls colors for UI Components.
 - The `tokenColors`and the `semanticTokenColors` mappings as well as the `semanticHighlighting` setting define the color and styles for the syntax and semantic highlighting in the editor. The [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.

--- a/api/extension-capabilities/theming.md
+++ b/api/extension-capabilities/theming.md
@@ -21,7 +21,7 @@ In Visual Studio Code, there are two types of themes:
 As you can see in the illustration, Color Theme defines colors for UI components as well as for highlighting in the editor:
 
 - The `colors` mapping that controls colors for UI Components.
-- The `tokenColors`and the `semanticTokenColors` mappings as well as the `semanticHighlighting` setting define the color and styles for the syntax and semantic highlighting in the editor. The [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
+- The `tokenColors` and the `semanticTokenColors` mappings as well as the `semanticHighlighting` setting define the color and styles for the syntax and semantic highlighting in the editor. The [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
 
 We have a [Color Theme Guide](/api/extension-guides/color-theme) and a [Color Theme Sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/theme-sample) that illustrates how to create a theme.
 

--- a/api/extension-guides/color-theme.md
+++ b/api/extension-guides/color-theme.md
@@ -12,7 +12,7 @@ MetaDescription: A guide to creating Color Theme in Visual Studio Code
 Colors visible in the Visual Studio Code user interface fall in two categories:
 
 - Workbench colors used in views and editors, from the Activity Bar to the Status Bar. A complete list of all these colors can be found in the [theme color reference](/api/references/theme-color).
-- Syntax colors used for source code in the editor. The theming of these colors is different as syntax colorization is based on TextMate grammars and TextMate themes.
+- Syntax colors and styles used for source code in the editor. The theming of these colors is different as syntax colorization is based on TextMate grammars and TextMate themes as well as semantic tokens.
 
 This guide will cover the different ways in which you can create themes.
 
@@ -49,6 +49,29 @@ For example, the following would change the color of comments within the editor:
 ```
 
 The setting supports a simple model with a set of common token types such as 'comments', 'strings' and 'numbers' available. If you want to color more than that, you need to use TextMate theme rules directly, which are explained in detail in the [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide).
+
+
+## Semantic colors
+
+Semantic highlighting is available for TypeScript and JavaScript in VS Code release 1.43. We expect it to be adopted by other languages soon.
+
+Semantic highlighting enriches syntax coloring based on symbol information from the language service, which has more complete understanding of the project. The coloring changes appear once the language server is running and has computed the semantic tokens.
+
+Each theme controls whether to enable semantic highlighting with a specific setting that is part of the theme definition. The style of each semantic token is defined by the theme's styling rules.
+
+Users can override the semantic highlighting feature and colorization rules using the `editor.tokenColorCustomizations` setting:
+
+Enable semantic highlighting for a specific theme:
+
+```json
+"editor.tokenColorCustomizations": {
+    "[Material Theme]": {
+        "semanticHighlighting": true
+    }
+},
+```
+
+Themes can define theming rules for semantic tokens as described in the [Syntax Highlighting Guide](/api/language-extensions/syntax-highlight-guide#semantic-theming).
 
 
 ## Create a new Color Theme

--- a/api/language-extensions/images/semantic-highlighting/no-semantic-highlighting.png
+++ b/api/language-extensions/images/semantic-highlighting/no-semantic-highlighting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d43f05d690527f99019d3e15f5ddeaca8662e7d0c245d8bbc383e12ed2de815
+size 44628

--- a/api/language-extensions/images/semantic-highlighting/with-semantic-highlighting.png
+++ b/api/language-extensions/images/semantic-highlighting/with-semantic-highlighting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08cf38497ba86f64746bfd293ecb0c73fc2a436a817aafdb5e1029f654e7b03c
+size 45828

--- a/api/language-extensions/images/syntax-highlighting/scope-inspector.png
+++ b/api/language-extensions/images/syntax-highlighting/scope-inspector.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36bfacee23e05f84a0f59809039c4dbba925b9fc6b1ce0d16511a572b1a34e43
-size 116065
+oid sha256:02d70bf247d624f77a40f44de133be52d178bf7edf3142e762c9d05f7a8c852c
+size 98589

--- a/api/language-extensions/images/syntax-highlighting/scopes.png
+++ b/api/language-extensions/images/syntax-highlighting/scopes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b63ed7f5c0538820b890cc0050b6154097c5f01f55feabf8b072fbbdd4a63ad
-size 61491
+oid sha256:29fc621ebd77790f0d7b70c03916be7677414dfd09060c2919487af031d728a7
+size 34112

--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -11,7 +11,7 @@ MetaDescription: A guide to syntax highlighting
 
 Semantic highlighting is an addition to syntax highlighting as described in the [Syntax Highlight Guide](syntax-highlight-guide).
 
-VS Code uses TextMate grammars as the main tokenization engine. TextMate grammars work on a single file as input and break it up based based on lexical rules expressed in regular expressions. 
+VS Code uses TextMate grammars as the main tokenization engine. TextMate grammars work on a single file as input and break it up based based on lexical rules expressed in regular expressions.
 
 Semantic tokenization has been added a new feature in 1.44. It allows language servers to provide additional token information based on the language server's knowledge on how to resolve symbols in the context of a project.
 
@@ -106,11 +106,36 @@ Extensions can define new types and modifiers through the `semanticTokenTypes` a
 A contributed type can name a super type from which it will inherit all styling rules.
 
 
+## Theming
+
+Theming is about assigning colors and styles to tokens. Theming rules are specified in color themes, but users can customize the theming rules in the user settings.
+
+Using the `semanticHighlighting` setting, a color theme can tell the editor whether semantic tokens should be shown or not.
+
+If enabled, semantic tokens are first matched against the semantic token rules defined in `semanticTokenColors`:
+
+```json
+{
+	"semanticTokenColors": {
+		"variable.readonly:java": "#ff0000"
+	}
+}
+```
+`variable.readonly:java` is called a selector and has the form (*|type)(.modifier)*(:language)?
+
+Here are other examples of selectors and styles:
+
+  - "*.declaration": { "fontStyle": "bold" }: // all declarations are bold
+  - "class:java": { "foreground": "#00ff00" "fontStyle": "bold" } // classes in java
+
+The semantic token selector has the format `(*|tokenType)(.tokenModifier)*(:tokenLanguage)?`.
+
+
+If no rule matches, the VSCode uses the [Semantic Token Scope Map][#semantic-token-scope-map] to evaluate a TextMate scope for the given semantic token. That scope is matched against the TextMate theming rules in `tokenColors`.
+
 ## Semantic Token Scope Map
 
-Color themes can define rules that directly match against the semantic token types and modifiers. This is described in the [Semantic Theming Rule](#semantic theming rules) section.
-
-However, in order to make semantic highlighting also work for themes that have not defined any specific semantic rules and to serve as fallback for custom token types and modifiers, VSCode maintains a map from semantic token selectors to TextMate scopes.
+In order to make semantic highlighting also work for themes that have not defined any specific semantic rules and to serve as fallback for custom token types and modifiers, VSCode maintains a map from semantic token selectors to TextMate scopes.
 
 If a theme has semantic highlighting enabled, but does not contain a rule for the given semantic token, these TextMate scopes are used to find a TextMate theming rule instead.
 
@@ -175,31 +200,6 @@ There are two use cases for extensions to do that:
 }
 ```
 
-## Theming
+### Sample
 
-Theming is about assigning colors and styles to tokens. Theming rules are specified in color themes, but users can customize the theming rules in the user settings.
-
-Using the `semanticHighlighting` setting, a color theme can tell the editor whether semantic tokens should be shown or not.
-
-If enabled, semantic tokens are first matched against the semantic token rules defined in `semanticTokenColors`:
-
-```json
-{
-	"semanticTokenColors": {
-		"variable.readonly:java": "#ff0000"
-	}
-}
-```
-`variable.readonly:java` is called a selector and has the form (*|type)(.modifier)*(:language)?
-
-Here are other examples of selectors and styles:
-
-  - "*.declaration": { "fontStyle": "bold" }: // all declarations are bold
-  - "class:java": { "foreground": "#00ff00" "fontStyle": "bold" } // classes in java
-
-The semantic token selector has the format `(*|tokenType)(.tokenModifier)*(:tokenLanguage)?`.
-
-
-If no rule matches, the VSCode uses the [Semantic Token Scope Map][#semantic-token-scope-map] to evaluate a TextMate scope for the given semantic token. That scope is matched against the TextMate theming rules in `tokenColors`.
-
-
+We have a [Semantic Tokens Sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/semantic-tokens-sample) that illustrates how to create a semantic token provider

--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -13,10 +13,9 @@ Semantic highlighting is an addition to syntax highlighting as described in the 
 
 VS Code uses TextMate grammars as the main tokenization engine. TextMate grammars work on a single file as input and break it up based based on lexical rules expressed in regular expressions.
 
-Semantic tokenization has been added a new feature in 1.44. It allows language servers to provide additional token information based on the language server's knowledge on how to resolve symbols in the context of a project.
+Semantic tokenization allows language servers to provide additional token information based on the language server's knowledge on how to resolve symbols in the context of a project.
 
-Themes can opt-in to use semantic tokens to improve and refine the syntax highlighting based on the TextMate grammar. The editor applies the highlighting that comes from semantic tokens on top of the highlighting from syntax tokens.
-
+Themes can opt-in to use semantic tokens to improve and refine the syntax highlighting from grammars. The editor applies the highlighting from semantic tokens on top of the highlighting from grammars.
 
 Here's an example of what semantic highlighting can add:
 
@@ -200,6 +199,8 @@ There are two use cases for extensions to do that:
 }
 ```
 
-### Sample
+### Try it out
 
 We have a [Semantic Tokens Sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/semantic-tokens-sample) that illustrates how to create a semantic token provider
+
+The [scope inspector](syntax-highlight-guide#scope-inspector) allows you to explore what semanitc tokens are present in a source file and what theme rules they match to. To see semantic token, use a built-in theme (e.g. Dark+) on a TypeScript file.

--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -1,0 +1,205 @@
+---
+# DO NOT TOUCH — Managed by doc writer
+ContentId: 2bb06188-d394-4b98-872c-0bf26c8a674d
+DateApproved: 3/9/2020
+
+# Summarize the whole topic in less than 300 characters for SEO purpose
+MetaDescription: A guide to syntax highlighting
+---
+
+# Semantic Highlight Guide
+
+Semantic highlighting is an addition to syntax highlighting as described in the [Syntax Highlight Guide](syntax-highlight-guide).
+
+VS Code uses TextMate grammars as the main tokenization engine. TextMate grammars work on a single file as input and break it up based based on lexical rules expressed in regular expressions. 
+
+Semantic tokenization has been added a new feature in 1.44. It allows language servers to provide additional token information based on the language server's knowledge on how to resolve symbols in the context of a project.
+
+Themes can opt-in to use semantic tokens to improve and refine the syntax highlighting based on the TextMate grammar. The editor applies the highlighting that comes from semantic tokens on top of the highlighting from syntax tokens.
+
+
+Here's an example of what semantic highlighting can add:
+
+Without semantic highlighting:
+
+![without semantic highlighting](images/semantic-highlighting/no-semantic-highlighting.png)
+
+With semantic highlighting:
+
+![with semantic highlighting](images/semantic-highlighting/with-semantic-highlighting.png)
+
+Notice the color differences based on language service symbol understanding:
+
+- line 10: `languageMode` is colored as a parameter
+- line 11: `Range` and `Position` are colored as classes and `document` as a parameter.
+- line 13: `getFoldingRanges` is colored as a function.
+
+
+## Semantic token provider
+
+To do so, language extensions can register a `semantic token provider` by document language and/or file name. The editor will make requests to the providers when semantic tokens are needed.
+
+```ts
+const tokenTypes = ['class', 'interface', 'enum', 'function', 'variable'];
+const tokenModifiers = ['declaration', 'documentation'];
+const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+
+const provider: vscode.DocumentSemanticTokensProvider = {
+  provideDocumentSemanticTokens(document: vscode.TextDocument): vscode.ProviderResult<vscode.SemanticTokens> {
+    // analyze the document and return semantic tokens
+  }
+};
+
+const selector = { language: 'java', scheme: 'file' }; // register for all Java documents from the local file system
+
+vscode.languages.registerDocumentSemanticTokensProvider(selector, provider, legend);
+```
+
+The semantic token provider API comes in 2 flavors to accommodate each language servers capabilities
+
+`DocumentSemanticTokensProvider` always takes a full document as input
+
+- `provideDocumentSemanticTokens`: provides all tokens of a document
+- `provideDocumentSemanticTokensEdits`: provides all tokens of a document as a delta to the previous response
+
+The `DocumentRangeSemanticTokensProvider` works only on a range:
+
+- `provideDocumentRangeSemanticTokens`: provides all tokens of a document range
+
+Each token returned by the provider comes with a classification that consists of a token type, any number of token modifiers and a token language. This information is similar than the TextMate scopes described above, but we chose to define a new, cleaner classification system.
+
+As seen in the example above, the provider names the types and modifiers it's going to use in a `SemaniticTokensLegend`. That allows the `provide` APIs to return token types and modifies as an index to the legend.
+
+## Semantic Token Classification
+
+These are the standard semantic token types and semantic token modifiers predefined by VSCode.
+
+  - standard semantic token types:
+      - namespace
+      - type, class, enum, interface, struct, typeParameter
+      - parameter, variable, property, enumMember, event
+      - function, member, macro
+      - label
+      - comment, string, keyword, number, regexp, operator
+  - standard semantic token modifiers:
+      - declaration
+      - readonly, static, deprecated, abstract
+      - async, modification, documentation, defaultLibrary
+
+Extensions can define new types and modifiers through the `semanticTokenTypes` and `semanticTokenModifiers` contribution points.
+
+```json
+{
+  "contributes": {
+    "semanticTokenTypes": [{
+      "id": "templateType",
+      "superType": "type",
+      "description": "A template type."
+    }],
+    "semanticTokenModifiers": [{
+      "id": "native",
+      "description": "Annotates a symbol that is implemented nativly"
+    }]
+  }
+}
+```
+A contributed type can name a super type from which it will inherit all styling rules.
+
+
+## Semantic Token Scope Map
+
+Color themes can define rules that directly match against the semantic token types and modifiers. This is described in the [Semantic Theming Rule](#semantic theming rules) section.
+
+However, in order to make semantic highlighting also work for themes that have not defined any specific semantic rules and to serve as fallback for custom token types and modifiers, VSCode maintains a map from semantic token selectors to TextMate scopes.
+
+If a theme has semantic highlighting enabled, but does not contain a rule for the given semantic token, these TextMate scopes are used to find a TextMate theming rule instead.
+
+The following table shows the predefined mappings.
+
+| Semantic Token Selector       | Fallback TextMate Scope                   |
+| ----------------------------- | -------------------------------- |
+| `namespace`|`entity.name.namespace`|
+| `type`|`entity.name.type`|
+| `type.defaultLibrary`|`support.type`|
+| `struct`|`storage.type.struct`|
+| `class`|`entity.name.type.class`|
+| `class.defaultLibrary`|`support.class`|
+| `interface`|`entity.name.type.interface`|
+| `enum`|`entity.name.type.enum`|
+| `function`|`entity.name.function`|
+| `function.defaultLibrary`|`support.function`|
+| `member`|`entity.name.function.member`|
+| `macro`|`entity.name.other.preprocessor.macro`|
+| `variable`|`variable.other.readwrite` , `entity.name.variable`|
+| `variable.readonly`|`variable.other.constant`|
+| `variable.readonly.defaultLibrary`|`support.constant`|
+| `parameter`|`variable.parameter`|
+| `property`|`variable.other.property`|
+| `property.readonly`|`variable.other.constant.property`|
+| `enumMember`|`variable.other.enummember`|
+| `event`|`variable.other.event`|
+
+
+This map can be extended by new rules through the `semanticTokenScopes` contribution point.
+
+There are two use cases for extensions to do that:
+
+- The extension that defines custom token types and token modifiers provides TextMate scopes as fallback when a theme does not define a theming rule for the added semantic token type or modifiers:
+```json
+{
+  "contributes": {
+    "semanticTokenScopes": [
+      {
+        "scopes": {
+          "templateType": [ "entity.name.type.template" ]
+        }
+      }
+    ]
+  }
+}
+```
+
+- The provider of a TextMate grammar can describe the language specific scopes. That helps with themes that contain language specific theming rules.
+```json
+{
+  "contributes": {
+    "semanticTokenScopes": [
+      {
+        "language": "typescript",
+        "scopes": {
+          "property.readonly": ["variable.other.constant.property.ts"],
+        }
+      }
+    ]
+  }
+}
+```
+
+## Theming
+
+Theming is about assigning colors and styles to tokens. Theming rules are specified in color themes, but users can customize the theming rules in the user settings.
+
+Using the `semanticHighlighting` setting, a color theme can tell the editor whether semantic tokens should be shown or not.
+
+If enabled, semantic tokens are first matched against the semantic token rules defined in `semanticTokenColors`:
+
+```json
+{
+	"semanticTokenColors": {
+		"variable.readonly:java": "#ff0000"
+	}
+}
+```
+`variable.readonly:java` is called a selector and has the form (*|type)(.modifier)*(:language)?
+
+Here are other examples of selectors and styles:
+
+  - "*.declaration": { "fontStyle": "bold" }: // all declarations are bold
+  - "class:java": { "foreground": "#00ff00" "fontStyle": "bold" } // classes in java
+
+The semantic token selector has the format `(*|tokenType)(.tokenModifier)*(:tokenLanguage)?`.
+
+
+If no rule matches, the VSCode uses the [Semantic Token Scope Map][#semantic-token-scope-map] to evaluate a TextMate scope for the given semantic token. That scope is matched against the TextMate theming rules in `tokenColors`.
+
+

--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -31,6 +31,7 @@ VSCode uses a two step approach:
 - [Semantic tokenization](#semantic-tokenization) is optional on applied on top of syntax tokens. Semantic tokens come from language servers. A language server has the full understanding of the source file and can classify each symbol identifier with the symbol it resolves to. A constant variable name is rendered as constant throughout the file, not just in its declaration. Same for parameter names, property names, class names and so on.
 As language servers take a while to load and analyze the project, semantic tokens come in with a delay.
 
+Before diving into the details, a good start is to play with the [scope inspector](#scope-inspector) and explore what tokens are present in a source file. To see both semantic and syntax token, use a built-in theme (e.g. Dark+) on a TypeScipt file.
 
 ## Syntax tokenization
 
@@ -411,7 +412,7 @@ The scope inspector displays the following information:
 
 1. The current token.
 1. Metadata about the token and information about its computed appearance. If you are working with embedded languages, the important entries here `language` and `token type`.
-1. The semantic token section only is shown when the current theme supports semantic highlighting and there is a semantic token provider available for the current language. It shows the current semantic token type and modifiers alonng with the theme rules that match the current semantic token type and modifiers.
-1. The TextMate section shows the  scope list for the current TextMate token, with the most specific scope at the top. It also sThows the theme rules that apply to the token. This only shows the theme rules that are responsible for the token's current style, it does not show overridden rules. If semantic tokens are present, the theme rules are only shown when they differ from the rule matching the semantic token.
+1. The semantic token section is only shown when a semantic token provider is available for the current language and when the current theme supports semantic highlighting. It shows the current semantic token type and modifiers along with the theme rules that match the semantic token type and modifiers.
+1. The TextMate section shows the scope list for the current TextMate token, with the most specific scope at the top. It also shows the most specific theme rules that match the scopes. This only shows the theme rules that are responsible for the token's current style, it does not show overridden rules. If semantic tokens are present, the theme rules are only shown when they differ from the rule matching the semantic token.
 
 [tm-grammars]: https://macromates.com/manual/en/language_grammars

--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -22,7 +22,7 @@ Before diving into the details, a good start is to play with the [scope inspecto
 
 The tokenization of text is about breaking the text into segments and to classify each segment with a token type.
 
-VSCode uses a two step approach:
+VS Code uses a two step approach:
 
 - [Syntax tokenization](#syntax-tokenization) is based on lexical rules that are expressed as regular expressions contained in a TextMate grammar. The TextMate engine runs in the same process as the renderer and tokens are updated as the user types.
 

--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -13,16 +13,30 @@ Syntax highlighting determines the color and style of source code displayed in t
 
 There are two components to syntax highlighting:
 
-- Breaking text into a list of tokens and scopes using a grammar
-- Then using a theme to map these scopes to specific colors and styles
+- Breaking text into a list of tokens
+- Using a theme to map the tokens to specific colors and styles
 
-This document only discusses the first part: breaking text into tokens and scopes that existing color themes can colorize. For more information about customizing the styling of different scopes in the editor, see the [Color Theme Guide](/api/extension-guides/color-theme#syntax-colors)
+This document discusses the first part: breaking text into syntax and semantic tokens.
 
-## TextMate grammars
+How tokens are mapped to colors and styles is covered in the [Color Theme Guide](/api/extension-guides/color-theme#syntax-colors).
 
-VS Code uses [TextMate grammars][tm-grammars] to break text into a list of tokens. TextMate grammars are a structured collection of [Oniguruma regular expressions](https://macromates.com/manual/en/regular_expressions) and are typically written as a plist or JSON. You can find a good introduction to TextMate grammars [here](https://www.apeth.com/nonblog/stories/textmatebundle.html), and you can take a look at existing TextMate grammars to learn more about how they work.
+## Tokenization
 
-### Tokens and scopes
+The tokenization of text is about breaking the text into segments and to classify each segment with a token type.
+
+VSCode uses a two step approach:
+
+- [Syntax tokenization](#syntax-tokenization) is based on lexical rules that are expressed as regular expressions contained in a TextMate grammar. The TextMate engine runs in the same process as the renderer and tokens are updated as the user types.
+
+- [Semantic tokenization](#semantic-tokenization) is optional on applied on top of syntax tokens. Semantic tokens come from language servers. A language server has the full understanding of the source file and can classify each symbol identifier with the symbol it resolves to. A constant variable name is rendered as constant throughout the file, not just in its declaration. Same for parameter names, property names, class names and so on.
+As language servers take a while to load and analyze the project, semantic tokens come in with a delay.
+
+
+## Syntax tokenization
+
+VS Code uses [TextMate grammars][tm-grammars] as the syntax tokenization engine. TextMate grammars are a structured collection of [Oniguruma regular expressions](https://macromates.com/manual/en/regular_expressions) and are typically written as a plist or JSON. You can find a good introduction to TextMate grammars [here](https://www.apeth.com/nonblog/stories/textmatebundle.html), and you can take a look at existing TextMate grammars to learn more about how they work.
+
+### TextMate tokens and scopes
 
 Tokens are one or more characters that are part of the same program element. Example tokens include operators such as `+` and `*`, variable names such as `myVar`, or strings such as `"my string"`.
 
@@ -156,7 +170,7 @@ The `embeddedLanguages` contribution point maps a scope in the embedded language
 
 Now if you try to comment code or trigger snippets inside an set of tokens marked `meta.embedded.block.javascript`, they will get the correct `//` JavaScript style comment and the correct JavaScript snippets.
 
-## Developing a new grammar extension
+### Developing a new grammar extension
 
 To quickly create a new grammar extension, use [VS Code's Yeoman templates](/api/get-started/your-first-extension) to run `yo code` and select the `New Language` option:
 
@@ -178,13 +192,13 @@ After answering all the questions, Yeoman will create a new extension with the s
 
 Remember, if you are contributing a grammar to a language that VS Code already knows about, be sure to delete the `languages` contribution point in the generated `package.json`.
 
-### Converting an existing TextMate grammar
+#### Converting an existing TextMate grammar
 
 `yo code` can also help convert an existing TextMate grammar to a VS Code extension. Again, start by running `yo code` and selecting `Language extension`. When asked for an existing grammar file, give it the full path to either a `.tmLanguage` or `.json` TextMate grammar file:
 
 ![Converting an existing TextMate grammar](images/syntax-highlighting/yo-convert.png)
 
-### Using YAML to write a grammar
+#### Using YAML to write a grammar
 
 As a grammar grows more complex, it can become difficult to understand and maintain it as json. If you find yourself writing complex regular expressions or needing to add comments to explain aspects of the grammar, consider using yaml to define your grammar instead.
 
@@ -202,29 +216,8 @@ $ npm install js-yaml --save-dev
 $ npx js-yaml syntaxes/abc.tmLanguage.yaml > syntaxes/abc.tmLanguage.json
 ```
 
-### Scope inspector
 
-VS Code's built-in scope inspector tool helps debug grammars. It displays the scopes for the token at the current position in a file, along with metadata about which theme rules apply to that token.
-
-Trigger the scope inspector from the Command Palette with the `Developer: Inspect TM Scopes` command or [create a keybinding](/docs/getstarted/keybindings) for it:
-
-```json
-{
-  "key": "cmd+alt+shift+i",
-  "command": "editor.action.inspectTMScopes"
-}
-```
-
-![scope inspector](images/syntax-highlighting/scope-inspector.png)
-
-The scope inspector displays the following information:
-
-1. The current token.
-1. Metadata about the token and information about its computed appearance. If you are working with embedded languages, the important entries here `language` and `token type`.
-1. Theme rules that apply to the token. This only shows the theme rules that are responsible for the token's current style, it does not show overridden rules.
-1. Complete scope list, with the most specific scope at the top.
-
-## Injection grammars
+### Injection grammars
 
 Injection grammars let you extend an existing grammar. An injection grammar is a regular TextMate grammar that is injected into a specific scope within an existing grammar. Example applications of injection grammars:
 
@@ -232,7 +225,7 @@ Injection grammars let you extend an existing grammar. An injection grammar is a
 - Add more specific scope information to an existing grammar.
 - Adding highlighting for a new language to Markdown fenced code blocks.
 
-### Creating a basic injection grammar
+#### Creating a basic injection grammar
 
 Injection grammars are contributed though the `package.json` just like regular grammars. However, instead of specifying a `language`, an injection grammar uses `injectTo` to specify a list of target language scopes to inject the grammar into.
 
@@ -274,7 +267,7 @@ The grammar itself is a standard TextMate grammar except for the top level `inje
 
 The `L:` in the injection selector means that the injection is added to the left of existing grammar rules. This basically means that our injected grammar's rules will be applied before any existing grammar rules.
 
-### Embedded languages
+#### Embedded languages
 
 Injection grammars can also contribute embedded languages to their parent grammar. Just like with a normal grammar, an injection grammars can use `embeddedLanguages` to map scopes from the embedded language to a top level language scope.
 
@@ -297,7 +290,7 @@ An extension that highlights sql queries in javascript strings for example may u
 }
 ```
 
-### Token types and embedded languages
+#### Token types and embedded languages
 
 There is one additional complication for injection languages embedded languages: by default, VS Code treats all tokens within a string as string contents and all tokens with a comment as token content. Since features such as bracket matching and auto closing pairs are disabled inside of strings and comments, if the embedded language appears inside a string or comment, these features will also be disabled in the embedded language.
 
@@ -324,5 +317,101 @@ If you can't add a `meta.embedded.*` scope to your grammar, you can alternativel
   }
 }
 ```
+
+## Semantic Tokenization
+
+Semantic tokenization has been added a new feature in 1.44. It allows language servers to provide additional token information based on the language server's knowledge on symbols in the source file. Themes can opt-in to use that information to improve and refine the syntax highlighting based on the TextMate grammar. The editor applies the highlighting that comes from semantic tokens on top of the highlighting from syntax tokens.
+.
+To do so, language extensions can register a `semantic token provider` by document language and/or file name. The editor will make requests to the providers when semantic tokens are needed.
+
+```ts
+const tokenTypes = ['class', 'interface', 'enum', 'function', 'variable'];
+const tokenModifiers = ['declaration', 'documentation'];
+const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+
+const documentSemanticHighlightProvider: vscode.DocumentSemanticTokensProvider = {
+  provideDocumentSemanticTokens(document: vscode.TextDocument): vscode.ProviderResult<vscode.SemanticTokens> {
+    // analyze the document and return semantic tokens
+  }
+};
+
+const selector = { language: 'java', scheme: 'file' };
+
+vscode.languages.registerDocumentSemanticTokensProvider(selector, documentSemanticHighlightProvider, legend);
+```
+
+The semantic token provider API comes in several flavors to accomodate each language servers capabilities, and each token provider can decide which APIs to implement.
+
+- provide all tokens of a document
+- provide all tokens of a document as a delta to the previous response
+- provide all tokens of a document range
+
+Each token returned by the provider comes with a classification that consists of a token type, any number of token modifiers and a token language. This information is similar than the TextMate scopes described above, but we chose to define a new, cleaner classification system.
+
+
+### Semantic Token Classification
+
+These are the standard semantic token types and semantic token modifiers predefined by VSCode.
+
+  - standard semantic token types:
+      - namespace,
+      - type, class, enum, interface, struct, typeParameter
+      - parameter, variable, property, enumMember, event
+      - function, member, macro
+      - label,
+      - comment, string, keyword, number, regexp, operator
+  - standard semantic token modifiers:
+      - declaration
+      - readonly, static, deprecated, abstract
+      - async, modification, documentation, defaultLibrary
+
+Themes can define rules that directly match against the semantic token types and modifiers. Additionally, VSCode has map from semantic tokens to TextMate scopes and can use the TextMate scopes as fallback when a theme does not define a semantic token themeing rule.
+
+Extensions can define new types and modifiers through the `semanticTokenTypes` and `semanticTokenModifiers` contribution points. Additionally, the `semanticTokenScopes` contribution point allows to extend the semantic tokens to TextMate scopes map.
+```json
+{
+  "contributes": {
+    "semanticTokenTypes": [{
+      "id": "templateType",
+      "superType": "type",
+      "description": "A template type."
+    }],
+    "semanticTokenModifiers": [{
+      "id": "native",
+      "description": "Annotates a symbol that is implemented nativly"
+    }],
+    "semanticTokenScopes": [
+      {
+        "language": "cpp",
+        "scopes": {
+          "templateType": [ "entity.name.type.template.cpp" ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Scope inspector
+
+VS Code's built-in scope inspector tool helps debug grammars and semantic tokens. It displays the scopes for the token and the semantic tokens at the current position in a file, along with metadata about which theme rules apply to that token.
+
+Trigger the scope inspector from the Command Palette with the `Developer: Inspect Editor Tokens and Scopes` command or [create a keybinding](/docs/getstarted/keybindings) for it:
+
+```json
+{
+  "key": "cmd+alt+shift+i",
+  "command": "editor.action.inspectTMScopes"
+}
+```
+
+![scope inspector](images/syntax-highlighting/scope-inspector.png)
+
+The scope inspector displays the following information:
+
+1. The current token.
+1. Metadata about the token and information about its computed appearance. If you are working with embedded languages, the important entries here `language` and `token type`.
+1. The semantic token section only is shown when the current theme supports semantic highlighting and there is a semantic token provider available for the current language. It shows the current semantic token type and modifiers alonng with the theme rules that match the current semantic token type and modifiers.
+1. The TextMate section shows the  scope list for the current TextMate token, with the most specific scope at the top. It also sThows the theme rules that apply to the token. This only shows the theme rules that are responsible for the token's current style, it does not show overridden rules. If semantic tokens are present, the theme rules are only shown when they differ from the rule matching the semantic token.
 
 [tm-grammars]: https://macromates.com/manual/en/language_grammars

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -111,7 +111,7 @@ Enable semantic highlighting for all themes:
 },
 ```
 
-The themes that ship with VS Code (for example the "Dark+" default) have `semanticHighlighting` enabled by default. You can disable sematic highlighting for those themes as described above.
+The themes that ship with VS Code (for example the "Dark+" default) have `semanticHighlighting` enabled by default. You can disable semantic highlighting for those themes as described above.
 
 The "Tomorrow Night Blue" color theme without semantic highlighting :
 


### PR DESCRIPTION
Doc on semantic highlighting

- show the relationship to syntax tokenization
- semantic token provider API overview (@alexdima FYI)
- semantic classification
- theming

I first planed to leave theming to https://code.visualstudio.com/api/extension-guides/color-theme but found that page to be more to be about on how to create theme, without much detail on the syntax on how to do token styling.

Therefore I added a theming section to the syntax highlighting document where I think it fits well.

I realized that we still lack detailed information on TextMate theming (TextMate rule selectors...)