### PR TITLE
Mention new VSCE --githubBranch flag

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -192,8 +192,8 @@ You can customize how your extension looks in the Visual Studio Marketplace. See
 Here are some tips for making your extension look great on the Marketplace:
 
 - A `README.md` file at the root of your extension will be used to populate the extension's Marketplace page's contents. `vsce` will modify README links for you in two different ways:
-  - If you add a `repository` field to your `package.json` and if it is a public GitHub repository, `vsce` will automatically detect it and adjust the links accordingly.
-  - You can override that behavior and/or set it by using the `--baseContentUrl` and `--baseImagesUrl` flags when running `vsce package`. Then publish the extension by passing the path to the packaged `.vsix` file as an argument to `vsce publish`.
+  - If you add a `repository` field to your `package.json` and it is a public GitHub repository, `vsce` will automatically detect it and adjust relative links accordingly (using the `master` branch by default). You can override the GitHub branch with the `--githubBranch` flag when running `vsce package` or `vsce publish`.
+  - For more fine-grained control, you can set the `--baseContentUrl` and `--baseImagesUrl` flags to set the base URLs for relative links.
 - A `LICENSE` file at the root of your extension will be used as the contents for the extension's license.
 - A `CHANGELOG.md` file at the root of your extension will be used as the contents for the extension's change log.
 - You can set the banner background color by setting `galleryBanner.color` to the intended hex value in `package.json`.

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -192,7 +192,7 @@ You can customize how your extension looks in the Visual Studio Marketplace. See
 Here are some tips for making your extension look great on the Marketplace:
 
 - A `README.md` file at the root of your extension will be used to populate the extension's Marketplace page's contents. `vsce` will modify README links for you in two different ways:
-  - If you add a `repository` field to your `package.json` and it is a public GitHub repository, `vsce` will automatically detect it and adjust relative links accordingly (using the `master` branch by default). You can override the GitHub branch with the `--githubBranch` flag when running `vsce package` or `vsce publish`.
+  - If you add a `repository` field to your `package.json` and it is a public GitHub repository, `vsce` will automatically detect it and adjust relative links accordingly, using the `master` branch by default. You can override the GitHub branch with the `--githubBranch` flag when running `vsce package` or `vsce publish`.
   - For more fine-grained control, you can set the `--baseContentUrl` and `--baseImagesUrl` flags to set the base URLs for relative links.
 - A `LICENSE` file at the root of your extension will be used as the contents for the extension's license.
 - A `CHANGELOG.md` file at the root of your extension will be used as the contents for the extension's change log.


### PR DESCRIPTION
The PR https://github.com/microsoft/vscode-vsce/pull/474 added a new `--githubBranch` flag to override the GitHub branch for relative links in the `README`.
