### PR TITLE
Update index page to fix an issue in section list

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -38,13 +38,13 @@ If you'd like to have a more comprehensive overview of the Extension API, refer 
 
 Building a good extension can take a lot of effort. Here is what each section of the API doc can help you with:
 
-* ***Get Started** teaches fundamental concepts for building extensions with the [Hello World](https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample) sample.
-* ***Extension Capabilities** dissects VS Code's vast API into smaller categories and points you to more detailed topics.
-* ***Extension Guides** includes guides and code samples that explain specific usages of VS Code Extension API.
-* ***Language Extensions** illustrates how to add support for a programming language with guides and code samples.
-* ***Testing and Publishing** includes in-depth guides on various extension development topics, such as [testing](/api/working-with-extensions/testing-extension) and [publishing](/api/working-with-extensions/publishing-extension) extensions.
-* ***Advanced Topics** explains advanced concepts such as [Extension Host](/api/advanced-topics/extension-host), [Supporting Remote Development and GitHub Codespaces](/api/advanced-topics/remote-extensions), and [Proposed API](/api/advanced-topics/using-proposed-api).
-* ***References** contains exhaustive references for the [VS Code API](/api/references/vscode-api), [Contribution Points](/api/references/contribution-points), and many other topics.
+* **Get Started** teaches fundamental concepts for building extensions with the [Hello World](https://github.com/microsoft/vscode-extension-samples/tree/master/helloworld-sample) sample.
+* **Extension Capabilities** dissects VS Code's vast API into smaller categories and points you to more detailed topics.
+* **Extension Guides** includes guides and code samples that explain specific usages of VS Code Extension API.
+* **Language Extensions** illustrates how to add support for a programming language with guides and code samples.
+* **Testing and Publishing** includes in-depth guides on various extension development topics, such as [testing](/api/working-with-extensions/testing-extension) and [publishing](/api/working-with-extensions/publishing-extension) extensions.
+* **Advanced Topics** explains advanced concepts such as [Extension Host](/api/advanced-topics/extension-host), [Supporting Remote Development and GitHub Codespaces](/api/advanced-topics/remote-extensions), and [Proposed API](/api/advanced-topics/using-proposed-api).
+* **References** contains exhaustive references for the [VS Code API](/api/references/vscode-api), [Contribution Points](/api/references/contribution-points), and many other topics.
 
 ## What's new?
 


### PR DESCRIPTION
The sections listed in the section "How to build extensions" had a formatting issue, i.e. it had an extra asterisk in addition to the two that were required to boldify the section title - for example, "* ***Get Started** teaches fundamental concepts". 

This PR fixes the issue by removing that extra asterisk and make it as "* **Get Started** teaches fundamental concepts".