### PR TITLE
RAM requirements much bigger?

### DIFF
--- a/docs/supporting/requirements.md
+++ b/docs/supporting/requirements.md
@@ -15,7 +15,7 @@ Visual Studio Code is a small download (< 100 MB) and has a disk footprint of 20
 We recommend:
 
 * 1.6 GHz or faster processor
-* 1 GB of RAM
+* 4 GB of RAM
 
 ## Platforms
 


### PR DESCRIPTION
I googled the RAM requirements a bit and there are posts on Reddit and elsewhere mentioning how big this 1GB requirement is for Code.. Yet for me it is 3.8GB, not 1. 

It likely depends on the programs being run: I'm playing with an Typescript, React, Prettier and ESLint app. As many I made the switch to Code because of TS, and the other tools there are not expendable. 

Shall one deduce that the requirement is in reality 4GB?