### PR TITLE
Fix "Marketplace" capitalization

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -38,7 +38,7 @@ $ cd myExtension
 $ vsce package
 # myExtension.vsix generated
 $ vsce publish
-# <publisherID>.myExtension published to VS Code MarketPlace
+# <publisherID>.myExtension published to VS Code Marketplace
 ```
 
 `vsce` can also search, retrieve metadata, and unpublish extensions. For a reference on all the available `vsce` commands, run `vsce --help`.
@@ -153,7 +153,7 @@ vsce unpublish (publisher name).(extension name)
 
 ## Packaging extensions
 
-If you want to test an extension on your local install of VS Code or distribute an extension without publishing it to VS Code MarketPlace, you can choose to package your extension. `vsce` can package your extension into a `VSIX` file, from which users can easily install. Some extensions publish VSIX files to each GitHub release.
+If you want to test an extension on your local install of VS Code or distribute an extension without publishing it to VS Code Marketplace, you can choose to package your extension. `vsce` can package your extension into a `VSIX` file, from which users can easily install. Some extensions publish VSIX files to each GitHub release.
 
 For extension authors, they can run `vsce package` in extension root folder to create such VSIX files.
 

--- a/docs/editor/extension-gallery.md
+++ b/docs/editor/extension-gallery.md
@@ -11,7 +11,7 @@ MetaDescription: Discover, add, update, disable and uninstall Visual Studio Code
 
 **Increase the power of Visual Studio Code through Extensions**
 
-The features that Visual Studio Code includes out-of-the-box are just the start. VS Code extensions let you add languages, debuggers, and tools to your installation to support your development workflow. VS Code's rich extensibility model lets extension authors plug directly into the VS Code UI and contribute functionality through the same APIs used by VS Code.  This topic explains how to find, install, and manage VS Code extensions from the [Visual Studio Code MarketPlace](https://marketplace.visualstudio.com/VSCode).
+The features that Visual Studio Code includes out-of-the-box are just the start. VS Code extensions let you add languages, debuggers, and tools to your installation to support your development workflow. VS Code's rich extensibility model lets extension authors plug directly into the VS Code UI and contribute functionality through the same APIs used by VS Code.  This topic explains how to find, install, and manage VS Code extensions from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/VSCode).
 
 ## Browse for extensions
 


### PR DESCRIPTION
Very minor chore, but the inconsistency bothered me.

## Changes

- Changed all instances of "MarketPlace" to "Marketplace" which is the official spelling as found everywhere else it is referenced, as well as in the Marketplace itself.