### PR TITLE
Change compilerPath example to full path

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -342,7 +342,7 @@ The `compilerPath` search order is:
 * Then look for g++ on Windows Subsystem for Linux (WSL)
 * Then g++ for Mingw-w64.
 
-If you have Visual Studio or WSL installed, you may need to change `compilerPath` to match the preferred compiler for your project. For example, if you installed Mingw-w64 version 8.1.0 using the i686 architecture, Win32 threading, and sjlj exception handling install options, the path would look like this: `C:\Program Files (x86)\mingw-w64\i686-8.1.0-win32-sjlj-rt_v6-rev0`.
+If you have Visual Studio or WSL installed, you may need to change `compilerPath` to match the preferred compiler for your project. For example, if you installed Mingw-w64 version 8.1.0 using the i686 architecture, Win32 threading, and sjlj exception handling install options, the path would look like this: `C:\Program Files (x86)\mingw-w64\i686-8.1.0-win32-sjlj-rt_v6-rev0\mingw64\bin\g++.exe`.
 
 ## Next steps
 


### PR DESCRIPTION
`compilerPath` should the full path to the compiler.