### PR TITLE
Update Pipeline publishing steps to explicitly map secret variable

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -95,9 +95,11 @@ You can enable the build to run continuously when pushing to a branch and even o
 
 ```yaml
 trigger:
-  tags:
+  branches:
     include:
     - master
+  tags:
+    include:
     - refs/tags/v*
 ```
 

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -83,7 +83,7 @@ You can enable the build to run continuously when pushing to a branch and even o
 
 1. Set up `VSCE_PAT` as a secret variable using the [Azure DevOps secrets instructions](https://docs.microsoft.com/azure/devops/pipelines/process/variables?tabs=classic%2Cbatch#secret-variables).
 2. Install `vsce` as a `devDependencies` (`npm install vsce --save-dev` or `yarn add vsce --dev`).
-3. Declare a `deploy` script in `package.json` without the PAT.
+3. Declare a `deploy` script in `package.json` without the PAT (by default, `vsce` will use the `VSCE_PAT` environment variable as the Personal Access Token).
 
 ```json
 "scripts": {
@@ -109,6 +109,8 @@ trigger:
     yarn deploy
   displayName: Publish
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Agent.OS'], 'Linux'))
+  env:
+    VSCE_PAT: $(VSCE_PAT)
 ```
 
 The [condition](https://docs.microsoft.com/azure/devops/pipelines/process/conditions) property tells the CI to run the publish step only in certain cases.
@@ -118,6 +120,8 @@ In our example, the condition has three checks:
 - `succeeded()` - Publish only if the tests pass.
 - `startsWith(variables['Build.SourceBranch'], 'refs/tags/')` - Publish only if a tagged (release) build.
 - `eq(variables['Agent.OS'], 'Linux')` - Include if your build runs on multiple agents (Windows, Linux, etc.). If not, remove that part of the condition.
+
+Since `VSCE_PAT` is a secret variable, it is not immediately usable as an environment variable. Thus, we need to explicitly map the environment variable `VSCE_PAT` to the secret variable.
 
 ## GitHub Actions
 


### PR DESCRIPTION
The current instructions for publishing using Azure Pipelines will cause the publishing step to fail, with an error like:
```
TF400813: Resource not available for anonymous access. Client authentication required.
```

Since `VSCE_PAT` is set as a secret variable, it cannot be immediately referenced and used as an environment variable (according to the [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables)). One has to explicitly map the secret variable using the `env` block.

I've updated the YAML snippet to set the mapping for the `VSCE_PAT` environment variable.