### PR TITLE
Add notebook menu contribution points

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -711,6 +711,11 @@ Currently extension writers can contribute to:
 - The Timeline view item context menu - `timeline/item/context`
 - The Extensions view context menu - `extension/context`
 - The Test Explorer item context menu - `testing/item/context`
+- The notebook toolbar - `notebook/toolbar`
+- The notebook cell title menu bar - `notebook/cell/title`
+- The notebook cell execution menu - `notebook/cell/execute`
+- The interactive toolbar - `interactive/toolbar`
+- The interactive cell title menu bar - `interactive/cell/title`
 - Any [contributed submenu](/api/references/contribution-points#contributes.submenus)
 
 > **Note:** When a command is invoked from a (context) menu, VS Code tries to infer the currently selected resource and passes that as a parameter when invoking the command. For instance, a menu item inside the Explorer is passed the URI of the selected resource and a menu item inside an editor is passed the URI of the document.


### PR DESCRIPTION
Noticed that the notebook and interactive menu contribution points were missing, so I added them in quick.

I tried to match up with the wording that was already in place in this file, for example I used "The notebook toolbar" which compares to "The debug toolbar" versus the text in the contribution code https://github.com/microsoft/vscode/blob/de1adedfaac7790ccbc3b64a4c4ab510eb6c74ed/src/vs/workbench/api/common/menusExtensionPoint.ts#L181 "The contributed notebook toolbar menu". 

Would be nice to have a menus section in the main notebooks page like scm-provider does, I could help with that, but didn't have the time right now and figured that it would still be good to get the basic menus listed.