### PR TITLE
suggest extension to provide intellisense for webview theme variables

### DIFF
--- a/api/extension-guides/webview.md
+++ b/api/extension-guides/webview.md
@@ -535,7 +535,7 @@ code {
 }
 ```
 
-Review the [Theme Color Reference](/api/references/theme-color) for the available theme variables.
+Review the [Theme Color Reference](/api/references/theme-color) for the available theme variables. [An extension](https://marketplace.visualstudio.com/items?itemName=connor4312.css-theme-completions) is available which provides Intellisense suggestions for the variables.
 
 The following font related variables are also defined:
 

--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -21,6 +21,8 @@ You can customize your active Visual Studio Code [color theme](/docs/getstarted/
 
 **Note**: If you want to use an existing color theme, see [Color Themes](/docs/getstarted/themes) where you'll learn how to set the active color theme through the **Preferences: Color Theme** dropdown (`kb(workbench.action.selectTheme)`).
 
+Theme colors are available as CSS variables in [webviews](/api/extension-huides/webview), and [an extension](https://marketplace.visualstudio.com/items?itemName=connor4312.css-theme-completions) is available which provides Intellisense for them.
+
 ## Color formats
 
 Color values can be defined in the RGB color model with an alpha channel for transparency. As format, the following hexadecimal notations are supported: `#RGB`, `#RGBA`, `#RRGGBB` and `#RRGGBBAA`. R (red), G (green), B (blue), and A (alpha) are hexadecimal characters (0-9, a-f or A-F). The three-digit notation (`#RGB`) is a shorter version of the six-digit form (`#RRGGBB`) and the four-digit RGB notation (`#RGBA`) is a shorter version of the eight-digit form (`#RRGGBBAA`). For example `#e35f` is the same color as `#ee3355ff`.


### PR DESCRIPTION
After sharing the theme completions extension in the VS Code Development Slack, several people suggested adding a pointer to it in the docs.