### PR TITLE
Fix section link in Debugging

### DIFF
--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -215,7 +215,7 @@ Here are some optional attributes available to all launch configurations:
 * `postDebugTask` - to launch a task at the very end of a debug session, set this attribute to the name of a task specified in [tasks.json](/docs/editor/tasks.md) (in the workspace's `.vscode` folder).
 * `internalConsoleOptions` - this attribute controls the visibility of the Debug Console panel during a debugging session.
 * `debugServer` - **for debug extension authors only**: this attribute allows you to connect to a specified port instead of launching the debug adapter.
-* `serverReadyAction` - if you want to open a URL in a web browser whenever the program under debugging outputs a specific message to the debug console or integrated terminal. For details see section [Automatically open a URI when debugging a server program](https://code.visualstudio.com/docs/editor/debugging#_remote-debugging) below.
+* `serverReadyAction` - if you want to open a URL in a web browser whenever the program under debugging outputs a specific message to the debug console or integrated terminal. For details see section [Automatically open a URI when debugging a server program](#automatically-open-a-uri-when-debugging-a-server-program) below.
 
 Many debuggers support some of the following attributes:
 


### PR DESCRIPTION
A link for "Automatically open a URI when debugging a server program" is currently directed at the section above that, "Remote debugging".