### PR TITLE
Update emmet.md

### DIFF
--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -357,6 +357,5 @@ You can set the preferences using the setting `emmet.preferences`. Only a subset
 Of course!
 
 - In CSS abbreviations, when you use `:`, the left part is used to fuzzy match with the CSS property name and the right part is used to match with CSS property value. Take full advantage of this by using abbreviations like `pos:f`, `trf:rx`, `fw:b`, etc.
-- Use the new command **Emmet: Wrap Individual Lines with Abbreviation** instead of **Emmet: Wrap with Abbreviation** when you want each selected line to be wrapped by a repeater in the given abbreviation. For example, use `ul>li*` to wrap selected lines in an unordered list with each line as a list item.
 - Explore all other Emmet features as documented in [Emmet Actions](https://docs.emmet.io/actions/).
 - Don't hesitate to create your own [custom Emmet snippets](/docs/editor/emmet.md#using-custom-emmet-snippets).

--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -142,7 +142,7 @@ in VS Code, you would use a simpler:
 
 ### Trim filter (t)
 
-This filter is applicable only when providing abbreviations for the **Emmet: Wrap Individual Lines with Abbreviation** command. It [removes line markers](https://docs.emmet.io/actions/wrap-with-abbreviation/#removing-list-markers) from wrapped lines.
+This filter is applicable only when providing abbreviations for the **Emmet: Wrap with Abbreviation** command. It [removes line markers](https://docs.emmet.io/actions/wrap-with-abbreviation/#removing-list-markers) from wrapped lines.
 
 ## Using custom Emmet snippets
 


### PR DESCRIPTION
**Emmet: Wrap Individual Lines with Abbreviation** was deprecated and removed (merged into **Emmet: Wrap with Abbreviation**).