### PR TITLE
fix python autoComplete configuration setting key

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -64,7 +64,7 @@ To enable IntelliSense for packages that are installed in other, non-standard lo
     "~/.local/lib/Google/google_appengine/lib/flask-0.12" ]
 ```
 
-The `python.autocomplete.addBrackets` setting (default `false`) also determines whether VS Code automatically adds parentheses (`()`) when autocompleting a function name. For example, if you set `addBrackets` to `true`:
+The `python.autoComplete.addBrackets` setting (default `false`) also determines whether VS Code automatically adds parentheses (`()`) when autocompleting a function name. For example, if you set `addBrackets` to `true`:
 
 ```json
   "python.autoComplete.addBrackets": true,


### PR DESCRIPTION
`python.autocomplete.addBrackets` doesn't exist.