### PR TITLE
Linking to recipe for debugging Lambda functions locally

### DIFF
--- a/docs/nodejs/debugging-recipes.md
+++ b/docs/nodejs/debugging-recipes.md
@@ -23,6 +23,7 @@ The Visual Studio Code editor supports debugging Node.js applications via the bu
 **Recipes:**
 
 * [Debugging Node.js with Nodemon](https://github.com/microsoft/vscode-recipes/tree/main/nodemon)
+* [Debugging Node.js AWS Lambda functions](https://github.com/Microsoft/vscode-recipes/tree/master/debugging-lambda-functions)
 
 ## Debug client-side JavaScript in Browsers
 


### PR DESCRIPTION
In relation to https://github.com/microsoft/vscode-docs/issues/4561.

Linking to a recipe for debugging Node.js Lambda functions locally https://github.com/microsoft/vscode-recipes/pull/299.