### PR TITLE
Fix sample code in notebook extension guide

### DIFF
--- a/api/extension-guides/notebook.md
+++ b/api/extension-guides/notebook.md
@@ -41,7 +41,7 @@ A notebook serializer is declared in `package.json` under the `contributes.noteb
 ```json
 {
     ...
-    "activationEvents": ["onNotebook:my-notebook-provider"],
+    "activationEvents": ["onNotebook:my-notebook"],
     "contributes": {
         ...
         "notebooks": [
@@ -63,6 +63,7 @@ A notebook serializer is declared in `package.json` under the `contributes.noteb
 The notebook serializer is then registered in the extension's activation event:
 
 ```ts
+import { TextDecoder, TextEncoder } from "util";
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -110,7 +111,7 @@ class SampleSerializer implements vscode.NotebookSerializer {
             });
         }
 
-        return new TextEncoder().encode(stringify(contents));
+        return new TextEncoder().encode(JSON.stringify(contents));
     }
 }
 ```


### PR DESCRIPTION
This PR fixes sample code in `api/extension-guides/notebook.md`.

I was following the extension guide `api/extension-guides/notebook.md` to create an extension using the Notebook API, but the sample code in the guide does not work as expected. (I created a project with `yo code` and copied the sample code in https://github.com/microsoft/vscode-docs/blob/5623594fb4c8372f9a17902377033dc6f4c771bf/api/extension-guides/notebook.md#example.)

I made it work by fixing several lines as shown in https://github.com/microsoft/vscode-docs/pull/4870/files. Since I am not familiar with the extension development, I may have made unnecessary changes, but as far as I understand, the fix I made is required to build the sample extension.