### PR TITLE
1797650: Remove '?view=azure-cli-latest' link syntax

### DIFF
--- a/docs/azure/kubernetes.md
+++ b/docs/azure/kubernetes.md
@@ -38,7 +38,7 @@ You can create a Kubernetes cluster running on Azure using the Kubernetes extens
 
 ![Create Kubernetes](images/kubernetes/create-k8s.gif)
 
-**Important**: To create a Kubernetes cluster on Azure, you need to install the [Azure CLI](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli?view=azure-cli-latest) and sign in.
+**Important**: To create a Kubernetes cluster on Azure, you need to install the [Azure CLI](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli) and sign in.
 
 **Tip**: You will encounter an error if you don't have an available RSA key file. Follow [create SSH public-private key](https://docs.microsoft.com/azure/virtual-machines/linux/mac-create-ssh-keys) to create your key before creating an Azure Kubernetes cluster.
 

--- a/docs/containers/bridge-to-kubernetes.md
+++ b/docs/containers/bridge-to-kubernetes.md
@@ -118,9 +118,9 @@ Learn more about Bridge to Kubernetes at [How Bridge to Kubernetes works][btk-ho
 [azds-cli]: https://docs.microsoft.com/azure/dev-spaces/how-to/install-dev-spaces#install-the-client-side-tools
 [azds-tmp-dir]: https://docs.microsoft.com/azure/dev-spaces/troubleshooting#before-you-begin
 [btk-vs-code]: https://marketplace.visualstudio.com/items?itemName=mindaro.mindaro
-[azure-cli]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
+[azure-cli]: https://docs.microsoft.com/cli/azure/install-azure-cli
 [azure-cloud-shell]: https://docs.microsoft.com/azure/cloud-shell/overview
-[az-aks-get-credentials]: https://docs.microsoft.com/cli/azure/aks?view=azure-cli-latest#az-aks-get-credentials
+[az-aks-get-credentials]: https://docs.microsoft.com/cli/azure/aks#az-aks-get-credentials
 [az-aks-vs-code]: https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-aks-tools
 [preview-terms]: https://azure.microsoft.com/support/legal/preview-supplemental-terms/
 [supported-regions]: https://azure.microsoft.com/global-infrastructure/services/?products=kubernetes-service


### PR DESCRIPTION
No code or content changes. Part of an effort to remove unnecessary versioning link syntax.

See user story [1797650](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1797650) for more information.