### PR TITLE
Note on browser support

### DIFF
--- a/docs/editor/vscode-web.md
+++ b/docs/editor/vscode-web.md
@@ -143,7 +143,9 @@ There are also extensions that run in the browser with partial support only. A g
 
 ### Browser support
 
-You can use VS Code for the Web in Chrome, Edge, Firefox, and Safari. Webviews might appear differently or have some unexpected behavior in Firefox and Safari.
+You can use VS Code for the Web in Chrome, Edge, Firefox, and Safari.
+
+Webviews might appear differently or have some unexpected behavior in Firefox and Safari. You can view issue queries in the VS Code GitHub repo to track issues related to specific browsers, such as with the [Safari label](https://github.com/microsoft/vscode/labels/safari) and [Firefox label](https://github.com/microsoft/vscode/labels/firefox).
 
 ### File system API
 

--- a/docs/editor/vscode-web.md
+++ b/docs/editor/vscode-web.md
@@ -143,7 +143,7 @@ There are also extensions that run in the browser with partial support only. A g
 
 ### Browser support
 
-You can use VS Code for the Web in Chrome, Edge, Firefox, and Safari.
+You can use VS Code for the Web in Chrome, Edge, Firefox, and Safari. Webviews might appear differently or have some unexpected behavior in Firefox and Safari.
 
 ### File system API
 

--- a/docs/editor/vscode-web.md
+++ b/docs/editor/vscode-web.md
@@ -141,6 +141,10 @@ When extensions are executed in the browser sandbox, they are more restricted. E
 
 There are also extensions that run in the browser with partial support only. A good example is a language extension that [restricts its support](/docs/nodejs/working-with-javascript.md#partial-intellisense-mode) to single files or the currently opened files.
 
+### Browser support
+
+You can use VS Code for the Web in Chrome, Edge, Firefox, and Safari.
+
 ### File system API
 
 Edge and Chrome today support the [File System API](https://developer.mozilla.org/docs/Web/API/File_System_Access_API), allowing web pages to access the local file system. If your browser does not support the File System API, you cannot open a folder locally, but you can open files instead.


### PR DESCRIPTION
Based on recent discussions, I wanted to add a note on official browser support in VS Code for the Web and any potential limitations.

Added an initial note on which browsers are supported - it's my understanding there may be something to note for webviews in Firefox (@alexr00?), and @jrieken I think you've done notable testing in Safari. Would love to know if there's anything specific we should highlight for these or other browsers (cc @digitarald too).