### PR TITLE
docs: add gitlab ci example

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -209,8 +209,10 @@ before_script:
 
 test:
   script:
-    - apt update; apt install -y libasound2 libgbm-dev libgtk-3-0 libnss3 xvfb;
-      xvfb-run -a npm run test;
+    - |
+      apt update
+      apt install -y libasound2 libgbm-dev libgtk-3-0 libnss3 xvfb
+      xvfb-run -a npm run test
 ```
 
 ### GitLab CI automated publishing

--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -197,6 +197,44 @@ In our example, the condition has three checks:
 - `startsWith( github.ref, 'refs/tags/releases/')` - Publish only if a tagged (release) build.
 - `matrix.os == 'ubuntu-latest'` - Include if your build runs on multiple agents (Windows, Linux, etc.). If not, remove that part of the condition.
 
+## GitLab CI
+
+GitLab CI can be used to test and publish the extension in headless Docker containers. This can be done by pulling a preconfigured Docker image, or installing `xvfb` and the libraries required to run Visual Studio Code during the pipeline.
+
+```yml
+image: node:12-buster
+
+before_script:
+  - npm install
+
+test:
+  script:
+    - apt update; apt install -y libasound2 libgbm-dev libgtk-3-0 libnss3 xvfb;
+      xvfb-run -a npm run test;
+```
+
+### GitLab CI automated publishing
+
+1. Set up `VSCE_PAT` as a masked variable using the [GitLab CI documentation](https://docs.gitlab.com/ee/ci/variables/README.html#mask-a-cicd-variable).
+2. Install `vsce` as a `devDependencies` (`npm install vsce --save-dev` or `yarn add vsce --dev`).
+3. Declare a `deploy` script in `package.json` without the PAT.
+
+```json
+"scripts": {
+  "deploy": "vsce publish --yarn"
+}
+```
+
+4. Add a `deploy` job that calls `npm run deploy` with the masked variable which will only trigger on tags.
+
+```yaml
+deploy:
+  only:
+    - tags
+  script:
+    - npm run deploy
+```
+
 ## Travis CI
 
 [vscode-test](https://github.com/microsoft/vscode-test) also includes a [Travis CI build definition](https://github.com/microsoft/vscode-test/blob/main/.travis.yml). The way to define environment variables in Travis CI is different from other CI frameworks, so the `xvfb` script is also different:


### PR DESCRIPTION
This updates the Continuous Integration documentation to include an example for GitLab CI.

This is based on the configuration here:
https://gitlab.com/Elypia/magick-image-reader/-/pipelines/302079622

---

This might not be ideal as installing packages in the pipeline isn't optimal, but it's a solution that works on the shared runners without creating ones own Docker image.

An alternative solution could be to make a Docker image just for testing Visual Studio Code Extensions, similarly to how there are containers for testing in Chromium. Like this, it could be based on a node:buster image that just installed the packages to allows us to run a headless instance of Visual Studio Code.

