### PR TITLE
Fix TypeScript website link in typescript.md docs

### DIFF
--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -11,7 +11,7 @@ MetaSocialImage: images/typescript/Languages_typescript.png
 
 # TypeScript in Visual Studio Code
 
-[TypeScript](https://www.typescriptlang.org) is a typed superset of JavaScript that compiles to plain JavaScript. It offers classes, modules, and interfaces to help you build robust components. The [TypeScript language specification](https://github.com/microsoft/TypeScript/tree/master/doc) has full details about the language.
+[TypeScript](https://www.typescriptlang.org) is a typed superset of JavaScript that compiles to plain JavaScript. It offers classes, modules, and interfaces to help you build robust components. The [TypeScript website](https://www.typescriptlang.org) has full details about the language.
 
 ![Working with TypeScript in Visual Studio Code](images/typescript/overview.png)
 


### PR DESCRIPTION
The TypeScript language spec is no longer updated.