### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/api/language-extensions/programmatic-language-features.md
+++ b/api/language-extensions/programmatic-language-features.md
@@ -383,7 +383,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 Allow the user to see all occurrences of a symbol in the open editor.
 
-![Select a symbol to highlight all occurences](images/language-support/document-highlights.gif)
+![Select a symbol to highlight all occurrences](images/language-support/document-highlights.gif)
 
 #### Language Server Protocol
 

--- a/api/references/vscode-api.md
+++ b/api/references/vscode-api.md
@@ -11671,7 +11671,7 @@ loading data for the next step in user input.</p>
 
 <a name="InputBox.ignoreFocusOut"></a><span class="ts" id=2245 data-target="#details-2245" data-toggle="collapse"><span class="ident">ignoreFocusOut</span><span>: </span><a class="type-intrinsic">boolean</a></span>
 <div class="details collapse" id="details-2245">
-<div class="comment"><p>If the UI should stay open even when loosing UI focus. Defaults to false.</p>
+<div class="comment"><p>If the UI should stay open even when losing UI focus. Defaults to false.</p>
 </div>
 </div>
 
@@ -13431,7 +13431,7 @@ loading data for the next step in user input.</p>
 
 <a name="QuickInput.ignoreFocusOut"></a><span class="ts" id=2193 data-target="#details-2193" data-toggle="collapse"><span class="ident">ignoreFocusOut</span><span>: </span><a class="type-intrinsic">boolean</a></span>
 <div class="details collapse" id="details-2193">
-<div class="comment"><p>If the UI should stay open even when loosing UI focus. Defaults to false.</p>
+<div class="comment"><p>If the UI should stay open even when losing UI focus. Defaults to false.</p>
 </div>
 </div>
 
@@ -13669,7 +13669,7 @@ loading data for the next step in user input.</p>
 
 <a name="QuickPick.ignoreFocusOut"></a><span class="ts" id=2222 data-target="#details-2222" data-toggle="collapse"><span class="ident">ignoreFocusOut</span><span>: </span><a class="type-intrinsic">boolean</a></span>
 <div class="details collapse" id="details-2222">
-<div class="comment"><p>If the UI should stay open even when loosing UI focus. Defaults to false.</p>
+<div class="comment"><p>If the UI should stay open even when losing UI focus. Defaults to false.</p>
 </div>
 </div>
 

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -162,7 +162,7 @@ You can easily generate an options file using Pylint itself:
 pylint --generate-rcfile > .pylintrc
 ```
 
-For PowerShell you have to explictly specify a UTF-8 output encoding:
+For PowerShell you have to explicitly specify a UTF-8 output encoding:
 
 ```ps
 pylint --generate-rcfile | Out-File -Encoding utf8 .pylintrc

--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -125,7 +125,7 @@ For example, you might install the Go stack in WSL (compiler, debugger, linters,
 
 It’s true that you can run binaries in WSL from Windows and vice-versa, but regular VS Code extensions don’t know how to do this. This is how we started out supporting debugging in WSL, but quickly realized we would have to update all extensions to know about WSL.
 
-We decided instead to make parts of VS Code run in WSL and let the UI running on Windows talk to the VS Code server running in WSL. This is what the Remote - WSL extension enables and with it, the Go extension runs in WSL along with the rest of the Go tools (complier, debugger, linters), while VS Code runs on Windows.
+We decided instead to make parts of VS Code run in WSL and let the UI running on Windows talk to the VS Code server running in WSL. This is what the Remote - WSL extension enables and with it, the Go extension runs in WSL along with the rest of the Go tools (compiler, debugger, linters), while VS Code runs on Windows.
 
 With this approach, language features like smart completions just work against what is in WSL without having to set up anything on Windows. You don't have to worry about path issues or set up different versions of development stacks on Windows. If you are deploying applications to Linux, you can set up your WSL instances to look like your runtime environment while still getting a rich editing experience on Windows.
 


### PR DESCRIPTION
Scope of changes is restricted to markdown docs only.