### PR TITLE
Add links to extension guidelines

### DIFF
--- a/api/extension-capabilities/overview.md
+++ b/api/extension-capabilities/overview.md
@@ -110,6 +110,10 @@ On the other hand, VS Code also offers a set of [Debug Extension API](/api/refer
 - Register new source control provider, such as Mercurial.
 - Implement a custom file search provider. -->
 
+## Extension Guidelines
+
+To help make your extension fit seemlessly into the VS Code user interface, refer to the [Extension Guidelines](/api/references/extension-guidelines), where you'll learn the best practices for creating extension UI and conventions for following the preferred VS Code workflows.
+
 ## Restrictions
 
 There are certain restrictions we impose upon extensions. Here are the restrictions and their purposes.

--- a/api/extension-guides/overview.md
+++ b/api/extension-guides/overview.md
@@ -23,7 +23,7 @@ In each guide or sample, you can expect to find:
 
 ## Guides & Samples
 
-Here are the guides on the VS Code website, including their usage of the [VS Code API](/api/references/vscode-api) and [Contribution Points](/api/references/contribution-points).
+Here are the guides on the VS Code website, including their usage of the [VS Code API](/api/references/vscode-api) and [Contribution Points](/api/references/contribution-points). Don't forget to refer to the [Extension Guidelines](/api/references/extension-guidelines) to learn the best practices for creating extensions.
 
 | Guide on VS Code Website | API & Contribution |
 | --- | --- |

--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -9,7 +9,7 @@ MetaDescription: Create your first Visual Studio Code extension (plug-in) with a
 
 # Your First Extension
 
-In this topic, we'll teach you the fundamental concepts for building extensions. Make sure you have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) with:
+In this topic, we'll teach you the fundamental concepts for building extensions. Be sure to first review our [extension guidelines](/api/get-started/your-first-extension) to follow the best practices. Next, make sure you have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) with:
 
 ```bash
 npm install -g yo generator-code
@@ -77,7 +77,7 @@ You can learn more about debugging Node.js apps in VS Code in the [Node.js Debug
 
 In the next topic, [Extension Anatomy](/api/get-started/extension-anatomy), we'll take a closer look at the source code of the `Hello World` sample and explain key concepts.
 
-You can find the source code of this tutorial at: [https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample](https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample). The [Extension Guides](/api/extension-guides/overview) topic contains other samples, each illustrating a different VS Code API or Contribution Point.
+You can find the source code of this tutorial at: [https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample](https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample). The [Extension Guides](/api/extension-guides/overview) topic contains other samples, each illustrating a different VS Code API or Contribution Point, and references to our [Extension Guidelines](/api/get-started/your-first-extension).
 
 ### Using JavaScript
 

--- a/api/index.md
+++ b/api/index.md
@@ -16,6 +16,7 @@ This documentation describes:
 - How to build, run, debug, test and publish an extension
 - How to take advantage of VS Code's rich Extension API
 - Where to find [guides](https://code.visualstudio.com/api/extension-guides/overview) and [code samples](https://github.com/microsoft/vscode-extension-samples) to help get you started
+- Following our [extension guidelines](/api/get-started/your-first-extension) for best practices
 
 Code samples are available at [Microsoft/vscode-extension-samples](https://github.com/microsoft/vscode-extension-samples).
 


### PR DESCRIPTION
This updates sections of the docs to link to our new extension guidelines. Feel free to tweak as needed.