### PR TITLE
Added relevant WSL terminal launch code 1 issue.

### DIFF
--- a/docs/supporting/troubleshoot-terminal-launch.md
+++ b/docs/supporting/troubleshoot-terminal-launch.md
@@ -43,6 +43,13 @@ If none of these steps helped solve the issue, you can also try:
 
 This can happen if you run VS Code in compatibility mode, which may be turned on automatically if you have upgraded to Windows 10. You can change the mode by right-clicking the executable and selecting properties, then uncheck the **Run this program in compatibility mode** option in the compatibility tab.
 
+#### The terminal exited with code 1 on Windows 10 (with WSL as the default shell)
+
+This can happen if WSL is not set up with a valid default Linux distribution. __Note:__ docker-desktop-data is not a valid distribution. 
+* Open __PowerShell__ and enter `wslconfig.exe /l` to confirm WSL is installed correctly and the list the currently available linux distributions within your system.
+Confirm a valid distribution has __(default)__ next to it.
+* To change the default value enter `wslconfig.exe /setdefault "distributionNameAsShownInList"`
+
 ### The terminal not working when running the 32-bit Windows client on 64-bit Windows?
 
 The easy fix for this issue is to use the 64-bit version. If you must use the 32-bit version, you need to use the sysnative path when configuring your shell path instead of System32. Adding this setting should fix the issue:


### PR DESCRIPTION
This was not clearly documented on stackoverflow or other sources and took too long to sort.
More and more developers are moving to the WSL for day-to-day development so seems pertinent to have this included here.