### PR TITLE
object used for `in` can't map to functions

### DIFF
--- a/api/references/when-clause-contexts.md
+++ b/api/references/when-clause-contexts.md
@@ -221,6 +221,7 @@ vscode.commands.executeCommand('setContext', 'ext.supportedFolders', [ 'test', '
 // or
 
 // Note in this case (using an object), the value doesn't matter, it is based on the existence of the key in the object
+// The value must be of a simple type
 vscode.commands.executeCommand('setContext', 'ext.supportedFolders', { 'test': true, 'foo': 'anything', 'bar': false });
 ```
 


### PR DESCRIPTION
This tripped me up, "the value doesn't matter" is making a stronger claim than it should be.

https://github.com/microsoft/vscode/issues/140359