### PR TITLE
Doc: Fix vscode.executeDefinitionProvider return type

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -31,7 +31,7 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 
 - _uri_ - Uri of a text document
 - _position_ - Position of a symbol
-- _(returns)_ - A promise that resolves to an array of Location instances.
+- _(returns)_ - A promise that resolves to an array of LocationLink instances.
 
 `vscode.executeDeclarationProvider` - Execute all declaration providers.
 


### PR DESCRIPTION
Seems the returned object is of type LocationLink (based on a debug inspection of the values)