### PR TITLE
Fix/update Python invocations from the command-line

### DIFF
--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -67,23 +67,13 @@ The built-in Python 3 installation on Linux works well, but to install other Pyt
 
 ## Verify the Python installation
 
-To verify that you've installed Python successfully on your machine, run one of the following commands (depending on your operating system):
-
-- Linux/macOS: open a Terminal Window and type the following command:
+To verify that you've installed Python successfully on your machine, open a Terminal, Command Prompt, or PowerShell window and type the following command:
 
     ```bash
     python3 --version
     ```
 
-- Windows: open a command prompt and run the following command:
-
-    ```ps
-    py -3 --version
-    ```
-
 If the installation was successful, the output window should show the version of Python that you installed.
-
-   > **Note** You can use the `py -0` command in the VS Code integrated terminal to view the versions of python installed on your machine. The default interpreter is identified by an asterisk (*).
 
 ## Start VS Code in a project (workspace) folder
 

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -69,9 +69,9 @@ The built-in Python 3 installation on Linux works well, but to install other Pyt
 
 To verify that you've installed Python successfully on your machine, open a Terminal, Command Prompt, or PowerShell window and type the following command:
 
-    ```bash
-    python3 --version
-    ```
+```bash
+python3 --version
+```
 
 If the installation was successful, the output window should show the version of Python that you installed.
 
@@ -245,26 +245,17 @@ A best practice among Python developers is to avoid installing packages into a g
 
    ![Virtual environment dialog](images/tutorial/virtual-env-dialog.png)
 
-   **For Windows**
-
-   ```cmd
-   py -3 -m venv .venv
-   .venv\scripts\activate
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
    ```
 
-   If the activate command generates the message "Activate.ps1 is not digitally signed. You cannot run this script on the
+   >**Note**: If the activate command generates the message "Activate.ps1 is not digitally signed. You cannot run this script on the
    current system.", then you need to temporarily change the PowerShell execution policy to allow scripts to
    run (see [About Execution Policies](https://go.microsoft.com/fwlink/?LinkID=135170) in the PowerShell documentation):
 
    ```cmd
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
-   ```
-
-   **For macOS/Linux**
-
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
    ```
 
 1. Select your new environment by using the **Python: Select Interpreter** command from the **Command Palette**.
@@ -274,11 +265,8 @@ A best practice among Python developers is to avoid installing packages into a g
    ```bash
    # Don't use with Anaconda distributions because they include matplotlib already.
 
-   # macOS
+   # Windows (may require elevation) and macOS
    python3 -m pip install matplotlib
-
-   # Windows (may require elevation)
-   python -m pip install matplotlib
 
    # Linux (Debian)
    apt-get install python3-tk

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -69,9 +69,9 @@ The built-in Python 3 installation on Linux works well, but to install other Pyt
 
 To verify that you've installed Python successfully on your machine, open a Terminal, Command Prompt, or PowerShell window and type the following command:
 
-```bash
-python3 --version
-```
+    ```bash
+    python3 --version
+    ```
 
 If the installation was successful, the output window should show the version of Python that you installed.
 
@@ -245,17 +245,26 @@ A best practice among Python developers is to avoid installing packages into a g
 
    ![Virtual environment dialog](images/tutorial/virtual-env-dialog.png)
 
-   ```bash
+   **For Windows**
+
+   ```cmd
    python3 -m venv .venv
-   source .venv/bin/activate
+   .venv\scripts\activate
    ```
 
-   >**Note**: If the activate command generates the message "Activate.ps1 is not digitally signed. You cannot run this script on the
+   If the activate command generates the message "Activate.ps1 is not digitally signed. You cannot run this script on the
    current system.", then you need to temporarily change the PowerShell execution policy to allow scripts to
    run (see [About Execution Policies](https://go.microsoft.com/fwlink/?LinkID=135170) in the PowerShell documentation):
 
    ```cmd
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+   ```
+
+   **For macOS/Linux**
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
    ```
 
 1. Select your new environment by using the **Python: Select Interpreter** command from the **Command Palette**.


### PR DESCRIPTION
Hello

The subject of this pull request asks the reader to run a `python3` command in macOS/Linux, but a `py` command in Windows instead. In my test on Windows 10, Visual Studio Code 1.62.3, and Python 3.10 (Microsoft Store):

- The `python3` command works in Windows too. 
- The `py` command doesn't work.
- The `python` command works in Windows and seems to be the equivalent of the `python3` command.

This PR eliminates all platforms distinctions and uses the `python3` command uniformly throughout the document.

This PR probably needs a thorough review.