### PR TITLE
 Change "environment" to "env" in launch.json

### DIFF
--- a/docs/cpp/launch-json-reference.md
+++ b/docs/cpp/launch-json-reference.md
@@ -99,7 +99,7 @@ Sets the working directory of the application launched by the debugger.
 
 ### environment
 
-Environment variables to add to the environment for the program. Example: `[ { "name": "config", "value": "Debug" } ]`, not `[ { "config": "Debug" } ]`.
+Environment variables to add to the environment for the program. Example: `[ { "config": "Debug" } ]`.
 
 **Example:**
 
@@ -110,7 +110,9 @@ Environment variables to add to the environment for the program. Example: `[ { "
    "request": "launch",
    "program": "${workspaceFolder}/a.out",
    "args": ["arg1", "arg2"],
-   "environment": [{"name": "config", "value": "Debug"}],
+   "env": {
+      "config": "Debug"
+   },
    "cwd": "${workspaceFolder}"
 }
 ```


### PR DESCRIPTION
I'm on VSCode 1.60 and the current docs suggested this format for launch profile environment variables:

```json
"environment": [
    {"name": "config", "value": "Debug"}
]
```
however

```json
"env": {
   "config": "Debug"
}
```
is the format that worked for me.

There was some discussion here https://github.com/microsoft/vscode-cpptools/issues/116 about this issue, but I can't find where this was updated.

Also this link https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes says `env` is the correct property to use. So it looks like the vscode cpp docs are out of sync for this property.