### PR TITLE
Add a clear step to open the Vs code in the "helloworld" folder  your-first-extension.md

### DIFF
--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -28,9 +28,9 @@ yo code
 # ? What's the description of your extension? LEAVE BLANK
 # ? Initialize a git repository? Yes
 # ? Which package manager to use? npm
-
-code ./helloworld
 ```
+
+Launch VS Code, choose **File > Open** and pick the folder `helloworld` that you generated.
 
 Then, inside the editor, press `kb(workbench.action.debug.start)`. This will compile and run the extension in a new **Extension Development Host** window.
 


### PR DESCRIPTION
It is not clear in the documentation that we have to open the visual code in the ``helloworld`` folder. 

The command is in the end line of the scaffold and use environment variable. 