### PR TITLE
settings-sync docs: handle one more error case for linux

### DIFF
--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -148,6 +148,35 @@ If the keychain throws the error "No such interface "org.freedesktop.Secret.Coll
 
 If the error is "Writing login information to the keychain failed with error 'Unknown or unsupported transport “disabled” for address “disabled:”'", check that `dbus-launch` has been started by following the instructions in [issue #120392](https://github.com/microsoft/vscode/issues/120392#issuecomment-814210643).
 
+If the error is "Writing login information to the keychain failed with error 'Cannot create an item in a locked collection'.", you need to:
+
+1. add this to your `~/.xinitrc`
+
+```sh
+# see https://unix.stackexchange.com/a/295652/332452
+source /etc/X11/xinit/xinitrc.d/50-systemd-user.sh
+
+# see https://wiki.archlinux.org/title/GNOME/Keyring#xinitrc
+eval $(/usr/bin/gnome-keyring-daemon --start)
+export SSH_AUTH_SOCK
+
+# see https://github.com/NixOS/nixpkgs/issues/14966#issuecomment-520083836
+mkdir -p "$HOME"/.local/share/keyrings
+```
+
+2. re-login
+
+3. have the following programs installed (installation assumes arch/pacman, should be similar to other distros)
+
+```sh
+sudo pacman -S gnome-keyring libsecret libgnome-keyring
+```
+
+4. launch `seahorse`, unlock the default password keyring or create a new one and keep it unlocked
+
+5. restart the login procedure
+
+
 ## Can I share settings between VS Code Stable and Insiders?
 
 Yes. Please refer to the [Syncing Stable versus Insiders](#syncing-stable-versus-insiders) section for more information.


### PR DESCRIPTION
note - this document's url popped up once I got the error's notification so I'm adding this here. But it isn't only specific to settings-sync - it's anything that tries to sign into github or other authorized apps (e.g. I tried copilot today). cheers