### PR TITLE
Add new C++ debugging options to launch.json

### DIFF
--- a/docs/cpp/launch-json-reference.md
+++ b/docs/cpp/launch-json-reference.md
@@ -135,6 +135,10 @@ Additional arguments to pass to the debugger (such as gdb).
 
 If set to true, the debugger should stop at the entry-point of the target (ignored on attach). Default value is `false`.
 
+### stopAtConnect
+
+If set to true, the debugger should stop after connecting to the target. If set to false, the debugger will continue after connecting. Default value is `false`.
+
 ### setupCommands
 
 JSON array of commands to execute in order to set up the GDB or LLDB. Example: `"setupCommands": [ { "text": "target-run", "description": "run target", "ignoreFailures": false }]`.
@@ -208,7 +212,15 @@ Arguments for the debugger server.
 
 ### serverStarted
 
-Server-started pattern to look for in the debug server output.
+Server-started pattern to look for in the debug server output. Regular expressions are supported.
+
+### filterStdout
+
+If set to true, search `stdout` stream for server-started pattern and log stdout to debug output. Default value is `true`.
+
+### filterStderr
+
+If set to true, search `stderr` stream for server-started pattern and log stderr to debug output. Default value is `false`.
 
 ### serverLaunchTimeout
 
@@ -217,6 +229,10 @@ Time in milliseconds, for the debugger to wait for the debugServer to start up. 
 ### pipeTransport
 
 For information about attaching to a remote process, such as debugging a process in a Docker container, see the [Pipe transport](/docs/cpp/pipe-transport.md) settings article.
+
+### hardwareBreakpoints
+
+If provided, this explicitly controls hardware breakpoint behavior for remote targets. If `require` is set to true, always use hardware breakpoints. Default value is `false`. `limit` is an optional limit on the number of available hardware breakpoints to use which is only enforced when `require` is true and `limit` is greater than 0. Defaults value is 0. Example: ```"hardwareBreakpoints": { require: true, limit: 6 }```.
 
 ## Additional properties
 


### PR DESCRIPTION
`filterStdout` and `filterStderr` are existing (undocumented) options. `stopAtConnect` and `hardwareBreakpoints` are new options available in the Insiders release of the C++ extension.

FYI @aleun @robotdad