### PR TITLE
Fixed a hyperlink typo in programmatic-language-features.md

### DIFF
--- a/api/language-extensions/programmatic-language-features.md
+++ b/api/language-extensions/programmatic-language-features.md
@@ -37,7 +37,7 @@ The process seems more complicated, but it provides two major benefits:
 - The Language Server can be written in any language
 - The Language Server can be reused to provide smart editing features for multiple editors
 
-For a more in-depth guide, head over to the [Language Server Extension Guide](/api/language-extensions/language-server-extension-guide).
+For a more in-depth guide, head over to the [Language Server Extension Guide](/api/language-extensions/language-server-extension-guide.md).
 
 ---
 


### PR DESCRIPTION
Hi,
This PR is just a small hyperlink typo fix present in [vscode-docs/api/language-extensions/programmatic-language-features.md](https://github.com/microsoft/vscode-docs/blob/main/api/language-extensions/programmatic-language-features.md#programmatic-language-features). If I'm right then hyperlink in line 40 of that readme should point to `.../language-server-extension-guide.md`, however currently it's pointing to a page `.../language-server-extension-guide` which does not exist.

Thank you,
-Kartik