### PR TITLE
Fix typo in "Build, test, and diagnose" section

### DIFF
--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -61,7 +61,7 @@ You can also navigate back and forth between a Go file and its test implementati
 
 The Go language server (`gopls`) detects build and vet errors found on the workspace. The errors and warnings from running any/all of the above will be shown red/green squiggly lines in the editor. These diagnostics also show up in the **Problems** panel  (**View** > **Problems**).
 
-You can add additional lint checks using the `go.lintOnSave` setting and configuring your choice of linting tool (`staticcheck`, `golangci-lint`, or `revive`) using the `go.listTool` setting.
+You can add additional lint checks using the `go.lintOnSave` setting and configuring your choice of linting tool (`staticcheck`, `golangci-lint`, or `revive`) using the `go.lintTool` setting.
 
 You can configure the extension to run tests and compute test coverage using:
 


### PR DESCRIPTION
To configure the lint tool one should be using `go.lintTool` setting.