### PR TITLE
Update reactjs-tutorial.md

### DIFF
--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -16,21 +16,18 @@ MetaSocialImage: /assets/images/nodejs_javascript_vscode.png
 
 ## Welcome to React
 
-We'll be using the `create-react-app` [generator](https://facebook.github.io/react/docs/installation.html#creating-a-new-application) for this tutorial. To install and use the generator as well as run the React application server, you'll need [Node.js](https://nodejs.org/) JavaScript runtime and [npm](https://www.npmjs.com/) (Node.js package manager) installed. npm is included with Node.js which you can download and install from [Node.js downloads](https://nodejs.org/en/download/).
+We'll be using the `create-react-app` [generator](https://facebook.github.io/react/docs/installation.html#creating-a-new-application) for this tutorial. To use the generator as well as run the React application server, you'll need [Node.js](https://nodejs.org/) JavaScript runtime and [npm](https://www.npmjs.com/) (Node.js package manager) installed. npm is included with Node.js which you can download and install from [Node.js downloads](https://nodejs.org/en/download/).
 
 >**Tip**: To test that you have Node.js and npm correctly installed on your machine, you can type `node --version` and `npm --version` in a terminal or command prompt.
 
-To install the `create-react-app` generator, in a terminal or command prompt type:
+You can now create a new React application by typing:
 
 ```bash
-npm install -g create-react-app
+npx create-react-app my-app
 ```
+If you've previously installed create-react-app globally via npm install -g create-react-app, we recommend you uninstall the package using npm uninstall -g create-react-app to ensure that npx always uses the latest version.
 
-This may take a few minutes to install. You can now create a new React application by typing:
-
-```bash
-create-react-app my-app
-```
+([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))
 
 where `my-app` is the name of the folder for your application. This may take a few minutes to create the React application and install its dependencies.
 


### PR DESCRIPTION
Using create-react-app globally via npm install -g create-react-app let users to use outdated create-react-app. Using outdated create-react-app makes error that cannot provide a template.
(https://github.com/facebook/create-react-app)