### PR TITLE
For GitHub Actions use xvfb directly

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -127,7 +127,7 @@ Since `VSCE_PAT` is a secret variable, it is not immediately usable as an enviro
 
 ## GitHub Actions
 
-You can also configure GitHub Actions to run your extension CI using the [gabrielbb xvfb action](https://github.com/marketplace/actions/gabrielbb-xvfb-action). This automatically checks if Linux is the current OS and runs the tests in an Xvfb enabled environment accordingly:
+You can also configure GitHub Actions to run your extension CI. In headless Linux CI machines `xvfb` is required to run VS Code, so if Linux is the current OS run the tests in an Xvfb enabled environment:
 
 ```yaml
 on:
@@ -149,10 +149,10 @@ jobs:
       with:
         node-version: 10.x
     - run: npm install
-    - name: Run tests
-      uses: GabrielBB/xvfb-action@v1.2
-      with:
-        run: npm test
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'
 ```
 
 ### GitHub Actions automated publishing


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode-docs/issues/4060

Previously if someone used this script directly any failing npm tests would not fail the Actions build due to a bug in version 1.2 of GabrielBB/xvfb-action. Xvfb is included in the GitHub Actions Linux images now so we can instead use Xvfb directly. [`xvfb-run`](https://manpages.ubuntu.com/manpages/trusty/man1/xvfb-run.1.html) is a wrapper for the Xvfb command which simplifies the task of running commands within a virtual X server environment.

I've also tested that this method correctly fails the Actions build if any tests fail as shown in this PR on my own extension https://github.com/golf1052/code-sync/pull/47