### PR TITLE
Don't download the GPG key instead read the bytes.

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -32,8 +32,8 @@ Note that other binaries are also available on the [VS Code download page](/Down
 Installing the .deb package will automatically install the apt repository and signing key to enable auto-updating using the system's package manager. Alternatively, the repository and key can also be installed manually with the following script:
 
 ```bash
-wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-sudo sh -c 'echo "deb https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+sudo echo "deb https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list
 ```
 
 Then update the package cache and install the package using:

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -32,10 +32,8 @@ Note that other binaries are also available on the [VS Code download page](/Down
 Installing the .deb package will automatically install the apt repository and signing key to enable auto-updating using the system's package manager. Alternatively, the repository and key can also be installed manually with the following script:
 
 ```bash
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
-sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
-rm -f packages.microsoft.gpg
+wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+sudo sh -c 'echo "deb https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
 ```
 
 Then update the package cache and install the package using:


### PR DESCRIPTION
- Its a pretty simple change, instead of downloading the GPG key it will read it off the bytes and than save that.