### PR TITLE
Replace deprecated `assert.equal`

### DIFF
--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -142,8 +142,8 @@ suite('Extension Test Suite', () => {
   });
 
   test('Sample test', () => {
-    assert.equal(-1, [1, 2, 3].indexOf(5));
-    assert.equal(-1, [1, 2, 3].indexOf(0));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
   });
 });
 ```


### PR DESCRIPTION
`assert.equal` is [deprecated](https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message) in favour of `assert.strictEqual`