### PR TITLE
Change apt key install directory

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -49,8 +49,8 @@ The repository and key can also be installed manually with the following script:
 
 ```bash
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -o root -g root -m 644 packages.microsoft.gpg /usr/share/keyrings/
-sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
+sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 
 Then update the package cache and install the package using:


### PR DESCRIPTION
On Debian-based systems, it is [recommended](https://www.debian.org/doc/packaging-manuals/fhs/fhs-3.0.html#ftn.idm236087550400) to not install local files outside of `/usr/local/` or `/etc/`, so we should not be manually installing files `/usr/share/`. Instead, we can use the existing `/etc/apt/trusted.gpg.d/` directory for apt archive keys.