### PR TITLE
Update dev containers docs

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -253,6 +253,18 @@ When you rebuild and reopen in your container, the features you selected will be
 
 The features are sourced from the [script library](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) in the vscode-dev-containers repo.
 
+## Pre-building
+
+You can pre-build images with the tools you need rather than newly creating and building images for each project. Using pre-built images can be simpler and allows you to pin to a specific version of tools, avoiding potential breaks. Pre-building is especially valuable in CI processes.
+
+You can use the [devcontainer CLI](/remote/devcontainer-cli.md) to facilitate pre-builds.
+
+The process could be as follows:
+* Create a source code repository
+* Create a dev container configuration, customizing as you wish (including [features](#Dev-container-features))
+* Use the `devcontainer CLI` to build your image (the `devcontainer CLI` supports building images with features)
+* Push your image: `docker push <your_image_name>`
+
 ## Inspecting volumes
 
 Occasionally you may run into a situation where you are using a Docker named volume that you want to inspect or make changes in. You can use VS Code to work with these contents without creating or modifying `devcontainer.json` file by selecting the **Remote-Containers: Explore a Volume in a Development Container...** from the Command Palette (`kbstyle(F1)`).

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -237,13 +237,13 @@ To learn more about creating `devcontainer.json` files, see [Create a Developmen
 
 ## Dev container features
 
-Dev container features provide a smooth path for customizizing your container definitions.
+Dev container features provide a smooth path for customizing your container definitions.
 
-When you use **Remote-Containers: Add Development Container Configuration Files**, you'll be presented a list of scripts to customize the existing dev container configurations, such as installing Git or the Azure CLI:
+When you use **Remote-Containers: Add Development Container Configuration Files**, you're presented a list of scripts to customize the existing dev container configurations, such as installing Git or the Azure CLI:
 
 ![Dev container features in Command Palette](images/containers/container-features.png)
 
-When you rebuild and reopen in your container, the features you added will be available in your `devcontainer.json`:
+When you rebuild and reopen in your container, the features you selected will be available in your `devcontainer.json`:
 
 ```json
 "features": {

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -98,7 +98,11 @@ This quick start covers how to set up a dev container for an existing project to
 
     ![Select a node dev container definition](images/containers/select-dev-container-def.png)
 
-    The list will be automatically sorted based on the contents of the folder you open. Note the dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
+    The list will be automatically sorted based on the contents of the folder you open.
+
+    You will also be able to customize your dev container with additional features, which [you can read more about below](#Dev-container-features).
+
+    Note the dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
 
 3. After picking the starting point for your container, VS Code will add the dev container configuration files to your project (`.devcontainer/devcontainer.json`).
 
@@ -230,6 +234,24 @@ You can use any image, Dockerfile, or set of Docker Compose files as a starting 
 Selecting the **Remote-Containers: Add Development Container Configuration Files...** command from the Command Palette (`kbstyle(F1)`) will add the needed files to your project as a starting point, which you can further customize for your needs. The command lets you pick a pre-defined container configuration from a list based on your folder's contents, reuse an existing Dockerfile, or reuse an existing Docker Compose file.
 
 To learn more about creating `devcontainer.json` files, see [Create a Development Container](/docs/remote/create-dev-container.md).
+
+## Dev container features
+
+Dev container features provide a smooth path for customizizing your container definitions.
+
+When you use **Remote-Containers: Add Development Container Configuration Files**, you'll be presented a list of scripts to customize the existing dev container configurations, such as installing Git or the Azure CLI:
+
+![Dev container features in Command Palette](images/containers/container-features.png)
+
+When you rebuild and reopen in your container, the features you added will be available in your `devcontainer.json`:
+
+```json
+"features": {
+		"github-cli": "latest"
+	}
+```
+
+The features are sourced from the [script library](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) in the vscode-dev-containers repo.
 
 ## Inspecting volumes
 

--- a/docs/remote/devcontainerjson-reference.md
+++ b/docs/remote/devcontainerjson-reference.md
@@ -63,6 +63,7 @@ You may need different commands to be run at different points in the container's
 | `onCreateCommand` | string,<br>array | A command to run when creating the container. If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell. |
 | `userEnvProbe` | enum | Indicates the type of shell VS Code should use to "probe" for user environment variables to use by default while debugging or running a task: `none` (default), `interactiveShell`, `loginShell`, or `loginInteractiveShell`. Interactive shells will typically include variables set in `/etc/bash.bashrc` and `.bashrc` while login shells usually include variables from these "rc" files, `/etc/profile`, and `.profile`. The default is `none`, since the other modes can slow startup. |
 | `devPort` | integer | Allows you to force a specific port that the VS Code Server should use in the container. Defaults to a random, available port. |
+| `features` | object | Scripts to install in the dev container when the container is built. |
 
 If you've already built the container and connected to it, be sure to run **Remote-Containers: Rebuild Container** or **Codespaces: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up the change.
 

--- a/docs/remote/images/containers/container-features.png
+++ b/docs/remote/images/containers/container-features.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:988540f7409a0051a4ace4ba787c6a23d84c8fc938608acf17820164e9e4d291
+size 89935


### PR DESCRIPTION
Adding documentation based on https://github.com/microsoft/vscode-remote-release/issues/5442.

- Document new dev container features
- Document how pre-building generally works, and how it relates to features and the `devcontainer CLI`

Would love to get your thoughts on content, formatting, anything else we should include, etc. Thanks!

cc @Chuxel @chrmarti @2percentsilk 