### PR TITLE
-y flag to apt-get install

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -598,13 +598,13 @@ If you do not have GPG set up, on **Windows**, you can install [Gpg4win](https:/
 Next, install `gnupg2` in your container by updating your Dockerfile. For example:
 
 ```bash
-RUN apt-get update && apt-get install gnupg2
+RUN apt-get update && apt-get install gnupg2 -y
 ```
 
 Or if running as a [non-root user](/docs/remote/containers-advanced.md#adding-a-nonroot-user-to-your-dev-container):
 
 ```bash
-RUN sudo apt-get update && sudo apt-get install gnupg2
+RUN sudo apt-get update && sudo apt-get install gnupg2 -y
 ```
 
 The next time the container starts, your GPG keys should be accessible inside the container as well.


### PR DESCRIPTION
`apt-get install` will fail (without a meaningful error message) in a Docker `RUN` command if it seeks `[Y|n]` input from the command line. We need to tell it not to ask.