### PR TITLE
Adding section on JS/TS partial IntelliSense mode

### DIFF
--- a/docs/nodejs/images/working-with-javascript/partial-mode-status-item.png
+++ b/docs/nodejs/images/working-with-javascript/partial-mode-status-item.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a18dd35338bc91ff608bf0318ff65bb5d815bae5ec44eb47b32ad1211668468a
+size 17858

--- a/docs/nodejs/working-with-javascript.md
+++ b/docs/nodejs/working-with-javascript.md
@@ -308,3 +308,44 @@ If you prefer to use JavaScript language features supported by other JavaScript 
 To disable JavaScript/TypeScript support, go to the Extensions view (`kb(workbench.view.extensions)`) and filter on built-in extensions (**Show Built-in Extensions** in the **...** **More Actions** dropdown), then type 'typescript'. Select the **TypeScript and JavaScript Language Features** extension and press the **Disable** button. VS Code built-in extensions cannot be uninstalled, only disabled, and can be re-enabled at any time.
 
 ![TypeScript and JavaScript Language Features extension](images/working-with-javascript/disable-TS-language.png)
+
+## Partial IntelliSense Mode
+
+VS Code tries to provide project-wide IntelliSense for JavaScript and TypeScript, which is what make features such as auto-imports and `go to definition` possible. However there are some cases where VS Code is limited to working only with your currently opened files and is unable to load the other files that make up your JavaScript or TypeScript project.
+
+This can happen in a few instances:
+
+- You are working with JavaScript or TypeScript code on `github.dev`.
+
+- You open a file from a virtual file system (such using [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub)).
+
+- The project is currently loading. Once loading completes, you will start getting project-wide IntelliSense for it.
+
+In these cases, VS Code's IntelliSense will operate in 'partial mode'. Partial mode tries its best to provide IntelliSense for any JavaScript or TypeScript files have you open, but is limited and is not able to offer any cross-file IntelliSense features.
+
+### Which features are impacted?
+
+Here's an incomplete list of features that are either disabled or have more limited functionality in partial mode:
+
+- All opened files are treated as part of a single project.
+- Configuration options from your `jsconfig` or `tsconfig` (such as `target`) are not respected.
+- Only syntax errors are reported. Semantic errors — such as accessing an unknown property or passing the wrong type to a function — are not reported.
+- Quick fixes for semantic errors are disabled.
+- Symbols can only be resolved within the current file. Any symbols imported from other files will be treated as being of the `any` type.
+- Commands such as `Go to definition` and `find all references` will only work for opened files instead of across the entire entire project. This also means that symbol from any packages you install under `node_module` will not be resolved.
+- Workspace symbol search will only include symbols from currently opened files.
+- Auto imports are disabled.
+- Renaming is disabled.
+- Many refactorings are disabled.
+
+Some additional features are disabled on `github.dev`:
+
+- [Automatic type acquisition](/docs/nodejs/working-with-javascript#typings-and-automatic-type-acquisition)) is currently not supported.
+
+### Checking if you are in partial mode
+
+To check if the current file is using partial mode IntelliSense instead of project-wide IntelliSense, hover over the `JavaScript` or `TypeScript` language status item in the status bar:
+
+![Partial mode status item](images/working-with-javascript/partial-mode-status-item.png)
+
+The status item will show `Partial mode` if the current file is in partial mode.


### PR DESCRIPTION
This adds notes on partial mode IntelliSense for JS/TS

Partial mode is used on GitHub.dev as well as when opening files on virtual file systems