### PR TITLE
Include new Azure Cache extension in 1.48 release notes

### DIFF
--- a/release-notes/v1_48.md
+++ b/release-notes/v1_48.md
@@ -55,6 +55,13 @@ The addition of drag and drop selection, shift and ctrl click selection, and hol
 ![Multi Select](images/1_48/hex-selection.gif)
 
 
+## Documentation and extensions
+
+### Azure extensions
+
+There is a new extension for working with Azure assets directly from within VS Code.
+
+* [Azure Cache](https://marketplace.visualstudio.com/items?itemName=ms-azurecache.vscode-azurecache) - Browse through data in your Azure Caches.
 
 ## Notable fixes
 


### PR DESCRIPTION
Hello,

I'm an intern on the Azure Cache team and we recently released a new VS Code extension ([link](https://marketplace.visualstudio.com/items?itemName=ms-azurecache.vscode-azurecache)) that lets users interact and view data in their Azure Caches.

We're hoping to have the extension featured in the next VS Code release notes, similar to how it's done [here](https://code.visualstudio.com/updates/v1_46#_azure-extensions).
