### PR TITLE
Improve black warning troubleshooting

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -154,17 +154,8 @@ If formatting fails, check the following possible causes:
 | The path to the python interpreter is incorrect. | Check the `pythonPath` setting. |
 | The formatter is not installed in the current environment. | Open a command prompt, navigate to the location specified in the `pythonPath` setting, and run `pip install` for the formatter.
 | The path to the formatter is incorrect. | Check the value of the appropriate `python.formatting.<formatter>Path` setting. |
-| Custom arguments for the formatter are incorrect. | Check that the appropriate `python.formatting.<formatter>Path` setting does not contain arguments, and that `python.formatting.<formatter>Args` contains a list of individual top-level argument elements such as `"python.formatting.yapfArgs": ["--style", "{based_on_style: chromium, indent_width: 20}"]`.
-
-When using the black formatter, VS Code issues the following warning when pasting source code into the editor: **Black does not support the "Format Select" command.**
-
-To prevent this warning, add the following entry to your user or workspace settings to disable format on paste for Python files:
-
-```json
-"[python]": {
-    "editor.formatOnPaste": false
-}
-```
+| Custom arguments for the formatter are incorrect. | Check that the appropriate `python.formatting.<formatter>Path` setting does not contain arguments, and that `python.formatting.<formatter>Args` contains a list of individual top-level argument elements such as `"python.formatting.yapfArgs": ["--style", "{based_on_style: chromium, indent_width: 20}"]`. |
+| Pop up with warning message `Black does not support the "Format Select" command.` | `black` does not support formatting sections of code, it can be solved with the following settings `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`. This will force formatting of the *whole* file at save.|
 
 ## Refactoring
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -155,7 +155,7 @@ If formatting fails, check the following possible causes:
 | The formatter is not installed in the current environment. | Open a command prompt, navigate to the location specified in the `pythonPath` setting, and run `pip install` for the formatter.
 | The path to the formatter is incorrect. | Check the value of the appropriate `python.formatting.<formatter>Path` setting. |
 | Custom arguments for the formatter are incorrect. | Check that the appropriate `python.formatting.<formatter>Path` setting does not contain arguments, and that `python.formatting.<formatter>Args` contains a list of individual top-level argument elements such as `"python.formatting.yapfArgs": ["--style", "{based_on_style: chromium, indent_width: 20}"]`. |
-| Pop up with warning message `Black does not support the "Format Select" command.` | `black` does not support formatting sections of code, it can be solved with the following settings `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`. This will force formatting of the *whole* file at save.|
+| Pop up with warning message `Black does not support the "Format Select" command.` | `black` does not support formatting sections of code, it can be prevented with the following settings `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
 
 ## Refactoring
 


### PR DESCRIPTION
- Move the warning pop up about `black` not supporting "Format Select" inside the troubleshooting table.
- Add setting for formatting the whole file at save (instead of only "modifications") since that also triggers the warning.