### PR TITLE
Update extension-manifest.md

### DIFF
--- a/api/references/extension-manifest.md
+++ b/api/references/extension-manifest.md
@@ -72,7 +72,7 @@ Here is a complete `package.json`
     "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
   },
   "devDependencies": {
-    "vscode": "0.10.x",
+    "@types/vscode": "^0.10.x",
     "typescript": "^1.6.2"
   },
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
fixed outdated . btw, i think References is more important to keep up to date, than shorts like /api/get-started/extension-anatomy.md#extension-manifest