### PR TITLE
Renamed C/C++ workload

### DIFF
--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -29,13 +29,13 @@ To successfully complete this tutorial, you must do the following:
 
    If you have a recent version of Visual Studio, open the Visual Studio Installer from the Windows Start menu and verify that the C++ workload is checked. If it's not installed, then check the box and click the **Modify** button in the installer.
 
-   You can also install just the **C++ Build Tools**, without a full Visual Studio IDE installation. From the Visual Studio [Downloads](https://visualstudio.microsoft.com/downloads#other) page, scroll down until you see **Tools for Visual Studio** under the **All downloads** section and select the download for **Build Tools for Visual Studio**.
+   You can also install the **Desktop development with C++** workload without a full Visual Studio IDE installation. From the Visual Studio [Downloads](https://visualstudio.microsoft.com/downloads#other) page, scroll down until you see **Tools for Visual Studio** under the **All downloads** section and select the download for **Build Tools for Visual Studio**.
 
    ![Build Tools for Visual Studio download](images/msvc/build-tools-for-vs.png)
 
-   This will launch the Visual Studio Installer, which will bring up a dialog showing the available Visual Studio Build Tools workloads. Check the **C++ build tools** workload and select **Install**.
+   This will launch the Visual Studio Installer, which will bring up a dialog showing the available Visual Studio Build Tools workloads. Check the **Desktop development with C++** workload and select **Install**.
 
-   ![Cpp build tools workload](images/msvc/cpp-build-tools.png)
+   ![Cpp build tools workload](images/msvc/desktop_development_with_cpp.png)
 
 >**Note**: You can use the C++ toolset from Visual Studio Build Tools along with Visual Studio Code to compile, build, and verify any C++ codebase as long as you also have a valid Visual Studio license (either Community, Pro, or Enterprise) that you are actively using to develop that C++ codebase.
 

--- a/docs/cpp/images/msvc/cpp-build-tools.png
+++ b/docs/cpp/images/msvc/cpp-build-tools.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73fe9a1f31beeb7ac92d10ba46c8cdb05018340b4fdc72ae86ae0f9a7dd23383
-size 242973

--- a/docs/cpp/images/msvc/desktop_development_with_cpp.png
+++ b/docs/cpp/images/msvc/desktop_development_with_cpp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc6f388755bad8148cbdab283c194e798049e5be5017e59bc0afbc36e16fde23
+size 161799


### PR DESCRIPTION
The workload for C/C++ development in VS Build Tools 2019 installer is called `Desktop development with C++`.

The old name is probably from the previous release.

A small update that might help avoid confusion.