### PR TITLE
Docker development environment topic updates

### DIFF
--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -9,7 +9,7 @@ MetaDescription: Guidance on choosing remote or local environments for developin
 ---
 # Your development environment
 
-You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation. Docker is supported on Windows, MacOS, and various Linux distributions; for system and hardware requirements refer to [Docker installation page](https://docs.docker.com/get-docker/).
+You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation. Docker is supported on Windows, macOS, and various Linux distributions; for system and hardware requirements refer to [Docker installation page](https://docs.docker.com/get-docker/).
 
 [A remote development environment](/docs/remote/remote-overview.md) is different from your developer workstation. It can be a remote machine accessible via SSH, a virtual machine running on your developer workstation, or a development container. A remote environment can have advantages over the local environment, the main one being the ability to use the same operating system during development, and when your service is running in production. To use a remote environment, you need to ensure that `docker` command (Docker CLI) [is available and functional within that environment](#enabling-docker-cli-inside-a-remote-development-environment).
 

--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -9,7 +9,7 @@ MetaDescription: Guidance on choosing remote or local environments for developin
 ---
 # Your development environment
 
-You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation.
+You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation. Docker is supported on Windows, MacOS, and various Linux distributions; for system and hardware requirements refer to [Docker installation page](https://docs.docker.com/get-docker/).
 
 [A remote development environment](/docs/remote/remote-overview.md) is different from your developer workstation. It can be a remote machine accessible via SSH, a virtual machine running on your developer workstation, or a development container. A remote environment can have advantages over the local environment, the main one being the ability to use the same operating system during development, and when your service is running in production. To use a remote environment, you need to ensure that `docker` command (Docker CLI) [is available and functional within that environment](#enabling-docker-cli-inside-a-remote-development-environment).
 
@@ -28,7 +28,7 @@ The second important choice is whether to debug your service running as an ordin
 
 1. Debugging your service running in a container is possible, but brings additional complexity. Use normal debugging by default, and debugging in the container when you need it.
 
-> The Docker extension natively supports container debugging for .NET- and Node.js-based services only.
+> The Docker extension natively supports container debugging for .NET-, Node.js-, and Python-based based services.
 
 ## Enabling Docker CLI inside a remote development environment
 

--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -28,7 +28,7 @@ The second important choice is whether to debug your service running as an ordin
 
 1. Debugging your service running in a container is possible, but brings additional complexity. Use normal debugging by default, and debugging in the container when you need it.
 
-> The Docker extension natively supports container debugging for .NET-, Node.js-, and Python-based based services.
+> The Docker extension natively supports container debugging for .NET-, Node.js-, and Python-based services.
 
 ## Enabling Docker CLI inside a remote development environment
 

--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -9,7 +9,7 @@ MetaDescription: Guidance on choosing remote or local environments for developin
 ---
 # Your development environment
 
-You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation. Docker is supported on Windows, macOS, and various Linux distributions; for system and hardware requirements refer to [Docker installation page](https://docs.docker.com/get-docker/).
+You can choose whether to develop a container-based service in the **local environment**, or in a **remote environment**. The local environment is the operating system of your developer workstation; using the local environment means you build and run your service container(s) using Docker installed on your workstation. Docker is supported on Windows, macOS, and various Linux distributions; for system and hardware requirements, refer to [Docker installation page](https://docs.docker.com/get-docker/).
 
 [A remote development environment](/docs/remote/remote-overview.md) is different from your developer workstation. It can be a remote machine accessible via SSH, a virtual machine running on your developer workstation, or a development container. A remote environment can have advantages over the local environment, the main one being the ability to use the same operating system during development, and when your service is running in production. To use a remote environment, you need to ensure that `docker` command (Docker CLI) [is available and functional within that environment](#enabling-docker-cli-inside-a-remote-development-environment).
 


### PR DESCRIPTION
1. Add Python as supported target for Docker debugging

2. Add a sentence that points to Docker installation documentation. 
We recently received a complaint from a user that tried to install Docker extension on Windows Family edition; this succeeds, but Docker is not supported on that Windows SKU and so it cannot be used for Docker development. This is an attempt to clarify the requirements