### PR TITLE
Fix example configuration for docker-compose task

### DIFF
--- a/docs/containers/reference.md
+++ b/docs/containers/reference.md
@@ -410,17 +410,19 @@ See [property reference](#compose-task-reference) for full list of all task prop
         {
             "label": "Run docker-compose up",
             "type": "docker-compose",
-            "up": {
-                "detached": true,
-                "build": true,
-                "services": [
-                  "myservice"
+            "dockerCompose": {
+                "up": {
+                    "detached": true,
+                    "build": true,
+                    "services": [
+                      "myservice"
+                    ]
+                },
+                "files": [
+                    "${workspaceFolder}/docker-compose.yml",
+                    "${workspaceFolder}/docker-compose.debug.yml"
                 ]
-            },
-            "files": [
-                "${workspaceFolder}/docker-compose.yml",
-                "${workspaceFolder}/docker-compose.debug.yml"
-            ]
+            }
         }
     ]
 }


### PR DESCRIPTION
The example configuration for a docker-compose task does not align with the reference outlined below it. I fixed this by adding the `dockerCompose` property to the example.
I ran in to this issue myself during configuring of a project that used docker-compose. The errors of the VSCode linter pointed me in the right direction, declaring that "up" was not an allowed property; Even though I just copied the example from the docs.