### PR TITLE
Use Dockerfile ENV key=value

### DIFF
--- a/docs/containers/debug-node.md
+++ b/docs/containers/debug-node.md
@@ -211,7 +211,7 @@ The solution is to remove that optimization from the `Dockerfile`:
 
 ```dockerfile
 FROM node:10.13-alpine
-ENV NODE_ENV production
+ENV NODE_ENV=production
 WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 # Remove the `&& mv node_modules ../` from the RUN command:

--- a/docs/python/tutorial-create-containers.md
+++ b/docs/python/tutorial-create-containers.md
@@ -111,10 +111,10 @@ The following steps summarize the configuration used in the [python-sample-vscod
     EXPOSE 5000
 
     # Indicate where uwsgi.ini lives
-    ENV UWSGI_INI uwsgi.ini
+    ENV UWSGI_INI=uwsgi.ini
 
     # Tell nginx where static files live.
-    ENV STATIC_URL /hello_app/static
+    ENV STATIC_URL=/hello_app/static
 
     # Set the folder where uwsgi looks for the app
     WORKDIR /hello_app
@@ -187,11 +187,11 @@ The following steps summarize the configuration used in the [python-sample-vscod
     EXPOSE 8000
 
     # Indicate where uwsgi.ini lives
-    ENV UWSGI_INI uwsgi.ini
+    ENV UWSGI_INI=uwsgi.ini
 
     # Tell nginx where static files live (as typically collected using Django's
     # collectstatic command.
-    ENV STATIC_URL /app/static_collected
+    ENV STATIC_URL=/app/static_collected
 
     # Copy the app files to a folder and run it from there
     WORKDIR /app


### PR DESCRIPTION
This PR cleans up the docs a bit to use the Dockerfile `ENV key=value` syntax.
I haven't changed the screenshots, I think it's good enough to have the copy-pastable code examples updated.

See also https://github.com/microsoft/vscode-docker/pull/2344