### PR TITLE
Remove duplicate 'the's

### DIFF
--- a/api/extension-guides/custom-editors.md
+++ b/api/extension-guides/custom-editors.md
@@ -175,7 +175,7 @@ The [custom editor extension sample][sample] includes a simple example custom bi
 
 ### CustomDocument
 
-With custom editors, your extension is responsible for implementing its own document model with the the `CustomDocument` interface. This leaves your extension free to store whatever data it needs on a `CustomDocument` in order to your custom editor, but it also means that your extension must implement basic document operations such as saving and backing up file data for hot exit.
+With custom editors, your extension is responsible for implementing its own document model with the `CustomDocument` interface. This leaves your extension free to store whatever data it needs on a `CustomDocument` in order to your custom editor, but it also means that your extension must implement basic document operations such as saving and backing up file data for hot exit.
 
 There is one `CustomDocument` per opened file. Users can open multiple editors for a single resource—such as by splitting the current custom editor—but all those editors will be backed by the same `CustomDocument`.
 

--- a/api/extension-guides/tree-view.md
+++ b/api/extension-guides/tree-view.md
@@ -336,7 +336,7 @@ Once you've created a View Container, you can use the [contributes.views](/api/r
 }
 ```
 
-A view can also have an optional `visibility` property which can be set to `visible`, `collapsed`, or `hidden`. This property is only respected by VS Code the first time a workspace is opened with this view. After that, the visibility is set to whatever the user has chosen. If you have a view container with many views, or if your view will not be useful to every user of your extension, consider setting the view the `collapsed` or `hidden`. A `hidden` view will appear in the the view containers "Views" menu:
+A view can also have an optional `visibility` property which can be set to `visible`, `collapsed`, or `hidden`. This property is only respected by VS Code the first time a workspace is opened with this view. After that, the visibility is set to whatever the user has chosen. If you have a view container with many views, or if your view will not be useful to every user of your extension, consider setting the view the `collapsed` or `hidden`. A `hidden` view will appear in the view containers "Views" menu:
 
 ![Views Menu](images/tree-view/views-menu.png)
 

--- a/api/references/vscode-api.md
+++ b/api/references/vscode-api.md
@@ -6414,7 +6414,7 @@ its current state, i.e. with the edits applied. Most commonly this means saving 
 the <code>ExtensionContext.storagePath</code>. When VS Code reloads and your custom editor is opened for a resource,
 your extension should first check to see if any backups exist for the resource. If there is a backup, your
 extension should load the file contents from there instead of from the resource in the workspace.</p>
-<p><code>backup</code> is triggered approximately one second after the the user stops editing the document. If the user
+<p><code>backup</code> is triggered approximately one second after the user stops editing the document. If the user
 rapidly edits the document, <code>backup</code> will not be invoked until the editing stops.</p>
 <p><code>backup</code> is not invoked when <code>auto save</code> is enabled (since auto save already persists the resource).</p>
 </div>

--- a/docs/cpp/natvis.md
+++ b/docs/cpp/natvis.md
@@ -461,7 +461,7 @@ The Natvis schema is provided here for convenience:
     </xs:choice>
     <xs:attribute name="HideRawView" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Specifies whether or not the the "[Raw View]" node for this object should be hidden. By default, this attribute is set to 'false',
+        <xs:documentation>Specifies whether or not the "[Raw View]" node for this object should be hidden. By default, this attribute is set to 'false',
         which will result in the raw view node of the current object visible to the user.
         </xs:documentation>
       </xs:annotation>

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -255,7 +255,7 @@ The Python extension settings support predefined variables. Similar to the gener
 - **${selectedText}** - the current selected text in the active file
 - **${execPath}** - the path to the running VS Code executable
 
-For additional information about predefined variables and example usages, see the the [Variables reference](/docs/editor/variables-reference.md) in the general VS Code docs.
+For additional information about predefined variables and example usages, see the [Variables reference](/docs/editor/variables-reference.md) in the general VS Code docs.
 
 ## Next steps
 


### PR DESCRIPTION
Some 'the the's are found in the document. This PR provides corrections of them.
I hope these are not intentional.
Thanks!