### PR TITLE
Fix #4555 Don't override the sudoers file by adding a user

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -471,7 +471,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
     && apt-get update \
     && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL >> /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # ********************************************************


### PR DESCRIPTION
While redirecting the output of echo `$USERNAME ALL=\(root\) NOPASSWD:ALL` the usage of ">" will override the sudoers file and destroy it. Use ">>" to append to the file