### PR TITLE
Update html.md

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -1519,7 +1519,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - force-aligned: Wrap each attribute except first and keep aligned.
     //  - force-expand-multiline: Wrap each attribute.
     //  - aligned-multiple: Wrap when line length is exceeded, align attributes vertically.
-    //  - preserve: Preserve wrapping of attributes
+    //  - preserve: Preserve wrapping of attributes.
     //  - preserve-aligned: Preserve wrapping of attributes but align.
     "html.format.wrapAttributes": "auto",
 

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -114,6 +114,9 @@ The HTML formatter is based on [js-beautify](https://www.npmjs.com/package/js-be
   * `force`: Wrap all attributes, except first
   * `force-aligned`: Wrap all attributes, except first, and align attributes
   * `force-expand-multiline`: Wrap all attributes
+  * `aligned-multiple`: Wrap when line length is exceeded, align attributes vertically
+  * `preserve`: Preserve wrapping of attributes
+  * `preserve-aligned`: Preserve wrapping of attributes but align
 
 >**Tip:** The formatter doesn't format the tags listed in the `html.format.unformatted` and `html.format.contentUnformatted` settings. Embedded JavaScript is formatted unless 'script' tags are excluded.
 


### PR DESCRIPTION
The `html.format.wrapAttributes` was missing 3 configuration values and their respective descriptions.
Also, I added a full stop in the `settings.md` for consistency but I guess that's a bit too nitpicky.

Closes #4048 