### PR TITLE
clarify how to disable pytest-cov when debugging

### DIFF
--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -341,7 +341,7 @@ See [unittest command-line interface](https://docs.python.org/3/library/unittest
 You can also configure pytest using a `pytest.ini` file as described on [pytest Configuration](https://docs.pytest.org/en/latest/customize.html).
 
 > **Note**
-> If you have the pytest-cov coverage module installed, VS Code doesn't stop at breakpoints while debugging because pytest-cov is using the same technique to access the source code being run. To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests, for example by adding `"env": {"PYTEST_ADDOPTS": "--no-cov"}` to your [launch configuration](#debug-tests). (For more information, see [Debuggers and PyCharm](https://pytest-cov.readthedocs.io/en/latest/debuggers.html) in the pytest-cov documentation.)
+> If you have the pytest-cov coverage module installed, VS Code doesn't stop at breakpoints while debugging because pytest-cov is using the same technique to access the source code being run. To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests, for example by adding `"env": {"PYTEST_ADDOPTS": "--no-cov"}` to your debug configuration.  (See [Debug Tests](#debug-tests) above about how to set up that launch configuration.) (For more information, see [Debuggers and PyCharm](https://pytest-cov.readthedocs.io/en/latest/debuggers.html) in the pytest-cov documentation.)
 
 ### Nose configuration settings
 

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -341,7 +341,7 @@ See [unittest command-line interface](https://docs.python.org/3/library/unittest
 You can also configure pytest using a `pytest.ini` file as described on [pytest Configuration](https://docs.pytest.org/en/latest/customize.html).
 
 > **Note**
-> If you have the pytest-cov coverage module installed, VS Code doesn't stop at breakpoints while debugging because pytest-cov is using the same technique to access the source code being run. To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests. (For more information, see [Debuggers and PyCharm](https://pytest-cov.readthedocs.io/en/latest/debuggers.html) in the pytest-cov documentation.)
+> If you have the pytest-cov coverage module installed, VS Code doesn't stop at breakpoints while debugging because pytest-cov is using the same technique to access the source code being run. To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests, for example by adding `"env": {"PYTEST_ADDOPTS": "--no-cov"}` to your [launch configuration](#debug-tests). (For more information, see [Debuggers and PyCharm](https://pytest-cov.readthedocs.io/en/latest/debuggers.html) in the pytest-cov documentation.)
 
 ### Nose configuration settings
 


### PR DESCRIPTION
The previous form, "To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests.", left ambiguous _how_ to modify a setting "when debugging tests".

Let's take advantage of the earlier-explained launch.json config. I haven't found any way to directly change Visual Studio Code settings there, but we can set the environment variable `PYTEST_ADDOPTS`, which will have much the same effect. With this snippet, test-running just "does the right thing": coverage on Run Tests, and debugging on Debug Tests.

As to _how_ to provide the snippet, I defaulted to just adding a subordinate clause, for minimal disruption to the existing text. I'm not entirely happy with how verbose it makes the paragraph. If we think it's a common enough case, it might be better to pull this out of an aside and provide a ready-pasteable launch config, much like the example above in "debug tests".