### PR TITLE
Add documentation about `markdownDescription` JSON schema extension

### DIFF
--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -186,6 +186,28 @@ Use the property `defaultSnippets` to specify any number of snippets for the giv
 
 Note that `defaultSnippets` is not part of the JSON schema specification but a VS Code-specific schema extension.
 
+### Use rich formatting in hovers
+
+VSCode will use the standard `description` field from the [JSON Schema specification](https://json-schema.org/latest/json-schema-core.html#rfc.section.7) in order to provide information about property on hover and during autocomplete.
+
+If you want your descriptions to support formatting like like links, you can opt-in by using [Markdown](https://code.visualstudio.com/docs/languages/markdown) in your formatting with the `markdownDescription` property.
+
+```json
+{
+   "$schema": "http://json-schema.org/schema",
+   "type": "object",
+   "properties": {
+       "name" : {
+           "type": "string",
+           "description": "The name of the entry",
+           "markdownDescription": "The name of the entry. [See the documentation](https://example.com)"
+       }
+   }
+}
+```
+
+Note that `markdownDescription` is not part of the JSON schema specification but a VS Code-specific schema extension.
+
 ### Offline mode
 
 `json.schemaDownload.enable` controls whether the JSON extension fetches JSON schemas from `http` and `https`.


### PR DESCRIPTION
Currently the json language service escapes markdown in description tooltips unless it is specified as `markdownDescription` instead of `description`.

|With `description`|With `markdownDescription`|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/102041749-38159e00-3d9e-11eb-9112-92938e776115.png)|![image](https://user-images.githubusercontent.com/1770056/102041768-45328d00-3d9e-11eb-8113-5320cf17e31a.png)|


Since this is a VSCode specific extension of JSON Schema, I figured it could use a spot in the documentation.

I did notice the other VSCode specific schema extension, `defaultSnippets`, [does have documentation](https://code.visualstudio.com/docs/languages/json#_define-snippets-in-json-schemas).

I would have had no idea how to do this if I hadn't gone digging into the language server's code.

https://github.com/microsoft/vscode-json-languageservice/blob/8a284774bf942ffd883d7f307f960a5255abfad3/src/services/jsonHover.ts#L72

```ts
markdownDescription = markdownDescription || s.schema.markdownDescription || toMarkdown(s.schema.description);

```

As you can see, it will check for a `markdownDescription` property in order to actually render markdown in descriptions. Otherwise it will pass the description contents to the `toMarkdown` function which escapes all markdown formatting.