### PR TITLE
Use aspnetcorerazor language.id in example instead of razor

### DIFF
--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -62,7 +62,7 @@ For example:
 "emmet.includeLanguages": {
     "javascript": "javascriptreact",
     "vue-html": "html",
-    "razor": "html",
+    "aspnetcorerazor": "html",
     "plaintext": "pug"
 }
 ```


### PR DESCRIPTION
The Razor tooling's language id is "aspnetcorerazor" (https://github.com/dotnet/aspnetcore-tooling/blob/b3ac44798c16fff5b95dbcfe62dea84aa9a1bd72/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json#L135)