### PR TITLE
Add missing properties to devcontainer.json ref, flesh out features and image pre-builds, misc corrections

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -5,7 +5,7 @@ TOCTitle: Containers
 PageTitle: Developing inside a Container using Visual Studio Code Remote Development
 ContentId: 7ec8a02b-2eb7-45c1-bb16-ddeaac694ff6
 MetaDescription: Developing inside a Container using Visual Studio Code Remote Development
-DateApproved: 12/8/2021
+DateApproved: 12/15/2021
 ---
 # Developing inside a Container
 
@@ -15,7 +15,7 @@ Workspace files are mounted from the local file system or copied or cloned into 
 
 ![Container Architecture](images/containers/architecture-containers.png)
 
-This lets VS Code provide a **local-quality development experience** — including full IntelliSense (completions), code navigation, and debugging — **regardless of where your tools (or code) are located**.
+This lets VS Code provide a **local-quality development experience** including full IntelliSense (completions), code navigation, and debugging **regardless of where your tools (or code) are located**.
 
 ## Getting started
 
@@ -23,11 +23,14 @@ This lets VS Code provide a **local-quality development experience** — includi
 
 ### System requirements
 
-**Local / SSH Host:**
+**Local / Remote Host:**
 
 * **Windows:** [Docker Desktop](https://www.docker.com/products/docker-desktop) 2.0+ on Windows 10 Pro/Enterprise. Windows 10 Home (2004+) requires Docker Desktop 2.3+ and the [WSL 2 back-end](https://aka.ms/vscode-remote/containers/docker-wsl2). (Docker Toolbox is not supported. Windows container images are not supported.)
 * **macOS**:  [Docker Desktop](https://www.docker.com/products/docker-desktop) 2.0+.
 * **Linux**: [Docker CE/EE](https://docs.docker.com/install/#supported-platforms) 18.06+ and [Docker Compose](https://docs.docker.com/compose/install) 1.21+. (The Ubuntu snap package is not supported.)
+* **Remote hosts:** 1 GB RAM is required, but at least 2 GB RAM and a 2-core CPU is strongly recommended.
+
+Other [Docker compliant CLIs](#can-i-use-podman-instead-of-docker) may work, but are not officially supported. Note that [attaching to a Kubernetes cluster](/docs/remote/attach-container.md#attach-to-a-container-in-a-kubernetes-cluster) only requires a properly configured [`kubectl` CLI](https://kubernetes.io/docs/reference/kubectl/overview/).
 
 **Containers**:
 
@@ -46,9 +49,9 @@ To get started, follow these steps:
 
     1. Install [Docker Desktop for Windows/Mac](https://www.docker.com/products/docker-desktop).
 
-    2. If you are using WSL 2 on Windows, to enable the [WSL 2 back-end](https://aka.ms/vscode-remote/containers/docker-wsl2): Right-click on the Docker taskbar item and select **Settings**. Check **Use the WSL 2 based engine** and verify your distribution is enabled under **Resources > WSL Integration**.
+    2. If you are using WSL 2 on Windows, to ensure the [WSL 2 back-end](https://aka.ms/vscode-remote/containers/docker-wsl2) is enabled: Right-click on the Docker taskbar item and select **Settings**. Check **Use the WSL 2 based engine** and verify your distribution is enabled under **Resources > WSL Integration**.
 
-    3. Right-click on the Docker task bar item, select **Settings** and update **Resources > File Sharing** with any locations your source code is kept. See [tips and tricks](/docs/remote/troubleshooting.md#container-tips) for troubleshooting. This option is not available if you have enabled the WSL 2 back-end in the step above.
+    3. When not using the WSL 2 back-end, right-click on the Docker task bar item, select **Settings** and update **Resources > File Sharing** with any locations your source code is kept. See [tips and tricks](/docs/remote/troubleshooting.md#container-tips) for troubleshooting.
 
     **Linux**:
 
@@ -131,13 +134,13 @@ The rest of the quick start applies as-is! You can learn more about the [Remote 
 
 ### Open a folder on a remote SSH host in a container
 
-You can use the [Remote - SSH](/docs/remote/ssh.md) and Remote - Containers extensions together. You do not even need to have a Docker client installed locally. To do so:
+If you are using a Linux or macOS SSH host, you can use the [Remote - SSH](/docs/remote/ssh.md) and Remote - Containers extensions together. You do not even need to have a Docker client installed locally. To do so:
 
 1. Follow the [installation](/docs/remote/ssh.md#installation) and SSH [host setup](/docs/remote/ssh.md#ssh-host-setup) steps for the Remote - SSH extension.
 1. **[Optional]** Set up SSH [key based authentication](/docs/remote/troubleshooting.md#configuring-key-based-authentication) to the server so you do not need to enter your password multiple times.
 1. [Install Docker](#installation) on your SSH host. You do not need to install Docker locally.
 1. Follow the [quick start](/docs/remote/ssh.md#connect-to-a-remote-host) for the Remote - SSH extension to connect to a host and open a folder there.
-1. Use the **Remote-Containers: Reopen in Container** command.
+1. Use the **Remote-Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
 
 The rest of the Remote - Containers quick start applies as-is. You can learn more about the [Remote - SSH extension in its documentation](/docs/remote/ssh.md). You can also see the [Develop on a remote Docker host](/remote/advancedcontainers/develop-remote-host.md) article for other options if this model does not meet your needs.
 
@@ -259,39 +262,33 @@ When you rebuild and reopen in your container, the features you selected will be
 
 ```json
 "features": {
-        "github-cli": "latest"
-    }
+    "github-cli": "latest"
+}
 ```
 
 You'll get IntelliSense when editing the `"features"` property in the `devcontainer.json` directly:
 
 ![Intellisense when modifying terraform feature](images/containers/features-intellisense.png)
 
-The features are sourced from the [script library](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library/docs) in the vscode-dev-containers repo.
+Built-in features are sourced from the [script library](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library/docs) folder in the vscode-dev-containers repo, but Remote - Containers and GitHub Codespaces includes an **early preview** of support for creating your own dev container features. For example, you can reference these as follows:
+
+```json
+"features": {
+    "your-github-id-or-org/your-repository/feature-name@v0.0.1": "latest"
+}
+```
+
+The form and format of these custom features is still in flux, but you can try creating your own dev container feature in its current form using the [dev-container-features-template](https://github.com/microsoft/dev-container-features-template) sample repository.  Let us know what you think!
 
 The **Remote-Containers: Configure Container Features** command allows you to update an existing configuration.
 
-> **Note:** Features support for GitHub Codespaces is coming soon.
-
 ## Pre-building dev container images
 
-You can pre-build images with the tools you need rather than creating and building the image each time you create a container for a project. Using pre-built images can be simpler and allows you to pin to a specific version of tools, avoiding potential breaks. Pre-building is especially valuable in CI processes.
+We strongly recommend pre-building images with the tools you need rather than creating and building an container image each time you open your project in a dev container. Using pre-built images will result in a faster container startup,  simpler configuration, and allows you to pin to a specific version of tools to improve supply-chain security and avoid potential breaks. You can automate pre-building your image by scheduling the build using a DevOps or continuous integration (CI) service like GitHub Actions.
 
-You can use the [devcontainer CLI](/docs/remote/devcontainer-cli.md) to facilitate pre-builds.
+We recommend using the [devcontainer CLI](/docs/remote/devcontainer-cli.md) to pre-build your images since it is kept in sync with the Remote - Container extension's latest capabilities - including [dev container features](#dev-container-features-preview). Once you've built your image, you can push it to a container registry (like the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images), or [Docker Hub](https://docs.docker.com/engine/reference/commandline/push)) and reference it directly.
 
-The process could be as follows:
-
-* [Create](/docs/editor/versioncontrol.md#initialize-a-repository) a source code repository.
-* Create a dev container configuration, customizing as you wish (including [features](#dev-container-features-preview)).
-* Use the [`devcontainer CLI`](/docs/remote/devcontainer-cli.md) to build your image (the `devcontainer CLI` supports building images with features).
-* [Push](https://docs.docker.com/engine/reference/commandline/push/) your image. You can then change the dev container in your source repository to reference the image directly.
-
-```bash
-devcontainer build --image-name your-registry.azurecr.io/your-image-name
-docker push your-registry.azurecr.io/your-image-name
-```
-
-You can push your image to a container registry, like [Docker Hub](https://docs.docker.com/engine/reference/commandline/push), the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), or [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images).
+See the **[devcontainer CLI article on pre-building images for more information](/docs/remote/devcontainer-cli.md#building-a-dev-container-image)**.
 
 ## Inspecting volumes
 
@@ -605,6 +602,8 @@ the file schema to help you customize your development containers and control ho
 * Docker Toolbox on Windows is not supported.
 * If you clone a Git repository using SSH and your SSH key has a passphrase, VS Code's pull and sync features may hang when running remotely. Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
 * Local proxy settings are not reused inside the container, which can prevent extensions from working unless the appropriate proxy information is configured (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information).
+* You cannot use Remote - Containers from a Remote - SSH connection to a Windows machine.
+
 
 See [here for a list of active issues](https://aka.ms/vscode-remote/containers/issues) related to Containers.
 
@@ -618,7 +617,7 @@ See the Docker troubleshooting guide for [Windows](https://docs.docker.com/docke
 
 ### Docker Extension limitations
 
-While the Docker extension can run both remotely and locally, if it is already installed locally, you will be unable to install in a container without first uninstalling it locally. We will address this problem in a future VS Code release.
+If you are using the Docker or Kubernetes extension from a Remote - WSL or Remote - SSH window, you will not be able to use the right-click "Attach to Container" option. This will only work if you are using it from your local machine.
 
 ### Extension limitations
 

--- a/docs/remote/create-dev-container.md
+++ b/docs/remote/create-dev-container.md
@@ -110,7 +110,9 @@ sudo apt-get update
 sudo apt-get install git
 ```
 
-You may also use the `"features"` property in the `devcontainer.json` to install tools and languages from a set of [scripts](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library/docs).
+You may also use the `"features"` property in the `devcontainer.json` to install tools and languages from a set pre-defined set of [scripts](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library/docs) or even your own.
+
+> **Note:** Features support is in preview.
 
 For example, you could install the latest version of the Azure CLI with the following:
 
@@ -120,7 +122,7 @@ For example, you could install the latest version of the Azure CLI with the foll
   }
 ```
 
-  > **Note:** Features support for GitHub Codespaces is coming soon.
+See the article on [dev container features](/docs/remote/containers.md#dev-container-features-preview) for more details.
 
 ### Rebuild
 

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -5,19 +5,24 @@ TOCTitle: devcontainer CLI
 PageTitle: Installing and working with the devcontainer CLI
 ContentId: 8946213d-716e-41ca-955f-944a41c70353
 MetaDescription: Documentation on using the devcontainer command line interface with the Visual Studio Code Remote - Containers extension
-DateApproved: 12/8/2021
+DateApproved: 12/17/2021
 ---
 # devcontainer command line interface
 
-The [Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) has a `devcontainer` command line interface (CLI) which allows you to interact with a dev container from your terminal.
+Given the growing number of use cases for dev containers, there is a companion `devcontainer` command line interface (CLI) that will include several features that can be useful outside of [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or GitHub Codespaces. This article will walk you through its installation and how to use it in different scenarios.
 
-## Installing the devcontainer CLI
+## System requirements
 
-You can install the dev container CLI within VS Code or from the command line.
+To use the `devcontainer` CLI, you'll need the following on your system or CI/DevOps environment:
+
+1. [Node.js 14+](https://nodejs.org/en/).
+1. [The `docker` CLI](/docs/remote/containers#installation).
+
+## Installation
 
 ### Install using VS Code
 
-1. Ensure you have the latest version of the [Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed (must be at least `v0.188.0`).
+1. Ensure you have the latest version of the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed (must be at least `v0.188.0`).
 
 2. Launch Visual Studio Code and select  **Remote-Containers: Install devcontainer CLI** from the Command Palette (`kbstyle(F1)`).
 
@@ -29,14 +34,16 @@ You can install the dev container CLI within VS Code or from the command line.
 3. From an external terminal (one not inside Visual Studio Code), run `devcontainer --help` to test the installation and see the CLI's built-in help. Note that you may need to restart your shell for `PATH` changes to take effect.
 
     ```bash
-     $ devcontainer --help
+    $ devcontainer --help
     devcontainer <command>
-    :
-      devcontainer open [path]             Open a dev container in VS Code
-      devcontainer build [path] [options]  Build a dev container image
+
+    Commands:
+      devcontainer open [path]   Open a dev container in VS Code
+      devcontainer build [path]  Build a dev container image
 
     Options:
-      -h, --help  Show help  [boolean]
+      -h, --help               Show help  [boolean]
+          --disable-telemetry  Disable telemetry  [boolean] [default: false]
     ```
 
 ### Install from the command line
@@ -65,15 +72,114 @@ Visual Studio Code has many [command line options](/docs/editor/command-line.md)
 
 With the devcontainer CLI, you can use the `devcontainer open` command to open the current folder straight into dev container mode, skipping the prompt.
 
-You can optionally specify the path to the folder to open, for example `devcontainer open ~/source/my-folder` to open the `~/source/my-folder` folder within a dev container.
+You can optionally specify the path to the folder to open, for example `devcontainer open /source/my-folder` to open the `/source/my-folder` folder within a dev container.
 
 ## Building a dev container image
 
-The `devcontainer build` command allows you to build the dev container image for a folder. As with the `open` command, `build` accepts a path to the folder to build the image for and defaults to the current working folder in your shell. For example, `devcontainer build` will build the dev container image for the current folder and `devcontainer build ~/source/my-folder` will build the container image for the `~/source/my-folder` folder.
+The `devcontainer build` command allows you to build quickly build dev container image following the same steps the Remote - Containers extension or GitHub Codespaces will. This is particularly useful when you want to pre-build a dev container image using a CI or DevOps product like GitHub Actions.
+
+As with the `open` command, `build` accepts a path to the folder containing a `.devcontainer` folder or `.devcontainer.json` file. If omitted, the current working folder us used. For example, `devcontainer build` will build the dev container image for the current folder and `devcontainer build /source/my-folder` will build the container image for the `/source/my-folder` folder.
+
+### Example of building and publishing an image
+
+For example, you may want to pre-build a number of images that you then reuse across multiple projects or repositories. To do so, follow these steps:
+
+1. [Create](/docs/editor/versioncontrol.md#initialize-a-repository) a source code repository.
+
+1. Create dev container configuration for each image you want to pre-build, customizing as you wish (including [dev container features](#dev-container-features-preview)). For example, consider this devcontainer.json file:
+
+    ```json
+    {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "docker-in-docker": "latest"
+        }
+    }
+    ```
+
+1. Use the `devcontainer build` command to build the image. See documentation for your image registry (like the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images), or [Docker Hub](https://docs.docker.com/engine/reference/commandline/push)) for information on image naming and additional steps like authentication.
+
+    ```bash
+    devcontainer build \
+        --image-name ghcr.io/your-org/your-repo/your-image-name \
+        change-me-to-repository-folder-with-dot-devcontainer
+    ```
+
+1. Next [push](https://docs.docker.com/engine/reference/commandline/push/) the image to your registry.
+
+    ```bash
+    docker push ghcr.io/your-org/your-image-name
+    ```
+
+1. Finally, for each project or repository that will use your image, craft a simplified devcontainer.json file that either uses the `image` property or references it in a Docker Compose file. Include any dev container features you added in your pre-build configuration in step 2. For example:
+
+    ```json
+    {
+        "image": "ghcr.io/your-org/your-image-name",
+        "features": {
+            "docker-in-docker": "latest"
+        }
+    }
+    ```
+
+That's it!
+
+### Adding automation
+Steps to automate pre-building your image will vary by CI/DevOps system, but here's an example GitHub Actions workflow that will automate the process for a sub-folder called `change-me` and push it to GitHub Container Registry once a month and whenever the dev container folder is modified in the `main` branch:
+
+```yaml
+name: Generate Dev Container Image
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'change-me/.devcontainer/**/*'
+permissions:
+  contents: read
+  packages: write
+jobs:
+  devcontainer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -e
+
+          # Update this based on your image name and the path of the .devcontainer folder in your repository
+          FOLDER_WITH_DOT_DEVCONTAINER="change-me"
+          IMAGE_NAME="your-image-name"
+          IMAGE_REPOSITORY="$(echo "ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+
+          # [Optional] Enable buildkit, set output to plain text for logging
+          export DOCKER_BUILDKIT=1
+          export BUILDKIT_PROGRESS=plain
+
+          # Do the build - update
+          npm install -g "@vscode/dev-container-cli"
+          devcontainer build --no-cache --image-name "${IMAGE_REPOSITORY}" "${FOLDER_WITH_DOT_DEVCONTAINER}"
+
+          # Push image to GitHub Container Registry
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push "${IMAGE_REPOSITORY}"
+```
+
+### devcontainer CLI build options
+
+The following options can be used with the `build` command:
+
+* `--no-cache` : By default, building a Docker container image reuses layers from previous image builds. The `--no-cache` option prevents the cache being used and forces the image to be rebuilt.
+* `--image-name` : The Remote-Containers extension typically determines its own name for the images it builds. You can specify the name to use for the built image using the `--image-name` option.
+
+You can also type `devcontainer build --help` to see a full list of available options.
 
 ### [Optional] Avoiding problems with images built using Docker
 
-In order for your dev container to build properly, it may need to be built by the dev container CLI, the Remote - Containers extension, or in a GitHub Codespace, rather than a manual user build with Docker. To avoid building with Docker manually, you can add a build argument that is verified in your Dockerfile and only set in `devcontainer.json` or a dev container specific Docker Compose file.
+Given Dockerfiles and Docker Compose files can be used without VS Code or the `devcontainer` CLI, you may want to let users know that they should not try to build the image directly if it will not work as expected. To solve this problem, you can add a build argument that needs to be specified for things to work.
 
 For example, you could add the following to your Dockerfile:
 
@@ -91,19 +197,10 @@ And the following in your `devcontainer.json`:
           // set vscode arg for Dockerfile
           "vscode": "true"
       },
-    },
+    }
 ```
 
-### devcontainer CLI build options
-
-The following options can be used with the `build` command:
-
-* `--no-cache` : By default, building a Docker container image reuses layers from previous image builds. The `--no-cache` option prevents the cache being used and forces the image to be rebuilt.
-* `--image-name` : The Remote-Containers extension typically determines its own name for the images it builds. You can specify the name to use for the built image using the `--image-name` option.
-
-## Visual Studio Code Insiders
-
- You can install the CLI for the Stable and Insiders builds of Visual Studio Code side-by-side. The Insiders CLI will be `devcontainer-insiders`, so use this in place of `devcontainer` in the steps above.
+In the Docker Compose case, you can add this argument to a separate [override file to extend your configuration](/docs/remote/create-dev-container.md#extend-your-docker-compose-file-for-development) that is located in a different place in your source tree than the primary Docker Compose file
 
 ## Next steps
 

--- a/docs/remote/devcontainerjson-reference.md
+++ b/docs/remote/devcontainerjson-reference.md
@@ -5,7 +5,7 @@ TOCTitle: devcontainer.json
 PageTitle: devcontainer.json reference
 ContentId: 52eaec33-21c6-410c-8e10-1ee3658a854f
 MetaDescription: devcontainer.json reference
-DateApproved: 12/8/2021
+DateApproved: 12/16/2021
 ---
 # devcontainer.json reference
 
@@ -13,15 +13,13 @@ A `devcontainer.json` file in your project tells Visual Studio Code (and other s
 
 [Set up a folder to run in a container](/docs/remote/create-dev-container.md#set-up-a-folder-to-run-in-a-container) has more information on configuring a dev container or you can use the **Remote-Containers: Add Development Container Configuration Files...** or **Codespaces: Add Development Container Configuration Files...** commands from the Command Palette (`kbstyle(F1)`) to add a wide variety of base configurations from the [vscode-dev-containers repository](https://github.com/microsoft/vscode-dev-containers/tree/main/containers).
 
-## devcontainer.json properties
-
 > **Tip:** If you've already built a container and connected to it, be sure to run **Remote-Containers: Rebuild Container** or **Codespaces: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
 
-### Scenario specific properties
+## Scenario specific properties
 
-While some `devcontainer.json` properties apply broadly, others are scenario specific. These properties vary depending on whether you want to set up your environment using an existing image, a Dockerfile, or a Docker Compose file.
+The focus of `devcontainer.json` is to describe how to enrich a container for the purposes of development rather than acting as a multi-container orchestrator format. Instead, orchestrator formats can be referenced when needed. Today, `devcontainer.json` includes scenario specific properties for working without a container orchestrator (by directly referencing an image or Dockerfile) and for using Docker Compose as a simple multi-container orchestrator.
 
-**Image or Dockerfile specific properties**
+### Image or Dockerfile specific properties
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -39,7 +37,7 @@ While some `devcontainer.json` properties apply broadly, others are scenario spe
 | `workspaceFolder` | string | Requires `workspaceMount` be set. Sets the default path that VS Code and other `devcontainer.json` supporting services / tools should open when connecting to the container. Defaults to the automatic source code mount location. <br /><br />⚠️ Not yet supported in Codespaces or when using Clone Repository in Container Volume. |
 | `runArgs` | array | An array of [Docker CLI arguments](https://docs.docker.com/engine/reference/commandline/run/) that should be used when running the container. Defaults to `[]`. For example, this allows ptrace based debuggers like C++ to work in the container:<br /> `"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ]` . |
 
-**Docker Compose specific properties**
+### Docker Compose specific properties
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -48,23 +46,23 @@ While some `devcontainer.json` properties apply broadly, others are scenario spe
 | `runServices` | array | An array of services in your Docker Compose configuration that should be started by VS Code and other `devcontainer.json` supporting services / tools. These will also be stopped when you disconnect unless `"shutdownAction"` is `"none"`. Defaults to all services. |
 | `workspaceFolder` | string | Sets the default path that VS Code and other `devcontainer.json` supporting services / tools should open when connecting to the container (which is often the path to a volume mount where the source code can be found in the container). Defaults to `"/"`. |
 
-### General devcontainer.json properties
+## General devcontainer.json properties
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `name` | string | A display name for the container. |
 | `forwardPorts` | array | An array of port numbers or `"host:port"` values  (e.g. `[3000, "db:5432"]`) that should always be forwarded from inside the primary container to the local machine (including on the web for Codespaces). The property is most useful for forwarding ports that cannot be auto-forwarded because the related process that starts before VS Code connects or for forwarding a service not in the primary container in Docker Compose scenarios (e.g. `"db:5432"`). Defaults to `[]`. <br /><br /> ⚠️ Codespaces does not yet support the `"host:port"` variation of this property. |
-| `portsAttributes` | object | Object that maps a port number, `"host:port"` value, range, or regular expression to a set of default options. See [port attributes](#port-attributes) for available options. For example: <br />`"portsAttributes": { "3000": { "label": "Application port" } }` <br /><br /> ⚠️ Codespaces does not yet support the `"host:port"` variation of this property.|
-| `otherPortsAttributes` | object | Default options for ports, port ranges, and hosts that aren't configured using `portsAttributes`. See [port attributes](#port-attributes) for available options. For example: <br /> `"otherPortsAttributes": { "onAutoForward": "silent" }` |
+| `portsAttributes` | object | Object that maps a port number, `"host:port"` value, range, or regular expression to a set of default options. See [port attributes](#port-attributes) for available options. For example: <br />`"portsAttributes": {"3000": {"label": "Application port"}}` <br /><br /> ⚠️ Codespaces does not yet support the `"host:port"` variation of this property.|
+| `otherPortsAttributes` | object | Default options for ports, port ranges, and hosts that aren't configured using `portsAttributes`. See [port attributes](#port-attributes) for available options. For example: <br /> `"otherPortsAttributes": {"onAutoForward": "silent"}` |
 | `remoteEnv` | object | A set of name-value pairs that sets or overrides environment variables for VS Code (or sub-processes like terminals) but not the container as a whole. Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the values. Be sure **Terminal > Integrated: Inherit Env** is checked in settings or the variables will not appear in the terminal. For example: <br />`"remoteEnv": { "PATH": "${containerEnv:PATH}:/some/other/path", "MY_VARIABLE": "${localEnv:MY_VARIABLE}" }`<br />Updates are applied when VS Code is restarted (or the window is reloaded) |
 | `remoteUser` | string | Overrides the user that VS Code and other `devcontainer.json` supporting services tools / runs as in the container (along with sub-processes like terminals, tasks, or debugging). Does not change the user the container as a whole runs as which can be set using `containerUser` for images and Dockerfiles or [in your Docker Compose file](https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir) instead. Defaults to the user the container as a whole is running as (often `root`).<br>Updates are applied when VS Code is restarted (or the window is reloaded). |
 | `updateRemoteUserUID` | boolean | On Linux, if `containerUser` or `remoteUser` is specified, the container user's UID/GID will be updated to match the local user's UID/GID to avoid permission problems with bind mounts. Defaults to `true`.<br>Requires the container be recreated / rebuilt for updates to take effect. |
 | `userEnvProbe` | enum | Indicates the type of shell to use to "probe" for user environment variables to include in VS Code or other connected tool's processes: `none`, `interactiveShell`, `loginShell`, or `loginInteractiveShell` (default). The specific shell used is based on the default shell for the user (typically bash). For example, bash interactive shells will typically include variables set in `/etc/bash.bashrc` and `~/.bashrc` while login shells usually include variables from `/etc/profile` and `~/.profile`. Setting this property to `loginInteractiveShell` will get variables from all four files. |
 | `overrideCommand` | boolean | Tells VS Code and other `devcontainer.json` supporting services / tools whether they should run `/bin/sh -c "while sleep 1000; do :; done"` when starting the container instead of the container's default command (since the container can shut down if the default command fails). Set to `false` if the default command must run for the container to function properly. Defaults to `true` for when using an image Dockerfile and `false` when referencing a Docker Compose file. |
-| `features` | object | An object of [dev container features](/docs/remote/containers.md#dev-container-features-preview) and related options to be added into your primary container. The specific options  that are available varies by feature, so see its documentation for additional details. For example, `"features": { "github-cli": "latest" }` <br /><br /> ⚠️ Currently in preview. |
+| `features` | object | An object of [dev container features](/docs/remote/containers.md#dev-container-features-preview) and related options to be added into your primary container. The specific options  that are available varies by feature, so see its documentation for additional details. For example: <br />`"features": {"github-cli": "latest"}` <br /><br /> ⚠️ Currently in preview. |
 | `shutdownAction` | enum | Indicates whether VS Code and other `devcontainer.json` supporting tools should stop the containers when the related tool window is closed / shut down.<br>Values are  `none`, `stopContainer` (default for image or Dockerfile), and `stopCompose` (default for Docker Compose).<br /><br /> ⚠️ Does not apply to Codespaces. |
 
-### VS Code specific properties
+## VS Code specific properties
 
 While most properties apply to any `devcontainer.json` supporting tool or service, a few are specific to VS Code.
 
@@ -74,7 +72,7 @@ While most properties apply to any `devcontainer.json` supporting tool or servic
 | `settings` | object | Adds default `settings.json` values into a container/machine specific settings file. Defaults to `{}`. |
 | `devPort` | integer | Allows you to force a specific port that VS Code Server should use in the container. Defaults to a random, available port. |
 
-### Lifecycle scripts
+## Lifecycle scripts
 
 When creating or working with a dev container, you may need different commands to be run at different points in the container's lifecycle. The table below lists a set of command properties you can use to update what the container's contents in the order in which they are run (for example, `onCreateCommand` will run after `initializeCommand`). Each command property is an string or list of command arguments that should execute from the `workspaceFolder`.
 
@@ -90,7 +88,17 @@ When creating or working with a dev container, you may need different commands t
 
 For each command property, if the value is a single string, it will be run in `/bin/sh`. Use `&&` in a string to execute multiple commands. For example, `"yarn install"` or `"apt-get update && apt-get install -y curl"`. The array syntax `["yarn", "install"]` will invoke the command (in this case `yarn`) directly without using a shell. Each fires after your source code has been mounted, so you can also run shell scripts from your source tree. For example: `bash scripts/install-dev-tools.sh`
 
-### Port attributes
+## Minimum host requirements
+
+While devcontainer.json does not focus on hardware or VM provisioning, it can be useful to know your containers minimum RAM, CPU, and storage requirements. This is what `hostRequirements` property allows you to do. Cloud services like GitHub Codespaces use these properties to automatically default to the best compute option available, while in other cases you will be presented with a warning if the requirements are not met.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hostRequirements.cpus` | integer | Indicates the minimum required number of CPUs / virtual CPUs / cores. For example: `"hostRequirements": {"cpus": 2}` |
+| `hostRequirements.memory` | string |  A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"memory": "4gb"}` |
+| `hostRequirements.storage` | string | A string indicating minimum storage requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"storage": "32gb"}` |
+
+## Port attributes
 
 The `portsAttributes` and `otherPortsAttributes` properties allow you to map default port options for one or more manually or automatically forwarded ports. The following is a list of options that can be set in the configuration object assigned to the property.
 
@@ -102,7 +110,7 @@ The `portsAttributes` and `otherPortsAttributes` properties allow you to map def
 | `requireLocalPort` | boolean | Dictates when port forwarding is required to map the port in the container to the same port locally or not. If set to `false`, VS Code and other `devcontainer.json` supporting services /  tools will attempt to use the specified port forward to `localhost`, and silently map to a different one if it is unavailable. If set to `true`, you will be notified if it is not possible to use the same port. Defaults to `false`. |
 | `elevateIfNeeded` | boolean | Forwarding low ports like 22, 80, or 443 to `localhost` on the same port from VS Code (client) may require elevated permissions on certain operating systems. Setting this property to `true` will automatically try to elevate VS Code's or another `devcontainer.json` supporting tool's permissions in this situation. Defaults to `false`. |
 
-### Formatting string vs. array properties
+## Formatting string vs. array properties
 
 The format of certain properties will vary depending on the involvement of a shell.
 
@@ -132,7 +140,7 @@ By contrast, the array format will keep the single quotes and write them to stan
 "postAttachCommand": ["echo", "foo='bar'"]
 ```
 
-### Variables in devcontainer.json
+## Variables in devcontainer.json
 
 Variables can be referenced in certain string values in `devcontainer.json` in the following format: **${variableName}**. The following is a list of available variables you can use.
 

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -5,7 +5,7 @@ TOCTitle: SSH
 PageTitle: Developing on Remote Machines using SSH and Visual Studio Code
 ContentId: 42e65445-fb3b-4561-8730-bbd19769a160
 MetaDescription: Developing on Remote Machines or VMs using Visual Studio Code Remote Development and SSH
-DateApproved: 12/8/2021
+DateApproved: 12/15/2021
 ---
 # Remote Development using SSH
 
@@ -15,7 +15,7 @@ No source code needs to be on your local machine to gain these benefits since th
 
 ![SSH Architecture](images/ssh/architecture-ssh.png)
 
-This lets VS Code provide a **local-quality development experience** — including full IntelliSense (completions), code navigation, and debugging — **regardless of where your code is hosted**.
+This lets VS Code provide a **local-quality development experience** - including full IntelliSense (completions), code navigation, and debugging - **regardless of where your code is hosted**.
 
 ## Getting started
 
@@ -31,13 +31,12 @@ This lets VS Code provide a **local-quality development experience** — includi
 - ARMv7l (AArch32) Raspberry Pi OS (previously called Raspbian) Stretch/9+ (32-bit).
 - ARMv8l (AArch64) Ubuntu 18.04+ (64-bit).
 - Windows 10 / Server 2016/2019 (1803+) using the [official OpenSSH Server](https://docs.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse).
-- macOS 10.14+ (Mojave) SSH hosts with [Remote Login enabled](https://support.apple.com/guide/mac-help/allow-a-remote-computer-to-access-your-mac-mchlp1066/mac).
+- macOS 10.14+ (Mojave) SSH hosts with [Remote Login enabled](https://support.apple.com/guide/mac-help/allow-a-remote-computer-to-access-your-mac-mchlp1066/mac).
+- 1 GB RAM is required for remote hosts, but at least 2 GB RAM and a 2-core CPU is strongly recommended.
 
 Other `glibc` based Linux distributions for x86_64, ARMv7l (AArch32), and ARMv8l (AArch64) should work if they have the needed prerequisites. See the [Remote Development with Linux](/docs/remote/linux.md) article for information prerequisites and tips for getting community supported distributions up and running.
 
 While ARMv7l (AArch32) and ARMv8l (AArch64) support is available, some extensions installed on these devices may not work due to the use of x86 native code in the extension.
-
-> **Note:** While 1 GB RAM is required (similar to the [hardware requirements](/docs/supporting/requirements.md) for VS Code), at least 2 GB RAM and a 2-core CPU is recommended.
 
 ### Installation
 
@@ -104,6 +103,17 @@ To connect to a remote host for the first time, follow these steps:
 From here, [install any extensions](#managing-extensions) you want to use when connected to the host and start editing!
 
 > **Note:** On ARMv7l / ARMv8l `glibc` SSH hosts, some extensions may not work due to x86 compiled native code inside the extension.
+
+### Open a folder on a remote SSH host in a container
+
+If you are using a Linux or macOS SSH host, you can use the Remote - SSH and [Remote - Containers](/docs/remote/containers.md) extensions together to open a folder on your remote host inside of a container! You do not even need to have a Docker client installed locally. To do so:
+
+1. Follow the [installation](/docs/remote/containers.md#installation) steps for the Remote - Containers extension on your remote host.
+1. **[Optional]** Set up SSH [key based authentication](/docs/remote/troubleshooting.md#configuring-key-based-authentication) to the server so you do not need to enter your password multiple times.
+1. Follow the [quick start](#connect-to-a-remote-host) for the Remote - SSH extension to connect to a host and open a folder there.
+1. Use the **Remote-Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
+
+The rest of the [Remote - Containers quick start](/docs/remote/containers.md#quick-start-open-an-existing-folder-in-a-container) applies as-is. You can learn more about the [Remote - Containers extension in its documentation](/docs/remote/containers.md). You can also see the [Develop on a remote Docker host](/remote/advancedcontainers/develop-remote-host.md) article for other options if this model does not meet your needs.
 
 ### Disconnect from a remote host
 
@@ -279,11 +289,12 @@ SSHFS is the most convenient option and does not require any file sync'ing. Howe
 - PuTTY is not supported on Windows.
 - If you clone a Git repository using SSH and your SSH key has a passphrase, VS Code's pull and sync features may hang when running remotely. Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
 - Local proxy settings are not reused on the remote host, which can prevent extensions from working unless the appropriate proxy information is configured on the remote host (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information).
+- You cannot use Remote - Containers from a Remote - SSH connection to a Windows machine.
 - See [here for a list of active issues](https://aka.ms/vscode-remote/ssh/issues) related to SSH.
 
 ### Docker Extension limitations
 
-While the Docker extension can run both remotely and locally, if it is already installed locally, you will be unable to install on a remote SSH host without first uninstalling it locally. We will address this problem in a future VS Code release.
+If you are using the Docker or Kubernetes extension in a Remote - SSH window, you will not be able to use the right-click "Attach VS Code to Container" option. This will only work if you are using it from your local machine.
 
 ### Extension limitations
 

--- a/remote/advancedcontainers/develop-remote-host.md
+++ b/remote/advancedcontainers/develop-remote-host.md
@@ -5,7 +5,7 @@ TOCTitle: Develop on a remote Docker host
 PageTitle: Develop a container on a remote Docker host
 ContentId: 661004c9-d96c-4898-8b33-91eefb893466
 MetaDescription: Develop a container on a remote Docker host
-DateApproved: 12/8/2021
+DateApproved: 12/15/2021
 ---
 # Develop on a remote Docker host
 
@@ -13,13 +13,13 @@ Sometimes you may want to use the Remote - Containers extension to develop insid
 
 ## Connect using the Remote - SSH extension (recommended)
 
-You can use the [Remote - SSH](/docs/remote/ssh.md) and Remote - Containers extensions together. You do not even need to have a Docker client installed locally. To do so:
+If you are using a Linux or macOS SSH host, you can use the [Remote - SSH](/docs/remote/ssh.md) and Remote - Containers extensions together. You do not even need to have a Docker client installed locally. To do so:
 
 1. Follow the [installation](/docs/remote/ssh.md#installation) and SSH [host setup](/docs/remote/ssh.md#ssh-host-setup) steps for the Remote - SSH extension.
 1. **[Optional]** Set up SSH [key based authentication](/docs/remote/troubleshooting.md#configuring-key-based-authentication) to the server so you do not need to enter your password multiple times.
 1. [Install Docker](/docs/remote/containers#installation) on your SSH host. You do not need to install Docker locally.
 1. Follow the [quick start](/docs/remote/ssh.md#connect-to-a-remote-host) for the Remote - SSH extension to connect to a host and open a folder there.
-1. Use the **Remote-Containers: Reopen in Container** command.
+1. Use the **Remote-Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
 
 The rest of the Remote - Containers quick start applies as-is. You can learn more about the [Remote - SSH extension in its documentation](/docs/remote/ssh.md).
 


### PR DESCRIPTION
This PR:

1. Adds the missing hostRequirements property set to the devcontainer.json reference
2. Tries to address some formatting issues with the devcontainer.json reference
3. Adds more details about pre-building container images, strengthens recommendation
4. Adds some known issues and misc corrections on SSH + Containers support