### PR TITLE
Update publishing-extension.md

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -65,6 +65,7 @@ Visual Studio Code uses [Azure DevOps](https://azure.microsoft.com/services/devo
 ### Get a Personal Access Token
 
 First off, follow the documentation to [create your own organization](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/create-organization?view=azure-devops) in Azure DevOps. In the following examples, the organization's name is `vscode`, you should use your new organization name as appropriate.
+The organization's name need not be same as your publisher name. 
 
 From your organization's home page (for example: `https://dev.azure.com/vscode`), open the User settings dropdown menu next to your profile image and select **Personal access tokens**:
 

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -64,7 +64,7 @@ Visual Studio Code uses [Azure DevOps](https://azure.microsoft.com/services/devo
 
 ### Get a Personal Access Token
 
-First off, follow the documentation to [create your own organization](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/create-organization?view=azure-devops) in Azure DevOps. In the following examples, the organization's name is `vscode`, you should use your new organization name as appropriate. The organization's name need not be same as your publisher name. 
+First off, follow the documentation to [create your own organization](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/create-organization?view=azure-devops) in Azure DevOps. In the following examples, the organization's name is `vscode`, you should use your new organization name as appropriate. Note that the organization's name doesn't necessarily have to be same as your publisher name.
 
 From your organization's home page (for example: `https://dev.azure.com/vscode`), open the User settings dropdown menu next to your profile image and select **Personal access tokens**:
 

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -64,8 +64,7 @@ Visual Studio Code uses [Azure DevOps](https://azure.microsoft.com/services/devo
 
 ### Get a Personal Access Token
 
-First off, follow the documentation to [create your own organization](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/create-organization?view=azure-devops) in Azure DevOps. In the following examples, the organization's name is `vscode`, you should use your new organization name as appropriate.
-The organization's name need not be same as your publisher name. 
+First off, follow the documentation to [create your own organization](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/create-organization?view=azure-devops) in Azure DevOps. In the following examples, the organization's name is `vscode`, you should use your new organization name as appropriate. The organization's name need not be same as your publisher name. 
 
 From your organization's home page (for example: `https://dev.azure.com/vscode`), open the User settings dropdown menu next to your profile image and select **Personal access tokens**:
 


### PR DESCRIPTION
Unlike AzureDevops Extensions, VSCode extensions are not tied to AzureDevops Organization. So to publish VSCode extensions, publishers can use any organization to generate PAT tokens. It's just that the customer has to login with the same email id as the one he/she used to create the publisher.

Also another point where publishers are getting confused a lot it is, having access to a publisher should also give them access to the AzureDevopsorganization with the same name. For Example, if I have access to a publisher 'Andy', it doesn't essentially mean that he/she has access to that organization dev.azure.come/Andy and only that organization should be used to generate the PAT token