### PR TITLE
GH Universe video in release notes

### DIFF
--- a/release-notes/v1_52.md
+++ b/release-notes/v1_52.md
@@ -29,8 +29,6 @@ After focusing on housekeeping, we have also addressed several feature requests 
 * **[Sticky tab stops for spaces](#sticky-tab-stops-when-indenting-with-spaces)** - Improved experience when indenting with spaces.
 * **[New Remote Development resources](#documentation)** - Check out the new video and Learn module.
 
-Video: **[How we make VS Code in the open](https://aka.ms/AAakyjs)**. Watch the recording of developers Alex Ross and Banjamin Pasero's session at GitHub Universe to learn how our team builds VS Code in the open.
-
 ## Workbench
 
 ### Preview editor improvements
@@ -820,6 +818,10 @@ There are several new ways to learn about VS Code Remote Development:
 * Check out our new Learn module on how to best leverage the editor's GitHub integration with this [Introduction to GitHub in Visual Studio Code](https://docs.microsoft.com/en-us/learn/modules/introduction-to-github-visual-studio-code/).
 
 ![GitHub and VS Code Microsoft Learn module](images/1_52/github-learn-module.png)
+
+### How we make VS Code in the open
+
+Watch the recording of developers Alex Ross and Banjamin Pasero's session at GitHub Universe [How we make VS Code in the open](https://aka.ms/AAakyjs) to learn how our team builds VS Code as open source and collaborates with the community on GitHub.
 
 
 ### VS Code on Chromebooks

--- a/release-notes/v1_52.md
+++ b/release-notes/v1_52.md
@@ -821,7 +821,7 @@ There are several new ways to learn about VS Code Remote Development:
 
 ### How we make VS Code in the open
 
-Watch the recording of developers Alex Ross and Banjamin Pasero's session at GitHub Universe [How we make VS Code in the open](https://aka.ms/AAakyjs) to learn how our team builds VS Code as open source and collaborates with the community on GitHub.
+Watch the recording of developers Alex Ross and Benjamin Pasero's session at GitHub Universe [How we make VS Code in the open](https://aka.ms/AAakyjs) to learn how our team builds VS Code as open source and collaborates with the community on GitHub.
 
 
 ### VS Code on Chromebooks

--- a/release-notes/v1_52.md
+++ b/release-notes/v1_52.md
@@ -29,6 +29,8 @@ After focusing on housekeeping, we have also addressed several feature requests 
 * **[Sticky tab stops for spaces](#sticky-tab-stops-when-indenting-with-spaces)** - Improved experience when indenting with spaces.
 * **[New Remote Development resources](#documentation)** - Check out the new video and Learn module.
 
+Video: **[How we make VS Code in the open](https://aka.ms/AAakyjs)**. Watch the recording of developers Alex Ross and Banjamin Pasero's session at GitHub Universe to learn how our team builds VS Code in the open.
+
 ## Workbench
 
 ### Preview editor improvements


### PR DESCRIPTION
This adds a blurb at the top (is that the right place?) with a link to the GH Universe session. The video should be live by the time we publish tomorrow. Once the video is on YouTube, I will update the link to point to our YT channel (where I'll syndicate the video) instead.