### PR TITLE
Fix broken setup container link

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -1020,7 +1020,7 @@ See the [Advanced Container Configuration](/docs/remote/containers-advanced.md) 
 
 ## devcontainer.json reference
 
-See [Setting up a folder to run in a container](#in-depth-setting-up-a-folder-to-run-in-a-container) for more information on configuring a dev container or the [vscode-dev-containers repository](https://github.com/Microsoft/vscode-dev-containers/tree/master/containers) for a wide variety of base configurations.
+See [Setting up a folder to run in a container](#indepth-setting-up-a-folder-to-run-in-a-container) for more information on configuring a dev container or the [vscode-dev-containers repository](https://github.com/Microsoft/vscode-dev-containers/tree/master/containers) for a wide variety of base configurations.
 
 | Property | Type | Description |
 |----------|------|-------------|


### PR DESCRIPTION
"Setting up a folder to run in a container" link has an extra `-` which is breaking the link in the docs website. See: https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference

