### PR TITLE
Fix a typo in semantic-highlight-guide.md

### DIFF
--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -25,7 +25,7 @@ With semantic highlighting:
 
 Notice the color differences based on language service symbol understanding:
 
-- line 10: `languageMode` is colored as a parameter
+- line 10: `languageModes` is colored as a parameter
 - line 11: `Range` and `Position` are colored as classes and `document` as a parameter.
 - line 13: `getFoldingRanges` is colored as a function.
 

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -101,7 +101,7 @@ The "Tomorrow Night Blue" color theme with semantic highlighting:
 
 Notice the color differences based on language service symbol understanding:
 
-- line 10: `languageMode` is colored as a parameter.
+- line 10: `languageModes` is colored as a parameter.
 - line 11: `Range` and `Position` are colored as classes and `document` as a parameter.
 - line 13: `getFoldingRanges` is colored as a function.
 


### PR DESCRIPTION
In the screenshot the variable is `languageModes` while the text has `languageMode`.