### PR TITLE
fix .ssh/ path

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -398,9 +398,9 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
    RUNNING_AGENT="`ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]'`"
    if [ "$RUNNING_AGENT" = "0" ]; then
         # Launch a new instance of the agent
-        ssh-agent -s &> .ssh/ssh-agent
+        ssh-agent -s &> $HOME/.ssh/ssh-agent
    fi
-   eval `cat .ssh/ssh-agent`
+   eval `cat $HOME/.ssh/ssh-agent`
 fi
 ```
 


### PR DESCRIPTION
In some cases, relative paths doesn't work correctly. (For example, if .zprofile is a symlink)
The solution is to use an absolute path.