### PR TITLE
Rename to Extension Pack for MicroProfile

### DIFF
--- a/docs/java/extensions.md
+++ b/docs/java/extensions.md
@@ -52,7 +52,7 @@ Here are a few useful extensions:
 2. [Jetty](https://marketplace.visualstudio.com/items?itemName=SummerSun.vscode-jetty)
 3. [Server Connector](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-server-connector)
 4. [Community Server Connectors](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-community-server-connector)
-5. [MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack)
+5. [Extension Pack for MicroProfile](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack)
 6. [CheckStyle](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle)
 7. [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 8. [Java Linter](https://marketplace.visualstudio.com/items?itemName=faustinoaq.javac-linter)

--- a/docs/java/java-tomcat-jetty.md
+++ b/docs/java/java-tomcat-jetty.md
@@ -67,4 +67,4 @@ You can use the [Community Server Connectors](https://marketplace.visualstudio.c
 
 The [Server Connector](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-server-connector) extension by Red Hat allows you to start, stop, and deploy to a Red Hat server and runtime products like WildFly, JBoss EAP, Minishift, CDK.
 
-[MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) provides tools for creating MicroProfile projects to develop and deploy to runtimes such as Open Liberty, Quarkus, and Payara.
+[Extension Pack for MicroProfile](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) provides tools for creating MicroProfile projects to develop and deploy to runtimes such as Open Liberty, Quarkus, and Payara.

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -62,7 +62,7 @@ There are also other popular Java extensions you can pick for your own needs, in
 5. [Jetty](https://marketplace.visualstudio.com/items?itemName=SummerSun.vscode-jetty)
 6. [Community Server Connectors](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-community-server-connector)
 7. [Server Connector](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-server-connector)
-8. [MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack)
+8. [Extension Pack for MicroProfile](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack)
 9. [CheckStyle](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle)
 10. [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 


### PR DESCRIPTION
The "MicroProfile Extension Pack" has been renamed to "Extension Pack for MicroProfile". Update all references to use the new name.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>