### PR TITLE
`jsconfig.json`: Update link to `compilerOptions`

### DIFF
--- a/docs/languages/jsconfig.md
+++ b/docs/languages/jsconfig.md
@@ -95,7 +95,7 @@ Option  | Description
 `baseUrl`|Base directory to resolve non-relative module names.
 `paths`|Specify path mapping to be computed relative to baseUrl option.
 
-You can read more about the available `compilerOptions` in the [TypeScript compilerOptions documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
+You can read more about the available `compilerOptions` in the [TypeScript compilerOptions documentation](https://www.typescriptlang.org/tsconfig#compilerOptions).
 
 ## Using webpack aliases
 


### PR DESCRIPTION
The existing link to the TypeScript `compilerOptions` documentation links to the `tsc` CLI options, which does not actually contain documentation on `compilerOptions`.

Let's link to the `compilerOptions` section in the `tsconfig` reference instead.