### PR TITLE
Error in devcontainer.env file location

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -76,10 +76,10 @@ ANOTHER_ENV_VAR_NAME=your-value-goes-here
 
 Next, depending on what you reference in `devcontainer.json`:
 
-* **Dockerfile or image**: Edit `devcontainer.json` and add a path to the `devcontainer.env` file relative to the location of `devcontainer.json`:
+* **Dockerfile or image**: Edit `devcontainer.json` and add a path to the `devcontainer.env` :
 
     ```json
-    "runArgs": ["--env-file","devcontainer.env"]
+    "runArgs": ["--env-file",".devcontainer/devcontainer.env"]
     ```
 
 * **Docker Compose:** Edit `docker-compose.yml` and add a path to the `devcontainer.env` file relative to the Docker Compose file:


### PR DESCRIPTION
The correct location, for the devcontainer.env file is the complete path ".devcontainer/devcontainer.env" and not as  described, relative to the devcontainer.json file.