### PR TITLE
Fixed typo in contributes.menus

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -731,7 +731,7 @@ Currently extension writers can contribute to:
 - The debug callstack view context menu - `debug/callstack/context`
 - The debug callstack view inline actions - `debug/callstack/context` group `inline`
 - The debug variables view context menu - `debug/variables/context`
-- The debug toolbar - `debug/toolbar`
+- The debug toolbar - `debug/toolBar`
 - The [SCM title menu](/api/extension-guides/scm-provider#menus) - `scm/title`
 - [SCM resource groups](/api/extension-guides/scm-provider#menus) menus - `scm/resourceGroup/context`
 - [SCM resource folders](/api/extension-guides/scm-provider#menus) menus - `scm/resourceFolder/context`


### PR DESCRIPTION
fix: changed typo in docs (see [here](https://github.com/microsoft/vscode/blob/5c85bdc1998f501306e305e48825747c6a12c8fa/src/vs/workbench/services/actions/common/menusExtensionPoint.ts#L84) )