### PR TITLE
Remove confusion about .NET Core Docker Config Deprication

### DIFF
--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -78,7 +78,7 @@ Example `launch.json` configuration for debugging a Python application:
 
 More information about debugging .NET Core applications within Docker containers can be found in [Debug .NET Core within Docker containers](/docs/containers/debug-netcore.md).
 
-> The previous (Preview) .NET Core Docker debugging support is being deprecated. You can still find documentation on that support at [Debug .NET Core - Deprecated](https://github.com/microsoft/vscode-docker/wiki/Debug-NetCore-Deprecated).
+> The previous (Preview) .NET Core Docker debugging support (utilizing `"type": "docker-coreclr"` instead of the current preview's `"type": "docker"`) is being deprecated. You can still find documentation on that support at [Debug .NET Core - Deprecated](https://github.com/microsoft/vscode-docker/wiki/Debug-NetCore-Deprecated).
 
 Example `launch.json` configuration for debugging a .NET Core application:
 


### PR DESCRIPTION
In VSCode, creating a new launch config within launch.json with the template name Docker: .NET Core Attach (Preview) will create a config listed in the .NET Core section. I believe the quote saying "previous (Preview)" is deprecated is ambiguous, since the documentation doesn't say that the current version of the config available as a launch config template is still labeled as a preview. This let me to believe that the config I had added within my launch.json was the deprecated implementation.

I propose this simple change to clear up my original confusion.
See comment: https://github.com/microsoft/vscode-docker/issues/2248#issuecomment-680043505