### PR TITLE
Python linter pep8 was renamed to pycodestyle

### DIFF
--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -60,7 +60,7 @@ IntelliSense quickly shows methods, class members, and documentation as you type
 
 Linting analyzes your Python code for potential errors, making it easy to navigate to and correct different problems.
 
-The Python extension can apply a number of different linters including Pylint, Pep8, Flake8, mypy, pydocstyle, prospector, and pylama. See [Linting](/docs/python/linting.md).
+The Python extension can apply a number of different linters including Pylint, pycodestyle, Flake8, mypy, pydocstyle, prospector, and pylama. See [Linting](/docs/python/linting.md).
 
 <video id="python-linting-video" src="https://az754404.vo.msecnd.net/public/python-linting.mp4" poster="/images/python_python-linting-placeholder.png" autoplay loop controls muted></video>
 

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -68,7 +68,7 @@ The following table provides a summary of available Python linters and their bas
 | [Flake8](#flake8) | [flake8](https://pypi.org/project/flake8/) | Disabled | flake8Enabled | flake8Args | flake8Path |
 | [mypy](#mypy) | [mypy](https://pypi.org/project/mypy/) | Disabled | mypyEnabled | mypyArgs | mypyPath |
 | [pydocstyle](#pydocstyle) | [pydocstyle](https://pypi.org/project/pydocstyle/) | Disabled | pydocstyleEnabled | pydocstyleArgs | pydocstylePath |
-| [Pep8 (pycodestyle)](#pep8-pycodestyle) | [pep8](https://pypi.org/project/pep8/) | Disabled | pep8Enabled | pep8Args | pep8Path |
+| [pycodestyle (pep8)](#pycodestyle-pep8) | [pycodestyle](https://pypi.org/project/pycodestyle/) | Disabled | pycodestyleEnabled | pycodestyleArgs | pycodestylePath |
 | [prospector](#prospector) | [prospector](https://pypi.org/project/prospector/) | Disabled | prospectorEnabled | prospectorArgs | prospectorPath |
 | pylama | [pylama](https://pypi.org/project/pylama/) | Disabled | pylamaEnabled | pylamaArgs | pylamaPath |
 | bandit | [bandit](https://pypi.org/project/bandit/) | Disabled | banditEnabled | banditArgs | banditPath |
@@ -203,26 +203,26 @@ For more information, see [Configuration Files](http://www.pydocstyle.org/en/2.1
 
 The Python extension maps all pydocstyle errors to the Convention (C) category.
 
-## Pep8 (pycodestyle)
+## pycodestyle (pep8)
 
 ### Command-line arguments and configuration files
 
-See [pycodestyle example usage and output](https://pep8.readthedocs.io/en/latest/intro.html#example-usage-and-output) for general switches. For example, to ignore error E303 (too many blank lines), add the following line to your `settings.json` file:
+See [pycodestyle example usage and output](https://pycodestyle.pycqa.org/en/latest/intro.html#example-usage-and-output) for general switches. For example, to ignore error E303 (too many blank lines), add the following line to your `settings.json` file:
 
 ```json
-"python.linting.pep8Args": ["--ignore=E303"]
+"python.linting.pycodestyleArgs": ["--ignore=E303"]
 ```
 
-Pep8 options are read from the `[pep8]` section of a `tox.ini` or `setup.cfg` file located in any parent folder of the path(s) being processed. For details, see [pycodestyle configuration](https://pep8.readthedocs.io/en/latest/intro.html#configuration).
+pycodestyle options are read from the `[pycodestyle]` section of a `tox.ini` or `setup.cfg` file located in any parent folder of the path(s) being processed. For details, see [pycodestyle configuration](https://pycodestyle.pycqa.org/en/latest/intro.html#configuration).
 
 ### Message category mapping
 
-The Python extension maps pep8 message categories to VS Code categories through the following settings. If desired, change the setting to change the mapping.
+The Python extension maps pycodestyle message categories to VS Code categories through the following settings. If desired, change the setting to change the mapping.
 
-| Pep8 category | Applicable setting<br/>(python.linting.) | VS Code category mapping |
+| pycodestyle category | Applicable setting<br/>(python.linting.) | VS Code category mapping |
 | --- | --- | --- |
-| W | pep8CategorySeverity.W | Warning |
-| E | pep8CategorySeverity.E | Error |
+| W | pycodestyleCategorySeverity.W | Warning |
+| E | pycodestyleCategorySeverity.E | Error |
 
 ## Prospector
 

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -146,15 +146,15 @@ To suppress the "undefined-variable" messages, for example, use the setting `"py
 | pylintCategorySeverity.error | `"Error"` | Mapping for Pylint error message to VS Code type. | [Linting](/docs/python/linting.md) |
 | pylintCategorySeverity.fatal | `"Error"` | Mapping for Pylint fatal message to VS Code type. | [Linting](/docs/python/linting.md) |
 
-### Pep8/pycodestyle
+### pycodestyle (pep8)
 
 | Setting<br/>(python.linting.) | Default | Description | See also |
 | --- | --- | --- | --- |
-| pep8Enabled | `false` | Specifies whether to enable pep8. | [Linting](/docs/python/linting.md) |
-| pep8Args | `[]` | Additional arguments for pep8, where each top-level element that's separated by a space is a separate item in the list. | [Linting](/docs/python/linting.md) |
-| pep8Path | `"pep8"` | The path to pep8. | [Linting](/docs/python/linting.md) |
-| pep8CategorySeverity.W | `"Warning"` | Mapping for pep8 W message to VS Code type.| [Linting](/docs/python/linting.md) |
-| pep8CategorySeverity.E | `"Error"` | Mapping for pep8 E message to VS Code type.| [Linting](/docs/python/linting.md) |
+| pycodestyleEnabled | `false` | Specifies whether to enable pycodestyle. | [Linting](/docs/python/linting.md) |
+| pycodestyleArgs | `[]` | Additional arguments for pycodestyle, where each top-level element that's separated by a space is a separate item in the list. | [Linting](/docs/python/linting.md) |
+| pycodestylePath | `"pycodestyle"` | The path to pycodestyle. | [Linting](/docs/python/linting.md) |
+| pycodestyleCategorySeverity.W | `"Warning"` | Mapping for pycodestyle W message to VS Code type.| [Linting](/docs/python/linting.md) |
+| pycodestyleCategorySeverity.E | `"Error"` | Mapping for pycodestyle E message to VS Code type.| [Linting](/docs/python/linting.md) |
 
 ### Flake8
 


### PR DESCRIPTION
Update documentation to match https://github.com/microsoft/vscode-python/pull/6570