### PR TITLE
Add instructions to install vscode as alternative

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -162,7 +162,7 @@ sudo update-alternatives --set editor /usr/bin/code
 If Visual Studio Code doesn't show up as an alternative to `editor`, you need to register it:
 
 ```bash
-sudo update-alternatives --install editor /usr/bin/editor </path/to/code> 
+sudo update-alternatives --install editor /usr/bin/editor $(which code)
 ```
 
 To see where Visual Studio Code is installed, run

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -159,6 +159,18 @@ Debian-based distributions allow setting a default **editor** using the [Debian 
 sudo update-alternatives --set editor /usr/bin/code
 ```
 
+If Visual Studio Code doesn't show up as an alternative to `editor`, you need to register it:
+
+```bash
+sudo update-alternatives --install editor /usr/bin/editor </path/to/code> 
+```
+
+To see where Visual Studio Code is installed, run
+
+```bash
+whereis code
+```
+
 ## Windows as a Linux developer machine
 
 Another option for Linux development with VS Code is use a Windows machine with the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/install-win10) (WSL).

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -165,12 +165,6 @@ If Visual Studio Code doesn't show up as an alternative to `editor`, you need to
 sudo update-alternatives --install editor /usr/bin/editor $(which code)
 ```
 
-To see where Visual Studio Code is installed, run
-
-```bash
-whereis code
-```
-
 ## Windows as a Linux developer machine
 
 Another option for Linux development with VS Code is use a Windows machine with the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/install-win10) (WSL).


### PR DESCRIPTION
Although https://github.com/microsoft/vscode/issues/3541 shows `code` as an `editor` alternative, it doesn't show as a valid option when installed as an Snap package. This commit add instructions on how to manually install `code` as an editor alternative.