### PR TITLE
Changing the reference for MERN

### DIFF
--- a/docs/nodejs/debugging-recipes.md
+++ b/docs/nodejs/debugging-recipes.md
@@ -65,7 +65,7 @@ This recipe shows how to run and debug a MERN (Mongo, Express, React and Node.js
 
 **Recipes:**
 
-- [Developing the MERN Starter in VS Code](https://github.com/microsoft/vscode-recipes/tree/master/MERN-Starter)
+- TO DO
 
 ## Electron - Debug Electron applications
 


### PR DESCRIPTION
https://github.com/microsoft/vscode-recipes/tree/master/MERN-Starter is using the MERN project at https://github.com/Hashnode/mern-starter 
However, the MERN is deprecated and is no longer actively maintained.