### PR TITLE
Updated automated publishing steps

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -19,8 +19,6 @@ The publish command is similar to publishing from a local environment using [`vs
 
 # Example Implementations
 
-The following examples use a sample project that uses [Yarn](https://yarnpkg.com/), but can be adapted to use [npm](https://www.npmjs.com/) as well.
-
 ## Azure Pipelines
 
 <a href="https://azure.microsoft.com/services/devops/"><img alt="Azure Pipelines" src="/assets/api/working-with-extensions/continuous-integration/pipelines-logo.png" width="318" /></a>
@@ -253,3 +251,9 @@ The [`stages`](https://docs.travis-ci.com/user/conditional-builds-stages-jobs#co
 In our example, the condition has one check:
 
 - `env(TRAVIS_TAG) =~ ^v` - Publish only if a tagged (release) build that starts with the letter `v`.
+
+## Common questions
+
+### Do I need to use Yarn for continuous integration?
+
+All of the above examples refer to a hypothetical project built with [Yarn](https://yarnpkg.com/), but can be adapted to use [npm](https://www.npmjs.com/), [Grunt](https://gruntjs.com/), [Gulp](https://gulpjs.com/), or any other Javascript build tool.

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -15,9 +15,7 @@ Extension integration tests can be run on CI services. The [`vscode-test`](https
 
 You can also configure the CI to publish a new version of the extension automatically.
 
-The publish command is similar to publishing from a local environment using the [`vsce`](https://github.com/Microsoft/vsce) service but the command needs to also include the Personal Access Token (PAT). [`vsce`](https://github.com/Microsoft/vsce) can also pick up on the `VSCE_PAT` environmental variable for the Personal Access Token.
-
-You shouldn't expose the PAT with the rest of the source code (it's a sensitive information), so you can store it in a "secret variable". The value of that variable will not be exposed and you can use it in the CI pipline.
+The publish command is similar to publishing from a local environment using [`vsce`](https://github.com/Microsoft/vsce), but you must somehow provide the Personal Access Token (PAT) in a secure way. By storing the PAT as a `VSCE_PAT` _secret variable_, `vsce` will be able to use it. Secret variables are never exposed, so they are safe to use in a CI pipeline.
 
 # Example Implementations
 

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -132,7 +132,7 @@ The publish command is similar to publishing from a local environment using the 
 
 You shouldn't expose the PAT with the rest of the source code (it's a sensitive information), so you can store it in a "secret variable". The value of that variable will not be exposed and you can use it in the `azure-pipelines.yml` file.
 
-To create a secret variable named `VSCE_PAT`, follow the [Azure DevOps Secrets instructions](https://docs.microsoft.com/azure/devops/pipelines/process/variables?tabs=classic%2Cbatch#secret-variables).
+To setup `VSCE_PAT` as a secret variable, follow the [Azure DevOps Secrets instructions](https://docs.microsoft.com/azure/devops/pipelines/process/variables?tabs=classic%2Cbatch#secret-variables).
 
 Next steps will be:
 

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -128,7 +128,7 @@ cache: yarn
 
 You can configure the CI to publish a new version of the extension automatically.
 
-The publish command is similar to publishing from a local environment using the [`vsce`](https://github.com/Microsoft/vsce) service but the command needs to also include the Personal Access Token (PAT). By default, [`vsce`](https://github.com/Microsoft/vsce) will use an environmental variable named `VSCE_PAT` (if defined) for the Personal Access Token.
+The publish command is similar to publishing from a local environment using the [`vsce`](https://github.com/Microsoft/vsce) service but the command needs to also include the Personal Access Token (PAT). [`vsce`](https://github.com/Microsoft/vsce) can also pick up on the `VSCE_PAT` environmental variable for the Personal Access Token.
 
 You shouldn't expose the PAT with the rest of the source code (it's a sensitive information), so you can store it in a "secret variable". The value of that variable will not be exposed and you can use it in the `azure-pipelines.yml` file.
 

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -128,11 +128,11 @@ cache: yarn
 
 You can configure the CI to publish a new version of the extension automatically.
 
-The publish command is similar to publishing from a local environment using the [`vsce`](https://github.com/Microsoft/vsce) service but the command needs to also include the Personal Access Token (PAT).
+The publish command is similar to publishing from a local environment using the [`vsce`](https://github.com/Microsoft/vsce) service but the command needs to also include the Personal Access Token (PAT). By default, [`vsce`](https://github.com/Microsoft/vsce) will use an environmental variable named `VSCE_PAT` (if defined) for the Personal Access Token.
 
 You shouldn't expose the PAT with the rest of the source code (it's a sensitive information), so you can store it in a "secret variable". The value of that variable will not be exposed and you can use it in the `azure-pipelines.yml` file.
 
-To create a secret variable, follow the [Azure DevOps Secrets instructions](https://docs.microsoft.com/azure/devops/pipelines/process/variables?tabs=classic%2Cbatch#secret-variables).
+To create a secret variable named `VSCE_PAT`, follow the [Azure DevOps Secrets instructions](https://docs.microsoft.com/azure/devops/pipelines/process/variables?tabs=classic%2Cbatch#secret-variables).
 
 Next steps will be:
 
@@ -155,12 +155,12 @@ trigger:
     include: ['*']
 ```
 
-4. Add a `publish` step in `azure-pipelines.yml` that calls `yarn deploy` with the secret variable. (`VSCODE_MARKETPLACE_TOKEN` in the example should be replaced with the name of the secret you created at the beginning of the process).
+4. Add a `publish` step in `azure-pipelines.yml` that calls `yarn deploy` with the secret variable.
 
 ```yaml
 - bash: |
     echo ">>> Publish"
-    yarn deploy -p $(VSCODE_MARKETPLACE_TOKEN)
+    yarn deploy
   displayName: Publish
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Agent.OS'], 'Linux'))
 ```

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -78,7 +78,7 @@ Give the Personal Access Token a name, optionally extend its expiration date to 
 
 ![Personal access token details](images/publishing-extension/token3.png)
 
-Finally, scroll down the list of possible scopes until you find **Marketplace** and select both **Acquire** and **Manage**:
+Finally, scroll down the list of possible scopes until you find **Marketplace** and select **Manage**:
 
 ![Personal access token details](images/publishing-extension/token4.png)
 
@@ -254,7 +254,7 @@ This will always invoke the [TypeScript](https://www.typescriptlang.org/) compil
 
 ### I get 403 Forbidden (or 401 Unauthorized) error when I try to publish my extension?
 
-One easy mistake to make when creating the PAT (Personal Access Token) is to not select `all accessible accounts` in the Accounts field drop-down (instead selecting a specific account). You should also set the Authorized Scopes to `All scopes` for the publish to work.
+One easy mistake to make when creating the PAT (Personal Access Token) is to not select `all accessible accounts` in the Accounts field drop-down (instead selecting a specific account). You should also set the Authorized Scopes to `Marketplace (Manage)` for the publish to work.
 
 ### I can't unpublish my extension through the `vsce` tool?
 

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -114,13 +114,6 @@ You can also enter your Personal Access Token as you publish with an optional pa
 vsce publish -p <token>
 ```
 
-Your Personal Access Token may also be defined by the `VSCE_PAT` environmental variable.
-
-```bash
-export VSCE_PAT=97bd38305a81f2d89b5f3aa44500ec964b87cf8a
-vsce publish
-```
-
 ## Auto-incrementing the extension version
 
 You can auto-increment an extension's version number when you publish by specifying the [SemVer](https://semver.org/) compatible number to increment: `major`, `minor`, or `patch`.

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -266,4 +266,4 @@ Please note that when building and publishing your extension from Windows, all t
 
 ### Can I publish from a continuous integration (CI) build?
 
-Yes, see the [Automated publishing](/api/working-with-extensions/continuous-integration#automated-publishing) section of the [Continuous Integration](/api/working-with-extensions/continuous-integration) topic to learn how to configure Azure DevOps to automatically publish your extension to the Marketplace.
+Yes, see the [Automated publishing](/api/working-with-extensions/continuous-integration#automated-publishing) section of the [Continuous Integration](/api/working-with-extensions/continuous-integration) topic to learn how to configure Azure DevOps, GitHub Actions, and TravisCI to automatically publish your extension to the Marketplace.

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -114,6 +114,13 @@ You can also enter your Personal Access Token as you publish with an optional pa
 vsce publish -p <token>
 ```
 
+Your Personal Access Token may also be defined by the `VSCE_PAT` environmental variable.
+
+```bash
+export VSCE_PAT=97bd38305a81f2d89b5f3aa44500ec964b87cf8a
+vsce publish
+```
+
 ## Auto-incrementing the extension version
 
 You can auto-increment an extension's version number when you publish by specifying the [SemVer](https://semver.org/) compatible number to increment: `major`, `minor`, or `patch`.


### PR DESCRIPTION
As part of https://github.com/microsoft/vscode-vsce/pull/447, supplying a PAT is now possible via an environmental variable.

This change updates the relevant documentation to reflect the ability to use convention over configuration and/or explicit coding to inject a PAT in order to publish an extension.