### PR TITLE
added clarity to location of the inspectMode property

### DIFF
--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -99,7 +99,7 @@ When the Docker extension adds files to the application, it also adds a **VS Cod
 
     > Note that, because the debugger attaches *after* the application starts, the breakpoint may missed the first time around; you might have to refresh the browser to see the debugger break on the second try.
     >
-    > You can configure the application to wait for the debugger to attach before starting execution by setting the [inspectMode](/docs/containers/reference.md#node-object-properties-docker-run-task) property to `break` in the `docker-run: debug` task in `tasks.json`.
+    > You can configure the application to wait for the debugger to attach before starting execution by setting the [inspectMode](/docs/containers/reference.md#node-object-properties-docker-run-task) property to `break` in the `docker-run: debug` task in `tasks.json` under the `node` object.
 
 ## Next steps
 


### PR DESCRIPTION
Made a small tweak so a developer could easily find the location of the inspectMode property when making an edit to tasks.json