### PR TITLE
Update Go extension documentation to reflect the recent change

### DIFF
--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -9,19 +9,26 @@ MetaDescription: Learn about Visual Studio Code editor features (code completion
 ---
 # Go in Visual Studio Code
 
-Using the Go extension for Visual Studio Code, you get language features like IntelliSense, code navigation, symbol search, bracket matching, snippets, and many more that will help you in [Golang](https://golang.org/) development.
+Using the Go extension for Visual Studio Code, you get features like IntelliSense, code navigation, symbol search, testing, debugging and many more that will help you in [Go](https://golang.org/) development.
 
 ![go extension banner](images/go/go-extension.png)
 
 You can install the Go extension from the VS Code [Marketplace](https://marketplace.visualstudio.com/items?itemName=golang.go).
 
+Watch ["Getting
+started with VS Code Go"](https://youtu.be/1MXIGYrMk80) for an explanation of how to build your first Go
+application using VS Code Go.
+
+This article provides only a subset of features the Go extension provides. See the extension's  [documentation](https://github.com/golang/vscode-go/blob/master/docs/features.md) for the full, up-to-date list of supported features.
 ## IntelliSense
+
+![IntelliSense](images/go/completion-signature-help.gif)
+
+IntelliSense features are provided by the Go language server,[`gopls`](https://golang.org/s/gopls), maintained by the Go team. You can configure the behavior of `gopls` using the [`gopls` settings](https://github.com/golang/vscode-go/blob/master/docs/settings.md#settings-for-gopls).
 
 ### Auto completions
 
 As you type in a Go file, you can see IntelliSense providing you with suggested completions. This even works for members in current, imported, and not yet imported packages. Just type any package name followed by `.`, and you will get suggestions for the corresponding package members.
-
-By setting `go.autocompleteUnimportedPackages` to `true` in your [settings](/docs/getstarted/settings.md), you can also get suggestion for packages that you could import. Select one of these suggestions and an import to the selected package will be added to your file.
 
 >**Tip**: Use `kb(editor.action.triggerSuggest)` to trigger the suggestions manually.
 
@@ -29,19 +36,11 @@ By setting `go.autocompleteUnimportedPackages` to `true` in your [settings](/doc
 
 Hovering on any variable, function, or struct will give you information on that item such as documentation, signature, etc.
 
-![Information on hover](images/go/hover.png)
-
-By default, the extension uses `godef` and `godoc` to get this information. You can choose to use `gogetdoc` instead by changing the setting `go.docsTool` in your User or Workspace Settings.
-
 ### Signature help
 
 When you open the `(` while calling a function, a pop-up provides signature help for the function. As you keep typing the parameters, the hint (underline) moves to the next parameter.
 
-![Signature Help](images/go/signaturehelp.png)
-
 >**Tip**: Use `kb(editor.action.triggerParameterHints)` to manually trigger the signature help when the cursor is inside the `()` in the function call.
-
-The extension's signature help also uses `godef` and `godoc`. You can choose to use `gogetdoc` instead by changing the setting `go.docsTool` in your User or Workspace Settings.
 
 ## Code navigation
 
@@ -50,6 +49,7 @@ Code navigation features are available in the context menu in the editor.
 - **Go To Definition** `kb(editor.action.revealDefinition)` - Go to the source code of the type definition.
 - **Peek Definition** `kb(editor.action.peekDefinition)` - Bring up a Peek window with the type definition.
 - **Go to References** `kb(editor.action.goToReferences)` - Show all references for the type.
+- **Show Call Hierarchy** `kb(editor.showCallHierarchy)` - Show all calls from or to a function.
 
 You can navigate via symbol search using the **Go to Symbol** commands from the **Command Palette** (`kb(workbench.action.showCommands)`).
 
@@ -58,20 +58,16 @@ You can navigate via symbol search using the **Go to Symbol** commands from the 
 
 You can also navigate back and forth between a Go file and its test implementation using the **Go: Toggle Test File** command.
 
-## Build, lint, and vet
+## Build, Test, and Diagnose
 
-On save, the Go extension can run `go build`, `go vet`, and your choice of linting tool (`golint` or `gometalinter`) on the package of the current file. You can control these features via the settings below:
+The Go language server (`gopls`) detects build and vet errors found on the workspace. The errors and warnings from running any/all of the above will be shown red/green squiggly lines in the editor. These diagnostics also show up in the **Problems** panel  (**View** > **Problems**).
 
-- `go.buildOnSave`
-- `go.buildFlags`
-- `go.vetOnSave`
-- `go.vetFlags`
-- `go.lintOnSave`
-- `go.lintFlags`
-- `go.lintTool`
+You can add additional lint checks using the `go.lintOnSave` setting and configuring your choice of linting tool (`staticcheck`, `golangci-lint`, or `revive`) using the `go.listTool` setting.
+
+You can configure the extension to run tests and compute test coverage using
 - `go.testOnSave`
-
-The errors and warnings from running any/all of the above will be shown red/green squiggly lines in the editor. These diagnostics also show up in the **Problems** panel  (**View** > **Problems**).
+- `go.coverOnSave`
+- `go.testFlags`
 
 ## Formatting
 
@@ -80,12 +76,26 @@ You can format your Go file using `kb(editor.action.formatDocument)` or by runni
 By default, formatting is run when you save your Go file. You can disable this behavior by setting `editor.formatOnSave` to `false` for the [Go] language. You can change this using your json setting files
 
 ```json
-"[go]":  {
+"[go]": {
         "editor.formatOnSave": false
-    }
+}
 ```
 
-You can choose among three formatting tools: `gofmt`, `goreturns`, and `goimports` by changing the setting `go.formatTool`.
+When you have multiple formatters activated for go files, you can select the Go extension as the default formatter.
+
+```json
+"[go]": {
+    "editor.defaultFormatter": "golang.go”
+}
+```
+
+Formatting is provided by `gopls`. If you want `gofumpt`-style formatting, you can configure `gopls` to use `gofumpt`.
+
+```json
+"gopls": {
+    "formatting.gofumpt": true
+}
+```
 
 ## Test
 
@@ -109,7 +119,7 @@ The Go extension lets you debug Go code as well. You will need to install the [D
 
 ## Next steps
 
-This has been a brief overview showing the Go extension features within VS Code. For more information, see the details provided in the Go extension [README](https://marketplace.visualstudio.com/items?itemName=golang.go).
+This has been a brief overview showing the Go extension features within VS Code. For more information, see the details provided in the Go extension [README](https://github.com/golang/vscode-go/blob/master/README.md).
 
 To stay up-to-date on the latest features/bug fixes for the Go extension, see the [CHANGELOG](https://github.com/golang/vscode-go/blob/master/CHANGELOG.md).
 

--- a/docs/languages/images/go/completion-signature-help.gif
+++ b/docs/languages/images/go/completion-signature-help.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5a7e0e3c2c235ab4e9e8e168172b3bf91e9ef40ffc7d42d291a4aeca275a22f
+size 1242020

--- a/docs/languages/images/go/go-extension.png
+++ b/docs/languages/images/go/go-extension.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0faca938c62571e05655bf6c384bc3b50ba1502da5b8a9005a5879e428af4d88
-size 50263
+oid sha256:b6fc5ceed1a38c9aeb7f740168f5420eb64279cc126fbbe8c14c41ee6b904c00
+size 49514

--- a/docs/languages/images/go/hover.png
+++ b/docs/languages/images/go/hover.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac8428baf3fd85cdb81f9eb9ca15089b32b0b2821320d36f6bfc8466df2e56d8
-size 12324

--- a/docs/languages/images/go/signaturehelp.png
+++ b/docs/languages/images/go/signaturehelp.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8cb7bbf7c9f308a1670b4a2f99dc308e23c4dc396eea32943a27d8eff241ef93
-size 10604


### PR DESCRIPTION
We are now using the gopls as the backend of the most language features.

https://blog.golang.org/gopls-vscode-go

This PR removes mention of old tools and replaces the two pngs with one gif to demonstrate all the intellisense features.
Also updates the extension image.