### PR TITLE
remove old recipe doc

### DIFF
--- a/docs/nodejs/debugging-recipes.md
+++ b/docs/nodejs/debugging-recipes.md
@@ -47,16 +47,6 @@ You can read more about how our Debugger for Chrome works in this introduction [
 
 * [Super-charged live editing and JavaScript debugging for Angular using VS Code](https://medium.com/@auchenberg/super-charged-live-editing-and-javascript-debugging-for-angular-using-visual-studio-code-c29da251ec71)
 
-## Debug Node.js in Docker containers
-
-This recipe shows how to run and debug a VS Code Node.js project written in TypeScript running inside a [Docker](https://www.docker.com) container.
-
-![Node.js TypeScript and Docker logos](images/recipes/node-typescript-docker.png)
-
-**Recipes:**
-
-- [Debugging Node.js with TypeScript in Docker](https://github.com/microsoft/vscode-recipes/tree/master/Docker-TypeScript)
-
 ## Electron - Debug Electron applications
 
 The Visual Studio Code editor supports debugging [Electron](https://electron.atom.io) applications via the built-in [Node.js](https://nodejs.org/) debugger and the [Debugger for Chrome extension](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome).

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -440,6 +440,10 @@ Here are some things to try when your breakpoints turn gray:
 
 ## Remote debugging
 
+> **Note:** VS Code now has universal [remote development capabilities](docs/remote/remote-overview). With this, Node.js development in remote scenarios and containers is no different than Node.js development in a local setup. *This is the recommended way to remote debug Node.js programs*. Check out the [Getting Started](docs/remote/remote-overview#_getting-started) section and the [Remote tutorials](docs/remote/remote-overview#_remote-tutorials) section to get started.
+
+If you are unable to use any of the Remote Development extensions to debug your Node.js program, below is a guide on how to debug a remote Node.js program from your local instance of VS Code.
+
 The Node.js debugger supports remote debugging where you attach to a process running on a different machine, or in a container. Specify a remote host via the `address` attribute. For example:
 
 ```json
@@ -465,12 +469,6 @@ By default, VS Code will stream the debugged source from the remote Node.js fold
     "remoteRoot": "C:\\Users\\username\\project\\server"
 }
 ```
-
-Two frequently used applications of remote debugging are:
-
-* **debugging Node.js in a Docker container:**
-
-  If you are running Node.js inside a [Docker](https://www.docker.com) container, you can use the approach from above to debug Node.js inside the Docker container and map back the remote source to files in your workspace. We have created a "recipe" on [GitHub](https://github.com/microsoft/vscode-recipes) that walks you through on how to set this up [Node.js in Docker with TypeScript](https://github.com/microsoft/vscode-recipes/tree/master/Docker-TypeScript).
 
 ## Access Loaded Scripts
 

--- a/release-notes/v1_13.md
+++ b/release-notes/v1_13.md
@@ -309,7 +309,7 @@ When an exception occurs, developers commonly follow through the exception stack
 
 Setting up Node.js debugging can be challenging for some non-standard or complex scenarios. With this release, we've started to collect recipes for these scenarios in a new [repository](https://github.com/microsoft/vscode-recipes).
 
-For example, there is a recipe for [Debugging TypeScript in a Docker Container](https://github.com/microsoft/vscode-recipes/tree/master/Docker-TypeScript).
+For example, there is a recipe for [Debugging TypeScript in a Docker Container](https://github.com/microsoft/vscode-recipes/tree/fc84ccc87a2f6248f7bc1a367d56045b8b1ed738/Docker-TypeScript).
 
 ### Copy All action in Debug Console
 
@@ -329,7 +329,7 @@ To facilitate remote debugging, VS Code already supports mapping JavaScript path
 
 Recently we've opened up launch configurations of request type `"launch"` to launch arbitrary programs and scripts (and not just the local Node.js target to debug). With this, it becomes possible to launch a remote Node.js target (for example in a Docker container) and have the VS Code Node.js Debugger attach to it. This feature diminishes the difference between "launching" and "attaching" even further and it makes sense to support `localRoot` and `remoteRoot` attributes for launch configurations of request type `"launch"` as well (in addition to request type `"attach"`).
 
-You can find an example for this in the [Debugging TypeScript in a Docker Container](https://github.com/microsoft/vscode-recipes/tree/master/Docker-TypeScript#further-simplifying-the-debugging-setup) recipe.
+You can find an example for this in the [Debugging TypeScript in a Docker Container](https://github.com/microsoft/vscode-recipes/tree/fc84ccc87a2f6248f7bc1a367d56045b8b1ed738/Docker-TypeScript#further-simplifying-the-debugging-setup) recipe.
 
 ## Extensions
 

--- a/release-notes/v1_16.md
+++ b/release-notes/v1_16.md
@@ -232,7 +232,7 @@ We added a new [Emmet topic](https://code.visualstudio.com/docs/editor/emmet) de
 
 ### VS Code recipes
 
-In May, we've started to collect recipes for some non-standard or complex debugging setups in a [VS Code Recipe](https://github.com/microsoft/vscode-recipes) repository. This repository has now moved to the new location [https://github.com/microsoft/vscode-recipes](https://github.com/microsoft/vscode-recipes). Here you can find working examples using [Angular](https://github.com/microsoft/vscode-recipes/tree/master/Angular-CLI) and [Docker](https://github.com/microsoft/vscode-recipes/tree/master/Docker-TypeScript) in VS Code.
+In May, we've started to collect recipes for some non-standard or complex debugging setups in a [VS Code Recipe](https://github.com/microsoft/vscode-recipes) repository. This repository has now moved to the new location [https://github.com/microsoft/vscode-recipes](https://github.com/microsoft/vscode-recipes). Here you can find working examples using [Angular](https://github.com/microsoft/vscode-recipes/tree/master/Angular-CLI) and [Docker](https://github.com/microsoft/vscode-recipes/tree/fc84ccc87a2f6248f7bc1a367d56045b8b1ed738/Docker-TypeScript) in VS Code.
 
 ## Extension Authoring
 


### PR DESCRIPTION
We will be removing the TypeScript-Docker recipe in https://github.com/microsoft/vscode-recipes/pull/290

because it was created for remote scenarios before Remote - * extensions were made available.

This PR:
* update release note references to a specific commit with this doc
* remove any references of this doc to be deleted
* rework the nodejs-debugging doc to mention Remote Development