### PR TITLE
Fix typo in Pylance autoImportCompletions setting

### DIFF
--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -71,7 +71,7 @@ The language server settings apply when `python.languageServer` is `Pylance` or 
 | extraPaths | [] | Specifies extra search paths for import resolution. Paths should be specified as strings and must be separated by commas when there are multiple paths. `["path 1","path 2"]` |
 | completeFunctionParens | false | Adds parentheses to function completions. Accepted values are `true` and `false`. |
 | useLibraryCodeForTypes | true | Parses the source code for a package when a typestub is not found. Available values are `true` and `false`. |
-| autoImportCompletion | true | Controls the offering of auto-imports in completions. Available values are `true` and `false`. |
+| autoImportCompletions | true | Controls the offering of auto-imports in completions. Available values are `true` and `false`. |
 | diagnosticSeverityOverrides | {} | Allows a user to override the severity levels for individual diagnostics. For each rule, the available severity levels are `error` (red squiggle), `warning` (yellow squiggle), `information` (blue squiggle), and `none` (rule disabled). For information about the keys to use for the diagnostic severity rules, see the **Diagnostic severity rules** section below. |
 
 > **Note:** Similar to the core Python extension, Pylance has an Insiders program that offers early access to new features and improvements. To enable the Insiders program, set `pylance.insidersChannel` to `daily`. This setting enables a daily check for new builds. At startup or when the Insiders setting is changed, Pylance will automatically update and prompt you to reload. To leave the Insiders program, just remove the setting, or explicitly set it to `off` instead. You might be prompted to downgrade your extension to the latest stable version.


### PR DESCRIPTION
Per https://github.com/microsoft/pylance-release/issues/1678.

This is `autoImportCompletions` not `autoImportCompletion`.