### PR TITLE
Fix typo in test script sample

### DIFF
--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -53,7 +53,7 @@ async function main() {
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath


### PR DESCRIPTION
`extensionDevelopmentPath` had an extra `..` in it.