### PR TITLE
Add additional extensionKind info

### DIFF
--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -153,7 +153,7 @@ When VS Code connects to a remote environment, extensions are classified as eith
 
 When a user installs an extension, VS Code attempts to infer the correct location and install it based on its type. Extensions that do not need to run remotely like themes and other UI customizations are automatically installed on the UI side. All others are treated as Workspace extensions since they are the most full-featured. However, extension authors can also override this location with an `extensionKind` property in `package.json`.
 
-See [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for additional details.
+If your extension is not functioning as expected, [there are steps to check](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location) if it is running in the correct location or should perhaps have a different `extensionKind`. Also see [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for additional details on what extension authors need to know about Remote Development and Codespaces.
 
 ## License and privacy
 

--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -153,7 +153,7 @@ When VS Code connects to a remote environment, extensions are classified as eith
 
 When a user installs an extension, VS Code attempts to infer the correct location and install it based on its type. Extensions that do not need to run remotely like themes and other UI customizations are automatically installed on the UI side. All others are treated as Workspace extensions since they are the most full-featured. However, extension authors can also override this location with an `extensionKind` property in `package.json`.
 
-If your extension is not functioning as expected, [there are steps to check](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location) if it is running in the correct location or should perhaps have a different `extensionKind`. Also see [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for additional details on what extension authors need to know about Remote Development and Codespaces.
+If your extension is not functioning as expected, [there are steps to check](/api/advanced-topics/remote-extensions#incorrect-execution-location) if it is running in the correct location or should perhaps have a different `extensionKind`. Also see [Supporting Remote Development](/api/advanced-topics/remote-extensions.md) for additional details on what extension authors need to know about Remote Development and Codespaces.
 
 ## License and privacy
 


### PR DESCRIPTION
After recent extension investigations, we thought perhaps there could be documentation improvements to clarify `extensionKind` to users, i.e. the concept itself, differences in extension kinds, when to define it.

Upon reviewing the docs even more closely, I feel as though they are quite well-defined already (but perhaps that's also because I'm rather close to the problem at this point).

One takeaway I thought could make the experience a bit easier to read/grasp would be linking users directly to the [troubleshooting section](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location) as that took a bit of scrolling to find and may not be immediately obvious if we just link users to the top of the [Supporting Remote Development](https://code.visualstudio.com/api/advanced-topics/remote-extensions) doc. I also tried to add a bit more context around the docs links.

This is an initial proposal - please let me know if you have other ideas in how we could improve this (or if this change even feels necessary). Thank you!