### PR TITLE
Documentation lacks information on builtin Snippets

### DIFF
--- a/docs/editor/images/userdefinedsnippets/builtin-javascript-snippets.png
+++ b/docs/editor/images/userdefinedsnippets/builtin-javascript-snippets.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a89ce576bc48ed583ed36d557ac0e223468d22c148e11ccabbed1e1ff52a3e8
+size 7438

--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -17,6 +17,16 @@ The snippet syntax follows the [TextMate snippet syntax](https://manual.macromat
 
 ![ajax snippet](images/userdefinedsnippets/ajax-snippet.gif)
 
+## Built-in snippets
+
+VS Code has built-in snippets for a number of languages such as: JavaScript, TypeScript, Markdown, and PHP.
+
+![builtin javascript snippet](images/userdefinedsnippets/builtin-javascript-snippets.png)
+
+You can see if there are available snippets for a language by running the **Insert Snippet** command in the Command Palette to get a list of the snippets for the language of the current file. This list also includes user snippets that you have defined, and any snippets provided by extension.
+
+To get a complete overview of all builtin snippets, you can install the extension [Snippets Ranger](https://marketplace.visualstudio.com/items?itemName=robole.snippets-ranger).
+
 ## Install snippets from the Marketplace
 
 Many [extensions](/docs/editor/extension-gallery.md) on the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode) include snippets.  If you find one you want to use, install it and restart VS Code and the new snippet will be available (see [Extension Marketplace](/docs/editor/extension-gallery.md#browse-and-install-extensions) for more instructions on installing an extension).

--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -23,9 +23,9 @@ VS Code has built-in snippets for a number of languages such as: JavaScript, Typ
 
 ![builtin javascript snippet](images/userdefinedsnippets/builtin-javascript-snippets.png)
 
-You can see if there are available snippets for a language by running the **Insert Snippet** command in the Command Palette to get a list of the snippets for the language of the current file. This list also includes user snippets that you have defined, and any snippets provided by extension.
+You can see the available snippets for a language by running the **Insert Snippet** command in the Command Palette to get a list of the snippets for the language of the current file. However, keep in mind that this list also includes user snippets that you have defined, and any snippets provided by extensions you have installed.
 
-To get a complete overview of all builtin snippets, you can install the extension [Snippets Ranger](https://marketplace.visualstudio.com/items?itemName=robole.snippets-ranger).
+To get a complete overview of all built-in snippets, you can install the extension [Snippets Ranger](https://marketplace.visualstudio.com/items?itemName=robole.snippets-ranger).
 
 ## Install snippets from the Marketplace
 


### PR DESCRIPTION
There is no reference to the built-in snippets available in the [Snippets in Visual Studio Code](https://code.visualstudio.com/docs/editor/userdefinedsnippets) User Guide. 

This topic was raised in issue #3642 .

In the PR, I have added a section about the built-in snippets.