### PR TITLE
Update extension-anatomy.md

### DIFF
--- a/api/get-started/extension-anatomy.md
+++ b/api/get-started/extension-anatomy.md
@@ -52,7 +52,7 @@ However, let's focus on `package.json` and `extension.ts`, which are essential t
 
 ### Extension Manifest
 
-Each VS Code extension must have a `package.json` as its [Extension Manifest](/api/references/extension-manifest). The `package.json` contains a mix of Node.js fields such as `scripts` and `dependencies` and VS Code specific fields such as `publisher`, `activationEvents` and `contributes`. You can find description of all VS Code specific fields in [Extension Manifest Reference](/api/references/extension-manifest). Here are some most important fields:
+Each VS Code extension must have a `package.json` as its [Extension Manifest](/api/references/extension-manifest). The `package.json` contains a mix of Node.js fields such as `scripts` and `devDependencies` and VS Code specific fields such as `publisher`, `activationEvents` and `contributes`. You can find description of all VS Code specific fields in [Extension Manifest Reference](/api/references/extension-manifest). Here are some most important fields:
 
 - `name` and `publisher`: VS Code uses `<publisher>.<name>` as a unique ID for the extension. For example, the Hello World sample has the ID `vscode-samples.helloworld-sample`. VS Code uses the ID to uniquely identify your extension
 - `main`: The extension entry point.


### PR DESCRIPTION
Use `devDependencies` instead of `dependencies` as the main part of `package.json`.
At [extension-anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy) `dependencies` introduced as the main part of `package.json`.
`yo` (version 4.1.0) recently generates a sample code for `Hello World` extension. Generated code contains `devDependencies` instead of `dependencies` in `package.json` file.
If `yeoman` is updated enough seems better to change this part of documentation. 