### PR TITLE
Add gpg config for agent loopback

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -512,6 +512,23 @@ If you do not have GPG set up, you can configure it for your platform:
   * Register a `pinentry` GUI in your WSL distro. `echo pinentry-program /mnt/c/Program\ Files\ \(x86\)/Gpg4win/bin/pinentry.exe > ~/.gnupg/gpg-agent.conf`
   * Reload the `gpg` agent in WSL. `gpg-connect-agent reloadagent /bye`
 
+Then, still on the host system, you need to enable loopback for `pinentry`.
+
+`~/gnupg/gpg.conf` should contain the lines:
+
+    use-agent
+    pinentry-mode loopback
+
+And `~/gnupg/gpg-agent.conf` should contain the line:
+
+    allow-loopback-pinentry
+    
+Then run the following command to restart the agent to make the changes take effect.
+
+```bash
+echo RELOADAGENT | gpg-connect-agent
+```
+
 Next, install `gnupg2` in your container by updating your Dockerfile.
 
 For example:


### PR DESCRIPTION
To get gpg agent forwarding to work on macOS 12 with gpg and pinentry installed from homebrew, I had to add the following config. Otherwise, I would get the error: `Inappropriate ioctl for device`. I haven't tried it on other OSes.

Source: https://d.sb/2016/11/gpg-inappropriate-ioctl-for-device-errors