### PR TITLE
update the return types

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -26,12 +26,12 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 
 * _uri_ - Uri of a text document
 * _position_ - A position in a text document
-* _(returns)_ - A promise that resolves to an array of SymbolInformation and DocumentSymbol instances.
+* _(returns)_ - A promise that resolves to an array of DocumentHighlight-instances.
 
 `vscode.executeDocumentSymbolProvider` - Execute document symbol provider.
 
 * _uri_ - Uri of a text document
-* _(returns)_ - A promise that resolves to an array of DocumentHighlight-instances.
+* _(returns)_ - A promise that resolves to an array of SymbolInformation and DocumentSymbol instances.
 
 `vscode.executeFormatDocumentProvider` - Execute document format provider.
 


### PR DESCRIPTION
With reference to [here](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostApiCommands.ts#L27) and [here](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostApiCommands.ts#L33), it might be possible a big typo for the original document.

So here is my quick fix.