### PR TITLE
Update tutorial to use up-to-date version of mingw-w64 via MSYS2

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -25,17 +25,13 @@ To successfully complete this tutorial, you must do the following steps:
 
     ![C/C++ extension](images/cpp/cpp-extension.png)
 
-1. Install Mingw-w64 via the SourceForge website. Click [Mingw-w64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe/download) to download the Windows Mingw-w64 installer.
-    1. Run the installer.
-    1. For **Architecture** select **x86_64** and then select **Next**.
-    1. On the Installation Folder page, use the default installation folder. Copy the location as you will need it later.
-    1. Select **Next** to start the installation.
+1. Get the latest version of Mingw-w64 via [MSYS2](https://www.msys2.org/), which provides up-to-date native builds of GCC, Mingw-w64, and other helpful C++ tools and libraries.  [Click here](https://github.com/msys2/msys2-installer/releases/download/2021-06-04/msys2-x86_64-20210604.exe) to download the MSYS2 installer. Then follow the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
 
 1. Add the path to your Mingw-w64 `bin` folder to the Windows `PATH` environment variable by using the following steps:
    1. In the Windows search bar, type 'settings' to open your Windows Settings.
    1. Search for **Edit environment variables for your account**.
    1. Choose the `Path` variable and then select **Edit**.
-   1. Select **New** and add the Mingw-w64 destination folder path to the system path. The exact path depends on which version of Mingw-w64 you have installed and where you installed it. If you used the settings above to install Mingw-w64, then add this to the path: `C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin`.
+   1. Select **New** and add the Mingw-w64 destination folder path to the system path. The exact path depends on which version of Mingw-w64 you have installed and where you installed it. If you used the settings above to install Mingw-w64, then add this to the path: `C:\msys64\mingw64\bin`.
    1. Select **OK** to save the updated PATH. You will need to reopen any console windows for the new PATH location to be available.
 
 ### Check your MinGW installation
@@ -47,7 +43,8 @@ g++ --version
 gdb --version
 ```
 
-If you don't see the expected output or `g++` or `gdb` is not a recognized command, check your installation (Windows **Control Panel** > **Programs**) and make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located.
+If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located.
+
 
 ## Create Hello World
 
@@ -128,12 +125,11 @@ Your new `tasks.json` file should look similar to the JSON below:
 
 ```json
 {
-    "version": "2.0.0",
     "tasks": [
         {
-            "type": "shell",
+            "type": "cppbuild",
             "label": "C/C++: g++.exe build active file",
-            "command": "C:\\Program Files\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin\\g++.exe",
+            "command": "C:/msys64/mingw64/bin/g++.exe",
             "args": [
                 "-g",
                 "${file}",
@@ -141,7 +137,7 @@ Your new `tasks.json` file should look similar to the JSON below:
                 "${fileDirname}\\${fileBasenameNoExtension}.exe"
             ],
             "options": {
-                "cwd": "${workspaceFolder}"
+                "cwd": "C:/msys64/mingw64/bin"
             },
             "problemMatcher": [
                 "$gcc"
@@ -149,9 +145,11 @@ Your new `tasks.json` file should look similar to the JSON below:
             "group": {
                 "kind": "build",
                 "isDefault": true
-            }
+            },
+            "detail": "compiler: C:/msys64/mingw64/bin/g++.exe"
         }
-    ]
+    ],
+    "version": "2.0.0"
 }
 ```
 
@@ -205,11 +203,11 @@ VS Code creates a `launch.json` file, opens it in the editor, and builds and run
             "program": "${fileDirname}\\${fileBasenameNoExtension}.exe",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
+            "cwd": "C:/msys64/mingw64/bin",
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:\\Program Files\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin\\gdb.exe",
+            "miDebuggerPath": "C:\\msys64\\mingw64\\bin\\gdb.exe",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -319,9 +317,10 @@ Visual Studio Code places these settings in `.vscode\c_cpp_properties.json`. If 
                 "_UNICODE"
             ],
             "windowsSdkVersion": "10.0.18362.0",
-            "compilerPath": "C:/Program Files/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/bin/g++.exe",
-            "cStandard": "c11",
-            "intelliSenseMode": "gcc-x64"
+            "compilerPath": "C:/msys64/mingw64/bin/g++.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-gcc-x64"
         }
     ],
     "version": 4

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -166,11 +166,11 @@ The `"isDefault": true` value in the `group` object specifies that this task wil
 1. To run the build task defined in `tasks.json`, press `kb(workbench.action.tasks.build)` or from the **Terminal** main menu choose **Run Build Task**.
 1. When the task starts, you should see the Integrated Terminal panel appear below the source code editor. After the task completes, the terminal shows output from the compiler that indicates whether the build succeeded or failed. For a successful g++ build, the output looks something like this:
 
-   ![G++ build output in terminal](images/mingw/build-output-in-terminal.png)
+   ![G++ build output in terminal](images/mingw/mingw-build-output.png)
 
 1. Create a new terminal using the **+** button and you'll have a new terminal with the `helloworld` folder as the working directory. Run `dir` and you should now see the executable `helloworld.exe`.
 
-    ![Hello World in PowerShell terminal](images/mingw/helloworld-in-terminal.png)
+    ![Hello World in PowerShell terminal](images/mingw/mingw-dir-output.png)
 
 1. You can run `helloworld` in the terminal by typing `helloworld.exe` (or `.\helloworld.exe` if you use a PowerShell terminal).
 
@@ -270,7 +270,7 @@ Now you're ready to start stepping through the code.
 
    When the loop has completed, you can see the output in the Integrated Terminal, along with some other diagnostic information that is output by GDB.
 
-   ![Debug output in terminal](images/mingw/debug-output.png)
+   ![Debug output in terminal](images/mingw/mingw-debug-output.png)
 
 ## Set a watch
 

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -45,7 +45,6 @@ gdb --version
 
 If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located.
 
-
 ## Create Hello World
 
 From a Windows command prompt, create an empty folder called `projects` where you can place all your VS Code projects. Then create a sub-folder called `helloworld`, navigate into it, and open VS Code in that folder by entering the following commands:

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -136,7 +136,7 @@ Your new `tasks.json` file should look similar to the JSON below:
                 "${fileDirname}\\${fileBasenameNoExtension}.exe"
             ],
             "options": {
-                "cwd": "C:/msys64/mingw64/bin"
+                "cwd": "${fileDirname}"
             },
             "problemMatcher": [
                 "$gcc"
@@ -202,7 +202,7 @@ VS Code creates a `launch.json` file, opens it in the editor, and builds and run
             "program": "${fileDirname}\\${fileBasenameNoExtension}.exe",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "C:/msys64/mingw64/bin",
+            "cwd": "${fileDirname}",
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",

--- a/docs/cpp/images/mingw/mingw-build-output.png
+++ b/docs/cpp/images/mingw/mingw-build-output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c474a04a2e2c6542a7c5e9ab28f2099b7940b12c53d2cae0a42234b9bc5d4537
+size 43538

--- a/docs/cpp/images/mingw/mingw-debug-output.png
+++ b/docs/cpp/images/mingw/mingw-debug-output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eccad6df1e9b4fd0c0aa464aabeeeb668d0201e3c4326d88380bbada11a89da
+size 130459

--- a/docs/cpp/images/mingw/mingw-dir-output.png
+++ b/docs/cpp/images/mingw/mingw-dir-output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ae44586bf033bbf6789e38732c3f579e122241d35e36ec0ef4e439e5837265
+size 93561

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -57,18 +57,7 @@ If you don't have a compiler installed, in the example below, we describe how to
 
 ## Example: Install MinGW-x64
 
-We will install Mingw-w64 via the SourceForge website. You can use this [Mingw-w64 link](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe/download) to download the Windows Mingw-w64 installer.
-
-1. Run the installer, which should be named `mingw-w64-install.exe` in your Download folder.
-
-   ![MinGW installation dialog welcome page](images/cpp/welcome-mingw-w64.png)
-
-2. For **Architecture** select **x86_64** and then select **Next**.
-
-   ![Choose x86_64 on the MinGW settings page](images/cpp/choose-x86-64.png)
-
-3. On the **Installation Folder** page, use the default location for the **Destination folder**. Copy the location as you will need it later.
-4. Select **Next** to start the installation.
+We will install Mingw-w64 via [MSYS2](https://www.msys2.org/), which provides up-to-date native builds of GCC, Mingw-w64, and other helpful C++ tools and libraries.  [Click here](https://github.com/msys2/msys2-installer/releases/download/2021-06-04/msys2-x86_64-20210604.exe) to download the MSYS2 installer. Then follow the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
 
 ### Add the MinGW compiler to your path
 
@@ -77,7 +66,7 @@ Add the path to your Mingw-w64 `bin` folder to the Windows `PATH` environment va
    1. In the Windows search bar, type 'settings' to open your Windows Settings.
    1. Search for **Edit environment variables for your account**.
    1. Choose the `Path` variable and then select **Edit**.
-   1. Select **New** and add the Mingw-w64 destination folder path, with `\mingw64\bin` appended, to the system path. The exact path depends on which version of Mingw-w64 you have installed and where you installed it. If you used the settings above to install Mingw-w64, then add this to the path: `C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin`.
+   1. Select **New** and add the Mingw-w64 destination folder path, with `\mingw64\bin` appended, to the system path. The exact path depends on which version of Mingw-w64 you have installed and where you installed it. If you used the settings above to install Mingw-w64, then add this to the path: `C:\msys64\mingw64\bin`.
    1. Select **OK** to save the updated PATH. You will need to reopen any console windows for the new PATH location to be available.
 
 ### Check your MinGW installation
@@ -89,7 +78,7 @@ g++ --version
 gdb --version
 ```
 
