### PR TITLE
Add new dev container repo link

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -701,6 +701,7 @@ The following articles may help answer your question:
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
 * Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+* Help [shape the direction](https://github.com/microsoft/dev-container-spec) of development containers and the dev container CLI.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.
 

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -208,3 +208,4 @@ In the Docker Compose case, you can add this argument to a separate [override fi
 * [Create a Development Container](/docs/remote/create-dev-container.md) - Create a custom container for your work environment.
 * [Advanced Containers](/remote/advancedcontainers/overview.md) - Find solutions to advanced container scenarios.
 * [devcontainer.json reference](/docs/remote/devcontainerjson-reference.md) - Review the `devcontainer.json` schema.
+* [Dev container spec repo](https://github.com/microsoft/dev-container-spec) - File and review issues to shape the direction of development containers and the dev container CLI.


### PR DESCRIPTION
Link to the new https://github.com/microsoft/dev-container-spec repo from the dev container doc and dev container CLI doc.