### PR TITLE
Remove old -S flag from sample `npm run`.

### DIFF
--- a/api/working-with-extensions/bundling-extension.md
+++ b/api/working-with-extensions/bundling-extension.md
@@ -31,10 +31,10 @@ Merge these entries into the `scripts` section in `package.json`:
 
 ```json
 "scripts": {
-    "vscode:prepublish": "npm run -S esbuild-base -- --minify",
+    "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
-    "esbuild": "npm run -S esbuild-base -- --sourcemap",
-    "esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
+    "esbuild": "npm run esbuild-base -- --sourcemap",
+    "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "tsc -p ./"
 },
 ```


### PR DESCRIPTION
This is no longer needed past npm v5, and is not documented anywhere. It
may confuse people.

**Note**: I saw the "Do not touch" note at the top of the file and read the contribution guidelines. I'm not sure if editing this `md` is the correct way to contribute, so please let me know if an alternate workflow is preferred. Thanks.