### PR TITLE
Slightly expanded Apple Silicon release notes

### DIFF
--- a/release-notes/v1_54.md
+++ b/release-notes/v1_54.md
@@ -469,7 +469,9 @@ Based on this information a client can enable or disable a **Restart Frame** con
 
 ### Apple Silicon
 
-We are now happy to announce our first release of stable Apple Silicon builds this iteration. Thanks to the community for self-hosting with the insiders build and reporting issues early in the iteration.
+We are happy to announce our first release of stable Apple Silicon builds this iteration. Users on Macs with M1 chips can now VS Code without emulation with Rosetta, and will notice better performance and longer battery life when running VS Code. Thanks to the community for self-hosting with the Insiders build and reporting issues early in the iteration.
+
+The default download of VS Code for macOS is now a Universal build which runs natively on all Macs. In the [Downloads](/download) page you can find additional links to architecture-specific builds for Intel or Apple Silicon, which are smaller downloads compared with the Universal package.
 
 ![Screenshot of website showing the new downloads view for Apple Silicon builds](images/1_54/apple-silicon-download.png)
 


### PR DESCRIPTION
Adding mentions of benefits (no emulation, better performance, longer battery life) and explain that the default builds are now Universal.

CC: @ornellaalt 