### PR TITLE
Java: add gradle part

### DIFF
--- a/docs/java/images/java-build/gradle-auto-completion.mp4
+++ b/docs/java/images/java-build/gradle-auto-completion.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b49812e3a164b5663a5779ac804f63a551acdf8f9d7d2597959022a96f0a2ad
+size 321846

--- a/docs/java/images/java-build/gradle-daemons.mp4
+++ b/docs/java/images/java-build/gradle-daemons.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72c4778cca8b455b9c81556859bc0b21f8b32ee8a09004c1c0ae8a781c4b4044
+size 200965

--- a/docs/java/images/java-build/gradle-dependencies.png
+++ b/docs/java/images/java-build/gradle-dependencies.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ac05188f1c1125da4c9338041b6dd7e1ceca9d2d8245e01c96869c033ea7332
+size 48032

--- a/docs/java/images/java-build/gradle-dependency-completion.mp4
+++ b/docs/java/images/java-build/gradle-dependency-completion.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:170a5b673a6142d6a84c2c07c42bf31a63ffe378e117abbd02473b81c7978c49
+size 300100

--- a/docs/java/images/java-build/gradle-highlighting.png
+++ b/docs/java/images/java-build/gradle-highlighting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4899b7cfb585e5535981494f2e09c0153b0659b744548df36ec1b7454e3ca8c3
+size 70549

--- a/docs/java/images/java-build/gradle-outline.png
+++ b/docs/java/images/java-build/gradle-outline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77cc26572beabdcbf904ee1afe3311522f962067aca2be7e52a5eb8c0d1bc5ab
+size 90709

--- a/docs/java/images/java-build/gradle-pinned-recent-tasks.mp4
+++ b/docs/java/images/java-build/gradle-pinned-recent-tasks.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6f5d2274bacdf9bcef0234e1e9c2d08415afd66737705137154ba4dcb40615
+size 382677

--- a/docs/java/images/java-build/gradle-problems.png
+++ b/docs/java/images/java-build/gradle-problems.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f6df1964ae982f2cadc3a2a8ed87ade1ea092adf585b9b4c8072a41042d89c6
+size 28537

--- a/docs/java/images/java-build/gradle-tasks.mp4
+++ b/docs/java/images/java-build/gradle-tasks.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:862a9a2968c6f5febd0d1c95255fd94ae44190a478c73e1861b2e01e0c549629
+size 480001

--- a/docs/java/java-build.md
+++ b/docs/java/java-build.md
@@ -132,7 +132,7 @@ When you open a Gradle project in VSCode, you can find some useful Gradle views 
   <source src="/docs/java/java-build/gradle-tasks.mp4" type="video/mp4">
 </video>
 
-When there are a lot of Gradle tasks in the workspace, it would be a little hard to find a specific task, the extension offers `Pinned Tasks` view to help you pin your favorite tasks so that you can easily find them in a separate view. You can also see the recently run tasks in the `Recent Tasks` view.
+When there are a lot of Gradle tasks in the workspace, it might be hard to find a specific task, the extension offers `Pinned Tasks` view to help you pin your favorite tasks so that you can easily find them in a separate view. You can also see recent executed tasks in the `Recent Tasks` view.
 
 <video autoplay loop muted playsinline controls>
   <source src="/docs/java/java-build/gradle-pinned-recent-tasks.mp4" type="video/mp4">

--- a/docs/java/java-build.md
+++ b/docs/java/java-build.md
@@ -140,7 +140,7 @@ When there are a lot of Gradle tasks in the workspace, it might be hard to find 
 
 ### Viewing Gradle Dependencies
 
-In the `Gradle Projects` view, you can find a `Dependencies` item under each Gradle project item. It includes all the dependencies in the specific configuration, you can easily check the dependency status of your project.
+In the `Gradle Projects` view, you can find a `Dependencies` item under each Gradle project item. It includes all the dependencies in your specified configuration, you can easily check the dependency status of your project.
 
 ![Gradle Dependencies](images/java-build/gradle-dependencies.png)
 

--- a/docs/java/java-build.md
+++ b/docs/java/java-build.md
@@ -122,13 +122,64 @@ There are two ways to generate a Maven project:
 
 ## Gradle
 
