### PR TITLE
docs(containers.md): proofread typo `daemon` from `deamon`

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -207,7 +207,7 @@ When [cloning a repository in a container volume](#quick-start-open-a-git-reposi
 
 [Inspecting a volume](#inspecting-volumes) starts in [Restricted Mode](/docs/editor/workspace-trust.md#restricted-mode), and you can trust the folder inside the container.
 
-### Docker deamon running remotely
+### Docker daemon running remotely
 
 This implies trusting [the machine the Docker daemon runs on](/docs/remote/containers-advanced.md#developing-inside-a-container-on-a-remote-docker-host). There are no additional prompts to confirm (only those listed for the local/WSL case above).
 


### PR DESCRIPTION
Proofread pass noted d**ae**mon as canonical spelling for Docker daemons
https://code.visualstudio.com/docs/remote/containers

https://docs.docker.com/get-started/overview
`dockerd`