### PR TITLE
Fix editor.renderIndentGuides deprecation

### DIFF
--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -376,7 +376,7 @@ To see the editor white spaces, enable **Toggle Render Whitespace**.
 
 - `editorWhitespace.foreground`: Color of whitespace characters in the editor.
 
-To see the editor indent guides, set `"editor.renderIndentGuides": true`.
+To see the editor indent guides, set `"editor.guides.indentation": true` and `"editor.guides.highlightActiveIndentation": true`.
 
 - `editorIndentGuide.background`: Color of the editor indentation guides.
 - `editorIndentGuide.activeBackground`: Color of the active editor indentation guide.

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -60,7 +60,7 @@ A Minimap (code outline) gives you a high-level overview of your source code, wh
 
 ### Indent Guides
 
-The image above also shows indentation guides (vertical lines) which help you quickly see matching indent levels. If you would like to disable indent guides, you can set `"editor.renderIndentGuides": false` in your user or workspace [settings](/docs/getstarted/settings.md).
+The image above also shows indentation guides (vertical lines) which help you quickly see matching indent levels. If you would like to disable indent guides, you can set `"editor.guides.indentation": false` in your user or workspace [settings](/docs/getstarted/settings.md).
 
 ## Breadcrumbs
 


### PR DESCRIPTION
I guess it's better to use non deprecated settings in docs. So here is the PR.

Ref:

> https://github.com/microsoft/vscode-docs/blob/main/release-notes/v1_61.md#indentation-guides-settings
>
> The `editor.renderIndentGuides` and `editor.highlightActiveIndentGuide` settings have been deprecated in favor of `editor.guides.indentation` and `editor.guides.highlightActiveIndentation`.

