### PR TITLE
IntelliSense minor update

### DIFF
--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -98,7 +98,7 @@ The settings shown below are the default settings. You can change these settings
     "editor.suggestOnTriggerCharacters": true,
 
     // Controls if pressing tab inserts the best suggestion and if tab cycles through other suggestions
-    "editor.tabCompletion": "on",
+    "editor.tabCompletion": "off",
 
     // Controls whether sorting favours words that appear close to the cursor
     "editor.suggest.localityBonus": true,


### PR DESCRIPTION
By default, `tabCompetition` is off.

https://code.visualstudio.com/docs/getstarted/settings#_default-settings

Although I still use `Tab` to confirm suggestions, even though it's disabled. 🤔