### PR TITLE
Mark 2 command switches ineffective in Portable

### DIFF
--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -93,8 +93,8 @@ There are several CLI options that help with reproducing errors and advanced set
 
 Argument|Description
 ------------------|-----------
-`--extensions-dir <dir>` | Set the root path for extensions.
-`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root.
+`--extensions-dir <dir>` | Set the root path for extensions. Has no effect in [Portable Mode](/docs/editor/portable.md).
+`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. Has no effect in [Portable Mode](/docs/editor/portable.md).
 `-s, --status` | Print process usage and diagnostics information.
 `-p, --performance` | Start with the **Developer: Startup Performance** command enabled.
 `--disable-gpu` | Disable GPU hardware acceleration.
@@ -136,7 +136,7 @@ You can use the URL in applications such as browsers or file explorers that can 
 
 ![vscode url in Windows Explorer](images/command-line/vscode-url.png)
 
->**Note**: If you are using VS Code [Insiders](/insiders) builds, the URL prefix is `vscode-insiders://`.
+> **Note**: If you are using VS Code [Insiders](/insiders) builds, the URL prefix is `vscode-insiders://`.
 
 ## Next steps
 


### PR DESCRIPTION
Portable mode (presence of  `/data/` folder in VSC installation directory) effectively prevents `--user-data-dir` and `--extensions-dir` switches from working.
Been told it is OK and will not be changed: https://github.com/microsoft/vscode/issues/63657
This info could potentially save a lot of WTH moments and confused fuddling to folks looking at this docs and not getting it working in their "Portable installs" when for example trying to launch a "vanilla" profile without touching their `/data/` directory.
(This edit is crude, probably would be better as a note below table, but I couldn't figure it out how to formulate and mark it.)