### PR TITLE
Add `envFile` to compose task spec

### DIFF
--- a/docs/containers/reference.md
+++ b/docs/containers/reference.md
@@ -443,6 +443,7 @@ Here are all properties available for configuring `docker-compose` task. All pro
 | `up` | Run a `docker-compose up` command. <br/> Either this or `down` must be specified, but not both. | `docker-compose up` |
 | `down` | Run a `docker-compose down` command. <br/> Either this or `up` must be specified, but not both. | `docker-compose down` |
 | `files` | The list of Docker Compose YAML files to use in the `docker-compose` command. If not specified, the Docker Compose CLI looks for `docker-compose.yml` and `docker-compose.override.yml`. | `-f <file>` |
+| `envFile` | File of environment variables read in and applied to the containers. | `--env-file <file>` |
 
 ### up object properties
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode-docker/pull/3339 I was going to remove `envFiles` from the docs but I discovered it was never added in the first place. So, adding the new `envFile` option that will replace it.

~~**NOTE**: Please hold off on merging until our 1.19 release, tentatively 17 Jan 22.~~ Ready to merge!