### PR TITLE
Fix page title in java-project.md

### DIFF
--- a/docs/java/java-project.md
+++ b/docs/java/java-project.md
@@ -3,7 +3,7 @@ Order: 5
 Area: java
 TOCTitle: Project Management
 ContentId: 251cba68-c77f-4ac6-a5de-1fab8dcca867
-PageTitle: Lightweight Mode, Maven Support, Java Package, and Dependency Management in Visual Studio Code
+PageTitle: Java project management in Visual Studio Code
 DateApproved: 6/10/2021
 MetaDescription: Lightweight Mode, Maven Support, Java Package and Dependency Management in Visual Studio Code
 MetaSocialImage:


### PR DESCRIPTION
Looks like this change might have been missed in #3846 (which did the same change for the `java-build.md` page).