### PR TITLE
Remove generator-aspnet from Additional tools

### DIFF
--- a/docs/setup/additional-components.md
+++ b/docs/setup/additional-components.md
@@ -36,7 +36,6 @@ The extensions shown above are the current most popular on Marketplace. Click on
 Visual Studio Code integrates with existing tool chains.  We think the following tools will enhance your development experiences.
 
 - [Yeoman](https://yeoman.io/) - An application scaffolding tool, a command line version of **File** > **New Project**.
-- [generator-aspnet](https://www.npmjs.com/package/generator-aspnet) - A Yeoman generator for scaffolding [ASP.NET Core](https://asp.net) applications.
 - [generator-hottowel](https://github.com/johnpapa/generator-hottowel) - A Yeoman generator for quickly creating AngularJS applications.
 - [Express](https://expressjs.com/) - An application framework for Node.js applications using the Pug template engine.
 - [Gulp](https://gulpjs.com/) - A streaming task runner system which integrates easily with VS Code tasks.


### PR DESCRIPTION
Front npm: https://www.npmjs.com/package/generator-aspnet

This package has been deprecated
Author message:

Use dotnet new instead