### PR TITLE
Fix up my code typo from my PR #3865

### DIFF
--- a/api/extension-guides/command.md
+++ b/api/extension-guides/command.md
@@ -217,7 +217,7 @@ If you are authoring your own VS Code extension and need to enable/disable comma
 The first example below sets the key `myExtension:showMyCommand` to true, which you can use in enablement of commands or with the `when` property. The second example stores a value which you could use with a `when` clause to check if the number of cool open things is greater than 2.
 
 ```js
-vscode.commands.executeCommand('setContext', '`myExtension:showMyCommand', true);
+vscode.commands.executeCommand('setContext', 'myExtension:showMyCommand', true);
 
-vscode.commands.executeCommand('setContext', '`myExtension:numberOfCoolOpenThings', 4);
+vscode.commands.executeCommand('setContext', 'myExtension:numberOfCoolOpenThings', 4);
 ```


### PR DESCRIPTION
CC @gregvanl went to use my own documentation today & then notice the typo in the code, note the **`** that is not needed in the string

Fixes typo introduced from my PR #3865 