### PR TITLE
Update typescript-tutorial.md

### DIFF
--- a/docs/typescript/typescript-tutorial.md
+++ b/docs/typescript/typescript-tutorial.md
@@ -111,7 +111,8 @@ Having the generated JavaScript file in the same folder as the TypeScript source
 }
 ```
 
-Delete `helloworld.js`, run `tsc` again and `helloworld.js` will be placed in the `out` directory.
+Delete `helloworld.js`, run just the command `tsc`.
+You will see `helloworld.js` will be placed in the `out` directory.
 
 See [Compiling TypeScript](/docs/typescript/typescript-compiling.md) to learn about other features of the TypeScript language service and how to use tasks to run your builds directly from VS Code.
 


### PR DESCRIPTION
Add emphasis on just running the command `tsc` and not the whole command `tsc helloworld.ts` 
This was something I was doing wrong and probably would help someone else too down the line. You can close the PR if you find this trivial and not needed. 

Also, `just` is not a nice word to have in docs but couldn't find a replacement.