### PR TITLE
Fix Disconnect After Debugging setting description

### DIFF
--- a/docs/containers/bridge-to-kubernetes.md
+++ b/docs/containers/bridge-to-kubernetes.md
@@ -158,7 +158,7 @@ Save your changes and press `kb(workbench.action.debug.restart)` or select **Run
 
 Select **Run** then **Stop Debugging** or press `kb(workbench.action.debug.stop)` to stop the debugger.
 
-> **Note**: By default, stopping the debugging task also disconnects your development computer from your Kubernetes cluster. You can change this behavior by searching for **Bridge to Kubernetes: Disconnect After Debugging** in the Visual Studio Code settings and removing the check next to **Disconnect automatically when Debugging ends**. After updating this setting, your development computer will remain connected when you stop and start debugging. To disconnect your development computer from your cluster, click on the Bridge to Kubernetes extension on the status bar then choose **Disconnect current session**.
+> **Note**: By default, stopping the debugging task also disconnects your development computer from your Kubernetes cluster. You can change this behavior by searching for **Bridge to Kubernetes: Disconnect After Debugging** in the Visual Studio Code settings and removing the check next to **Disconnect automatically when debugging stops**. After updating this setting, your development computer will remain connected when you stop and start debugging. To disconnect your development computer from your cluster, click on the Bridge to Kubernetes extension on the status bar then choose **Disconnect current session**.
 
 ## Additional configuration
 


### PR DESCRIPTION
The "Disconnect After Debugging" setting's description was a little bit different in the current version. I confirmed with Bridge to Kubernetes v1.0.120201118.

![image](https://user-images.githubusercontent.com/1618784/100364996-35971280-3042-11eb-90e1-ba0e3cf096ff.png)
