### PR TITLE
Fix TreeDataProvider.onDidChangeTreeData example

### DIFF
--- a/api/extension-guides/tree-view.md
+++ b/api/extension-guides/tree-view.md
@@ -208,13 +208,13 @@ Here's the extension in action:
 
 Our node dependencies view is simple, and once the data is shown, it isn't updated. However, it would be useful to have a refresh button in the view and update the node dependencies view with the current contents of the `package.json`. To do this, we can use the `onDidChangeTreeData` event.
 
-- `onDidChangeTreeData?: Event<T | undefined | null>` - Implement this if your tree data can change and you want to update the treeview.
+- `onDidChangeTreeData?: Event<T | undefined | null | void>` - Implement this if your tree data can change and you want to update the treeview.
 
 Add the following to your `NodeDependenciesProvider`.
 
 ```ts
-  private _onDidChangeTreeData: vscode.EventEmitter<Dependency | undefined> = new vscode.EventEmitter<Dependency | undefined>();
-  readonly onDidChangeTreeData: vscode.Event<Dependency | undefined> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<Dependency | undefined | null | void> = new vscode.EventEmitter<Dependency | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<Dependency | undefined | null | void> = this._onDidChangeTreeData.event;
 
   refresh(): void {
     this._onDidChangeTreeData.fire();


### PR DESCRIPTION
I believe #3831 was closed incorrectly, as it was referring to this docs example, not the auto-generated API reference.

I think the example code is overly wordy with repeating the type three times when once will suffice, but since that's how it already was I'm leaving that and simply updating it so that the provided example actually compiles.