### PR TITLE
Update remote troubleshooting

### DIFF
--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -1078,7 +1078,7 @@ If you run into an issue with one of the remote development extensions, it's imp
 
 Each remote extension has a command to view its logs.
 
-You can get the Remote - SSH logs with `F1` -> `Remote-SSH: Show Log`. This is the same as the output from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. When reporting Remote - SSH issues, please also verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
+You can get the Remote - SSH logs with `F1` -> `Remote-SSH: Show Log`. When reporting Remote - SSH issues, please also verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
 
 Similarly, you can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -1068,6 +1068,26 @@ Extensions that access locally attached devices will be unable to connect to the
 
 ## Questions and feedback
 
+### Reporting quality issues
+
+If you run into an issue with one of the remote development extensions, it's important to collect the correct logs so that we'll be able to help [diagnose your issue](https://aka.ms/vscode-remote/issues/new).
+
+We recommend turning on trace level telemetry to get the most detailed logs: `F1` -> `Developer: Set Log Level...` -> `Trace`. From here, the type of logs depends on the context of your issue.
+
+You can get the Remote - SSH logs from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown.
+
+You can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
+
+Similarly, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`.
+
+If you're experiencing issues using other extensions remotely (i.e. other extensions aren't loading or installing properly in a remote context), it's helpful to grab the log from the "Remote Extension Host" output channel: `F1` -> `Output: Focus on Output View`, and select "Log (Remote Extension Host)" from the dropdown.
+
+> **Note**: If you only see "Log (Extension Host)," this is the local extension host, and the remote extension host didn't launch. This is because the log channel is created only after the log file is created, so if the remote extension host does not launch, the remote extension host log file was not created, and this is not shown in the output view. This is helpful information to include in your issue.
+
+### Remote question and feedback resources
+
+We have a variety of other remote resources:
+
 - See [Remote Development FAQ](/docs/remote/faq.md).
 - Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 - Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -163,9 +163,9 @@ If you encounter an error when connecting, you may need to enable socket forward
 
 If you are running into problems with VS Code hanging while trying to connect (and potentially timing out), there are a few things you can do to try to resolve the issue.
 
-**General Remote-SSH troubleshooting**
+**General troubleshooting: Remove the server**
 
-One command helpful in a variety of troubleshooting situations is: `Remote-SSH: Kill VS Code Server on Host`. This will remove the server, which can fix a wide range of issues and error messages you may see, such as "Could not establish connection to `server_name`: The VS Code Server failed to start."
+One command helpful to troubleshoot a variety of Remote-SSH issues is: `Remote-SSH: Kill VS Code Server on Host`. This will remove the server, which can fix a wide range of issues and error messages you may see, such as "Could not establish connection to `server_name`: The VS Code Server failed to start."
 
 **See if VS Code is waiting on a prompt**
 
@@ -1076,11 +1076,13 @@ Extensions that access locally attached devices will be unable to connect to the
 
 If you run into an issue with one of the remote development extensions, it's important to collect the correct logs so that we'll be able to help [diagnose your issue](https://aka.ms/vscode-remote/issues/new).
 
-Each remote extension has a command to view its logs. You can get the Remote - SSH logs with `F1` -> `Remote-SSH: Show Log`, which is the same as the output from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. Also please verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
+Each remote extension has a command to view its logs.
+
+You can get the Remote - SSH logs with `F1` -> `Remote-SSH: Show Log`. This is the same as the output from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. When reporting Remote - SSH issues, please also verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
 
 Similarly, you can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
 
-Like the two extensions above, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`. Please also check if your issue may be tracked upstream in the [WSL repo](https://github.com/microsoft/WSL/issues) (rather than part of the Remote - WSL extension).
+Like the two above, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`. Please also check if your issue may be tracked upstream in the [WSL repo](https://github.com/microsoft/WSL/issues) (rather than part of the Remote - WSL extension).
 
 If you're experiencing issues using other extensions remotely (i.e. other extensions aren't loading or installing properly in a remote context), it's helpful to grab the log from the "Remote Extension Host" output channel: `F1` -> `Output: Focus on Output View`, and select "Log (Remote Extension Host)" from the dropdown.
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -163,9 +163,9 @@ If you encounter an error when connecting, you may need to enable socket forward
 
 If you are running into problems with VS Code hanging while trying to connect (and potentially timing out), there are a few things you can do to try to resolve the issue.
 
-**Server fails to start**
+**General Remote-SSH troubleshooting**
 
-If you get a message along the lines of "Could not establish connection to `server_name`: The VS Code Server failed to start," try running the command: `Remote-SSH: Kill VS Code Server on Host`. This will remove the server and can help in scenarios such as it was installed in a bad state if the host ran out of disk space.
+One command helpful in a variety of troubleshooting situations is: `Remote-SSH: Kill VS Code Server on Host`. This will remove the server, which can fix a wide range of issues and error messages you may see, such as "Could not establish connection to `server_name`: The VS Code Server failed to start."
 
 **See if VS Code is waiting on a prompt**
 
@@ -1076,13 +1076,11 @@ Extensions that access locally attached devices will be unable to connect to the
 
 If you run into an issue with one of the remote development extensions, it's important to collect the correct logs so that we'll be able to help [diagnose your issue](https://aka.ms/vscode-remote/issues/new).
 
-We recommend turning on trace level telemetry to get the most detailed logs: `F1` -> `Developer: Set Log Level...` -> `Trace`. From here, the type of logs depends on the context of your issue.
+Each remote extension has a command to view its logs. You can get the Remote - SSH logs with `F1` -> `Remote-SSH: Show Log`, which is the same as the output from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. Also please verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
 
-You can get the Remote - SSH logs from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. Also please verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
+Similarly, you can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
 
-You can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
-
-Similarly, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`. Please also check if your issue may be tracked upstream in the [WSL repo](https://github.com/microsoft/WSL/issues) (rather than part of the Remote - WSL extension).
+Like the two extensions above, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`. Please also check if your issue may be tracked upstream in the [WSL repo](https://github.com/microsoft/WSL/issues) (rather than part of the Remote - WSL extension).
 
 If you're experiencing issues using other extensions remotely (i.e. other extensions aren't loading or installing properly in a remote context), it's helpful to grab the log from the "Remote Extension Host" output channel: `F1` -> `Output: Focus on Output View`, and select "Log (Remote Extension Host)" from the dropdown.
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -163,6 +163,10 @@ If you encounter an error when connecting, you may need to enable socket forward
 
 If you are running into problems with VS Code hanging while trying to connect (and potentially timing out), there are a few things you can do to try to resolve the issue.
 
+**Server fails to start**
+
+If you get a message along the lines of "Could not establish connection to `server_name`: The VS Code Server failed to start," try running the command: `Remote-SSH: Kill VS Code Server on Host`. This will remove the server and can help in scenarios such as it was installed in a bad state if the host ran out of disk space.
+
 **See if VS Code is waiting on a prompt**
 
 Enable the `remote.SSH.showLoginTerminal` [setting](/docs/getstarted/settings.md) in VS Code and retry. If you are prompted to input a password or token, see [Enabling alternate SSH authentication methods](#enabling-alternate-ssh-authentication-methods) for details on reducing the frequency of prompts.
@@ -1074,11 +1078,11 @@ If you run into an issue with one of the remote development extensions, it's imp
 
 We recommend turning on trace level telemetry to get the most detailed logs: `F1` -> `Developer: Set Log Level...` -> `Trace`. From here, the type of logs depends on the context of your issue.
 
-You can get the Remote - SSH logs from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown.
+You can get the Remote - SSH logs from the SSH Output channel: `F1` -> `Output: Focus on Output View`, and select "Remote - SSH" from the dropdown. Also please verify if you're able to SSH into your machine from an external terminal (not using Remote - SSH).
 
 You can get the Remote - Containers logs with `F1` -> `Remote-Containers: Show Log`.
 
-Similarly, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`.
+Similarly, you can get the Remote - WSL logs with `F1` -> `Remote WSL: Show Log`. Please also check if your issue may be tracked upstream in the [WSL repo](https://github.com/microsoft/WSL/issues) (rather than part of the Remote - WSL extension).
 
 If you're experiencing issues using other extensions remotely (i.e. other extensions aren't loading or installing properly in a remote context), it's helpful to grab the log from the "Remote Extension Host" output channel: `F1` -> `Output: Focus on Output View`, and select "Log (Remote Extension Host)" from the dropdown.
 


### PR DESCRIPTION
### Context

One of my goals this iteration is to make some updates to help with troubleshooting and triaging issues in remote-release.

1) I've noticed that we often first ask users for their logs. We don't currently ask for logs in the issue reporter, and there's some complexity since we have 3 different extensions. I've added a section about reporting quality issues to the remote troubleshooting doc, which largely includes how to grab the correct logs.

2) In addition to logging info, I've also included a couple other pieces of info in this new section based on common questions we often ask users, i.e.:

- Can they SSH into their machine from an external terminal?
- Does their WSL issue lie on the WSL side or the Remote - WSL side?

3) I wanted to update the doc with any tips or settings that folks commonly use to troubleshoot. I added a section about `Remote-SSH: Kill VS Code Server on Host` and was considering any others that could be useful for any of the remote extensions.

4) Once we merge in any changes to this troubleshooting doc, I thought it'd make sense to update the remote-release issue reporter (I believe a few of us have discussed this) in hopes of folks taking some of those initial logging and troubleshooting steps to report higher quality issues.

This was my initial idea for the updated reporter template (additions are bolded):

![reporter](https://user-images.githubusercontent.com/25310137/113643867-2f402500-9638-11eb-89b8-5b4f7ab3a17c.png)

### Getting your input

I'd really like to get your input here, since I hope this effort could help you all in some way. If you have input on common troubleshooting steps, settings, or commands we should document more clearly, any of the updates I've included here, or even just the format and overall idea of updating the issue reporter and docs, I'd love to hear it. 

Thank you!