### PR TITLE
Added CELA-approved note about MSVC license

### DIFF
--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -26,7 +26,7 @@ To successfully complete this tutorial, you must do the following:
     ![C/C++ extension](images/cpp/cpp-extension.png)
 
 1. Install the Microsoft Visual C++ (MSVC) compiler toolset.
-
+   
    If you have a recent version of Visual Studio, open the Visual Studio Installer from the Windows Start menu and verify that the C++ workload is checked. If it's not installed, then check the box and click the **Modify** button in the installer.
 
    You can also install just the **C++ Build Tools**, without a full Visual Studio IDE installation. From the Visual Studio [Downloads](https://visualstudio.microsoft.com/downloads#other) page, scroll down until you see **Tools for Visual Studio** under the **All downloads** section and select the download for **Build Tools for Visual Studio**.
@@ -36,6 +36,8 @@ To successfully complete this tutorial, you must do the following:
    This will launch the Visual Studio Installer, which will bring up a dialog showing the available Visual Studio Build Tools workloads. Check the **C++ build tools** workload and select **Install**.
 
    ![Cpp build tools workload](images/msvc/cpp-build-tools.png)
+   
+    You can use the C++ Toolset from Visual Studio Build Tools along with Visual Studio Code to compile, build, and verify any C++ codebases as long as you also have a valid Visual Studio license (either Community, Pro or Enterprise) that you are actively using to develop these C++ codebases.
 
 ### Check your Microsoft Visual C++ installation
 


### PR DESCRIPTION
"You can use the C++ Toolset from Visual Studio Build Tools along with Visual Studio Code to compile, build, and verify any C++ codebases as long as you also have a valid Visual Studio license (either Community, Pro or Enterprise) that you are actively using to develop these C++ codebases."