### PR TITLE
Clarify that web extensions run on desktop too

### DIFF
--- a/api/extension-guides/web-extensions.md
+++ b/api/extension-guides/web-extensions.md
@@ -9,9 +9,11 @@ MetaDescription: Learn how to run extensions in Visual Studio Code for the web a
 
 # Web Extensions
 
-Visual Studio Code can run as an editor in the browser. One example is the `github.dev` user interface reached by pressing `.` (the period key) in the GitHub **<> Code** tab. When VS Code is used in the Web, installed extensions are run in an extension host in the browser, called the 'web extension host'. An extension that can run in a web extension host is called a 'web extension'.
+Visual Studio Code can run as an editor in the browser. One example is the `github.dev` user interface reached by pressing `.` (the period key) when browsing a repository or Pull Request in GitHub. When VS Code is used in the Web, installed extensions are run in an extension host in the browser, called the 'web extension host'. An extension that can run in a web extension host is called a 'web extension'.
 
 Web extensions share the same structure as regular extensions, but given the different runtime, don't run with the same code as extensions written for a Node.js runtime. Web extensions still have access to the full VS Code API, but no longer to the Node.js APIs and module loading. Instead, web extensions are restricted by the browser sandbox and therefore have [limitations](#web-extension-main-file) compared to normal extensions.
+
+The web extension runtime is supported on VS Code desktop too. If you decide to create your extension as web extension, it will be supported on VS Code for the Web (including `github.dev`) as well as on the desktop and in services like [GitHub Codespaces](/docs/remote/codespaces).
 
 ## Web extension anatomy
 


### PR DESCRIPTION
Adding a blurb to the api/extension-guides/web-extension doc to clarify that web extensions are supported on desktop too.