### PR TITLE
Change default VS Code path to use %localappdata%

### DIFF
--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -35,7 +35,7 @@ Open up **Unity Preferences**, **External Tools**, then browse for the Visual St
 
 ![Unity Preferences](images/unity/Unity_Preferences_External_Script_Editor.gif)
 
-> The Visual Studio Code executable can be found at `/Applications/Visual Studio Code.app` on macOS, `C:\users\{username}\AppData\Local\Programs\Microsoft VS Code\Code.exe` on Windows by default.
+> The Visual Studio Code executable can be found at `/Applications/Visual Studio Code.app` on macOS, `%localappdata%\Programs\Microsoft VS Code\Code.exe` on Windows by default.
 
 **Unity has built-in support for opening scripts in Visual Studio Code** as an external script editor on Windows and macOS. Unity will detect when Visual Studio Code is selected as an external script editor and pass the correct arguments to it when opening scripts from Unity. Unity will also set up a default `.vscode/settings.json` with file excludes, if it does not already exist (from [Unity 5.5 Release notes](https://unity3d.com/unity/whats-new/unity-5.5.0)).
 


### PR DESCRIPTION
The documentation presumed that the users folder is on C: and used a {username} pseudo-wildcard. Using %localappdata% ensures that the path goes to the user's local appdata folder and allows them to copy paste the path from the docs.