### PR TITLE
Add documentation on how to share and run extensions using the Proposed API

### DIFF
--- a/api/advanced-topics/images/proposed-api/install-from-vsix.gif
+++ b/api/advanced-topics/images/proposed-api/install-from-vsix.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d902b326557fbe2ce4f529f31667de6cef862576a35049c78bc96832a8ee1154
+size 138280

--- a/api/advanced-topics/using-proposed-api.md
+++ b/api/advanced-topics/using-proposed-api.md
@@ -40,3 +40,24 @@ You can solve this issue by either:
 
 - Remove dependency on `@types/vscode` and use `npx vscode-dts main` to download `vscode.d.ts` from `microsoft/vscode` main branch.
 - Use `@types/vscode@<version>` and also use `npx vscode-dts dev <version>` to download the `vscode.proposed.d.ts` from an old branch of `microsoft/vscode`. However, be careful the API might have changed in the latest version of VS Code Insiders.
+
+## Sharing extensions using the Proposed API
+
+While you're not able to publish extensions using the Proposed API on the marketplace, you can still share your extension with your peers by packaging and sharing your packaged extension.
+
+To package your extension, you can run `vsce package` to create a VSIX file of your extension. You can then share this VSIX file to others to install the extension in their VS Code.
+
+To install an extension from a VSIX file you would go into the Extension Marketplace tab and then click on the elipsies to see a menu item that allows you to install an extension from a VSIX; this is demoed by this short video below.
+
+![Demo showing a user going into the Extension Marketplace to find the menu item to install an extension from a VSIX file](images/proposed-api/install-from-vsix.gif)
+
+For extensions using the Proposed API, there's a couple more steps to enable your extension. After installing from your VSIX then you should quit the VS Code Insiders. Then launch VS Code Insiders from command line with `code-insiders --enable-proposed-api=<YOUR-EXTENSION-ID> .` in the folder you'd like to open VS Code Insiders with with your extension enabled.
+
+If you'd like to set it so your extension using the Proposed API is always available to use on every launch of VS Code Insiders, you can edit `~/.vscode-insiders/argv.json` on Mac or `C:\Users\<USER>\.vscode-insiders\argv.json` on Windows to  set a list of extensions that are enabled with the Proposed API on launch of VS Code Insiders.
+
+```json
+{
+    ...
+    "enable-proposed-api": ["<YOUR-EXTENSION-ID>"]
+}
+```


### PR DESCRIPTION
Not sure about how to give the appropriate path for Mac or Windows depending on their machine.