### PR TITLE
Update typescript-tutorial.md

### DIFF
--- a/docs/typescript/typescript-tutorial.md
+++ b/docs/typescript/typescript-tutorial.md
@@ -78,6 +78,8 @@ When you select a method, you then get parameter help and can always get hover i
 
 So far in this tutorial, you have been relying on the TypeScript compiler's default behavior to compile your TypeScript source code. You can modify the TypeScript compiler options by adding a `tsconfig.json` file that defines the TypeScript [project settings](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) such as the [compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) and the files that should be included.
 
+**Important**: To use `tsconfig.json` for the rest of this tutorial, invoke `tsc` without input files. The TypeScript compiler knows to look at your `tsconfig.json` for project settings and compiler options.
+
 Add a simple `tsconfig.json` which set the options to compile to ES5 and use **CommonJS** [modules](http://www.commonjs.org/specs/modules/1.0).
 
 ```json
@@ -94,8 +96,6 @@ When editing `tsconfig.json`, IntelliSense (`kb(editor.action.triggerSuggest)`) 
 ![tsconfig.json IntelliSense](images/tutorial/tsconfig-intellisense.png)
 
 By default, TypeScript includes all the `.ts` files in the current folder and subfolders if the `files` attribute isn't included, so we don't need to list `helloworld.ts` explicitly.
-
-Now to build from the terminal, you can just type `tsc` and the TypeScript compiler knows to look at your `tsconfig.json` for project settings and compiler options.
 
 ### Change the build output
 


### PR DESCRIPTION
Added more explicit instructions for invoking tsc without input files in order to use tsconfig.json. I may have been skimming too quickly, but this point tripped me up while trying to complete the tutorial. So, I made it more prominent.