### PR TITLE
VS Code no longer adjusts given diagnostic ranges

### DIFF
--- a/api/language-extensions/language-server-extension-guide.md
+++ b/api/language-extensions/language-server-extension-guide.md
@@ -506,9 +506,6 @@ documents.onDidChangeContent(async(change) => {
 
 ### Diagnostics Tips and Tricks
 
-- If the start and end positions are the same, VS Code will underline with a squiggle the word at that position.
-- If you want to underline with a squiggle until the end of the line, then set the character of the end position to Number.MAX_VALUE.
-
 To run the Language Server, do the following steps:
 
 - Press `kb(workbench.action.tasks.build)` to start the build task. The task compiles both the client and the server.


### PR DESCRIPTION
This behavior was removed in the following commit:
https://github.com/microsoft/vscode/commit/7443621e3b4366b7dabca94b0ba988cf8f47e164