### PR TITLE
Add Open Liberty to 'Working with application servers in Visual Studio Code'

### DIFF
--- a/docs/java/images/java-tomcat-jetty/open-liberty.mp4
+++ b/docs/java/images/java-tomcat-jetty/open-liberty.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e3f79bb02b4a5e0163bb85b24b6ed473694fe57697725ca468be3f9696d2d46
+size 4731893

--- a/docs/java/java-tomcat-jetty.md
+++ b/docs/java/java-tomcat-jetty.md
@@ -5,7 +5,7 @@ TOCTitle: Application Servers
 ContentId: 4f5e169c-d91d-46b7-8c36-b695b5862313
 PageTitle: Working with application servers in Visual Studio Code
 DateApproved: 1/2/2019
-MetaDescription: Tomcat and Jetty extensions for Java developer using Visual Studio Code.
+MetaDescription: Tomcat, Jetty and Open Liberty extensions for Java developer using Visual Studio Code.
 ---
 
 # Working with Application Servers in VS Code
@@ -51,9 +51,9 @@ More details could be found in the [GitHub repository](https://github.com/summer
 
 ## Open Liberty
 
-The [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension lets you run your application on Open Liberty in development mode, allowing you to deploy, test and debug your application from Visual Studio Code.
+The [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension lets you run your application on Open Liberty, allowing you to deploy, test and debug your application from Visual Studio Code.
 
-While your Open Liberty server is running in development mode your code is automatically compiled and deployed to the running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
+After you start your application with the Open Liberty tools extension, your code is automatically compiled and deployed to the running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
 
 More details can be found in the [GitHub repository](https://github.com/OpenLiberty/liberty-dev-vscode-ext) of the [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension.
 

--- a/docs/java/java-tomcat-jetty.md
+++ b/docs/java/java-tomcat-jetty.md
@@ -12,7 +12,7 @@ MetaDescription: Tomcat and Jetty extensions for Java developer using Visual Stu
 
 Visual Studio Code is a code editor-centric development tool, so it doesn't come with any embedded application server. For most servers, you will need to deploy them using the command line, and then use the appropriate debugger [configuration](https://code.visualstudio.com/docs/java/java-debugging#_configuration) if you wish to attach to it.
 
-On the other hand, we know that for certain Java workloads, server integration is very useful. With Visual Studio Code, you can find 3rd party extensions for popular application servers, for example [Tomcat](https://tomcat.apache.org/) and [Jetty](https://www.eclipse.org/jetty/), which are helpful when working with those servers locally.
+On the other hand, we know that for certain Java workloads, server integration is very useful. With Visual Studio Code, you can find 3rd party extensions for popular application servers, for example [Tomcat](https://tomcat.apache.org/), [Jetty](https://www.eclipse.org/jetty/) and [Open Liberty](https://openliberty.io/), which are helpful when working with those servers locally.
 
 For [Spring Boot Dashboard](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-spring-boot-dashboard), see [Spring Boot in Visual Studio Code](/docs/java/java-spring-boot.md).
 
@@ -48,6 +48,14 @@ The extension includes the following features:
 </video>
 
 More details could be found in the [GitHub repository](https://github.com/summersun/vscode-jetty) of the [Jetty for Java](https://marketplace.visualstudio.com/items?itemName=SummerSun.vscode-jetty) extension.
+
+## Open Liberty
+
+The [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension lets you run your application on Open Liberty in development mode, allowing you to deploy, test and debug your application from Visual Studio Code.
+
+While your Open Liberty server is running in development mode your code is automatically compiled and deployed to the running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
+
+More details can be found in the [GitHub repository](https://github.com/OpenLiberty/liberty-dev-vscode-ext) of the [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension.
 
 ## Other servers
 

--- a/docs/java/java-tomcat-jetty.md
+++ b/docs/java/java-tomcat-jetty.md
@@ -53,7 +53,11 @@ More details could be found in the [GitHub repository](https://github.com/summer
 
 The [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension lets you run your application on Open Liberty, allowing you to deploy, test and debug your application from Visual Studio Code.
 
-After you start your application with the Open Liberty tools extension, your code is automatically compiled and deployed to the running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
+After you start your application with the Open Liberty Tools extension, your code is automatically compiled and deployed to the running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-tomcat-jetty/open-liberty.mp4" type="video/mp4">
+</video>
 
 More details can be found in the [GitHub repository](https://github.com/OpenLiberty/liberty-dev-vscode-ext) of the [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) extension.
 


### PR DESCRIPTION
Hi 👋, we over at IBM/Open Liberty would like to add a section for Open Liberty and the Open Liberty Tools vscode extension in the `Working with application servers in Visual Studio Code` section of the java docs.

We wrote up a draft here for you to review and also included a small video similar to Tomcat and Jetty.

cc @yeekangc @ericglau
