### PR TITLE
settings: clarify editor can't write defaults

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -20,6 +20,8 @@ VS Code provides two different scopes for settings:
 
 Workspace settings override user settings. Workspace settings are specific to a project and can be shared across developers on a project.
 
+>**Note**: You cannot use the settings editor to create a workspace setting that matches the setting's default value. If you want your workspace to enforce that a particular setting has its default value even if somebody has configured that setting as a user setting, you must add it to the workspace settings file manually.
+
 >**Note**: A VS Code "workspace" is usually just your project root folder. Workspace settings as well as [debugging](/docs/editor/debugging.md) and [task](/docs/editor/tasks.md) configurations are stored at the root in a `.vscode` folder. You can also have more than one root folder in a VS Code workspace through a feature called [Multi-root workspaces](/docs/editor/multi-root-workspaces.md). You can learn more in the [What is a VS Code "workspace"?](/docs/editor/workspaces.md) article.
 
 ## Creating User and Workspace Settings


### PR DESCRIPTION
The interactive settings editor will not write a default value to the workplace settings file. While there are good reasons for this, it is somewhat confusing, as many have noted on https://github.com/microsoft/vscode/issues/58038. This PR documents the current behavior and suggests the workaround of manually editing the workspace settings file.