### PR TITLE
Add release notes about `editor.autoClosingDelete`

### DIFF
--- a/release-notes/v1_55.md
+++ b/release-notes/v1_55.md
@@ -178,6 +178,12 @@ Last release, we introduced automatic relaunching of terminals when an extension
 
 There is also a new setting to disable this automatic relaunching all together `terminal.integrated.environmentChangesRelaunch`.
 
+## Editor
+
+### New auto closing pair deletion
+
+The behavior of pressing `kbstyle(Backspace)` has changed when inside auto-closing pairs. The editor will now delete the matching closing bracket or matching closing quote only if the editor auto-inserted that character. This behavior is controlled via a newly introduced setting called `editor.autoClosingDelete`, which can be configured to `"always"` to get the previous behavior.
+
 ## Debugging
 
 ### Improvements to breakpoints


### PR DESCRIPTION
I forgot to mention this in the release notes.

See also https://github.com/microsoft/vscode/issues/118270#issuecomment-813995203