### PR TITLE
Fix property name in config example

### DIFF
--- a/docs/cpp/customize-default-settings-cpp.md
+++ b/docs/cpp/customize-default-settings-cpp.md
@@ -20,7 +20,7 @@ C_Cpp.default.includePath                          : string[]
 C_Cpp.default.defines                              : string[]
 C_Cpp.default.compileCommands                      : string
 C_Cpp.default.macFrameworkPath                     : string[]
-C_Cpp.default.forcedIncludes                       : string[]
+C_Cpp.default.forcedInclude                        : string[]
 C_Cpp.default.intelliSenseMode                     : string
 C_Cpp.default.compilerPath                         : string
 C_Cpp.default.cStandard                            : c89 | c99 | c11
@@ -47,13 +47,13 @@ A special variable has been added to the accepted syntax of `c_cpp_properties.js
             "${default}"
         ],
         "defines": [
-            "${default}",
+            "${default}"
         ],
         "macFrameworkPath": [
             "${default}",
             "additional/paths"
         ],
-        "forceInclude": [
+        "forcedInclude": [
             "${default}",
             "additional/paths"
         ],


### PR DESCRIPTION
Fixed the 'forcedInclude' property name on the "C++ / Customizing default settings" page.
Also removed the trailing comma from the configuration example.