### PR TITLE
Fix conditional operators table

### DIFF
--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -256,7 +256,7 @@ Operator | Symbol | Example
 -------- | ------ | -----
 Equality | `==` | `"editorLangId == typescript"`
 Inequality | `!=` | `"resourceExtname != .js"`
-Or | `||` | `"isLinux || isWindows"`
+Or | <code>\|\|</code> | `"isLinux || isWindows"`
 And | `&&` | `"textInputFocus && !editorReadonly"`
 Matches | `=~` | `"resourceScheme =~ /^untitled$|^file$/"`
 Greater than | `>` `>=` | `"gitOpenRepositoryCount >= 1"`


### PR DESCRIPTION
Was not rendering the line for 'Or' correctly on GitHub due to GitHub's handling of pipe characters