### PR TITLE
docs: update disabling crash reporter section

### DIFF
--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -25,22 +25,6 @@ If you use the JSON editor for your settings, add the following line:
     "telemetry.enableTelemetry": false
 ```
 
-## Disable crash reporting
-
-VS Code collects data about any crashes that occur and sends it to Microsoft to help improve our products and services.
-
-If you don't wish to send crash data to Microsoft, you can set the `telemetry.enableCrashReporter` user [setting](/docs/getstarted/settings.md) to `false`.
-
-From **File** > **Preferences** > **Settings** (macOS: **Code** > **Preferences** > **Settings**), search for `crash`, and uncheck the **Telemetry: Enable Crash Reporter** setting.
-
-If you use the JSON editor for your settings, add the following line:
-
-```json
-    "telemetry.enableCrashReporter": false
-```
-
-> **Note**: This option requires a restart of VS Code to take effect.
-
 ## Extensions and telemetry
 
 VS Code lets you add features to the product by installing Microsoft and third-party extensions. These extensions may be collecting their own usage data and are not controlled by the `telemetry.enableTelemetry` setting. Consult the specific extension's documentation to learn about its telemetry reporting and whether it can be disabled.

--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -25,6 +25,18 @@ If you use the JSON editor for your settings, add the following line:
     "telemetry.enableTelemetry": false
 ```
 
+## Disable crash reporting
+
+VS Code collects data about any crashes that occur and sends it to Microsoft to help improve our products and services.
+
+If you don't wish to send crash data to Microsoft, you can change the `enable-crash-reporter` runtime argument to `false`
+
+* Open the Command Palette (`kb(workbench.action.showCommands)`).
+* Run the **Preferences: Configure Runtime Arguments** command.
+* This command will open a `argv.json` file to configure runtime arguments.
+* Edit `"enable-crash-reporter": false`.
+* Restart VS Code.
+
 ## Extensions and telemetry
 
 VS Code lets you add features to the product by installing Microsoft and third-party extensions. These extensions may be collecting their own usage data and are not controlled by the `telemetry.enableTelemetry` setting. Consult the specific extension's documentation to learn about its telemetry reporting and whether it can be disabled.

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -37,11 +37,13 @@ From **File** > **Preferences** > **Settings** (macOS: **Code** > **Preferences*
 
 VS Code collects data about any crashes that occur and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409) and [telemetry documentation](/docs/getstarted/telemetry.md) to learn more.
 
-If you don't wish to send crash data to Microsoft, you can set the `telemetry.enableCrashReporter` user [setting](/docs/getstarted/settings.md) to `false`.
+If you don't wish to send crash data to Microsoft, you can change the `enable-crash-reporter` runtime argument to `false`
 
-From **File** > **Preferences** > **Settings** (macOS: **Code** > **Preferences** > **Settings**), search for `crash`, and uncheck the **Telemetry: Enable Crash Reporter** setting.
-
-> **Important Notice**: This option requires a restart of VS Code to take effect.
+* Open the Command Palette (`kb(workbench.action.showCommands)`).
+* Run the **Preferences: Configure Runtime Arguments** command.
+* This command will open a `argv.json` file to configure runtime arguments.
+* Edit `"enable-crash-reporter": false`.
+* Restart VS Code.
 
 ## GDPR and VS Code
 


### PR DESCRIPTION
With Electron 9 that is going out with `1.49` we have changed the preferred way of disabling crash reporter.