### PR TITLE
Update mocha code on "testing-extension"

### DIFF
--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -91,9 +91,9 @@ import * as glob from 'glob';
 export function run(): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha({
-    ui: 'tdd'
+    ui: 'tdd',
+    color: true
   });
-  mocha.useColors(true);
 
   const testsRoot = path.resolve(__dirname, '..');
 


### PR DESCRIPTION
Since [Mocha 8.0.0](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#800--2020-06-10) `useColors` was removed, and now we should set the `color` as `true` on on `new Mocha`