### PR TITLE
sysctl.conf is systemd not arch

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -211,7 +211,7 @@ When you see this notification, it indicates that the VS Code file watcher is ru
 cat /proc/sys/fs/inotify/max_user_watches
 ```
 
-The limit can be increased to its maximum by editing `/etc/sysctl.conf` (except on Arch Linux, read below) and adding this line to the end of the file:
+The limit can be increased to its maximum by editing `/etc/sysctl.d/*.conf` by adding this line to the end of the file:
 
 ```bash
 fs.inotify.max_user_watches=524288
@@ -220,8 +220,6 @@ fs.inotify.max_user_watches=524288
 The new value can then be loaded in by running `sudo sysctl -p`.
 
 While 524,288 is the maximum number of files that can be watched, if you're in an environment that is particularly memory constrained, you may wish to lower the number. Each file watch [takes up 1080 bytes](https://stackoverflow.com/a/7091897/1156119), so assuming that all 524,288 watches are consumed, that results in an upper bound of around 540 MiB.
-
-[Arch](https://www.archlinux.org/)-based distros (including Manjaro) require you to change a different file; follow [these steps](https://gist.github.com/tbjgolden/c53ca37f3bc2fab8c930183310918c8c) instead.
 
 Another option is to exclude specific workspace directories from the VS Code file watcher with the `files.watcherExclude` [setting](/docs/getstarted/settings.md). The default for `files.watcherExclude` excludes `node_modules` and some folders under `.git`, but you can add other directories that you don't want VS Code to track.
 


### PR DESCRIPTION
sysctl.conf is here for all distributions with systemd-207 or greater. see e.g. https://archlinux.org/news/deprecation-of-etcsysctlconf/ (arch), https://manpages.debian.org/stable/procps/sysctl.conf.5.en.html (debian).