### PR TITLE
Update provideCodeActions signature

### DIFF
--- a/api/language-extensions/programmatic-language-features.md
+++ b/api/language-extensions/programmatic-language-features.md
@@ -554,7 +554,7 @@ In addition, your language server needs to respond to the `textDocument/codeActi
 #### Direct Implementation
 
 ```typescript
-class GoCodeActionProvider implements vscode.CodeActionProvider {
+class GoCodeActionProvider implements vscode.CodeActionProvider<vscode.CodeAction> {
     public provideCodeActions(
         document: vscode.TextDocument, range: vscode.Range | vscode.Selection,
         context: vscode.CodeActionContext, token: vscode.CancellationToken):

--- a/api/language-extensions/programmatic-language-features.md
+++ b/api/language-extensions/programmatic-language-features.md
@@ -556,9 +556,9 @@ In addition, your language server needs to respond to the `textDocument/codeActi
 ```typescript
 class GoCodeActionProvider implements vscode.CodeActionProvider {
     public provideCodeActions(
-        document: vscode.TextDocument, range: vscode.Range,
+        document: vscode.TextDocument, range: vscode.Range | vscode.Selection,
         context: vscode.CodeActionContext, token: vscode.CancellationToken):
-        Thenable<vscode.Command[]> {
+        Thenable<vscode.CodeAction[]> {
     ...
     }
 }


### PR DESCRIPTION
Update the provideCodeActions signature to match what's in https://code.visualstudio.com/api/references/vscode-api#CodeActionProvider%3CT%3E.
I had a fun time trying to figure out how to mark a code action as a quick fix until I realized that the docs were telling me to use a legacy return signature :).