### PR TITLE
Remove uneeded sudo from `dnf check-update`

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -76,7 +76,7 @@ sudo sh -c 'echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.m
 Then update the package cache and install the package using `dnf` (Fedora 22 and above):
 
 ```bash
-sudo dnf check-update
+dnf check-update
 sudo dnf install code
 ```
 


### PR DESCRIPTION
For RHEL, Fedora, and CentOS based distributions the command `dnf check-update` can be executed without sudo.