### PR TITLE
Make capitalization of language ID consistent

### DIFF
--- a/api/extension-guides/file-icon-theme.md
+++ b/api/extension-guides/file-icon-theme.md
@@ -65,7 +65,7 @@ The following properties are supported:
 
 ### File association
 
-Icons can be associated to folders, folder names, files, file extensions, file names and [language ids](/api/references/contribution-points#contributes.languages).
+Icons can be associated to folders, folder names, files, file extensions, file names and [language IDs](/api/references/contribution-points#contributes.languages).
 
 Additionally each of these associations can be refined for 'light' and 'highContrast' color themes.
 
@@ -100,7 +100,7 @@ Each file association points to an icon definition.
 }
 ```
 
-- `file` is the default file icon, shown for all files that don't match any extension, filename or language id. Currently all properties defined by the definition of the file icon will be inherited (only relevant for font glyphs, useful for the fontSize).
+- `file` is the default file icon, shown for all files that don't match any extension, filename or language ID. Currently all properties defined by the definition of the file icon will be inherited (only relevant for font glyphs, useful for the fontSize).
 - `folder` is the folder icon for collapsed folders, and if `folderExpanded` is not set, also for expanded folders. Icons for specific folder names can be associated using the `folderNames` property.
   The folder icon is optional. If not set, no icon will be shown for folder.
 - `folderExpanded` is the folder icon for expanded folders. The expanded folder icon is optional. If not set, the icon defined for `folder` will be shown.
@@ -110,7 +110,7 @@ Each file association points to an icon definition.
 - `rootFolderExpanded` is the folder icon for expanded workspace root folders. If not set, the icon defined for `rootFolder` will be shown for exanded workspace root folders.
 - `languageIds` associates languages to icons. The key in the set is the language id as defined in the [language contribution point](/api/references/contribution-points#contributes.languages). The language of a file is evaluated based on the file extensions and file names as defined in the language contribution. Note that the 'first line match' of the language contribution is not considered.
 - `fileExtensions` associates file extensions to icons. The key in the set is the file extension name. The extension name is a file name segment after a dot (not including the dot). File names with multiple dots such as `lib.d.ts` can match multiple extensions; 'd.ts' and 'ts'. Extensions are compared case insensitive.
-- `fileNames` associates file names to icons. The key in the set is the full file name, not including any path segments. Patterns or wildcards are not supported. File name matching is case insensitive. A 'fileName' match is the strongest match, and the icon associated to the file name will be preferred over an icon of a matching fileExtension and also of a matching language Id.
+- `fileNames` associates file names to icons. The key in the set is the full file name, not including any path segments. Patterns or wildcards are not supported. File name matching is case insensitive. A 'fileName' match is the strongest match, and the icon associated to the file name will be preferred over an icon of a matching fileExtension and also of a matching language ID.
 
 A file extension match is preferred over a language match, but is weaker than a file name match.
 

--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -180,9 +180,9 @@ To quickly create a new grammar extension, use [VS Code's Yeoman templates](/api
 
 Yeoman will walk you through some basic questions to scaffold the new extension. The important questions for creating a new grammar are:
 
-- `Language Id` - A unique identifier for your language.
-- `Language Name` - A human readable name for your language.
-- `Scope names` - Root TextMate scope name for your grammar
+- `Language id` - A unique identifier for your language.
+- `Language name` - A human readable name for your language.
+- `Scope names` - Root TextMate scope name for your grammar.
 
 ![Filling in the 'new language' questions](images/syntax-highlighting/yo-new-language-questions.png)
 

--- a/api/references/vscode-api.md
+++ b/api/references/vscode-api.md
@@ -802,7 +802,7 @@ mouse, positioning the hover, keeping the hover stable etc. is taken care of by 
     }
 });
 </code></pre>
-<p>Registration is done using a <a href="#DocumentSelector">document selector</a> which is either a language id, like <code>javascript</code> or
+<p>Registration is done using a <a href="#DocumentSelector">document selector</a> which is either a language ID, like <code>javascript</code> or
 a more complex <a href="#DocumentFilter">filter</a> like <code>{ language: &#39;typescript&#39;, scheme: &#39;file&#39; }</code>. Matching a document against such
 a selector will result in a <a href="#languages.match">score</a> that is used to determine if and how a provider shall be used. When
 scores are equal the provider that came last wins. For features that allow full arity, like <a href="#languages.registerHoverProvider">hover</a>,
@@ -3031,7 +3031,7 @@ when the <a href="#TextDocument.getText">contents</a> changes but also when othe
 
 <a name="workspace.onDidCloseTextDocument"></a><span class="ts" id=2970 data-target="#details-2970" data-toggle="collapse"><span class="ident">onDidCloseTextDocument</span><span>: </span><a class="type-ref" href="#Event">Event</a>&lt;<a class="type-ref" href="#TextDocument">TextDocument</a>&gt;</span>
 <div class="details collapse" id="details-2970">
-<div class="comment"><p>An event that is emitted when a <a href="#TextDocument">text document</a> is disposed or when the language id
+<div class="comment"><p>An event that is emitted when a <a href="#TextDocument">text document</a> is disposed or when the language ID
 of a text document <a href="#languages.setTextDocumentLanguage">has been changed</a>.</p>
 <p><em>Note 1:</em> There is no guarantee that this event fires when an editor tab is closed, use the
 <a href="#window.onDidChangeVisibleTextEditors"><code>onDidChangeVisibleTextEditors</code></a>-event to know when editors change.</p>
@@ -3069,7 +3069,7 @@ files change on disk, e.g triggered by another application, or when using the
 
 <a name="workspace.onDidOpenTextDocument"></a><span class="ts" id=2969 data-target="#details-2969" data-toggle="collapse"><span class="ident">onDidOpenTextDocument</span><span>: </span><a class="type-ref" href="#Event">Event</a>&lt;<a class="type-ref" href="#TextDocument">TextDocument</a>&gt;</span>
 <div class="details collapse" id="details-2969">
-<div class="comment"><p>An event that is emitted when a <a href="#TextDocument">text document</a> is opened or when the language id
+<div class="comment"><p>An event that is emitted when a <a href="#TextDocument">text document</a> is opened or when the language ID
 of a text document <a href="#languages.setTextDocumentLanguage">has been changed</a>.</p>
 <p>To add an event listener when a visible text document is opened, use the <a href="#TextEditor">TextEditor</a> events in the
 <a href="#window">window</a> namespace. Note that:</p>
@@ -8566,7 +8566,7 @@ its resource, or a glob-pattern that is applied to the <a href="#TextDocument.fi
 
 <a name="DocumentFilter.language"></a><span class="ts" id=557 data-target="#details-557" data-toggle="collapse"><span class="ident">language</span><span>?</span><span>: </span><a class="type-intrinsic">string</a></span>
 <div class="details collapse" id="details-557">
-<div class="comment"><p>A language id, like <code>typescript</code>.</p>
+<div class="comment"><p>A language ID, like <code>typescript</code>.</p>
 </div>
 </div>
 
@@ -20907,7 +20907,7 @@ const values = config.get(&#39;configurations&#39;);
 often consists of a <em>default</em> value, a global or installation-wide value,
 a workspace-specific value, folder-specific value
 and language-specific values (if <a href="#WorkspaceConfiguration">WorkspaceConfiguration</a> is scoped to a language).</p>
-<p>Also provides all language ids under which the given configuration setting is defined.</p>
+<p>Also provides all language IDs under which the given configuration setting is defined.</p>
 <p><em>Note:</em> The configuration name must denote a leaf in the configuration tree
 (<code>editor.fontSize</code> vs <code>editor</code>) otherwise no result is returned.</p>
 </div>

--- a/docs/cpp/natvis.md
+++ b/docs/cpp/natvis.md
@@ -209,7 +209,7 @@ The Natvis schema is provided here for convenience:
     </xs:attribute>
     <xs:attribute name="LanguageId" type="GuidType" use="optional">
       <xs:annotation>
-        <xs:documentation>Specifies the language id used to identify the debugger component that implements the function. This must match the filter constraints of the IDkmIntrinsicFunctionEvaluator140 implementation.</xs:documentation>
+        <xs:documentation>Specifies the language ID used to identify the debugger component that implements the function. This must match the filter constraints of the IDkmIntrinsicFunctionEvaluator140 implementation.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="Id" type="xs:unsignedInt" use="optional">

--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -207,7 +207,7 @@ Below are Emmet [settings](/docs/getstarted/settings.md) that you can use to cus
 
 * `emmet.includeLanguages`
 
-    Use this setting to add mapping between the language of your choice and one of the Emmet supported languages to enable Emmet in the former using the syntax of the latter. Make sure to use language ids for both sides of the mapping.
+    Use this setting to add mapping between the language of your choice and one of the Emmet supported languages to enable Emmet in the former using the syntax of the latter. Make sure to use language IDs for both sides of the mapping.
 
     For example:
 

--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -286,7 +286,7 @@ And many, many [other customizations](/docs/getstarted/settings.md).
 
 ### Language specific settings
 
-You can scope the settings that you only want for specific languages by the language identifier. You can find a list of commonly used language ids in the [Language Identifiers](/docs/languages/identifiers.md) reference.
+You can scope the settings that you only want for specific languages by the language identifier. You can find a list of commonly used language IDs in the [Language Identifiers](/docs/languages/identifiers.md) reference.
 
 ```json
 "[languageid]": {

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -136,7 +136,7 @@ VS Code supports [Emmet snippet](https://emmet.io/) expansion. Emmet abbreviatio
 
 >**Tip:** See the HTML section of the [Emmet cheat sheet](https://docs.emmet.io/cheat-sheet) for valid abbreviations.
 
-If you'd like to use HTML Emmet abbreviations with other languages, you can associate one of the Emmet modes (such as `css`, `html`) with other languages with the `emmet.includeLanguages` [setting](/docs/getstarted/settings.md). The setting takes a [language id](/docs/languages/overview.md#language-id) and associates it with the language id of an Emmet supported mode.
+If you'd like to use HTML Emmet abbreviations with other languages, you can associate one of the Emmet modes (such as `css`, `html`) with other languages with the `emmet.includeLanguages` [setting](/docs/getstarted/settings.md). The setting takes a [language ID](/docs/languages/overview.md#language-id) and associates it with the language ID of an Emmet supported mode.
 
 For example, to use Emmet HTML abbreviations inside JavaScript:
 

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -47,7 +47,7 @@ In VS Code, we default the language support for a file based on its filename ext
 
 **Tip**: You can get the same dropdown by running the **Change Language Mode** command (`kb(workbench.action.editor.changeLanguageMode)`).
 
-## Language Id
+## Language identifier
 
 VS Code associates a language mode with a specific language identifier so that various VS Code features can be enabled based on the current language mode.
 

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -73,7 +73,7 @@ For example, the setting below adds the `.myphp` file extension to the `php` lan
 
 IntelliSense (`kb(editor.action.triggerSuggest)`) will show you the available language identifiers.
 
-![language id IntelliSense](images/overview/language-id-intellisense.png)
+![Language ID IntelliSense](images/overview/language-id-intellisense.png)
 
 ## Next steps
 

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -99,7 +99,7 @@ If you use the JSON editor to modify your settings, add the following line:
 
 ### Location
 
-You can find the VS Code licenses, third party notices and [Chromium](https://www.chromium.org) Open Source credit list under your VS Code installation location `resources\app` folder. VS Code's `ThirdPartyNotices.txt`, Chromium's `Credits_*.html`, and VS Code's English language `LICENSE.txt` are available under `resources\app`. Localized versions of `LICENSE.txt` by Language ID are under `resources\app\licenses`.
+You can find the VS Code licenses, third party notices and [Chromium](https://www.chromium.org) Open Source credit list under your VS Code installation location `resources\app` folder. VS Code's `ThirdPartyNotices.txt`, Chromium's `Credits_*.html`, and VS Code's English language `LICENSE.txt` are available under `resources\app`. Localized versions of `LICENSE.txt` by language ID are under `resources\app\licenses`.
 
 ### Why does Visual Studio Code have a different license than the vscode GitHub repository?
 


### PR DESCRIPTION
This pull request replaces instances of "id" and "Id" with "ID". One instance of "Id" was replaced with "identifier", in another instance "id" was used to match the Yeoman screenshot.