### PR TITLE
Add tip from remote-release on non-manual build

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -281,27 +281,6 @@ docker push your-registry.azurecr.io/your-image-name
 
 You can push your image to a container registry, like [Docker Hub](https://docs.docker.com/engine/reference/commandline/push), the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), or [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images).
 
-In order for your dev container to build properly, it must be built by VS Code and the Remote - Containers extension rather than a manual user build with Docker. 
-
-You can promote pre-building and ensuring VS Code builds the container through something like the following in your Dockerfile:
-
-```bash
-ARG vscode
-RUN if [[ -z "$vscode" ]] ; then printf "\nERROR: This Dockerfile needs to be built with VS Code !" && exit 1; else printf "VS Code is detected: $vscode"; fi
-```
-
-And the following in your `devcontainer.json`:
-
-```bash
- "build": {
-      "dockerfile": "Dockerfile",
-      "args": {
-          // set vscode arg for Dockerfile
-          "vscode": "true"
-      },
-    },
-```
-
 ## Inspecting volumes
 
 Occasionally you may run into a situation where you are using a Docker named volume that you want to inspect or make changes in. You can use VS Code to work with these contents without creating or modifying `devcontainer.json` file by selecting the **Remote-Containers: Explore a Volume in a Development Container...** from the Command Palette (`kbstyle(F1)`).

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -281,6 +281,27 @@ docker push your-registry.azurecr.io/your-image-name
 
 You can push your image to a container registry, like [Docker Hub](https://docs.docker.com/engine/reference/commandline/push), the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), or [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images).
 
+In order for your dev container to build properly, it must be built by VS Code and the Remote - Containers extension rather than a manual user build with Docker. 
+
+You can promote pre-building and ensuring VS Code builds the container through something like the following in your Dockerfile:
+
+```bash
+ARG vscode
+RUN if [[ -z "$vscode" ]] ; then printf "\nERROR: This Dockerfile needs to be built with VS Code !" && exit 1; else printf "VS Code is detected: $vscode"; fi
+```
+
+And the following in your `devcontainer.json`:
+
+```bash
+ "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+          // set vscode arg for Dockerfile
+          "vscode": "true"
+      },
+    },
+```
+
 ## Inspecting volumes
 
 Occasionally you may run into a situation where you are using a Docker named volume that you want to inspect or make changes in. You can use VS Code to work with these contents without creating or modifying `devcontainer.json` file by selecting the **Remote-Containers: Explore a Volume in a Development Container...** from the Command Palette (`kbstyle(F1)`).

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -71,9 +71,11 @@ You can optionally specify the path to the folder to open, for example `devconta
 
 The `devcontainer build` command allows you to build the dev container image for a folder. As with the `open` command, `build` accepts a path to the folder to build the image for and defaults to the current working folder in your shell. For example, `devcontainer build` will build the dev container image for the current folder and `devcontainer build ~/source/my-folder` will build the container image for the `~/source/my-folder` folder.
 
-In order for your dev container to build properly, it must be built by VS Code and the Remote - Containers extension rather than a manual user build with Docker.
+### [Optional] Avoiding problems with images built using Docker
 
-You can promote pre-building and ensuring VS Code builds the container through something like the following in your Dockerfile:
+In order for your dev container to build properly, it may need to be built by the dev container CLI, the Remote - Containers extension, or GitHub Codespaces rather than a manual user build with Docker. To avoid this problem, you can add a build argument that is verified in your Dockerfile and only set in `devcontainer.json` or a dev container specific Docker Compose file.
+
+For example, you could add the following to your Dockerfile:
 
 ```bash
 ARG vscode

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -71,6 +71,27 @@ You can optionally specify the path to the folder to open, for example `devconta
 
 The `devcontainer build` command allows you to build the dev container image for a folder. As with the `open` command, `build` accepts a path to the folder to build the image for and defaults to the current working folder in your shell. For example, `devcontainer build` will build the dev container image for the current folder and `devcontainer build ~/source/my-folder` will build the container image for the `~/source/my-folder` folder.
 
+In order for your dev container to build properly, it must be built by VS Code and the Remote - Containers extension rather than a manual user build with Docker.
+
+You can promote pre-building and ensuring VS Code builds the container through something like the following in your Dockerfile:
+
+```bash
+ARG vscode
+RUN if [[ -z "$vscode" ]] ; then printf "\nERROR: This Dockerfile needs to be built with VS Code !" && exit 1; else printf "VS Code is detected: $vscode"; fi
+```
+
+And the following in your `devcontainer.json`:
+
+```bash
+ "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+          // set vscode arg for Dockerfile
+          "vscode": "true"
+      },
+    },
+```
+
 ### devcontainer CLI build options
 
 The following options can be used with the `build` command:


### PR DESCRIPTION
Including @fyyyyy's tip from https://github.com/microsoft/vscode-remote-release/issues/5779 in our section in pre-building.