### PR TITLE
Fix up some errors in the `setKeysForSync` example

### DIFF
--- a/api/extension-capabilities/common-capabilities.md
+++ b/api/extension-capabilities/common-capabilities.md
@@ -54,7 +54,7 @@ You can use the following pattern:
 ```TypeScript
 // on activate
 const versionKey = 'shown.version';
-context.globalState.setKeysForSync([version]);
+context.globalState.setKeysForSync([versionKey]);
 
 // later on show page
 const currentVersion = context.extension.packageJSON.version;


### PR DESCRIPTION
Fixed two things in the example doc:
- Because `globalState` is extension bound, there is no need adding the extension ID to the key
- Changed `globalState.set()` to `globalState.update()`, because `update()` is the correct name for this function, `set()` doesn't exist on `globalState`