### PR TITLE
Fix: double quotation in docs/languages/go.md

### DIFF
--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -85,7 +85,7 @@ When you have multiple formatters activated for Go files, you can select the Go 
 
 ```json
 "[go]": {
-    "editor.defaultFormatter": "golang.go”
+    "editor.defaultFormatter": "golang.go"
 }
 ```
 


### PR DESCRIPTION
Change from `"golang.go”` to `"golang.go"`