### PR TITLE
Run $USERPROFILE/.bash_profile in Git Bash

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -66,7 +66,12 @@ Just like on other platforms you can fine tune the exact executable used in your
 // PowerShell
 "terminal.integrated.shell.windows": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
 // Git Bash
-"terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe"
+"terminal.integrated.shell.windows": "C:\\Program Files\\Git\\git-cmd.exe",
+"terminal.integrated.shellArgs.windows": [
+  "--command=usr/bin/bash.exe",
+  "-l",
+  "-i"
+]
 // Bash on Ubuntu (on Windows)
 "terminal.integrated.shell.windows": "C:\\Windows\\System32\\bash.exe"
 ```


### PR DESCRIPTION
Running Git Bash like the change in the pull request causes `$USERPROFILE/.bash_profile` to also be loaded, potentially loading important environment variables, aliases or other configuration.