### PR TITLE
clarify notebook's debugger section

### DIFF
--- a/api/extension-guides/notebook.md
+++ b/api/extension-guides/notebook.md
@@ -505,9 +505,9 @@ Samples:
 
 ## Supporting debugging
 
-For some kernels, such as those that implement a programming language, it can be desirable to allow debugging a cell's execution. To add debugging support, a notebook kernel can implement a [debug adapter](https://microsoft.github.io/debug-adapter-protocol/), either by directly implementing the protocol, or providing an interface between an existing notebook debugger and the protocol.
+For some kernels, such as those that implement a programming language, it can be desirable to allow debugging a cell's execution. To add debugging support, a notebook kernel can implement a [debug adapter](https://code.visualstudio.com/api/extension-guides/debugger-extension), either by directly implementing the [debug adapter protocol](https://microsoft.github.io/debug-adapter-protocol/) (DAP), or by delegating and transforming the protocol to an existing notebook debugger (see 'vscode-simple-jupyter-notebook'). A much simpler approach is to use an existing unmodified debug extension and transform the DAP for notebook needs on the fly (see 'vscode-nodebook').
 
 Samples:
 
-* [vscode-nodebook](https://github.com/microsoft/vscode-nodebook): Node.js notebook debugger, which directly implements the debug adapter protocol
+* [vscode-nodebook](https://github.com/microsoft/vscode-nodebook): Node.js notebook with debugging support provided by VS Code's built-in JavaScript debugger and some simple protocol transformations
 * [vscode-simple-jupyter-notebook](https://github.com/microsoft/vscode-simple-jupyter-notebook): Jupyter notebook with debugging support provided by the existing Xeus debugger


### PR DESCRIPTION
Since I've updated the notebook debugging samples to the latest APIs, I noticed that they are referred in the notebook API doc. I took the liberty to clarify how notebook debugging can be implemented and how this is shown in the samples.