### PR TITLE
Fix debug config name when debugging tests

### DIFF
--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -265,7 +265,7 @@ For example, the configuration below in the ```launch.json``` file disables the 
 
 ```py
 {
-    "name": "Python: Current File",
+    "name": "Python: Debug Tests",
     "type": "python",
     "request": "launch",
     "program": "${file}",


### PR DESCRIPTION
We had a configuration for debugging tests named "Python: Current File" which was misleading. This PR fixes it to become "Python: Debug Tests"