### PR TITLE
Update tasks-appendix.md

### DIFF
--- a/docs/editor/tasks-appendix.md
+++ b/docs/editor/tasks-appendix.md
@@ -11,7 +11,9 @@ This is additional information for Visual Studio Code [tasks](/docs/editor/tasks
 
 ## Schema for tasks.json
 
-The following interfaces define the schema of the tasks.json file.
+The following interfaces define the basic schema of the tasks.json file. 
+
+>**Note**: Because some options depend on the installed extensions, other options may be available. For a complete list, use the **Trigger Suggestions** command (`kb(editor.action.triggerSuggest)`).
 
 ```typescript
 


### PR DESCRIPTION
Include a note that additional options for tasks.json are viewable with the Trigger Suggestions command.

[A similar change was discussed](https://github.com/Microsoft/vscode-docs/issues/2480#issuecomment-544710599) but seems to be missing.

My personal motivation for this change is that it would have helped me discover [the `group` option](https://github.com/microsoft/vscode/pull/65973) under a task's `presentation` without having to refer to [old issues](https://github.com/Microsoft/vscode/issues/47265).