### PR TITLE
Fixed Using SSH keys example on Linux

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -607,7 +607,7 @@ eval "$(ssh-agent -s)"
 Then add these lines to your `~/.bash_profile` or `~/.zprofile` (for Zsh) so it starts on login:
 
 ```bash
-if [ ! -z "$SSH_AUTH_SOCK" ]; then
+if [ -z "$SSH_AUTH_SOCK" ]; then
    # Check for a currently running instance of the agent
    RUNNING_AGENT="`ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]'`"
    if [ "$RUNNING_AGENT" = "0" ]; then


### PR DESCRIPTION
I am not %100 sure of this, but the example of adding the ssh-agent to my profile file didn't work as expected. And after I googled around, I found an almost identical example at https://code.visualstudio.com/docs/remote/troubleshooting#_setting-up-the-ssh-agent
The only difference was that it enters the condition if `$SSH_AUTH_SOCK` is empty, while the one here checks it is *not* empty (as far as I can tell, at least). Making this change got it to work for me.