### PR TITLE
Add working (proper) way to send ctrl+f to shell to find section

### DIFF
--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -291,6 +291,14 @@ If you want `kbstyle(Ctrl+F)` to go to the shell instead of launching the Find c
                       "when": "terminalFocus" },
 ```
 
+Alternatively, you can add the following to your `settings.json`:
+
+```
+"terminal.integrated.commandsToSkipShell": [
+    "-workbench.action.terminal.focusFind"
+],
+```
+
 ## Run selected text
 
 To use the `runSelectedText` command, select text in an editor and run the command **Terminal: Run Selected Text in Active Terminal** via the **Command Palette** (`kb(workbench.action.showCommands)`):

--- a/docs/editor/integrated-terminal.md
+++ b/docs/editor/integrated-terminal.md
@@ -280,18 +280,7 @@ Note that the command only works with the `\u0000` format for using characters v
 
 The integrated terminal has find functionality that can be triggered with `kb(workbench.action.terminal.focusFind)`.
 
-If you want `kbstyle(Ctrl+F)` to go to the shell instead of launching the Find control on Linux and Windows, you will need to remove the keybinding like so:
-
-```js
-// Windows/Linux
-{ "key": "ctrl+f", "command": "-workbench.action.terminal.focusFind",
-                      "when": "terminalFocus" },
-// macOS
-{ "key": "cmd+f",  "command": "-workbench.action.terminal.focusFind",
-                      "when": "terminalFocus" },
-```
-
-Alternatively, you can add the following to your `settings.json`:
+If you want `kbstyle(Ctrl+F)` to go to the shell instead of launching the Find control on Linux and Windows, you will need to add the following to your settings.json which will tell the terminal not to skip the shell for keybindings matching the `workbench.action.terminal.focusFind` command:
 
 ```
 "terminal.integrated.commandsToSkipShell": [


### PR DESCRIPTION
Adds workaround for https://github.com/microsoft/vscode/issues/128914 to the documentation.

What is currently listed in the documentation doesn't align with the way keybindings should be handled in the shell as explained here: https://code.visualstudio.com/docs/editor/integrated-terminal#_keybindings-and-the-shell