### PR TITLE
Updated RPi setup document

### DIFF
--- a/docs/setup/raspberry-pi.md
+++ b/docs/setup/raspberry-pi.md
@@ -13,6 +13,8 @@ You can run Visual Studio Code on [Raspberry Pi](https://www.raspberrypi.org) de
 
 [![Raspberry Pi Logo](images/raspberry-pi-os/RPi-Logo-Landscape-Reg-SCREEN.png)](https://www.raspberrypi.org)
 
+By downloading and using Visual Studio Code, you agree to the [license terms](https://code.visualstudio.com/license) and [privacy statement](https://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409).
+
 ## Installation
 
 Visual Studio Code is officially distributed via the [Raspberry Pi OS](https://www.raspberrypi.org/software/operating-systems) (previously called Raspbian) APT repository.


### PR DESCRIPTION
Two changes:

- Added note about license acceptance (similarly to the Linux page)
- Renamed file to reset the URL and comments: once we're ready to go live, setup will be simplified and the issues that users have experienced ("cannot find package code") will not happen anymore