### PR TITLE
Fix dotnet cli command typo

### DIFF
--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -56,7 +56,7 @@ Watch a video tutorial for further C# setup help on [Windows](https://channel9.m
    * Enter the following command in the command shell:
 
    ```cmd
-   dotnet new console -lang F#
+   dotnet new console -lang "F#"
    ```
 
 2. Once it completes, open the project in Visual Studio Code:


### PR DESCRIPTION
The `-lang` parameter to create `F#` console applications must be quoted.


References:
https://docs.microsoft.com/en-us/dotnet/fsharp/get-started/get-started-vscode