### PR TITLE
Add theme color entry for `statusBarItem.focusBorder`

### DIFF
--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -629,6 +629,7 @@ The Status Bar is shown in the bottom of the workbench.
 - `statusBarItem.warningBackground`: Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.
 - `statusBarItem.warningForeground`: Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.
 - `statusBarItem.compactHoverBackground`: Status bar item background color when hovering an item that contains two hovers. The status bar is shown in the bottom of the window.
+- `statusBarItem.focusBorder`: Status bar item border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.
 
 Prominent items stand out from other Status Bar entries to indicate importance. One example is the **Toggle Tab Key Moves Focus** command change mode indicator.
 


### PR DESCRIPTION
Adds a new theme token to /api/references/theme-color to account for the [new theme token](https://github.com/microsoft/vscode/pull/142665) added to VS Code.