### PR TITLE
Add Microsoft Build of OpenJDK to list of recommended JDKs

### DIFF
--- a/docs/java/java-tutorial.md
+++ b/docs/java/java-tutorial.md
@@ -74,6 +74,7 @@ If you prefer, you can configure JDK settings using the VS Code Settings editor 
 
 If you need to install a JDK, we recommend you to consider installing from one of these sources:
 
+* [Microsoft Build of OpenJDK](https://www.microsoft.com/openjdk)
 * [Oracle Java SE](https://www.oracle.com/java/technologies/javase-downloads.html)
 * [AdoptOpenJDK](https://adoptopenjdk.net/)
 * [Azul Zulu for Azure - Enterprise Edition](https://www.azul.com/downloads/azure-only/zulu/)


### PR DESCRIPTION
The Microsoft Build of OpenJDK has been released for some time, I think it would be a great idea to list it under the recommended sources for JDK installs.
https://code.visualstudio.com/docs/java/java-tutorial#_installing-a-java-development-kit-jdk