### PR TITLE
Fix broken link

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -57,7 +57,7 @@ The system install of Python on macOS is not supported. Instead, an installation
 
 ### Linux
 
-The built-in Python 3 installation on Linux works well, but to install other Python packages you must install `pip` with [get-pip.py](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py).
+The built-in Python 3 installation on Linux works well, but to install other Python packages you must install `pip` with [get-pip.py](https://pip.pypa.io/en/stable/installation/#get-pip-py).
 
 ### Other options
 


### PR DESCRIPTION
- Link of `get-pip.py` has broken in [Linux section of python-tutorial](https://code.visualstudio.com/docs/python/python-tutorial#_linux)
- Change https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py to https://pip.pypa.io/en/stable/installation/#get-pip-py