### PR TITLE
Typo / Incorrect suffix

### DIFF
--- a/api/extension-guides/color-theme.md
+++ b/api/extension-guides/color-theme.md
@@ -86,7 +86,7 @@ You can also use an existing TextMate theme by telling the extension generator t
 }
 ```
 
-> **Tip:** Give your color definition file the `.color-theme.json` suffix and you will get hovers, code completion, color decorators, and color pickers when editing.
+> **Tip:** Give your color definition file the `-color-theme.json` suffix and you will get hovers, code completion, color decorators, and color pickers when editing.
 
 > **Tip:** [ColorSublime](https://colorsublime.github.io) has hundreds of existing TextMate themes to choose from. Pick a theme you like and copy the Download link to use in the Yeoman generator or into your extension. It will be in a format like `"https://raw.githubusercontent.com/Colorsublime/Colorsublime-Themes/master/themes/(name).tmTheme"`
 


### PR DESCRIPTION
Using the `.color-theme.json` suffix does not enable hover support and code completions.  The files generated by 'yo code' use a `-color-theme.json` suffix, which works.  Example `dark-color-theme.json`.