### PR TITLE
Ssh-Agent works best with "ForwardAgent yes" in .ssh/config

### DIFF
--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -333,6 +333,15 @@ fi
 
 The agent should be running by default on macOS.
 
+#### Making Local SSH Agent Available on the Remote
+
+An ssh-agent on your local machine allows Remote:SSH to connect to your chosen remote system without repeatedly prompting for a passphrase, but tools like Git which run on the remote don't have access to your locally-unlocked private keys.  You can see this by opening an embedded Terminal on the remote and running `ssh-add -l`.  This ought to list the unlocked keys, but instead reports an error about not being able to connect to the authentication agent.  Setting `ForwardAgent yes` makes the local ssh-agent available in the remote environment, solving this problem.  You can do this by editing your `.ssh/config` file (or whatever `Remote.SSH.configFile` is set to - use the `Remote-SSH: Open SSH Configuration File...` command to be sure) and adding this:
+```ssh-config
+Host *
+    ForwardAgent yes
+```
+though you might want to be more restrictive and only set the option for particular named hosts. 
+
 ### Fixing SSH file permission errors
 
 SSH can be strict about file permissions and if they are set incorrectly, you may see errors such as "WARNING: UNPROTECTED PRIVATE KEY FILE!". There are several ways to update file permissions in order to fix this, which are described in the sections below.


### PR DESCRIPTION
I spent ages trying figure out why I couldn't run "git" commands in an Terminal on the remote machine.  Turns out that VSCode doesn't automatically forward the local SSH Agent to the remote even when "remote.SSH.enableAgentForwarding" is set - you need to tell SSH to do this explicitly.