### PR TITLE
Remove stray character from Django tutorial

### DIFF
--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -666,7 +666,7 @@ class LogMessage(models.Model):
     def __str__(self):
         """Returns a string representation of a message."""
         date = timezone.localtime(self.log_date)
-        return f"'{self.message}' logged on {date.strftime('%A, %d %B, %Y at %X')}"
+        return "'{self.message}' logged on {date.strftime('%A, %d %B, %Y at %X')}"
 ```
 
 A model class can include methods that return values computed from other class properties. Models typically include a `__str__` method that returns a string representation of the instance.


### PR DESCRIPTION
It looks like a stray `f` was added to one of the code snippets so this removes that.