### PR TITLE
Fix minor mistake in v1.56 release notes about KaTeX

### DIFF
--- a/release-notes/v1_56.md
+++ b/release-notes/v1_56.md
@@ -229,7 +229,7 @@ You can now use math equations inside of notebook Markdown cells:
 VS Code uses [KaTeX](https://katex.org) for rendering the equations. There are two ways to embed a math equation into a Markdown cell:
 
 * Using single dollar signs: `$...$`. This creates an inline math equation.
-* Using single dollar signs:  `$$...$$`. This creates an centered, block math equation.
+* Using double dollar signs:  `$$...$$`. This creates a centered, block math equation.
 
 We implemented math support using an experimental notebook markup renders API, which is still in development. Our eventual goal with this API is to also allow extensions to extend the rendering of Markdown in notebooks.
 


### PR DESCRIPTION
It says single dollar signs but shows `$$`. Also fix a typo.