### PR TITLE
Add cuda language id

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -69,7 +69,7 @@ Coffeescript | `coffeescript`
 C | `c`
 C++ | `cpp`
 C# | `csharp`
-Cuda | `cuda-cpp`
+CUDA C++ | `cuda-cpp`
 CSS | `css`
 Diff | `diff`
 Dockerfile | `dockerfile`

--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -69,6 +69,7 @@ Coffeescript | `coffeescript`
 C | `c`
 C++ | `cpp`
 C# | `csharp`
+Cuda | `cuda-cpp`
 CSS | `css`
 Diff | `diff`
 Dockerfile | `dockerfile`


### PR DESCRIPTION
The cuda language is supported in vscode, see https://github.com/microsoft/vscode/pull/119444