### PR TITLE
Add documentation for specifying a different local port when setting up port forward

### DIFF
--- a/docs/remote/images/ssh/ssh-tunnel-different-local-port.png
+++ b/docs/remote/images/ssh/ssh-tunnel-different-local-port.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5cf9608ee7b1da70da5bed744a6d1fb603c9338384e993a8376a965580ffcbd
+size 11369

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -210,7 +210,7 @@ If you would like VS Code to remember any ports you have forwarded, check **Remo
 
 If you would like the local port of the tunnel to be different than the remote server's, you can change this via the **Forwarded Ports** panel.
 
-Right-click the tunnel you want to modify and select **Change Local Port** in the context menu.
+Right-click the tunnel you want to modify, and select **Change Local Port** in the context menu.
 
 ![Change Local Port](images/ssh/ssh-tunnel-different-local-port.png)
 

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -206,6 +206,14 @@ If you would like VS Code to remember any ports you have forwarded, check **Remo
 
 ![Restore forwarded ports setting](images/common/restore-forwarded-ports.png)
 
+#### Change local port on tunnel
+
+If you would like the local port of the tunnel to be different than the remote server's, you can change this via the **Forwarded Ports** panel.
+
+Right-click the tunnel you want to modify and select **Change Local Port** in the context menu.
+
+![Change Local Port](images/ssh/ssh-tunnel-different-local-port.png)
+
 ### Always forwarding a port
 
 If you have ports that you **always want to forward**, you can use the `LocalForward` directive in the same SSH config file you use to [remember hosts and advanced settings](#remember-hosts-and-advanced-settings).


### PR DESCRIPTION
Adding documentation for specifying a different local port when setting up port forwarding with a remote SSH server. 

I found the original commit and PR at: 
- https://github.com/microsoft/vscode/commit/b72188e25779fe5c165591e0f653cc04cbb349c9
- https://github.com/microsoft/vscode/issues/89031