### PR TITLE
[cpp] Include extra info for Linux to Attach

### DIFF
--- a/docs/cpp/cpp-debug.md
+++ b/docs/cpp/cpp-debug.md
@@ -138,7 +138,13 @@ Windows:
 
 Linux:
 
-* GDB needs elevated permissions to attach to a process. When using *attach to process*, you need to provide your password before the debugging session can begin.
+* You may see an error saying: `ptrace: Operation not permitted`. This is due to GDB needing elevated permissions in order to attach to a process. This can be solved using the solutions below:
+    1. When using *attach to process*, you need to provide your password before the debugging session can begin.
+    1. To disable this error temporarily, use the following command:
+
+        `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`
+
+    1. To remove the error permanently, edit `/etc/sysctl.d/10-ptrace.conf` and modify `kernel.yama.ptrace_scope` value of `1` to `0`.
 
 macOS:
 

--- a/docs/cpp/cpp-debug.md
+++ b/docs/cpp/cpp-debug.md
@@ -144,7 +144,7 @@ Linux:
 
         `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`
 
-    1. To remove the error permanently, edit `/etc/sysctl.d/10-ptrace.conf` and modify `kernel.yama.ptrace_scope` value of `1` to `0`.
+    1. To remove the error permanently, add a file called `10-ptrace.conf` to `/etc/sysctl.d/` and add the following `kernel.yama.ptrace_scope = 0`.
 
 macOS:
 


### PR DESCRIPTION
This PR adds the additional info to attach to a process in Linux with
GDB.

This information comes from
https://askubuntu.com/questions/41629/after-upgrade-gdb-wont-attach-to-process

@pieandcakes 