### PR TITLE
semantic highlighting: add semanticTokensBuilder example

### DIFF
--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -41,6 +41,15 @@ const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
 const provider: vscode.DocumentSemanticTokensProvider = {
   provideDocumentSemanticTokens(document: vscode.TextDocument): vscode.ProviderResult<vscode.SemanticTokens> {
     // analyze the document and return semantic tokens
+
+    const tokensBuilder = new vscode.SemanticTokensBuilder(legend);
+    // on line 1, characters 1-5 are a class declaration
+    tokensBuilder.push(
+      new vscode.Range(new vscode.Position(1, 1), new vscode.Position(1, 5)),
+      'class',
+      ['declaration'],
+    );
+    return tokensBuilder.build();
   }
 };
 


### PR DESCRIPTION
When I tried to implement semantic highlighting for my own extension, I read this guide. It doesn't explain how to actually construct a `SemanticTokens` response, it only has the comment:

```ts
     // analyze the document and return semantic tokens
```

Instead I read the documentation for [`provideDocumentSemanticTokens`](https://code.visualstudio.com/api/references/vscode-api#provideDocumentSemanticTokens) which walks you through how to transform your data to a low-level Uint32Array.

But I could have avoided this all by using the built-in `SemanticTokensBuilder`! Add a simple example using `SemanticTokensBuilder` that will actually highlight the text in the document.