### PR TITLE
Adding note about Visual Studio Code package

### DIFF
--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -39,6 +39,10 @@ Open up **Unity Preferences**, **External Tools**, then browse for the Visual St
 
 **Unity has built-in support for opening scripts in Visual Studio Code** as an external script editor on Windows and macOS. Unity will detect when Visual Studio Code is selected as an external script editor and pass the correct arguments to it when opening scripts from Unity. Unity will also set up a default `.vscode/settings.json` with file excludes, if it does not already exist (from [Unity 5.5 Release notes](https://unity3d.com/unity/whats-new/unity-5.5.0)).
 
+## Unity version 2019.2 or above
+
+![Since 2019.2](https://unity.com/releases/2019-2/programmer-tools?_ga=2.263983429.835985756.1588249450-1690575186.1582327051#ide-support-moving-packages) it is required to use the Visual Studio Code editor package. The built-in support for opening scipts from Unity and getting csproj and sln files generated has been removed.
+
 ## Editing Evolved
 
 With the solution file selected, you are now ready to start editing with VS Code. Here is a list of some of the things you can expect:


### PR DESCRIPTION
Since 2019.2 it is required to install the vscode package. This should be added to projects by default, but having this information here seems valuable.