### PR TITLE
Remove reference to unassigned keyboard shortcut

### DIFF
--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -183,7 +183,7 @@ To create a minimal Django app, then, it's necessary to first create the Django 
     ]
     ```
 
-1. Save all modified files with `kb(workbench.action.files.saveAll)`.
+1. Save all modified files.
 
 1. In the VS Code Terminal, again with the virtual environment activated, run the development server with `python manage.py runserver` and open a browser to  `http://127.0.0.1:8000/` to see a page that renders "Hello, Django".
 


### PR DESCRIPTION
The Save All command (`workbench.action.files.saveAll`) does not have a default keyboard shortcut (see [Visual Studio Code Key Bindings](https://code.visualstudio.com/docs/getstarted/keybindings#_file-management)) so is rendered `unassigned` in the tutorial. This doesn't make much sense to the reader of the tutorial, so I think it'd be best to remove the reference entirely.