-If you don't see the expected output or `g++` or `gdb` is not a recognized command, check your installation (Windows **Control Panel** > **Programs** > **Programs and Features**) and make sure your PATH entry matches the Mingw-w64 binary location where the compiler tools are located.
+If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compiler tools are located.
 
 ## Hello World
 
@@ -134,7 +123,7 @@ Now that we have a simple C++ program, let's build it. Select the **Terminal** >
 
 This will display a dropdown with various compiler task options. If you are using a GCC toolset like MinGW, you would choose **C/C++: g++.exe build active file**.
 
-![Select g++.exe task](images/cpp/select-gpp-task.png)
+![Select g++.exe task](images/cpp/gpp-build-task-msys64.png)
 
 This will compile `helloworld.cpp` and create an executable file called `helloworld.exe`, which will appear in the File Explorer.
 

--- a/docs/languages/images/cpp/gpp-build-task-msys64.png
+++ b/docs/languages/images/cpp/gpp-build-task-msys64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61a92daace2f022db3a141587b0658be9df86c154dea85c620d0e3d439b6f014
+size 60057


### PR DESCRIPTION
Still need to update screenshots that show terminal output after running the build task.

@sean-mcmanus, when I use the mingw-w64 that I installed with MSYS2, the default build task changes cwd to from "${workspaceFolder}" to "C:/msys64/mingw64/bin". This seems weird to me, but it works. When I changed it back to "${workspaceFolder}" the build failed. Do you know why we're doing this?