### PR TITLE
[docs] update settings docs with proper macOS path

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -68,7 +68,7 @@ By default VS Code shows the Settings editor, but you can still edit the underly
 Depending on your platform, the user settings file is located here:
 
 * **Windows** `%APPDATA%\Code\User\settings.json`
-* **macOS** `$HOME/Library/Application Support/Code/User/settings.json`
+* **macOS** `$HOME/Library/Application\ Support/Code/User/settings.json`
 * **Linux** `$HOME/.config/Code/User/settings.json`
 
 The workspace settings file is located under the `.vscode` folder in your root folder.


### PR DESCRIPTION
The path is technically correct as is, but can't be pasted into a terminal without the escape character.

My use case was I copied the path and ran `code` on the path in my terminal to open the editor with the code. It did not work without the escaped path.