### PR TITLE
Added note to install socat in WSL

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -423,6 +423,9 @@ Get-Service ssh-agent
 
 **Linux:**
 
+* On **WSL**:
+  * Install [socat](https://linux.die.net/man/1/socat) in your WSL distro. `sudo apt install socat`
+
 First, start the SSH Agent in the background by running the following in a terminal:
 
 ```bash


### PR DESCRIPTION
SSH forwarding will not work in WSL with out socat installed. fixes #4861 