### PR TITLE
Updated Codespaces

### DIFF
--- a/release-notes/v1_46.md
+++ b/release-notes/v1_46.md
@@ -318,7 +318,7 @@ In this iteration, we expanded support for many options:
 * `--wait` to let a program wait for files closing
 * `--add` to add a folder to the current workspace
 
-In [GitHub Codespaces](https://github.com/features/codespaces/), for example, this enables you to use the browser-based VS Code as an editor for Git:
+In Codespaces (public preview in [Visual Studio Codespaces](https://visualstudio.microsoft.com/services/visual-studio-codespaces/), private beta on [GitHub](https://github.com/features/codespaces)), for example, this enables you to use the browser-based VS Code as an editor for Git:
 
 ![VS Code Git Editor in Browser](images/1_46/code-git-editor.gif)
 


### PR DESCRIPTION
As per discussion with @pjmeyer , "GitHub Codespaces" is not a brand. Because Codespaces on GH is still in private beta, we recommend linking to both VS Codespaces which can be used today and the GH private beta.