### PR TITLE
Fix wrong link

### DIFF
--- a/blogs/2020/07/01/containers-wsl.md
+++ b/blogs/2020/07/01/containers-wsl.md
@@ -80,7 +80,7 @@ Installing the Remote - WSL extension added the Remote Explorer to VS Code. When
 We can leverage the [Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension to view and attach to containers, in addition to a variety of other scenarios, such as:
 * [Developing within a set of sample containers](https://code.visualstudio.com/docs/remote/containers-tutorial)
 * [Opening existing source code in a container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
-* [Working with a GitHub repository](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container) in an isolated container volume.
+* [Working with a GitHub repository](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) in an isolated container volume.
 
 These configurations allow you to easily recreate the same development environment across machines, install tools and extensions specific to a project into a DevContainer, and develop in a setup similar to the environment for deployment, leaving the local machine unchanged. We can also view and attach to containers using the [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) extension.
 


### PR DESCRIPTION
The list items 'Opening existing source code in a container' and 'Working with a GitHub repository' both refer to the same place in the documentation where it is described how to open an existing folder in a container.
However, there is a dedicated section about how to open a Git repository or GitHub PR which is probably more appropriate for the last list item.