### PR TITLE
Gunicorn edit

### DIFF
--- a/docs/containers/debug-python.md
+++ b/docs/containers/debug-python.md
@@ -228,49 +228,6 @@ When you select **Docker: Add Docker Files to Workspace** for Django or Flask, w
 1. Modify and save any file.
 1. Refresh the browser and validate changes have been made.
 
-## How to debug your app with Gunicorn
-
- The **Docker: Python - Django** and **Docker: Python - Flask** launch configurations automatically override the Gunicorn entry point of the container with the Python debugger. More information about Python debugger import usage can be found [here](https://github.com/microsoft/debugpy#debugpy-import-usage).
-
-To debug your app running with Gunicorn (or any other web server):
-
-1. Add debugpy to your `requirements.txt` file:
-
-    ```python
-    debugpy
-    ```
-
-1. Add the following code snippet to the file that you wish to debug:
-
-    ```python
-    import debugpy
-    debugpy.listen(5678)
-    debugpy.wait_for_client()
-    ```
-
-1. Add a **Python: Remote Attach** configuration to `launch.json` in the `.vscode` folder:
-
-    ```json
-    {
-      "name":"Python: Remote Attach",
-      "type":"python",
-      "request":"attach",
-      "port":5678,
-      "host":"localhost",
-      "pathMappings":[{
-          "localRoot":"${workspaceFolder}",
-          "remoteRoot":"/app"}
-      ]
-    }
-    ```
-
-1. Save the `launch.json` file.
-1. Modify the `docker-compose.yml` file to expose the debugger port by adding `5678:5678` to the [ports section](https://docs.docker.com/compose/). If you are using `docker run` to run your container from the terminal, you must append `-p 5678:5678`.
-1. Start the container by right-clicking on a `docker-compose.yml` file and selecting **Compose Up** or doing `docker run` from the command line.
-1. Set a breakpoint in the chosen file.
-1. Navigate to **Run and Debug** and select the **Python: Remote Attach** launch configuration.
-1. Hit `kb(workbench.action.debug.start)` to attach the debugger.
-
 ## Next steps
 
 Learn more about:

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -103,7 +103,7 @@ Create an **Attach** [launch configuration](/docs/editor/debugging.md#launch-con
 
 ### Python
 
-For debugging Python with Docker Compose, first read [How to debug your app with Gunicorn](/docs/containers/debug-python.md#how-to-debug-your-app-with-gunicorn), then follow these steps.
+For debugging Python with Docker Compose, follow these steps:
 
 1. On the **Debug** tab, choose the **Configuration** dropdown, choose **New Configuration**, choose **Python**, and select the `Remote Attach` configuration template.
 
@@ -128,25 +128,47 @@ For debugging Python with Docker Compose, first read [How to debug your app with
         }
     ```
 
-1. When done editing the **Attach** configuration, save `launch.json`, and select your new launch configuration as the active configuration. In the **Debug** tab, find the new configuration in the **Configuration** dropdown.
+1. When done editing the **Attach** configuration, save the `launch.json`. Navigate to the **Debug** tab and select **Python: Remote Attach** as the active configuration.
 
-1. Right-click on the `docker-compose.debug.yml` file and choose **Compose Up**.
+1. If you already have a valid Dockerfile, we highly recommend running the command **Docker: Add Docker Compose Files to Workspace**. This will create a `docker-compose.yml` file and also a `docker-compose.debug.yml` which volume maps and starts the Python debugger in the container. If you do not have a Dockerfile already, we recommend running **Docker: Add Docker Files to Workspace** and selecting **Yes** to include Docker Compose files.
 
-1. When you attach to a service that exposes an HTTP endpoint that returns HTML, the web browser doesn't open automatically. To open the app in the browser, choose the container in the sidebar, right-click and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
+    > Note: By default, when using **Docker: Add Docker Files to Workspace**, choosing the Django and Flask options will scaffold a Dockerfile configured for Gunicorn. Follow the instructions [here](/docs/containers/quickstart-python.md#gunicorn-modifications-for-djangoflask-apps
+) to ensure it is configured properly before proceeding.
+
+1. Right-click on the `docker-compose.debug.yml` file (example shown below) and choose **Compose Up**.
+
+    ```yml
+    version: '3.4'
+
+    services:
+      pythonsamplevscodedjangotutorial:
+        image: pythonsamplevscodedjangotutorial
+        build:
+          context: .
+          dockerfile: ./Dockerfile
+        command: ["sh", "-c", "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000 --nothreading --noreload"]
+        ports:
+          - 8000:8000
+          - 5678:5678
+    ```
+
+1. Once your container is built and running, attach the debugger by hitting `kb(workbench.action.debug.start)` with the **Python: Remote Attach** launch configuration selected.
+
+    ![Screenshot of debugging in Python](images/compose/docker-compose-python-debug.png)
+
+    > **Note:** If you would like to import the Python debugger into a specific file, more information can be found [here](https://github.com/microsoft/debugpy#debugpy-import-usage).
+
+1. When you attach to a service that exposes an HTTP endpoint and returns HTML, the web browser may not open automatically. To open the app in the browser, right-click the container in the Docker Explorer and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
 
    ![Screenshot - Open in Browser](images/compose/docker-compose-open-in-browser.png)
 
-1. Launch the debugger in the usual way. From the **Debug** tab, choose the green arrow (**Start** button) or use `kb(workbench.action.debug.start)`.
-
-You're now debugging your running app in the container.
-
-![Screenshot of debugging in Python](images/compose/docker-compose-python-debug.png)
+    You're now debugging your running app in the container.
 
 ### .NET
 
 1. On the **Debug** tab, choose the **Configuration** dropdown, choose **New Configuration** and select the `Docker Attach` configuration template **.NET Core Docker Attach (Preview)**.
 
-1. VS Code tries to copy `vsdbg` from the host machine to the target container using a default path. You can also provide a path to an existing instance of `vsdbg` in the **Attach** configuration.
+2. VS Code tries to copy `vsdbg` from the host machine to the target container using a default path. You can also provide a path to an existing instance of `vsdbg` in the **Attach** configuration.
 
    ```json
     "netCore": {
@@ -154,17 +176,17 @@ You're now debugging your running app in the container.
     }
    ```
 
-1. When done editing the **Attach** configuration, save `launch.json`, and select your new launch configuration as the active configuration. In the **Debug** tab, find the new configuration in the **Configuration** dropdown.
+3. When done editing the **Attach** configuration, save `launch.json`, and select your new launch configuration as the active configuration. In the **Debug** tab, find the new configuration in the **Configuration** dropdown.
 
-1. Right-click on the `docker-compose.debug.yml` file and choose **Compose Up**.
+4. Right-click on the `docker-compose.debug.yml` file and choose **Compose Up**.
 
-1. When you attach to a service that exposes an HTTP endpoint that returns HTML, the web browser doesn't open automatically. To open the app in the browser, choose the container in the sidebar, right-click and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
+5. When you attach to a service that exposes an HTTP endpoint that returns HTML, the web browser doesn't open automatically. To open the app in the browser, choose the container in the sidebar, right-click and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
 
-1. Launch the debugger in the usual way. From the **Debug** tab, choose the green arrow (**Start** button) or use `kb(workbench.action.debug.start)`.
+6. Launch the debugger in the usual way. From the **Debug** tab, choose the green arrow (**Start** button) or use `kb(workbench.action.debug.start)`.
 
    ![Screenshot of starting debugging](images/compose/docker-compose-attach.png)
 
-1. If you try to attach to a .NET Core app running in a container, you'll see a prompt ask to select your app's container.
+7. If you try to attach to a .NET Core app running in a container, you'll see a prompt ask to select your app's container.
 
    ![Screenshot of container selection](images/compose/select-container.png)
 

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -132,7 +132,7 @@ For debugging Python with Docker Compose, follow these steps:
 
 1. If you already have a valid Dockerfile, we highly recommend running the command **Docker: Add Docker Compose Files to Workspace**. This will create a `docker-compose.yml` file and also a `docker-compose.debug.yml` which volume maps and starts the Python debugger in the container. If you do not have a Dockerfile already, we recommend running **Docker: Add Docker Files to Workspace** and selecting **Yes** to include Docker Compose files.
 
-    > Note: By default, when using **Docker: Add Docker Files to Workspace**, choosing the Django and Flask options will scaffold a Dockerfile configured for Gunicorn. Follow the instructions [here](/docs/containers/quickstart-python.md#gunicorn-modifications-for-djangoflask-apps
+    > **Note**: By default, when using **Docker: Add Docker Files to Workspace**, choosing the Django and Flask options will scaffold a Dockerfile configured for Gunicorn. Follow the instructions [here](/docs/containers/quickstart-python.md#gunicorn-modifications-for-djangoflask-apps
 ) to ensure it is configured properly before proceeding.
 
 1. Right-click on the `docker-compose.debug.yml` file (example shown below) and choose **Compose Up**.

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -168,7 +168,7 @@ For debugging Python with Docker Compose, follow these steps:
 
 1. On the **Debug** tab, choose the **Configuration** dropdown, choose **New Configuration** and select the `Docker Attach` configuration template **.NET Core Docker Attach (Preview)**.
 
-2. VS Code tries to copy `vsdbg` from the host machine to the target container using a default path. You can also provide a path to an existing instance of `vsdbg` in the **Attach** configuration.
+1. VS Code tries to copy `vsdbg` from the host machine to the target container using a default path. You can also provide a path to an existing instance of `vsdbg` in the **Attach** configuration.
 
    ```json
     "netCore": {
@@ -176,17 +176,17 @@ For debugging Python with Docker Compose, follow these steps:
     }
    ```
 
-3. When done editing the **Attach** configuration, save `launch.json`, and select your new launch configuration as the active configuration. In the **Debug** tab, find the new configuration in the **Configuration** dropdown.
+1. When done editing the **Attach** configuration, save `launch.json`, and select your new launch configuration as the active configuration. In the **Debug** tab, find the new configuration in the **Configuration** dropdown.
 
-4. Right-click on the `docker-compose.debug.yml` file and choose **Compose Up**.
+1. Right-click on the `docker-compose.debug.yml` file and choose **Compose Up**.
 
-5. When you attach to a service that exposes an HTTP endpoint that returns HTML, the web browser doesn't open automatically. To open the app in the browser, choose the container in the sidebar, right-click and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
+1. When you attach to a service that exposes an HTTP endpoint that returns HTML, the web browser doesn't open automatically. To open the app in the browser, choose the container in the sidebar, right-click and choose **Open in Browser**. If multiple ports are configured, you'll be asked to choose the port.
 
-6. Launch the debugger in the usual way. From the **Debug** tab, choose the green arrow (**Start** button) or use `kb(workbench.action.debug.start)`.
+1. Launch the debugger in the usual way. From the **Debug** tab, choose the green arrow (**Start** button) or use `kb(workbench.action.debug.start)`.
 
    ![Screenshot of starting debugging](images/compose/docker-compose-attach.png)
 
-7. If you try to attach to a .NET Core app running in a container, you'll see a prompt ask to select your app's container.
+1. If you try to attach to a .NET Core app running in a container, you'll see a prompt ask to select your app's container.
 
    ![Screenshot of container selection](images/compose/select-container.png)
 

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -163,7 +163,7 @@ The Docker view provides an interactive experience to examine and manage Docker 
 You're done! Now that your container is ready, you may want to:
 
 - [Debug with Docker Compose](/docs/containers/docker-compose.md#python)
-- [Customize how you debug Python in a container](/docs/containers/debug-python.md)
+- [Customize how you debug Python apps in a container](/docs/containers/debug-python.md)
 - [Customize your Docker build and run tasks](/docs/containers/reference.md)
 - [Push your Django image to an Azure Container Registry](/docs/containers/tutorial-django-push-to-registry.md)
 - [Create a container registry using the Azure portal](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-portal)

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -48,15 +48,16 @@ After verifying your app runs properly, you can now Dockerize your application.
     ![Add Dockerfile to a Python project](images/quickstarts/python-add-python.png)
 
 1. When the prompt appears, select **Python: Django**, **Python: Flask**, or **Python: General** as the app type. For this tutorial, we will select **Python: Django**.
-2. Select either **Yes** or **No** when prompted to include [Docker Compose](/docs/containers/docker-compose.md) files. Compose is typically used when running multiple containers at once.
 
-3. Enter the relative path to the app's entry point. This excludes the workspace folder you start from. According to [official Django documentation](https://docs.djangoproject.com/en/3.0/intro/tutorial01/#creating-a-project), this path is commonly `manage.py` (root folder) or `subfolder_name/manage.py`. According to [official Flask documentation](https://flask.palletsprojects.com/en/1.1.x/api/), this is the path to where you create your Flask instance.
+1. Select either **Yes** or **No** when prompted to include [Docker Compose](/docs/containers/docker-compose.md) files. If you select **Yes**, you will need to [verify the path](quickstart-python.md/#django-apps) to your `wsgi.py` file in the `Dockerfile` to run the **Compose Up** command successfully. Compose is typically used when running multiple containers at once.
+
+1. Enter the relative path to the app's entry point. This excludes the workspace folder you start from. According to [official Django documentation](https://docs.djangoproject.com/en/3.0/intro/tutorial01/#creating-a-project), this path is commonly `manage.py` (root folder) or `subfolder_name/manage.py`. According to [official Flask documentation](https://flask.palletsprojects.com/en/1.1.x/api/), this is the path to where you create your Flask instance.
 
     >**Tip**: You may also enter the path to a folder name as long as this folder includes a `__main__.py` file.
 
-4. If **Python: Django** or **Python: Flask** was selected, specify app port for local development. Django defaults to port 8000 while Flask defaults to port 5000; however, any unused port will work. We recommend selecting port 1024 or above to mitigate security concerns from [running as a root user](/docs/containers/python-user-rights.md).
+1. If **Python: Django** or **Python: Flask** was selected, specify app port for local development. Django defaults to port 8000 while Flask defaults to port 5000; however, any unused port will work. We recommend selecting port 1024 or above to mitigate security concerns from [running as a root user](/docs/containers/python-user-rights.md).
 
-5. With all of this information, the Docker extension creates the following files:
+1. With all of this information, the Docker extension creates the following files:
 
     - A `Dockerfile`. To learn more about IntelliSense in this file, refer to the [overview](/docs/containers/overview.md).
 
@@ -125,7 +126,7 @@ The **Docker: Add Docker Files to Workspace...** command automatically creates a
       os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'helloworld.settings')
     ```
 
-    >**Note**: If you have created an app project as shown in the [Create a Django app](https://code.visualstudio.com/docs/python/tutorial-django#_create-a-django-app) section of the Django tutorial, you may set a breakpoint in `views.py` or wherever you choose.
+    >**Note**: If you have created an app project as shown in the [Create a Django app](https://code.visualstudio.com/docs/python/tutorial-django#_create-a-django-app) section of the Django tutorial, you can also set a breakpoint in `views.py` or wherever you choose.
 
 1. Navigate to **Run and Debug** and select **Docker: Python - Django**.
 
@@ -161,7 +162,8 @@ The Docker view provides an interactive experience to examine and manage Docker 
 
 You're done! Now that your container is ready, you may want to:
 
-- [Learn about debugging Python in a container](/docs/containers/debug-python.md)
+- [Debug with Docker Compose](/docs/containers/docker-compose.md#python)
+- [Customize how you debug Python in a container](/docs/containers/debug-python.md)
 - [Customize your Docker build and run tasks](/docs/containers/reference.md)
 - [Push your Django image to an Azure Container Registry](/docs/containers/tutorial-django-push-to-registry.md)
 - [Create a container registry using the Azure portal](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-portal)


### PR DESCRIPTION
Removed Gunicorn specific debug directions. We now have a compose debug file that allows our users to volume map the debugger into a container. 

Updated Docker Compose Python directions with clearer information. 
Note: Will likely be out for the rest of the year starting Dec 14th, so feel free to make any edits or you can wait until I am able to make the necessary changes.