### PR TITLE
Updates to remote section for 1.44 release

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -5,7 +5,7 @@ TOCTitle: Advanced Containers
 PageTitle: Advanced Container Configuration
 ContentId: f180ac25-1d59-47ec-bad2-3ccbf214bbd8
 MetaDescription: Advanced setup for using the VS Code Remote - Containers extension
-DateApproved: 3/9/2020
+DateApproved: 4/8/2020
 ---
 # Advanced Container Configuration
 
@@ -471,6 +471,29 @@ Note that on Alpine Linux, you'll need to install the `shadow` package first.
 
 ```Dockerfile
 RUN apk add --no-cache shadow
+```
+
+## Setting the project name for Docker Compose
+
+VS Code will respect the value of [the `COMPOSE_PROJECT_NAME` environment variable](https://docs.docker.com/compose/reference/envvars/#compose_project_name) if set for the VS Code process or in a `.env` file in the root of the project.
+
+For example, after shutting down all VS Code windows, you can start VS Code from the command line as follows:
+
+```bash
+# from bash
+COMPOSE_PROJECT_NAME=foo code .
+```
+
+```PowerShell
+# from PowerShell
+$env:COMPOSE_PROJECT_NAME=foo
+code .
+```
+
+Or add the following to a `.env` file in the root of the project (**not** in the `.devcontainer` folder):
+
+```
+COMPOSE_PROJECT_NAME=foo
 ```
 
 ## Using Docker or Kubernetes from a container

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -78,38 +78,25 @@ We will cover using a container as your full-time development environment first.
 
 Let's start by using a sample project to try things out.
 
-1. Clone one of the sample repositories below.
-
-    ```bash
-    git clone https://github.com/Microsoft/vscode-remote-try-node
-    git clone https://github.com/Microsoft/vscode-remote-try-python
-    git clone https://github.com/Microsoft/vscode-remote-try-go
-    git clone https://github.com/Microsoft/vscode-remote-try-java
-    git clone https://github.com/Microsoft/vscode-remote-try-dotnetcore
-    git clone https://github.com/Microsoft/vscode-remote-try-php
-    git clone https://github.com/Microsoft/vscode-remote-try-rust
-    git clone https://github.com/Microsoft/vscode-remote-try-cpp
-    ```
-
-2. Start VS Code and click on the quick actions Status Bar item in the lower left corner of the window.
+1. Start VS Code, and in a new window, click on the quick actions Status Bar item in the lower left corner.
 
     ![Quick actions Status bar item](images/common/remote-dev-status-bar.png)
 
-3. Select **Remote-Containers: Open Folder in Container...** from the command list that appears, and open the root folder of the project you just cloned.
+2. Select **Remote-Containers: Try a Sample...** from the command list that appears and select sample from the list.
 
-4. The window will then reload, but since the container does not exist yet, VS Code will create one. This may take some time, and a progress notification will provide status updates. Fortunately, this step isn't necessary the next time you open the folder since the container will already exist.
+    ![Select a sample from the list](images/containers/select-a-sample.png)
+
+3. The window will then reload, but since the container does not exist yet, VS Code will create one and clone the sample repository into an isolated [container volume](https://docs.docker.com/storage/volumes/). This may take some time, and a progress notification will provide status updates. Fortunately, this step isn't necessary the next time you open the folder since the container will already exist.
 
     ![Dev Container Progress Notification](images/containers/dev-container-progress.png)
 
-5. After the container is built, VS Code automatically connects to it and maps the project folder from your local file system into the container. Check out the **Things to try** section of `README.md` in the repository you cloned to see what to do next.
+4. After the container is built, VS Code automatically connects to it and maps the project folder from your local file system into the container. Check out the **Things to try** section of `README.md` in the repository you cloned to see what to do next.
 
-> **Tip:** Want to use a remote Docker host? See the [Advanced Containers article](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host) for details on setup.
+You may be wondering where the repository source code is located. In this case, the source code is stored in a [container volume](https://docs.docker.com/storage/volumes/) which is not directly accessible from your local operating system. However, you can work with content in your local filesystem from a container as well! We'll cover that next.
 
 ## Quick start: Open an existing folder in a container
 
-Next we will cover how to set up a dev container for an existing project to use as your full-time development environment.
-
-The steps are similar to those above:
+Next we will cover how to set up a dev container for an existing project to use as your full-time development environment using existing source code on your filesystem. Follow these steps:
 
 1. Start VS Code, run the **Remote-Containers: Open Folder in Container...** command from the Command Palette (`kbstyle(F1)`) or quick actions Status bar item, and select the project folder you would like to set up the container for.
 
@@ -137,6 +124,8 @@ You can now interact with your project in VS Code just as you could when opening
 
 > **Tip:** Want to use a remote Docker host? See the [Advanced Containers article](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host) for details on setup.
 
+While using this approach to [bind mount](https://docs.docker.com/storage/bind-mounts/) the local filesystem into a container is convenient, it does have some performance overhead on Windows and macOS. There are [some techniques](/docs/remote/containers-advanced.md#improving-container-disk-performance) that you can apply to improve disk performance, or you can [open a repository in a container using a isolated container volume](#quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) instead.
+
 ### Open an existing workspace in a container
 
 You can also follow a similar process to open a [VS Code multi-root workspace](/docs/editor/multi-root-workspaces) in a **single container** if the workspace only **references relative paths to sub-folders of the folder the `.code-workspace` file is in (or the folder itself).**
@@ -149,6 +138,40 @@ You can either:
 Once connected, you may want to **add the `.devcontainer` folder** to the workspace so you can easily edit its contents if it is not already visible.
 
 Also note that, while you cannot use multiple containers for the same workspace in the same VS Code window, you can use [multiple Docker Compose managed containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once) from separate windows.
+
+## Quick start: Open a Git repository or GitHub PR in an isolated container volume
+
+While you can [open a locally cloned repository in a container](#quick-start-open-an-existing-folder-in-a-container), you may want to work with an isolated copy of a repository for a PR review or to investigate another branch without impacting your work.
+
+Repository Containers use isolated, local Docker volumes instead binding to the local filesystem. In addition to not polluting your file tree, local volumes have the added benefit of improved performance on Windows and macOS. (See [Advanced Configuration](/docs/remote/containers-advanced.md#improving-container-disk-performance) for information on how to use these types of volumes in other scenarios.)
+
+For example, follow these steps to open one of the "try" repositories in a Repository Container:
+
+1. Start VS Code and run **Remote-Containers: Open Repository in Container...** from the Command Palette (`kbstyle(F1)`).
+
+2. Enter `microsoft/vscode-remote-try-node` (or one of the other "try" repositories), a Git URI, a GitHub branch URL, or a GitHub PR URL in the input box that appears and press `kbstyle(Enter)`.
+
+    ![Input box with a repository name in it](images/containers/vscode-remote-try-node.png)
+
+    > **Tip:** If you choose a private repository, you may want to setup a credential manager or add your SSH keys to your SSH agent. See [Sharing Git credentials with your container](#sharing-git-credentials-with-your-container).
+
+3. If your repository does not have a `.devcontainer/devcontainer.json` file in it, you'll be asked to pick a starting point from a filterable list or an existing [Dockerfile](https://docs.docker.com/engine/reference/builder/) or [Docker Compose file](https://docs.docker.com/compose/compose-file/#compose-file-structure-and-examples) (if one exists).
+
+    > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
+
+    ![Select a node dev container definition](images/containers/select-dev-container-def.png)
+
+    Note the dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
+
+4. The VS Code window (instance) will reload, clone the source code, and start building the dev container. A progress notification provides status updates.
+
+    ![Dev Container Progress Notification](images/containers/dev-container-progress.png)
+
+5. After the build completes, VS Code will automatically connect to the container.
+
+You can now work with the repository source code in this isolated environment as you would if you had cloned the code locally.
+
+> **Tip:** Want to use a remote Docker host? See the [Advanced Containers article](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host) for details on setup.
 
 ## Quick start: Configure a sandbox for multiple projects or folders
 
@@ -198,30 +221,6 @@ Let's set up a container for use with all of the Python projects in the `./Repos
     ![Container explorer with multiple folders under python container](images/containers/containers-explorer-python.png)
 
 > **Tip:** Instead of mounting the local filesystem, you can use a similar flow to set up a container with an isolated, more performant volume that you clone your source code into. See the [Advanced Containers](/docs/remote/containers-advanced.md#use-a-named-volume-for-your-entire-source-tree) article for details.
-
-## Quick start: Open a Git repository in an isolated container volume
-
-While you can [open a locally cloned repository in a container](#quick-start-open-an-existing-folder-in-a-container), you may want to work with an isolated copy of a repository for a PR review or to investigate another branch without impacting your work. If you are working with a GitHub repository with an existing `devcontainer.json` file, you can use a Repository Container instead.
-
-Repository Containers use isolated, local Docker volumes instead binding to the local filesystem. In addition to not polluting your file tree, local volumes have the added benefit of improved performance on Windows and macOS. (See [Advanced Configuration](/docs/remote/containers-advanced.md#improving-container-disk-performance) for information on how to use these types of volumes in other scenarios.)
-
-For example, follow these steps to open one of the "try" repositories in a Repository Container:
-
-1. Start VS Code and run **Remote-Containers: Open Repository in Container...** from the Command Palette (`kbstyle(F1)`).
-
-2. Enter `microsoft/vscode-remote-try-node` (or one of the other "try" repositories) in the input box that appears and press `kbstyle(Enter)`.
-
-    ![Input box with a repository name in it](images/containers/vscode-remote-try-node.png)
-
-    > **Tip:** If you choose a private repository, you may want to setup a credential manager or add your SSH keys to your SSH agent. See [Sharing Git credentials with your container](#sharing-git-credentials-with-your-container).
-
-3. The VS Code window (instance) will reload, clone the source code, and start building the dev container. A progress notification provides status updates.
-
-    ![Dev Container Progress Notification](images/containers/dev-container-progress.png)
-
-4. After the build completes, VS Code will automatically connect to the container.
-
-You can now work with the repository source code in this isolated environment as you would if you had cloned the code locally.
 
 ## Creating a devcontainer.json file
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -5,7 +5,7 @@ TOCTitle: Containers
 PageTitle: Developing inside a Container using Visual Studio Code Remote Development
 ContentId: 7ec8a02b-2eb7-45c1-bb16-ddeaac694ff6
 MetaDescription: Developing inside a Container using Visual Studio Code Remote Development
-DateApproved: 3/9/2020
+DateApproved: 4/7/2020
 ---
 # Developing inside a Container
 
@@ -995,6 +995,7 @@ See the [Advanced Container Configuration](/docs/remote/containers-advanced.md) 
 * [Improving container disk performance](/docs/remote/containers-advanced.md#improving-container-disk-performance)
 * [Adding a non-root user to your dev container](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container)
 * [Avoiding extension reinstalls on container rebuild](/docs/remote/containers-advanced.md#avoiding-extension-reinstalls-on-container-rebuild)
+* [Setting the project name for Docker Compose](/docs/remote/containers-advanced.md#setting-the-project-name-for-docker-compose)
 * [Using Docker or Kubernetes from inside a container](/docs/remote/containers-advanced.md#using-docker-or-kubernetes-from-a-container)
 * [Connecting to multiple containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once)
 * [Developing inside a container on a remote Docker Machine or SSH host](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host)

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -298,17 +298,19 @@ Beyond the advantages of having your team use a consistent environment and tool-
 
 ## Attaching to running containers
 
-While using VS Code to spin up a new container can be useful in many situations, it may not match your workflow and you may prefer to "attach" VS Code to an already running Docker container - regardless of how it was started (Docker, Docker Compose, Kubernetes with Docker as the container engine, etc.). Once attached, you can install extensions, edit, and debug like you can when you open a folder in a container using `devcontainer.json`.
+While using VS Code to spin up a new container can be useful in many situations, it may not match your workflow and you may prefer to "attach" VS Code to an already running Docker container - regardless of how it was started. Once attached, you can install extensions, edit, and debug like you can when you open a folder in a container using `devcontainer.json`.
 
 > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 
-You can either select the **Remote-Containers: Attach to Running Container...** command from the Command Palette (`kbstyle(F1)`) or use the **Remote Explorer** in the Activity Bar and select the **Connect to Container** inline action on the container you want to connect to.
+### Attaching to a Docker container
+
+To attach to a Docker container, either select the **Remote-Containers: Attach to Running Container...** command from the Command Palette (`kbstyle(F1)`) or use the **Remote Explorer** in the Activity Bar and select the **Connect to Container** inline action on the container you want to connect to.
 
 ![Containers Explorer screenshot](images/containers/containers-attach.png)
 
 ### Attached container configuration files
 
-VS Code supports image-level configuration files to speed up setup when you repeatedly connect to a given container. Once attached, anytime you open a folder, [install an extension](#managing-extensions), or [forward a port](#forwarding-or-publishing-a-port), a local image-specific configuration file will automatically be updated to remember your settings so that when you attach again, everything is back to the right place.
+VS Code supports image-level configuration files to speed up setup when you repeatedly connect to a given Docker container. Once attached, anytime you open a folder, [install an extension](#managing-extensions), or [forward a port](#forwarding-or-publishing-a-port), a local image-specific configuration file will automatically be updated to remember your settings so that when you attach again, everything is back to the right place.
 
 To see or edit the configuration, select **Remote-Containers: Open Attached Container Configuration File...** command from the Command Palette (`kbstyle(F1)`). The opened file supports a subset of `devcontainer.json` properties:
 
@@ -344,6 +346,14 @@ See the [attached container config reference](#attached-container-config-referen
 Once saved, whenever you open a container for the first time with the same image name, these properties will be used to configure the environment.
 
 Finally, if you have extensions you want installed regardless of the container you attach to, you can update `settings.json` to specify a list of [extensions that should always be installed](#always-installed-extensions). We will cover this option in the next section.
+
+### Attaching to a container in a Kubernetes cluster
+
+To attach to a container in a Kuberntes cluster, first install the [Kubernetes extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) and `kubectl` along with the Remote - Containers extension. Then select the Kubernetes explorer from the activity bar and expand the cluster and Pod where the container you want to attach to resides. Finally, right-click on the container and select **Attach Visual Studio Code** from context menu.
+
+> **Note:** Attached container configuration files are not yet supported for containers in a Kubernetes cluster.
+
+![Attach to Kubernetes Container](images/containers/k8s-attach.png)
 
 ## Managing extensions
 
@@ -1144,6 +1154,10 @@ You can install extensions manually without an internet connection using the **E
 Finally, some extensions (like C#) download secondary dependencies from `download.microsoft.com` or `download.visualstudio.microsoft.com`. Others (like [Visual Studio Live Share](https://docs.microsoft.com/visualstudio/liveshare/reference/connectivity#requirements-for-connection-modes)) may have additional connectivity requirements. Consult the extension's documentation for details if you run into trouble.
 
 VS Code Server runs on a random port inside the container and VS Code itself uses `docker exec` to communicate with it over Docker's configured communication channel.
+
+### Can I use the extension with source code stored in WSL2 on Windows?
+
+If you are using [Docker Desktop's WSL2 engine](https://docs.docker.com/docker-for-windows/wsl-tech-preview/), you can enable experimental support in the Remote - Containers extension that will allow you to open folders from the `\\wsl$` share in a container. Simply check **Remote > Containers: Experimental WSL** in [VS Code settings](/docs/getstarted/settings.md) and restart VS Code. See [this excellent blog post](https://stuartleeks.com/posts/vscode-devcontainers-wsl/) for complete setup details.
 
 ### As an extension author, what do I need to do to make sure my extension works?
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -167,9 +167,11 @@ For example, follow these steps to open one of the "try" repositories in a Repos
 
     ![Dev Container Progress Notification](images/containers/dev-container-progress.png)
 
-5. After the build completes, VS Code will automatically connect to the container.
+    If you pasted in a Github pull request URL in step 2, the PR will be automatically checked out and the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension will be installed in the container. The extension provides additional PR related features like a PR explorer, interacting with PR comments inline, and status bar visibility.
 
-You can now work with the repository source code in this isolated environment as you would if you had cloned the code locally.
+    ![PR status in status bar](images/containers/checkout-pr-status.png)
+
+5. After the build completes, VS Code will automatically connect to the container.You can now work with the repository source code in this isolated environment as you would if you had cloned the code locally.
 
 > **Tip:** Want to use a remote Docker host? See the [Advanced Containers article](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host) for details on setup.
 

--- a/docs/remote/images/containers/checkout-pr-status.png
+++ b/docs/remote/images/containers/checkout-pr-status.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fd9ecfc98dd7d1dfbf33a025180a73689382ac67acb267a2ab4e7109c9b1a22
+size 52998

--- a/docs/remote/images/containers/dev-container-progress.png
+++ b/docs/remote/images/containers/dev-container-progress.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:329172293068606d2c1ff0cea7db921a23ade92b9d0b6e3139b980c792fd696e
-size 21327
+oid sha256:15a562e6d6684fac1620b1b70478b16b40d89690451823ecb1ec936a85bdf2b9
+size 24550

--- a/docs/remote/images/containers/k8s-attach.png
+++ b/docs/remote/images/containers/k8s-attach.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aedadf801753eec556511fe9cb3e91bbb70ce43719b059f7530d00ba6a44f7dc
+size 406510

--- a/docs/remote/images/containers/select-a-sample.png
+++ b/docs/remote/images/containers/select-a-sample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3b145adf64dd6f473419c77abea7c7c21fa6afa1c387d6b5113445ce61e7652
+size 127413

--- a/docs/remote/images/containers/vscode-remote-try-node.png
+++ b/docs/remote/images/containers/vscode-remote-try-node.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a708e42b2f21ed12550c8d9a76481dfb6f3c3f3df3fbe1922f697637a56a5499
-size 20962
+oid sha256:edf8510701e9ffcf70aeb401ba448e75c09fe37f6e89c63e09f312cfcbf71b69
+size 35942

--- a/docs/remote/images/ssh/ssh-select-platform.png
+++ b/docs/remote/images/ssh/ssh-select-platform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49edf90cdcba6daff3d442af3a12d5e3c2279a4017e9f19394ed755a158a3ec5
+size 24549

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -5,7 +5,7 @@ TOCTitle: SSH
 PageTitle: Developing on Remote Machines using SSH and Visual Studio Code
 ContentId: 42e65445-fb3b-4561-8730-bbd19769a160
 MetaDescription: Developing on Remote Machines or VMs using Visual Studio Code Remote Development and SSH
-DateApproved: 3/9/2020
+DateApproved: 4/8/2020
 ---
 # Remote Development using SSH
 
@@ -67,19 +67,25 @@ To connect to a remote host for the first time, follow these steps:
 
     ![Illustration of user@host input box](images/ssh/ssh-user@box.png)
 
-3. After a moment, VS Code will connect to the SSH server and set itself up. VS Code will keep you up-to-date using a progress notification and you can see a detailed log in the `Remote - SSH` output channel.
+3. If VS Code cannot automatically detect the type of server you are connecting to, you will be asked to select the type manually.
+
+    ![Illustration of platform selection](images/ssh/ssh-select-platform.png)
+
+    Once you select a platform, it will be stored in [VS Code settings](/docs/getstarted/settings.md) under the `remote.SSH.remotePlatform` property so you can change it at any time.
+
+4. After a moment, VS Code will connect to the SSH server and set itself up. VS Code will keep you up-to-date using a progress notification and you can see a detailed log in the `Remote - SSH` output channel.
 
     > **Tip:** Connection hanging or failing? See [troubleshooting tips](/docs/remote/troubleshooting.md#troubleshooting-hanging-or-failing-connections) for information on resolving common problems.
     >
     > If you see errors about SSH file permissions, see the section on [Fixing SSH file permission errors](/docs/remote/troubleshooting.md#fixing-ssh-file-permission-errors).
 
-4. After you are connected, you'll be in an empty window. You can always refer to the Status bar to see which host you are connected to.
+5. After you are connected, you'll be in an empty window. You can always refer to the Status bar to see which host you are connected to.
 
     ![SSH Status bar item](images/ssh/ssh-statusbar.png)
 
     Clicking on the Status bar item will provide a list of remote commands while you are connected.
 
-5. You can then open any folder or workspace on the remote machine using **File > Open...** or **File > Open Workspace...** just as you would locally!
+6. You can then open any folder or workspace on the remote machine using **File > Open...** or **File > Open Workspace...** just as you would locally!
 
     ![File Open on a remote SSH host](images/ssh/ssh-open-folder.png)
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -541,6 +541,29 @@ git config --global core.autocrlf false
 
 Finally, you may need to clone the repository again for these settings to take effect.
 
+### Setting the project name for Docker Compose
+
+VS Code will respect the value of [the `COMPOSE_PROJECT_NAME` environment variable](https://docs.docker.com/compose/reference/envvars/#compose_project_name) if set for the VS Code process or in a `.env` file in the root of the project.
+
+For example, after shutting down all VS Code windows, you can start VS Code from the command line as follows:
+
+```bash
+# from bash
+COMPOSE_PROJECT_NAME=foo code .
+```
+
+```PowerShell
+# from PowerShell
+$env:COMPOSE_PROJECT_NAME=foo
+code .
+```
+
+Or add the following to a `.env` file in the root of the project (**not** in the `.devcontainer` folder):
+
+```
+COMPOSE_PROJECT_NAME=foo
+```
+
 ### Avoid setting up Git in a container when using Docker Compose
 
 See [Sharing Git credentials with your container](/docs/remote/containers.md#sharing-git-credentials-with-your-container) in the main containers article for information on resolving this issue.

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -542,29 +542,6 @@ git config --global core.autocrlf false
 
 Finally, you may need to clone the repository again for these settings to take effect.
 
-### Setting the project name for Docker Compose
-
-VS Code will respect the value of [the `COMPOSE_PROJECT_NAME` environment variable](https://docs.docker.com/compose/reference/envvars/#compose_project_name) if set for the VS Code process or in a `.env` file in the root of the project.
-
-For example, after shutting down all VS Code windows, you can start VS Code from the command line as follows:
-
-```bash
-# from bash
-COMPOSE_PROJECT_NAME=foo code .
-```
-
-```PowerShell
-# from PowerShell
-$env:COMPOSE_PROJECT_NAME=foo
-code .
-```
-
-Or add the following to a `.env` file in the root of the project (**not** in the `.devcontainer` folder):
-
-```
-COMPOSE_PROJECT_NAME=foo
-```
-
 ### Avoid setting up Git in a container when using Docker Compose
 
 See [Sharing Git credentials with your container](/docs/remote/containers.md#sharing-git-credentials-with-your-container) in the main containers article for information on resolving this issue.
@@ -732,6 +709,7 @@ See the [Advanced Container Configuration](/docs/remote/containers-advanced.md) 
 * [Adding a non-root user to your dev container](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container)
 * [Improving container disk performance](/docs/remote/containers-advanced.md#improving-container-disk-performance)
 * [Avoiding extension reinstalls on container rebuild](/docs/remote/containers-advanced.md#avoiding-extension-reinstalls-on-container-rebuild)
+* [Setting the project name for Docker Compose](/docs/remote/containers-advanced.md#setting-the-project-name-for-docker-compose)
 * [Using Docker or Kubernetes from inside a container](/docs/remote/containers-advanced.md#using-docker-or-kubernetes-from-a-container)
 * [Connecting to multiple containers at once](/docs/remote/containers-advanced.md#connecting-to-multiple-containers-at-once)
 * [Developing inside a container on a remote Docker Machine or SSH host](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host)

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -533,7 +533,7 @@ If you would prefer to still always upload Unix-style line endings (LF), you can
 git config --global core.autocrlf input
 ```
 
-If you'd prefer to disable line ending conversation entirely, run the following instead:
+If you'd prefer to disable line-ending conversion entirely, run the following instead:
 
 ```bash
 git config --global core.autocrlf false
@@ -851,7 +851,7 @@ For large workspace you may want to increase the polling interval, `remote.WSL.f
 
 ### Resolving Git line ending issues in WSL (resulting in many modified files)
 
-Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line ending conversion using a `.gitattributes` file or globally on the Windows side.
+Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line-ending conversion using a `.gitattributes` file or globally on the Windows side.
 
 Typically adding or modifying a  `.gitattributes` file in your repository is the most reliable way to solve this problem. Committing this file to source control will help others and allows you to vary behaviors by repository as appropriate. For example, adding the following to `.gitattributes` file to the root of your repository will force everything to be LF, except for Windows batch files that require CRLF:
 
@@ -869,7 +869,7 @@ If you would prefer to still always upload Unix-style line endings (LF), you can
 git config --global core.autocrlf input
 ```
 
-If you'd prefer to disable line ending conversation entirely, run the following instead:
+If you'd prefer to disable line-ending conversion entirely, run the following instead:
 
 ```bash
 git config --global core.autocrlf false

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -492,6 +492,8 @@ If you are running into Docker issues or would prefer not to run Docker locally,
 
 5. **Switch out of "Linux Containers on Windows (LCOW)" mode.** While disabled by default, recent versions of Docker support [Linux Containers on Windows (LCOW)](https://docs.microsoft.com/virtualization/windowscontainers/deploy-containers/linux-containers) that can allow you to use both Windows and Linux containers at the same time. However, this is a new feature, so you may encounter issues and the Remote - Containers extension only supports Linux containers currently. You can switch out of LCOW mode at any time by right-clicking on the Docker task bar item and selecting **Switch to Linux Containers...** from the context menu.
 
+6. **Enable experimental Docker WSL2 support in VS Code settings to work with content stored in the WSL2 filesystem.** If you are using [Docker Desktop's WSL2 engine](https://docs.docker.com/docker-for-windows/wsl-tech-preview/), you can enable experimental support in the Remote - Containers extension that will allow you to open folders from the `\\wsl$` share in a container. Simply check **Remote > Containers: Experimental WSL** in [VS Code settings](/docs/getstarted/settings.md) and restart VS Code. See [this excellent blog post](https://stuartleeks.com/posts/vscode-devcontainers-wsl/) for complete setup details.
+
 If you are still having trouble, see the [Docker Desktop for Windows troubleshooting guide](https://docs.docker.com/docker-for-windows/troubleshoot/#volumes).
 
 ### Enabling file sharing in Docker Desktop

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -5,7 +5,7 @@ TOCTitle: Tips and Tricks
 PageTitle: Visual Studio Code Remote Development Troubleshooting Tips and Tricks
 ContentId: 42e65445-fb3b-4561-8730-bbd19769a160
 MetaDescription: Visual Studio Code Remote Development troubleshooting tips and tricks for SSH, Containers, and the Windows Subsystem for Linux (WSL)
-DateApproved: 3/9/2020
+DateApproved: 4/8/2020
 ---
 # Remote Development Tips and Tricks
 
@@ -158,11 +158,8 @@ If you are still having trouble, set the following properties in `settings.json`
 
 ```json
 "remote.SSH.showLoginTerminal": true,
-"remote.SSH.useLocalServer": false,
-"remote.SSH.windowsRemotes": ["<your remote's hostname>"]
+"remote.SSH.useLocalServer": false
 ```
-
-The last property is only required if you are connecting to a Windows host.
 
 **Work around a bug with some versions of Windows OpenSSH server**
 
@@ -171,8 +168,15 @@ Due to a bug in certain versions of OpenSSH server for Windows, the default chec
 Fortunately, you can work around this problem by specifically telling VS Code if your SSH host is running Windows by adding the following to `settings.json`:
 
 ```json
-"remote.SSH.useLocalServer": false,
-"remote.SSH.windowsRemotes": ["<your remote's hostname>"]
+"remote.SSH.useLocalServer": false
+```
+
+You can also force VS Code to identify a particular host as Windows using the following property:
+
+```json
+"remote.SSH.remotePlatform": {
+    "host-in-ssh-config-or-fqdn": "windows"
+}
 ```
 
 A fix has been merged so this problem should be resolved in a version of the server greater than 8.1.0.0.
@@ -249,11 +253,8 @@ If you are still having trouble, you may need to the following properties in `se
 
 ```json
 "remote.SSH.showLoginTerminal": true,
-"remote.SSH.useLocalServer": false,
-"remote.SSH.windowsRemotes": ["<your remote's hostname>"]
+"remote.SSH.useLocalServer": false
 ```
-
-The last property is only required if you are connecting to a Windows host.
 
 If you are on macOS and Linux and want to reduce how often you have to enter a password or token, you can enable the `ControlMaster` feature on your **local machine** so that OpenSSH runs multiple SSH sessions over a single connection.
 

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -5,7 +5,7 @@ TOCTitle: Windows Subsystem for Linux
 PageTitle: Developing in the Windows Subsystem for Linux with Visual Studio Code
 ContentId: 79bcdbf9-d6a5-4e04-bbee-e7bb71f09f0a
 MetaDescription: Using Visual Studio Code Remote Development with the Windows Subsystem for Linux (WSL)
-DateApproved: 3/9/2020
+DateApproved: 4/7/2020
 ---
 # Developing in WSL
 

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -254,6 +254,10 @@ For example, the setting below will force the Docker extension to run locally an
 
 A value of `"ui"` instead of `"workspace"` will force the extension to run on the local UI/client side instead. Typically, this should only be used for testing unless otherwise noted in the extension's documentation since it **can break extensions**. See the article on [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for details.
 
+### Can I use the Remote - Containers extension to work with source code stored in WSL2 on Windows?
+
+If you are using [Docker Desktop's WSL2 engine](https://docs.docker.com/docker-for-windows/wsl-tech-preview/), you can enable experimental support in the Remote - Containers extension that will allow you to open folders from the `\\wsl$` share in a container. Simply check **Remote > Containers: Experimental WSL** in [VS Code settings](/docs/getstarted/settings.md) and restart VS Code. See [this excellent blog post](https://stuartleeks.com/posts/vscode-devcontainers-wsl/) for complete setup details.
+
 ### As an extension author, what do I need to do?
 
 The VS Code extension API abstracts away local/remote details so most extensions will work without modification. However, given extensions can use any node module or runtime they want, there are situations where adjustments may need to be made. We recommend you test your extension to be sure that no updates are required. See [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for details.

--- a/release-notes/v1_44.md
+++ b/release-notes/v1_44.md
@@ -389,7 +389,8 @@ Work continues on the [Remote Development extensions](https://marketplace.visual
 Feature highlights in 1.44 include:
 
 * Remote - Containers: Check out a PR directly into a container.
-* Remote - Containers: Kubernetes container support.
+* Remote - Containers: Kubernetes container attach support.
+* Remote - Containers: Experimental WSL2 Docker engine support.
 
 You can learn about new extension features and bug fixes in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/tree/master/remote-release-notes/v1_44.md).
 

--- a/remote-release-notes/v1_44.md
+++ b/remote-release-notes/v1_44.md
@@ -32,6 +32,14 @@ You can now attach to a container in Kubernetes. When the [Kubernetes extension]
 
 ![Attach to Kubernetes Container](images/1_44/k8s-attach.png)
 
+## Python pre-built container images
+
+You can now take advantage of set of pre-built 3, 3.6, 3.7, and 3.8 development container images that include common Python utilities (e.g. pylint) and dependencies, such as [Git](https://git-scm.com/), [zsh](https://en.wikipedia.org/wiki/Z_shell), and [Oh My Zsh!](https://ohmyz.sh/). Their README and sources are available in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3) repository.
+
+These same images are also used when you select the related language / platform by using the **Remote-Containers: Add Development Container Configuration Files** or **Remote-Containers: Open Folder in Container** / **Remote-Containers: Reopen Folder in Container** commands from the Command Palette (`kbstyle(F1)`) on an empty folder.
+
+Check out our [Docker Hub page](https://hub.docker.com/_/microsoft-vscode-devcontainers) for a list of other available images.
+
 ### Support user-supplied project name
 
 When using Docker-Compose for your devcontainer you can now specify a project name by environment variable (`COMPOSE_PROJECT_NAME`) or `.env` file in the project folder. This aligns Remote-Containers with the existing functionality in Docker-Compose.


### PR DESCRIPTION
This PR adds:
1. Some refactoring around quick starts given improvements to open repository in container. Specifically, it uses the "Remote-Containers: Try a sample..." command as a starting point, covers how to use an existing folder next, then covers open repository mentioning its perf benifits.
2. Attach support for Kubernetes
3. Notes on experimental WSL2 support
4. A tip on the COMPOSE_PROJECT_NAME environment variable
5. Some related tweaks to release notes like mentioning the Python pre-built images

