### PR TITLE
Fix identifier for notebook provider in package.json and fix typo

### DIFF
--- a/api/extension-guides/notebook.md
+++ b/api/extension-guides/notebook.md
@@ -39,12 +39,12 @@ A content provider is declared in `package.json` under the `contributes.notebook
 ```json
 {
     ...
-    "activationEvents": ["onNotebookEditor:notebook-renderer-demo"],
+    "activationEvents": ["onNotebook:my-notebook-provider"],
     "contributes": {
         ...
         "notebookProvider": [
             {
-                "viewType": "ny-notebook-provider",
+                "viewType": "my-notebook-provider",
                 "displayName": "My Notebook Provider",
                 "selector": [
                     {
@@ -65,7 +65,7 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.notebook.registerNotebookContentProvider(
-            "ny-notebook-provider", new SampleProvider()
+            "my-notebook-provider", new SampleProvider()
         )
     );
 }


### PR DESCRIPTION
Fix the identifier for the notebook provider according to example extensions: [Jupyter example](https://github.com/microsoft/notebook-extension-samples/blob/master/notebook-provider/package.json) and [GitHub issues example](https://github.com/microsoft/vscode-github-issue-notebooks/blob/master/package.json)

@JacksonKearl would you be able to verify if I made a right correction?