### PR TITLE
Add minikube-in-docker reference, tips for getting processes to start when the container starts

### DIFF
--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -533,17 +533,24 @@ COMPOSE_PROJECT_NAME=foo
 
 While you can build, deploy, and debug your application inside a dev container, you may also need to test it by running it inside a set of production-like containers. Fortunately, by installing the needed Docker or Kubernetes CLIs and mounting your local Docker socket, you can build and deploy your app's container images from inside your dev container.
 
-Once the needed CLIs are in place, you can also work with the appropriate container cluster using the [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) extension if you force it to run as a Workspace extension or the [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension.
+Once the needed CLIs are in place, you can also work with the appropriate container cluster using the [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) extension or the [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension.
 
 See the following example dev containers definitions for additional information on a specific scenario:
 
+**Running Docker or Minikube in a development container**
 * [Docker-in-Docker](https://aka.ms/vscode-remote/samples/docker-in-docker) - Illustrates how to run Docker (or Moby) entirely inside a container. Provides support for bind mounting all folders inside the development container, but cannot reuse your local machine's cache.
 
+* [Kuberntes - Minikube-in-Docker](https://aka.ms/vscode-remote/samples/kubernetes-helm-minikube) - Illustrates how to run Minikube entirely inside a container with similar benifits and limitations as Docker-in-Docker.
+
+**Accessing an existing Docker or Minikube instance from a container**
 * [Docker-from-Docker](https://aka.ms/vscode-remote/samples/docker-from-docker) - Also known as "Docker-outside-of-Docker", this illustrates how you can use the Docker (or Moby) CLI in your dev container to connect to your host's Docker daemon by bind mounting the Docker Unix socket. Lower overhead and can reuse your machine's cache, but has [bind mounting limitations](#mounting-host-volumes-with-docker-from-inside-a-container).
 
 * [Docker-from-Docker Compose](https://aka.ms/vscode-remote/samples/docker-from-docker-compose) - Variation of Docker-from-Docker for situations where you are using Docker Compose instead of a single Dockerfile.
 
-* [Kubernetes-Helm](https://aka.ms/vscode-remote/samples/kubernetes-helm) - Takes the Docker-from-Docker model and adds kubectl and Helm to illustrate how you can access a local Minikube or Docker provided Kubernetes cluster.
+* [Kubernetes - Local Configuration](https://aka.ms/vscode-remote/samples/kubernetes-helm) - Takes the Docker-from-Docker model and adds kubectl and Helm to illustrate how you can access a local Minikube or Docker provided Kubernetes cluster.
+
+
+There is also documentation on the [Docker-in-Docker](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md), [Docker-from-Docker](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md), and [Kubernetes](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md) instaall scripts that you can reuse and are referenced by the samples above.
 
 ### Mounting host volumes with Docker from inside a container
 

--- a/docs/remote/containers-advanced.md
+++ b/docs/remote/containers-advanced.md
@@ -94,7 +94,79 @@ Next, depending on what you reference in `devcontainer.json`:
 
 If you've already built the container and connected to it, run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up the change. Otherwise run **Remote-Containers: Open Folder in Container...** to connect to the container.
 
+## Starting a process when the container starts
+When you are working in a development container, you may want execute a command or start something each time the container starts. The easiest way to do this is using the `postStartCommand` property in `devcontainer.json`. For example, if you wanted to run `yarn install` every time you connected to the container to keep dependencies up to date, you could add the following:
+
+```json
+"postStartCommand": "yarn install"
+```
+
+In other cases, you may want to start up a process and leave it running. This can be accomplished by using `nohup` and putting the process into the background using `&`.  For example:
+
+```json
+"postStartCommand": "nohup bash -c 'your-command-here &'"
+```
+
+Those familiar with Linux may expect to be able to use the `systemctl` command to start and stop background services managed by something called `systemd`. Unfortuntely, `systemd` has quite a bit of overhead and is generally not used in containers as a result.
+
+In many cases there is a command you can just run instead (e.g. `sshd`). However, on Debian/Ubuntu, there are often still scripts under `/etc/init.d` that you can run directly instead.
+
+```json
+"postStartCommand": "/etc/init.d/ssh start"
+```
+
+These systems also include a `service` command that will use `systemd` or these init scripts based on what is installed.
+
+```json
+"postStartCommand": "service ssh start"
+```
+
+### Adding startup commands to the Docker image instead
+While postStartCommand is convienent and allows you to execute commands in your source tree, you can add these steps to a Dockerfile instead using a custom [ENTRYPOINT](https://docs.docker.com/engine/reference/builder/#entrypoint) or [CMD](https://docs.docker.com/engine/reference/builder/#cmd).
+
+When referencing a Dockerfile in `devcontainer.json`, the default entrypoint and command is overridden. First, disable this behavior using the `overrrideCommand` property.
+
+```json
+"overrideCommand": false
+```
+
+The `overrideCommand` property defaults to `true` because many images will immediately exit if a command is not specified. Instead, we will need to handle this in our Dockerfile.
+
+Next, consider this Dockerfile:
+
+```Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-focal
+
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "sleep", "infinity"' ]
+```
+
+The `CMD` here makes sure the container stays running by default. Keeping your startup steps in the `ENTRYPOINT` allows you to safely override the command when using `docker run` with your image or using Docker Compose. This resolves to the following:
+
+```bash
+/docker-entrypoint.sh sleep infinity
+```
+
+Next, let's create our `docker-entrypoint.sh` script:
+
+```bash
+#!/usr/env bash
+
+echo "Hello from our entrypoint!"
+
+exec "$@"
+```
+
+Anything you execute in this file will then fire each time the container starts. However, it's important to include the last `exec "$@"` line since this is what will cause the command `sleep infinity` in our example to fire.
+
+Finally, if you are using Docker Compose, be sure that neither the [entrypoint](https://docs.docker.com/compose/compose-file/compose-file-v3/#entrypoint) nor [command](https://docs.docker.com/compose/compose-file/compose-file-v3/#command) properties are set for your container.
+
+That's it!
+
 ## Adding another local file mount
+> **Note:** Mounting the local file system is not supported in GitHub Codespaces. See [developing inside a container on a remote Docker host](#developing-inside-a-container-on-a-remote-docker-host) for information on mounting remote folders in this sceanrio.
 
 You can add a volume bound to any local folder by using the following appropriate steps, based on what you reference in `devcontainer.json`:
 


### PR DESCRIPTION
@bamurtaugh @burkeholland @stuartleeks 

Added a reference to getting minikube up in a dev container as discussed.

I also added a tip on getting processes to start and keep running on container start.  I've been seeing quite a few questions on this lately from folks using Codespaces and noticed we didn't have a section on it.