### PR TITLE
Extra `'` typo in `CMD` causes container to break

### DIFF
--- a/remote/advancedcontainers/start-processes.md
+++ b/remote/advancedcontainers/start-processes.md
@@ -71,7 +71,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-focal
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD [ "sleep", "infinity"' ]
+CMD [ "sleep", "infinity" ]
 ```
 
 The `CMD` here makes sure the container stays running by default. Keeping your startup steps in the `ENTRYPOINT` allows you to safely override the command when using `docker run` with your image or using Docker Compose. This resolves to the following:


### PR DESCRIPTION
There's an extra '`' in the CMD that causes the container to break when following instructions