### PR TITLE
Remove the section for the language server JDK

### DIFF
--- a/docs/java/java-project.md
+++ b/docs/java/java-project.md
@@ -57,8 +57,6 @@ You can export your build to JAR from the projects view or by running the comman
 
 ## Configure Runtime for Projects
 
-> **Note**: The Java language server requires JDK version 11 or above to launch it self, but this is **NOT** a requirement to your projects' runtime. Check [Settings for the JDK](/docs/java/java-tutorial.md#settings-for-the-jdk) for more information about how to set the JDK for the extension itself.
-
 As Java evolves, it's common that developers work with multiple versions of JDK. You can map them to your local installation paths via the setting: `java.configuration.runtimes`. The setting has following format:
 
 ```json


### PR DESCRIPTION
Since we have enabled platform specific extensions, there is no need to let the user knows the concept of language server JDK now.

Signed-off-by: Sheng Chen <sheche@microsoft.com>