### PR TITLE
Update link to TS ESLint in 1.46 release notes

### DIFF
--- a/release-notes/v1_46.md
+++ b/release-notes/v1_46.md
@@ -661,7 +661,7 @@ We have added Electron `preload` scripts to VS Code for exposing certain Electro
 
 ### Extension samples now use ESLint
 
-Our [extension samples](https://github.com/Microsoft/vscode-extension-samples) have all been updated to use [ESLint](https://eslint.org) for linting instead of the now deprecated TSLint. If your  extension is still using TSLint, you can review the [TypeScript ESLint guide](https://eslint.org) and our newly updated extension samples to see how to migrate to ESLint.
+Our [extension samples](https://github.com/Microsoft/vscode-extension-samples) have all been updated to use [ESLint](https://eslint.org) for linting instead of the now deprecated TSLint. If your  extension is still using TSLint, you can review the [TSLint to ESLint Migration guide](https://code.visualstudio.com/api/advanced-topics/tslint-eslint-migration) and our newly updated extension samples to see how to migrate to ESLint.
 
 ### GitHub Triage Extension
 


### PR DESCRIPTION
Currently link navigates to eslint.org that has only few mentions of TS.

Looking at the sentence context [Migrate from TSLint to ESLint](https://code.visualstudio.com/api/advanced-topics/tslint-eslint-migration) in VS Code docs looks more appropriate.

@mjbvz could you confirm that this was your intention or provide better link please.