### PR TITLE
remove mention to (deprecated) tslint extension

### DIFF
--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -238,7 +238,7 @@ An example `extensions.json` could be:
 }
 ```
 
-which recommends two linter extensions: ESLint, and the Chrome debugger extension.
+which recommends a linter extension, ESLint, and the Chrome debugger extension.
 
 An extension is identified using its publisher name and extension identifier `publisher.extension`. You can see the name on the extension's detail page. VS Code will provide you with auto-completion for installed extensions inside these files.
 

--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -232,14 +232,13 @@ An example `extensions.json` could be:
 ```json
 {
     "recommendations": [
-        "ms-vscode.vscode-typescript-tslint-plugin",
         "dbaeumer.vscode-eslint",
         "msjsdiag.debugger-for-chrome"
     ]
 }
 ```
 
-which recommends two linter extensions, TSLint and ESLint, as well as the Chrome debugger extension.
+which recommends two linter extensions: ESLint, and the Chrome debugger extension.
 
 An extension is identified using its publisher name and extension identifier `publisher.extension`. You can see the name on the extension's detail page. VS Code will provide you with auto-completion for installed extensions inside these files.
 


### PR DESCRIPTION
since eslint is the successor to tslint, it might be best to just remove this from the docs to keep things current with the times