### PR TITLE
cpp.md: Apply the principle of least astonishment

### DIFF
--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -154,23 +154,17 @@ This has been a very simple example to help you get started with C++ development
 
 Get started with C++ and VS Code with tutorials for your environment:
 
-- [GCC on Windows via MinGW](/docs/cpp/config-mingw.md)
-- [Microsoft C++ on Windows](/docs/cpp/config-msvc.md)
-- [GCC on Linux](/docs/cpp/config-linux.md)
+- [GCC on Windows](/docs/cpp/config-mingw.md)
 - [GCC on Windows Subsystem For Linux](/docs/cpp/config-wsl.md)
+- [GCC on Linux](/docs/cpp/config-linux.md)
+- [Microsoft C++ on Windows](/docs/cpp/config-msvc.md)
 - [Clang/LLVM on macOS](/docs/cpp/config-clang-mac.md)
 - [CMake Tools on Linux](/docs/cpp/cmake-linux.md)
-
-## Documentation
-
-You can find more documentation on using the Microsoft C/C++ extension under the [C++ section](/docs/cpp) of the VS Code website, where you'll find topics on:
-
 - [Debugging](/docs/cpp/cpp-debug.md)
 - [Editing](/docs/cpp/cpp-ide.md)
+- [IntelliSense](/docs/cpp/configure-intellisense-crosscompilation.md)
 - [Settings](/docs/cpp/customize-default-settings-cpp.md)
 - [FAQ](/docs/cpp/faq-cpp.md)
-
-![C++ TOC on code.visualstudio.com](images/cpp/cpp-toc.png)
 
 ## Remote Development
 


### PR DESCRIPTION
There are several redundant and confusing elements on the live version of this page:

1. A link whose label reads "the C++ section of the VS Code website" but leads to "Using GCC with MinGW"! Please do not assume that all Windows developers (even veteran ones) know what GCC and MinGW are. And anyway, "Using GCC with MinGW" is hardly the equivalent of "the C++ section of the VS Code website."
2. A screenshot of a web browser showing VS Code website. I'm sure the developers know what a web browser is.
3. Two different sections, each listing a portion of all C++ doc articles. I'm confident that one section containing links is better.

To fix these issues, this proposed version recommends:

1. Merge the "Documentation" section into the "Tutorials" section
2. Add the missing link to "Configure IntelliSense for Cross-compilation"
3. Remove the non-intuitive link
4. Remove the redundant screenshot, which serves no real purpose