### PR TITLE
Update reference name to NotebookSerializer

### DIFF
--- a/api/extension-guides/notebook.md
+++ b/api/extension-guides/notebook.md
@@ -19,7 +19,7 @@ Visually:
 
 ## Serializer
 
-[NotebookContentProvider API Reference](https://github.com/microsoft/vscode/blob/e1a8566a298dcced016d8e16db95c33c270274b4/src/vs/vscode.d.ts#L11865-L11884)
+[NotebookSerializer API Reference](https://github.com/microsoft/vscode/blob/e1a8566a298dcced016d8e16db95c33c270274b4/src/vs/vscode.d.ts#L11865-L11884)
 
 A `NotebookSerializer` is responsible for taking the serialized bytes of a notebook and deserializing those bytes into `NotebookData`, which contains list of Markdown and code cells. It is responsible for the opposite conversion as well: taking `NotebookData` and converting the data into serialized bytes to be saved.
 


### PR DESCRIPTION
NotebookContentProvider no longer exists, and the link points to NotebookSerializer. 
Should remove the old name to avoid confusion.