### PR TITLE
C++ docs: Add redundancy to avoid pitfalls

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -43,7 +43,7 @@ g++ --version
 gdb --version
 ```
 
-If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located.
+If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located. If the compilers do not exist at that PATH entry, make sure you followed the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
 
 ## Create Hello World
 
@@ -341,6 +341,12 @@ The `compilerPath` search order is:
 * Then g++ for Mingw-w64.
 
 If you have Visual Studio or WSL installed, you may need to change `compilerPath` to match the preferred compiler for your project. For example, if you installed Mingw-w64 version 8.1.0 using the i686 architecture, Win32 threading, and sjlj exception handling install options, the path would look like this: `C:\Program Files (x86)\mingw-w64\i686-8.1.0-win32-sjlj-rt_v6-rev0\mingw64\bin\g++.exe`.
+
+## Troubleshooting
+
+### MSYS2 is installed, but g++ and gdb are still not found
+
+You must follow the steps on the [MSYS2 website](https://www.msys2.org/) and use the MSYS CLI to install Mingw-w64, which contains those tools.
 
 ## Next steps
 

--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -177,6 +177,8 @@ The `"isDefault": true` value in the `group` object specifies that this task wil
 
    ![C++ build output in terminal](images/msvc/build-output-in-terminal.png)
 
+If the build fails due to not finding `cl.exe`, or lacking an include path, make sure you have started VS Code from the **Developer Command Prompt for Visual Studio**.
+
 1. Create a new terminal using the **+** button and you'll have a new terminal (running PowerShell) with the `helloworld` folder as the working directory. Run `ls` and you should now see the executable `helloworld.exe` along with various intermediate C++ output and debugging files (`helloworld.obj`, `helloworld.pdb`).
 
     ![Hello World in PowerShell terminal](images/msvc/helloworld-in-terminal.png)
@@ -385,7 +387,13 @@ In certain circumstances, it isn't possible to run VS Code from **Developer Comm
 
 If you see the error "The term 'cl.exe' is not recognized as the name of a cmdlet, function, script file, or operable program.", this usually means you are running VS Code outside of a **Developer Command Prompt for Visual Studio** and VS Code doesn't know the path to the `cl.exe` compiler.
 
+VS Code must either be started from the Developer Command Prompt for Visual Studio, or the task must be configured to [run outside a Developer Command Prompt](#run-vs-code-outside-the-developer-command-prompt).
+
 You can always check that you are running VS Code in the context of the Developer Command Prompt by opening a new Terminal (`kb(workbench.action.terminal.new)`) and typing 'cl' to verify `cl.exe` is available to VS Code.
+
+### fatal error C1034: assert.h: no include path set
+
+In this case, `cl.exe` is available to VS Code through the `PATH` environment variable, but VS Code still needs to either be started from the **Developer Command Prompt for Visual Studio**, or be configured to [run outside the Developer Command Prompt](#run-vs-code-outside-the-developer-command-prompt). Otherwise, `cl.exe` does not have access to important environment variables such as `INCLUDE`.
 
 ## Next steps
 


### PR DESCRIPTION
Recently, I wanted to get a small C demo going (https://github.com/rzhao271/named-pipe-sample).

I read through the documentation too quickly, assumed that I knew what I was doing, and ended up stuck for a while, especially on the `cl.exe` setup.

This PR adds docs to and expands the troubleshooting sections of https://code.visualstudio.com/docs/cpp/config-mingw and https://code.visualstudio.com/docs/cpp/config-msvc to emphasize some steps that a user could've forgotten to do (or assumed were unimportant).

Edit: Commit https://github.com/microsoft/vscode-docs/pull/4846/commits/50045832a2f30f72703bdadde8b0c9e4e4fc435a says it is unverified, but that is because I don't have code signing set up on Codespaces.