### PR TITLE
Updated Azure deployment docs

### DIFF
--- a/docs/azure/deployment.md
+++ b/docs/azure/deployment.md
@@ -9,19 +9,25 @@ DateApproved: 5/7/2020
 ---
 # Deploying Applications to Azure
 
-Visual Studio Code makes it easy to deploy your applications to [Azure](https://azure.microsoft.com) and we've created walkthroughs to help you get started. Whether your workflow is through the [Azure CLI](https://docs.microsoft.com/cli/azure) or [Azure App Service](https://azure.microsoft.com/services/app-service), using a [Docker](https://www.docker.com) container, or creating serverless [Azure Functions](https://azure.microsoft.com/services/functions/), you'll find the deployment steps you need.
+Visual Studio Code makes it easy to deploy your applications to the cloud with [Azure](https://azure.microsoft.com) and we've created walkthroughs to help you get started.
+
+Whether your workflow is through the [Azure CLI](https://docs.microsoft.com/cli/azure) or [Azure App Service](https://azure.microsoft.com/services/app-service), using a Docker container, or creating serverless [Azure Functions](https://azure.microsoft.com/services/functions/), you'll find the deployment steps you need.
 
 ## Deployment tutorials
 
-The tutorials below, hosted on the [Azure JavaScript Developer Center](https://docs.microsoft.com/azure/javascript), walk you through different ways of creating a simple website and deploying it to Azure:
+The tutorials below, hosted on the Microsoft Docs platform, walk you through different ways of creating and deploying apps to Azure using Visual Studio Code:
 
 Tutorial | Description
 --- | ---
+[Automate CI/CD setup with the Deploy to Azure extension](https://docs.microsoft.com/en-us/azure/devops/pipelines/targets/deploy-to-azure-vscode) | Set up a Continuous Integration and Continuous Delivery (CI/CD) pipeline for your applications with GitHub Actions or Azure Pipelines, automatically with the Deploy to Azure extension. Supports services including Azure Web Apps, Azure Functions and Azure Kubernetes Service.
 [Deploy Azure Functions](https://docs.microsoft.com/azure/javascript/tutorial-vscode-serverless-node-01) | Build and manage Azure Functions serverless apps directly in VS Code with the Azure Functions extension.
 [Deploy using the App Service extension](https://docs.microsoft.com/azure/javascript/tutorial-vscode-azure-app-service-node-01) | Manage Azure resources directly in VS Code with the Azure App Service extension.
 [Deploy using Docker](https://docs.microsoft.com/azure/javascript/tutorial-vscode-docker-node-01) | Deploy your website using a Docker container.
 [Deploy using the Azure CLI](https://docs.microsoft.com/azure/javascript/tutorial-vscode-azure-cli-node-01) | Create, deploy, and update a website using a terminal and the Azure CLI.
 [Deploy a static website](https://docs.microsoft.com/azure/javascript/tutorial-vscode-static-website-node-01) | Create, deploy, and update a static website on Azure Storage.
+
+You can find additional tutorials and walkthroughs on the
+[Azure Developer Center](https://docs.microsoft.com/azure/developer), including language-specific articles for JavaScript and Node.js, Python, Java, and .NET.
 
 ## Next steps
 


### PR DESCRIPTION
Added the "Deploy to Azure" extension and other updates to the page.

The paragraph above the table had to be changed because the "Deploy to Azure" extension does not live within the JavaScript Dev Center.