### PR TITLE
fix invalid syntax in contribution-points.md

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -1052,7 +1052,7 @@ The task definition is defined using JSON schema syntax for the `required` and `
 
 - `"type": "npm"` associates the task definition with the npm tasks
 - `"required": [ "script" ]` defines that `script` attributes as mandatory. The `path` property is optional.
-- `"properties"` : { ... }` defines the additional properties and their types.
+- `"properties" : { ... }` defines the additional properties and their types.
 
 When the extension actually creates a Task, it needs to pass a `TaskDefinition` that conforms to the task definition contributed in the package.json file. For the `npm` example a task creation for the test script inside a package.json file looks like this:
 


### PR DESCRIPTION
removed an extra backtick in the `contributes.taskDefinitions` body