### PR TITLE
Show key binding for 'Find All References'

### DIFF
--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -674,7 +674,7 @@ Select a symbol then type `kb(editor.action.goToReferences)`. Alternatively, you
 
 ### Find All References view
 
-Select a symbol then type `kb(references-view.find)` to open the References view showing all your file's symbols in a dedicated view.
+Select a symbol then type `kb(references-view.findReferences)` to open the References view showing all your file's symbols in a dedicated view.
 
 ### Rename Symbol
 


### PR DESCRIPTION
Currently there is no key binding shown for **Find All References** because it refers to an invalid (probably old) command ID.  
By replacing it with the current ID the key binding should be shown again.

![image](https://user-images.githubusercontent.com/5146032/96370601-b1a65c80-115e-11eb-8cf6-4d662cd47574.png)