### PR TITLE
Clarify how "current workspace" is set

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -173,7 +173,9 @@ Finally, if you've already built the container and connected to it, run **Remote
 
 ## Changing the default source code mount
 
-If you add the `image` or `dockerFile` properties to `devcontainer.json`, VS Code will automatically "bind" mount your current workspace folder into the container. While this is convenient, you may want to change [mount settings](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems), alter the type of mount, location, or [run in a remote container](#developing-inside-a-container-on-a-remote-docker-host).
+If you add the `image` or `dockerFile` properties to `devcontainer.json`, VS Code will automatically "bind" mount your current workspace folder into the container.  If `git` is present on the host's `PATH` and the folder containing `./devcontainer/devcontainer.json` is within a `git` repository, the current workspace mounted will be the root of the repository.  If `git` is not present on the host's `PATH` the current workspace mounted will be the folder containing `./devcontainer/devcontainer.json`.
+
+While this is convenient, you may want to change [mount settings](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems), alter the type of mount, location, or [run in a remote container](#developing-inside-a-container-on-a-remote-docker-host).
 
 You can use the `workspaceMount` property in `devcontainer.json` to change the automatic mounting behavior. It expects the same value as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#add-bind-mounts-or-volumes-using-the---mount-flag).
 


### PR DESCRIPTION
After spending part of a day troubleshooting why one of my devs was having the actual folder containing `.devcontainer` mounted, while everyone else was having the repository root folder mounted within their dev containers, we discovered that is because the "current workspace" changes to the repository root only if git is present on the user's `PATH` environment variable.  This is apparently the default value for the `workspaceMount` setting.  To be clear, however, the `${localWorkspaceFolder}` variable value does not change.

My dev (on a Windows host) was using git embedded in his terminal of choice, meaning vscode was unaware of the presence of a git.exe or the surrounding repo.

I think this is appropriate behavior (and we rely on it), but it needs to be documented properly so folks aren't going on a wild goose chase.

Let me know if you have any questions or how I can better explain this.