### PR TITLE
wrong command

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -286,7 +286,7 @@ A best practice among Python developers is to avoid installing packages into a g
    python3 -m pip install matplotlib
 
    # Windows (may require elevation)
-   python -m pip install matplotlib
+   py -m pip install matplotlib
 
    # Linux (Debian)
    apt-get install python3-tk


### PR DESCRIPTION
installing matplotlib in windows should be the following.

py -m pip install matplotlib