### PR TITLE
Update Mac OS Setup M1 support documentation

### DIFF
--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -97,6 +97,6 @@ If VS Code doesn't update once it restarts, it might be set under quarantine by 
 
 ### Does VS Code run on Mac M1 machines?
 
-Yes, VS Code supports macOS ARM64 builds that can run on Macs with the Apple M1 chip. Currently, only [Insiders](/insiders) macOS ARM64 builds are available.
+Yes, VS Code supports macOS ARM64 builds that can run on Macs with the Apple M1 chip starting with version [1.54](/release-notes/v1_54.md) and [Insiders](/insiders) builds.
 
 ![macOS ARM64 Insiders build](images/mac/arm64-insiders.png)


### PR DESCRIPTION
As of version [1.5.4](https://code.visualstudio.com/updates/v1_54), VS Code provides stable Apple Silicon builds 🎉. I think the Mac OS setup documentation should reflect this awesome achievement.

Any tips on word-smithing would be greatly appreciated :) 