### PR TITLE
Fix default pytest path

### DIFF
--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -315,7 +315,7 @@ To suppress the "undefined-variable" messages, for example, use the setting `"py
 | Setting<br/>(python.testing.) | Default | Description | See also |
 | --- | --- | --- | --- |
 | pytestEnabled | `false` | Specifies whether pytest is enabled for testing. | [Testing](/docs/python/testing.md) |
-| pytestPath | `"py.test"` | Path to pytest. Use a full path if pytest is located outside the current environment. | [Testing](/docs/python/testing.md) |
+| pytestPath | `"pytest"` | Path to pytest. Use a full path if pytest is located outside the current environment. | [Testing](/docs/python/testing.md) |
 | pytestArgs | `[]` | Arguments to pass to pytest, where each top-level element that's separated by a space is a separate item in the list. When debugging tests with pytest-cov installed, include `--no-cov` in these arguments. | [Testing](/docs/python/testing.md) |
 
 ### Nose framework


### PR DESCRIPTION
The default path is "pytest", not "py.test":
https://github.com/microsoft/vscode-python/blob/f6100335a5260967031a2a1ee3684f701e95a932/package.json#L1837

Originally introduced in https://github.com/microsoft/vscode-python/commit/5b3cd6ee51754621c7be776c50157214d22a55da as "pytest".