-VS Code supports basic Gradle Java project (not including Android) via the [Gradle for Java extension](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle). Currently the extension supports the following features:
-* Gradle project and task management
-* Run Gradle tasks
-* Gradle file authoring (auto-completion, syntax highlighting, error reporting, etc)
-* Manage Gradle daemons
+VS Code supports Gradle Java project (not including Android) via the [Gradle for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle) extension. The extension provides a visual interface for your Gradle build, you can use this interface to view Gradle Tasks and Project dependencies, or run Gradle Tasks as VS Code Tasks. The extension also offers a better Gradle build file authoring experience including syntax highlighting, error reporting, and auto-completion.
 
-See full feature list at the GitHub [repo](https://github.com/microsoft/vscode-gradle)
+### Working with Gradle tasks
+
+When you open a Gradle project in VSCode, you can find some useful Gradle views by clicking the Gradle Side Bar item. `Gradle Projects` view lists all the Gradle projects found in the workspace. You can view, run or debug Gradle tasks here.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-build/gradle-tasks.mp4" type="video/mp4">
+</video>
+
+When there are a lot of Gradle tasks in the workspace, it would be a little hard to find a specific task, the extension offers `Pinned Tasks` view to help you pin your favorite tasks so that you can easily find them in a separate view. You can also see the recently run tasks in the `Recent Tasks` view.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-build/gradle-pinned-recent-tasks.mp4" type="video/mp4">
+</video>
+
+### Viewing Gradle Dependencies
+
+In the `Gradle Projects` view, you can find a `Dependencies` item under each Gradle project item. It includes all the dependencies in the specific configuration, you can easily check the dependency status of your project.
+
+![Gradle Dependencies](images/java-build/gradle-dependencies.png)
+
+### Managing Gradle Daemons
+
+The `Gradle Daemons` view shows the daemon status of the current workspace. It lists all the running Gradle daemons in the same version as the workspace. You can choose to stop a specific one or all the daemons in this view.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-build/gradle-daemons.mp4" type="video/mp4">
+</video>
+
+### Authoring build files
+
+The extension provides some useful authoring features on the Gradle build files.
+
+When opening a Groovy Gradle file, the extension will analyze the Gradle file and provide semantic tokens information, providing more precise highlighting results.
+
+![Gradle Highlighting](images/java-build/gradle-highlighting.png)
+
+In the `outline` view, the extension provides the document symbols of the opened Gradle file, which can help you to navigate to any part of the file easily.
+
+![Gradle Outline](images/java-build/gradle-outline.png)
+
+If there is any syntax error (missing characters, type not found, etc.) in the opened Gradle file, you can find them in the `Problems` view.
+
+![Gradle Problems](images/java-build/gradle-problems.png)
+
+The extension supports basic auto completions for a Gradle file, when you’re trying to type a Gradle closures or properties in a Gradle script, the extension will offer some available gradle closures or properties for you.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-build/gradle-auto-completion.mp4" type="video/mp4">
+</video>
+
+When you are trying to declare a new dependency, the extension will provide a dependency candidate list for you.
+
+<video autoplay loop muted playsinline controls>
+  <source src="/docs/java/java-build/gradle-dependency-completion.mp4" type="video/mp4">
+</video>
+
 
 ### Additional resources
 

--- a/docs/java/java-build.md
+++ b/docs/java/java-build.md
@@ -138,7 +138,7 @@ When there are a lot of Gradle tasks in the workspace, it might be hard to find 
   <source src="/docs/java/java-build/gradle-pinned-recent-tasks.mp4" type="video/mp4">
 </video>
 
-### Viewing Gradle Dependencies
+### Viewing Gradle dependencies
 
 In the `Gradle Projects` view, you can find a `Dependencies` item under each Gradle project item. It includes all the dependencies in your specified configuration, you can easily check the dependency status of your project.
 


### PR DESCRIPTION
This PR extends the Gradle part of `Build Tools` section with the description and demo from Gradle for Java extension. 

cc: @nickzhums 

Signed-off-by: Shi Chen chenshi@microsoft.com