### PR TITLE
Rename Inspect TM Scopes

### DIFF
--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -206,7 +206,7 @@ $ npx js-yaml syntaxes/abc.tmLanguage.yaml > syntaxes/abc.tmLanguage.json
 
 VS Code's built-in scope inspector tool helps debug grammars. It displays the scopes for the token at the current position in a file, along with metadata about which theme rules apply to that token.
 
-Trigger the scope inspector from the Command Palette with the `Developer: Inspect TM Scopes` command or [create a keybinding](/docs/getstarted/keybindings) for it:
+Trigger the scope inspector from the Command Palette with the `Developer: Inspect Editor Tokens and Scopes` command or [create a keybinding](/docs/getstarted/keybindings) for it:
 
 ```json
 {

--- a/blogs/2017/02/08/syntax-highlighting-optimizations.md
+++ b/blogs/2017/02/08/syntax-highlighting-optimizations.md
@@ -597,7 +597,7 @@ Folding is consuming a lot of memory, especially for large files (that's an opti
 
 ### New TextMate Scope Inspector Widget
 
-We've added a new widget to help with authoring and debugging themes or grammars: You can run it with **Developer: Inspect TM Scopes** in the **Command Palette** (`kb(workbench.action.showCommands)`).
+We've added a new widget to help with authoring and debugging themes or grammars: You can run it with **Developer: Inspect Editor Tokens and Scopes** in the **Command Palette** (`kb(workbench.action.showCommands)`).
 
 ![TextMate scope inspector](TM-scope-inspector.gif)
 


### PR DESCRIPTION
Command title was changes in v1.42 however docs still had old name.

This PR updates name in docs to match name in VS Code.

There is third mention of old name, however it is in v1.9 release notes and I don't think it make sense to rename it there.
https://github.com/microsoft/vscode-docs/blob/master/release-notes/v1_9.md#new-tools-for-inspecting-textmate-scopes