### PR TITLE
Fix doc bug mentioned in https://github.com/microsoft/vscode-dev-containers/issues/280

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -955,10 +955,12 @@ While the `postCreateCommand` property allows you to install additional tools in
 version: '3'
 services:
   your-service-name-here:
+      # Note that the path of the Dockerfile and context is relative to the *primary*
+      # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+      # array). The sample below assumes your primary file is in the root of your project.
       build:
         context: .
-        # Location is relative to folder containing this compose file
-        dockerfile: Dockerfile
+        dockerfile: .devcontainer/Dockerfile
       volumes:
         - .:/workspace:cached
       command: /bin/sh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
Path of custom dockerfile needs to be relative to the location of the primary docker compose file. 