### PR TITLE
Replace 'can not' with 'cannot' to conform with majority usage

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -233,7 +233,7 @@ You can use any of the validation JSON Schema properties to describe other const
 
 Not supported in the configuration section are:
 
-- `$ref` and `definition`: The configuration schemas needs to be self-contained and can not make assumptions how the aggregated settings JSON schema document looks like.
+- `$ref` and `definition`: The configuration schemas needs to be self-contained and cannot make assumptions how the aggregated settings JSON schema document looks like.
 
 
 For more details on these and other features, see the [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/index.html).

--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -150,7 +150,7 @@ Read on to find out about:
 
 ### 'code' is not recognized as an internal or external command
 
-Your OS can not find the VS Code binary `code` on its path. The VS Code Windows and Linux installations should have installed VS Code on your path. Try uninstalling and reinstalling VS Code. If `code` is still not found, consult the platform specific setup topics for [Windows](/docs/setup/windows.md) and [Linux](/docs/setup/linux.md).
+Your OS cannot find the VS Code binary `code` on its path. The VS Code Windows and Linux installations should have installed VS Code on your path. Try uninstalling and reinstalling VS Code. If `code` is still not found, consult the platform specific setup topics for [Windows](/docs/setup/windows.md) and [Linux](/docs/setup/linux.md).
 
 On macOS, you need to manually run the **Shell Command: Install 'code' command in PATH** command (available through the **Command Palette** `kb(workbench.action.showCommands)`). Consult the [macOS](/docs/setup/mac.md) specific setup topic for details.
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -269,7 +269,7 @@ Below is an example that passes `"args"` to the program differently on Windows:
 
 Valid operating properties are `"windows"` for Windows, `"linux"` for Linux and `"osx"` for macOS. Properties defined in an operating system specific scope override properties defined in the global scope.
 
-Please note that the `type` property can not be placed inside a platform-specific section, because `type` indirectly determines the platform in remote debugging scenarios, and that would result in a cyclic dependency.
+Please note that the `type` property cannot be placed inside a platform-specific section, because `type` indirectly determines the platform in remote debugging scenarios, and that would result in a cyclic dependency.
 
 In the example below debugging the program always **stops on entry** except on macOS:
 


### PR DESCRIPTION
Occurrences of 'can not' in release notes for previous versions have not been changed.