### PR TITLE
Update mac.md

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -12,9 +12,10 @@ MetaDescription: Get Visual Studio Code up and running on Mac (macOS).
 ## Installation
 
 1. [Download Visual Studio Code](https://go.microsoft.com/fwlink/?LinkID=534106) for macOS.
-2. Double-click on the downloaded archive to expand the contents.
-3. Drag `Visual Studio Code.app` to the `Applications` folder, making it available in the `Launchpad`.
-4. Add VS Code to your Dock by right-clicking on the icon to bring up the context menu and choosing **Options**, **Keep in Dock**.
+2. Open the browser's download list and locate the downloaded archive.
+3. Click on the 'spyglass' icon to open the archive.
+4. Drag `Visual Studio Code.app` to the `Applications` folder, making it available in the `Launchpad`.
+5. Add VS Code to your Dock by right-clicking on the icon to bring up the context menu and choosing **Options**, **Keep in Dock**.
 
 ## Launching from the command line
 


### PR DESCRIPTION
Double-clicking on the downloaded archive will run the installer rather than opening the archive (on Catalina at least - not sure about earlier macOS versions. Altered instructions to click the 'spyglass' icon instead.