### PR TITLE
docs: update packages for gitlab ci script

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -211,7 +211,7 @@ test:
   script:
     - |
       apt update
-      apt install -y libasound2 libgbm-dev libgtk-3-0 libnss3 xvfb
+      apt install -y libasound2 libgbm1 libgtk-3-0 libnss3 xvfb
       xvfb-run -a npm run test
 ```
 


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-docs/pull/4547

This is a minor change to the packages installed in `.gitlab-ci.yml`.
I replaced `libgbm-dev` with `libgbm1`, as the dev version isn't required to run `xvfb-run -a npm run test`.

I noticed this change in another repositories, and it appears to be valid here too:
https://github.com/puppeteer/puppeteer/pull/5693

The overall impact of the change is minimal, however:
* 104 packages installed -> 103 packages installed
* 62.9 MB downloaded -> 62.8 MB downloaded