### PR TITLE
Update clone in volume information

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -198,11 +198,15 @@ To learn more about creating `devcontainer.json` files, see [Create a Developmen
 
 ## Inspecting volumes
 
-Occasionally you may run into a situation where you are using a Docker named volume that you want to inspect or make changes in. You can use VS Code to work with these contents without creating or modifying `devcontainer.json` file by selecting the **Remote-Containers: Inspect Volume in Container...** from the Command Palette (`kbstyle(F1)`).
+Occasionally you may run into a situation where you are using a Docker named volume that you want to inspect or make changes in. You can use VS Code to work with these contents without creating or modifying `devcontainer.json` file by selecting the **Remote-Containers: Explore a Volume in a Development Container...** from the Command Palette (`kbstyle(F1)`).
 
-If you have the [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) installed, you can also right-click on a volume in the **Volumes** section of the **Docker Explorer** and select **Inspect in Visual Studio Code**.
+You can also inspect your volumes in the Remote Explorer. Make sure you have Containers selected in the dropdown, then you'll notice a **Dev Volumes** section. You can right-click on a volume to inspect its creation information, like when the volume was created, what repo was cloned into it, and the mountpoint. You can also explore it in a dev container.
 
-![Inspect in VS Code context menu](images/containers/inspect-volume-context-menu.png)
+![Right-click dev volumes in Remote Explorer](images/containers/dev-volumes.png)
+
+If you have the [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) installed, you can right-click on a volume in the **Volumes** section of the **Docker Explorer** and select **Explore in a Development Container**.
+
+![Explore in dev container in Docker context menu](images/containers/docker-explore-dev-container.png)
 
 ## Managing extensions
 

--- a/docs/remote/images/containers/dev-volumes.png
+++ b/docs/remote/images/containers/dev-volumes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7d1cbf01db14a7fd56a81d4aa54083dfbb6302c90e51d32a7087e21f68aed09
+size 39243

--- a/docs/remote/images/containers/docker-explore-dev-container.png
+++ b/docs/remote/images/containers/docker-explore-dev-container.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37d27799482107dc7b61bd2f38e0f4086b810922ff6c98e140a9a847562f5a0c
+size 45898


### PR DESCRIPTION
Updating the docs to reflect @egamma's latest updates to the Clone Repository in Container Volume flow.

- Update inspection command name to **Remote-Containers: Explore a Volume in a Development Container...**
- Add explanation and image for dev volumes section in Remote Explorer
- Update image for inspecting in Docker extension

I explored the other Remote - Containers docs (especially https://code.visualstudio.com/docs/remote/containers-advanced) to see if any content there needed to be updated, but the volume information there seems up-to-date (i.e. code-focused rather than impacted by the new command flow/UI). The [cloning quick start](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) also seemed pretty much unaffected. 

If there's anything else you think we should highlight regarding the new flow/functionality, please let me know. I considered adding extra info users may find interesting, i.e. how users can get more than one repo per volume, but since our docs are already rather long, I wasn't sure if that was necessary or would just get lost (and the command for creating a new volume is a Docker command `Docker volume create ...`, rather than something VS Code specific). 

Since these changes are live in Insiders but will ship with Stable, I think we can wait to push until the next Stable release. 

Fixes https://github.com/microsoft/vscode-docs/issues/4477.