### PR TITLE
Tasks: Add note of multiple errors on one line

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -1009,3 +1009,9 @@ Alternatively, you can override a task's shell with the `options.shell` property
     },
     ...
 ```
+
+### Why does the problem matcher display only one of multiple messages on a line?
+
+Because it is by design. We only allow one problem per location.
+
+>**Note:** If a line of your code generates a trivial notice message and a critical error message, the serious error message may be hidden. You must be careful in such cases.


### PR DESCRIPTION
I reported this issue as bug on https://github.com/microsoft/vscode/issues/111134 (open Nov, 23, 2020).
It was closed as a duplicated of https://github.com/microsoft/vscode/issues/105159 (opened Aug. 22, 2020).
And it was closed as "it is by design. We only allow one problem per location."

I still think this is a critical bug, but I have to follow your team's decision.

But this is a very important "feature" which VS code users should know.  It should be documented.

I also hope someone read this will create fix of this issue, which I could not make it.