### PR TITLE
咒術迴戰線上看-2022-完整版HD

### DIFF
--- a/docs/editor/extension-marketplace.md
+++ b/docs/editor/extension-marketplace.md
@@ -1,349 +1,113 @@
----
-Order: 3
-Area: editor
-TOCTitle: Extension Marketplace
-ContentId: 319916C4-93F2-471F-B448-FD416736C40C
-PageTitle: Managing Extensions in Visual Studio Code
-DateApproved: 3/3/2022
-MetaDescription: Discover, add, update, disable and uninstall Visual Studio Code extensions (plug-ins) through the Extension Marketplace.
----
-# Extension Marketplace
-
-**Increase the power of Visual Studio Code through Extensions**
-
-The features that Visual Studio Code includes out-of-the-box are just the start. VS Code extensions let you add languages, debuggers, and tools to your installation to support your development workflow. VS Code's rich extensibility model lets extension authors plug directly into the VS Code UI and contribute functionality through the same APIs used by VS Code.  This article explains how to find, install, and manage VS Code extensions from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/VSCode).
-
-## Browse for extensions
-
-You can browse and install extensions from within VS Code. Bring up the Extensions view by clicking on the Extensions icon in the **Activity Bar** on the side of VS Code or the **View: Extensions** command (`kb(workbench.view.extensions)`).
-
-![Extensions view icon](images/extension-marketplace/extensions-view-icon.png)
-
-This will show you a list of the most popular VS Code extensions on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode).
-
-![popular extensions](images/extension-marketplace/extensions-popular.png)
-
-Each extension in the list includes a brief description, the publisher, the download count, and a five star rating. You can select the extension item to display the extension's details page where you can learn more.
-
-> **Note:** If your computer's Internet access goes through a proxy server, you will need to configure the proxy server. See [Proxy server support](/docs/setup/network.md#proxy-server-support) for details.
-
-## Install an extension
-
-To install an extension, select the **Install** button. Once the installation is complete, the **Install** button will change to the **Manage** gear button.
-
-### Find and install an extension
-
-For example, let's install the popular [TODO Highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight) extension. This extension highlights text like 'TODO:' and 'FIXME:' in your source code so you can quickly find undone sections.
-
-![TODO Highlight extension highlighting in the editor](images/extension-marketplace/todo-highlighting.png)
-
-In the Extensions view (`kb(workbench.view.extensions)`), type 'todo' in the search box to filter the Marketplace offerings to extensions with 'todo' in the title or metadata. You should see the **TODO Highlight** extension in the list.
-
-![Search for todo in the Extensions view](images/extension-marketplace/search-for-todo-extension.png)
-
-An extension is uniquely identified by its publisher and extension IDs. If you select the **TODO Highlight** extension, you will see the Extension details page, where you can find the extension ID, in this case, `wayou.vscode-todo-highlight`. Knowing the extension ID can be helpful if there are several similarly named extensions.
-
-![TODO Highlight extension details with extension ID highlighted](images/extension-marketplace/todo-highlight-details.png)
-
-Select the **Install** button, and VS Code will download and install the extension from the Marketplace. When the installation is complete, the **Install** button will be replaced with a **Manage** gear button.
-
-![Manage gear button](images/extension-marketplace/manage-button.png)
-
-To see the TODO Highlight extension in action, open any source code file and add the text 'TODO:' and you will see the text highlighted.
-
-The TODO Highlight extension contributes the commands, **TODO-Highlight: List highlighted annotations** and **TODO-Highlight: Toggle highlight**, that you can find in the Command Palette (`kb(workbench.action.showCommands)`). The **TODO-Highlight: Toggle highlight** command lets you quickly disable or enable highlighting.
-
-![TODO Highlight commands in the Command Palette](images/extension-marketplace/todo-highlight-commands.png)
-
-The extension also provides settings for tuning its behavior, which you can find in the Settings editor (`kb(workbench.action.openSettings)`). For example, you might want the text search to be case insensitive and you can uncheck the **Todohighlight: Is Case Sensitive** setting.
-
-![TODO Highlight settings in the Settings editor](images/extension-marketplace/todo-highlight-settings.png)
-
-If an extension doesn't provide the functionality you want, you can always **Uninstall** the extension from the **Manage** button context menu.
-
-![Uninstall the TODO Highlight extension](images/extension-marketplace/todo-highlight-uninstall.png)
-
-This has been just one example of how to install and use an extension. The VS Code Marketplace has thousands of extensions supporting hundreds of programming languages and tasks. Everything from full featured language support for [Java](https://marketplace.visualstudio.com/items?itemName=redhat.java), [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python), [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go), and [C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) to simple extensions that [create GUIDs](https://marketplace.visualstudio.com/items?itemName=nwallace.createGUID), change the [color theme](https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme), or add [virtual pets](https://marketplace.visualstudio.com/items?itemName=tonybaloney.vscode-pets) to the editor.
-
-### Extension details
-
-On the extension details page, you can read the extension's README and review the extension's:
-
-* **Feature Contributions** - The extension's additions to VS Code such as settings, commands and keyboard shortcuts, language grammars, debugger, etc.
-* **Changelog** - The extension repository CHANGELOG if available.
-* **Dependencies** - Lists if the extension depends on any other extensions.
-
-![extension contributions](images/extension-marketplace/extension-contributions.png)
-
-If an extension is an Extension Pack, the **Extension Pack** section will display which extensions will be installed when you install the pack. [Extension Packs](/api/references/extension-manifest.md#extension-packs) bundle separate extensions together so they can be easily installed at one time.
-
-![Azure Tools extension pack](images/extension-marketplace/extension-pack.png)
-
-### Extensions view filter and commands
-
-You can filter the Extensions view with the **Filter Extensions** context menu.
-
-![Extensions view filter context menu](images/extension-marketplace/extensions-view-filter-menu.png)
-
-There are filters to show:
-
-* The list of currently installed extensions
-* The list of outdated extensions that can be updated
-* The list of currently enabled/disabled extensions
-* The list of recommended extensions based on your workspace
-* The list of globally popular extensions
-
-You can sort the extension list by **Install Count** or **Rating** in either ascending or descending order. You can learn more about extension search filters [below](#extensions-view-filters).
-
-You can run additional Extensions view commands via the `...` **View and More Actions** button.
-
-![more button](images/extension-marketplace/more-button.png)
-
-Through this context menu you can control extension updates, enable or disable all extensions, and use the [Extension Bisect](https://code.visualstudio.com/blogs/2021/02/16/extension-bisect) utility to isolate problematic extension behavior.
-
-![more dropdown](images/extension-marketplace/more-dropdown.png)
-
-### Search for an extension
-
-You can clear the Search box at the top of the Extensions view and type in the name of the extension, tool, or programming language you're looking for.
-
-For example, typing 'python' will bring up a list of Python language extensions:
-
-![python extensions](images/extension-marketplace/extensions-python.png)
-
-If you know the exact identifier for an extension you're looking for, you can use the `@id:` prefix, for example `@id:octref.vetur`. Additionally, to filter or sort results, you can use the [filter](#extensions-view-filters) and [sort](#sorting) commands, detailed below.
-
-## Manage extensions
-
-VS Code makes it easy to manage your extensions. You can install, disable, update, and uninstall extensions through the Extensions view, the **Command Palette** (commands have the **Extensions:** prefix) or command-line switches.
-
-### List installed extensions
-
-By default, the Extensions view will show the extensions you currently have enabled, all extensions that are recommended for you, and a collapsed view of all extensions you have disabled. You can use the **Show Installed Extensions** command, available in the **Command Palette** (`kb(workbench.action.showCommands)`) or the **More Actions** (`...`) dropdown menu, to clear any text in the search box and show the list of all installed extensions, which includes those that have been disabled.
-
-### Uninstall an extension
-
-To uninstall an extension, select the **Manage** gear button at the right of an extension entry and then choose **Uninstall** from the dropdown menu. This will uninstall the extension and prompt you to reload VS Code.
-
-![uninstall an extension](images/extension-marketplace/uninstall-extension.png)
-
-### Disable an extension
-
-If you don't want to permanently remove an extension, you can instead temporarily disable the extension by clicking the gear button at the right of an extension entry. You can disable an extension globally or just for your current Workspace. You will be prompted to reload VS Code after you disable an extension.
-
-If you want to quickly disable all installed extensions, there is a **Disable All Installed Extensions** command in the **Command Palette** and **More Actions** (`...`) dropdown menu.
-
-Extensions remain disabled for all VS Code sessions until you re-enable them.
-
-### Enable an extension
-
-Similarly if you have disabled an extension (it will be in the **Disabled** section of the list and marked ***Disabled***), you can re-enable it with the **Enable** or **Enable (Workspace)** commands in the dropdown menu.
-
-![enable extension](images/extension-marketplace/enable-extension.png)
-
-There is also an **Enable All Extensions** command in the **More Actions** (`...`) dropdown menu.
-
-### Extension auto-update
-
-VS Code checks for extension updates and installs them automatically. After an update, you will be prompted to reload VS Code. If you'd rather update your extensions manually, you can disable auto-update with the **Disable Auto Updating Extensions** command that sets the `extensions.autoUpdate` [setting](/docs/getstarted/settings.md) to `false`. If you don't want VS Code to even check for updates, you can set the `extensions.autoCheckUpdates` setting to false.
-
-### Update an extension manually
-
-If you have extensions auto-update disabled, you can quickly look for extension updates by using the **Show Outdated Extensions** command that uses the `@outdated` filter. This will display any available updates for your currently installed extensions. Select the **Update** button for the outdated extension and the update will be installed and you'll be prompted to reload VS Code. You can also update all your outdated extensions at one time with the **Update All Extensions** command. If you also have automatic checking for updates disabled, you can use the **Check for Extension Updates** command to check which of your extensions can be updated.
-
-## Recommended extensions
-
-You can see a list of recommended extensions using **Show Recommended Extensions**, which sets the `@recommended` [filter](#extensions-view-filters). Extension recommendations can either be:
-
-* **Workspace Recommendations** - Recommended by other users of your current workspace.
-* **Other Recommendations** - Recommended based on recently opened files.
-
-See the section below to learn how to [contribute](#workspace-recommended-extensions) recommendations for other users in your project.
-
-### Ignoring recommendations
-
-To dismiss a recommendation, select on the extension item to open the Details page and then select the **Manage** gear button to display the context menu. Select the **Ignore Recommendation** menu item. Ignored recommendations will no longer be recommended to you.
-
-![Ignore extension recommendation](images/extension-marketplace/ignore-recommendation.png)
-
-## Configuring extensions
-
-VS Code extensions may have very different configurations and requirements. Some extensions contribute [settings](/docs/getstarted/settings.md) to VS Code, which can be modified in the Settings editor. Other extensions may have their own configuration files. Extensions may also require installation and setup of additional components like compilers, debuggers, and command-line tools. Consult the extension's README (visible in the Extensions view details page) or go to the extension page on the [VS Code Marketplace](https://marketplace.visualstudio.com/VSCode) (click on the extension name in the details page). Many extensions are open source and have a link to their repository on their Marketplace page.
-
-## Command line extension management
-
-To make it easier to automate and configure VS Code, it is possible to list, install, and uninstall extensions from the [command line](/docs/editor/command-line.md). When identifying an extension, provide the full name of the form `publisher.extension`, for example `ms-python.python`.
-
-Example:
-
-```bash
-code --extensions-dir <dir>
-    Set the root path for extensions.
-code --list-extensions
-    List the installed extensions.
-code --show-versions
-    Show versions of installed extensions, when using --list-extension.
-code --install-extension (<extension-id> | <extension-vsix-path>)
-    Installs an extension.
-code --uninstall-extension (<extension-id> | <extension-vsix-path>)
-    Uninstalls an extension.
-code --enable-proposed-api (<extension-id>)
-    Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.
-```
-
-You can see the extension ID on the extension details page next to the extension name.
-
-![extension identifier](images/extension-marketplace/extension-identifier.png)
-
-## Extensions view filters
-
-The Extensions view search box supports filters to help you find and manage extensions. You may have seen filters such as `@installed` and `@recommended` if you used the commands **Show Installed Extensions** and **Show Recommended Extensions**. Also, there are filters available to let you sort by popularity or ratings and search by category (for example 'Linters') and tags (for example 'node'). You can see a complete listing of all filters and sort commands by typing `@` in the extensions search box and navigating through the suggestions:
-
-![intellisense on extension search filters](images/extension-marketplace/extension-search-filters.png)
-
-Here are the Extensions view filters:
-
-* `@builtin` - Show extensions that come with VS Code. Grouped by type (Programming Languages, Themes, etc.).
-* `@disabled` - Show disabled installed extensions.
-* `@installed` - Show installed extensions.
-* `@outdated` - Show outdated installed extensions. A newer version is available on the Marketplace.
-* `@enabled` - Show enabled installed extensions. Extensions can be individually enabled/disabled.
-* `@recommended` - Show recommended extensions. Grouped as Workspace specific or general use.
-* `@category` - Show extensions belonging to specified category. Below are a few of supported categories. For a complete list, type `@category` and follow the options in the suggestion list:
-  * `@category:themes`
-  * `@category:formatters`
-  * `@category:linters`
-  * `@category:snippets`
-
-These filters can be combined as well. For example: Use `@installed @category:themes` to view all installed themes.
-
-If no filter is provided, the Extensions view displays the currently installed and recommended extensions.
-
-### Sorting
-
-You can sort extensions with the `@sort` filter, which can take the following values:
-
-* `installs` - Sort by Marketplace installation count, in descending order.
-* `rating` - Sort by Marketplace rating (1-5 stars), in descending order.
-* `name` - Sort alphabetically by extension name.
-
-![sort by install count](images/extension-marketplace/sort-install-count.png)
-
-### Categories and tags
-
-Extensions can set **Categories** and **Tags** describing their features.
-
-![extension categories and tags](images/extension-marketplace/categories-and-tags.png)
-
-You can filter on category and tag by using `category:` and `tag:`.
-
-Supported categories are: `[Programming Languages, Snippets, Linters, Themes, Debuggers, Formatters, Keymaps, SCM Providers, Other, Extension Packs, Language Packs, Data Science, Machine Learning, Visualization, Notebooks, Education, Testing]`. They can be accessed through IntelliSense in the extensions search box:
-
-![categories debuggers](images/extension-marketplace/extension-search-categories.png)
-
-Note that you must surround the category name in quotes if it is more than one word (for example, `category:"SCM Providers"`).
-
-Tags may contain any string and are not provided by IntelliSense, so review the Marketplace to find helpful tags.
-
-## Install from a VSIX
-
-You can manually install a VS Code extension packaged in a `.vsix` file. Using the **Install from VSIX** command in the Extensions view command dropdown, or the **Extensions: Install from VSIX** command in the **Command Palette**, point to the `.vsix` file.
-
-You can also install using the VS Code `--install-extension` command-line switch providing the path to the `.vsix` file.
-
-```bash
-code --install-extension myextension.vsix
-```
-
-You may provide the `--install-extension` multiple times on the command line to install multiple extensions at once.
-
-If you'd like to learn more about packaging and publishing extensions, see our [Publishing Extensions](/api/working-with-extensions/publishing-extension.md) article in the Extension API.
-
-## Workspace recommended extensions
-
-A good set of extensions can make working with a particular workspace or programming language more productive and you'd often like to share this list with your team or colleagues. You can create a recommended list of extensions for a workspace with the **Extensions: Configure Recommended Extensions (Workspace Folder)** command.
-
-In a single folder workspace, the command creates an `extensions.json` file located in the workspace `.vscode` folder where you can add a list of extensions identifiers ({publisherName}.{extensionName}).
-
-In a [multi-root workspace](/docs/editor/multi-root-workspaces.md), the command will open your `.code-workspace` file where you can list extensions under `extensions.recommendations`. You can still add extension recommendations to individual folders in a multi-root workspace by using the **Extensions: Configure Recommended Extensions (Workspace Folder)** command.
-
-An example `extensions.json` could be:
-
-```json
-{
-    "recommendations": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
-    ]
-}
-```
-
-which recommends a linter extension and a code formatter extension.
-
-An extension is identified using its publisher name and extension identifier `publisher.extension`. You can see the name on the extension's detail page. VS Code will provide you with auto-completion for installed extensions inside these files.
-
-![Extension identifier](images/extension-marketplace/extension-identifier.png).
-
-VS Code prompts a user to install the recommended extensions when a workspace is opened for the first time. The user can also review the list with the **Extensions: Show Recommended Extensions** command.
-
-![Show Recommendations](images/extension-marketplace/recommendations.png)
-
-## Next steps
-
-Here are a few topics you may find interesting...
-
-* [Extension API](/api) - Start learning about the VS Code extension API.
-* [Your First Extension](/api/get-started/your-first-extension.md) - Try creating a simple Hello World extension.
-* [Publishing to the Marketplace](/api/working-with-extensions/publishing-extension.md) - Publish your own extension to the VS Code Marketplace.
-
-## Common questions
-
-### Where are extensions installed?
-
-Extensions are installed in a per user extensions folder. Depending on your platform, the location is in the following folder:
-
-* **Windows** `%USERPROFILE%\.vscode\extensions`
-* **macOS** `~/.vscode/extensions`
-* **Linux** `~/.vscode/extensions`
-
-You can change the location by launching VS Code with the `--extensions-dir <dir>` command-line [option](/docs/editor/command-line.md).
-
-### Whenever I try to install any extension, I get a connect ETIMEDOUT error
-
-You may see this error if your machine is going through a proxy server to access the Internet.  See the [Proxy server support](/docs/setup/network.md#proxy-server-support) section in the setup topic for details.
-
-### Can I download an extension directly from the Marketplace?
-
-Some users prefer to download an extension once from the Marketplace and then install it multiple times from a local share. This is useful when there are connectivity concerns or if your development team wants to use a fixed set of extensions.
-
-To download an extension, navigate to the details page for the specific extension within the [Marketplace](https://marketplace.visualstudio.com/vscode). On that page, there is a **Download Extension** link in the **Resources** section, which is located on the right-hand side of the page.
-
-Once downloaded, you can then install the extension via the **Install from VSIX** command in the Extensions view command dropdown.
-
-### Can I stop VS Code from providing extension recommendations?
-
-Yes, if you would prefer to not have VS Code display extension recommendations in the Extensions view or through notifications, you can modify the following settings:
-
-* `extensions.showRecommendationsOnlyOnDemand` - Set to true to remove the **RECOMMENDED** section.
-* `extensions.ignoreRecommendations` - Set to true to silence extension recommendation notifications.
-
-The **Show Recommended Extensions** command is always available if you want to see recommendations.
-
-### Can I trust extensions from the Marketplace?
-
-The Marketplace runs a virus scan on each extension package that's published to ensure its safety. The virus scan is run for each new extension and for each extension update. Until the scan is all clear, the extension won't be published in the Marketplace for public usage.
-
-The Marketplace also prevents extension authors from name-squatting on official publishers such as Microsoft and RedHat.
-
-If a malicious extension is reported and verified, or a vulnerability is found in an extension dependency:
-
-1. The extension is removed from the Marketplace.
-2. The extension is added to a kill list so that if it has been installed, it will be automatically uninstalled by VS Code.
-
-The Marketplace also provides you with resources to make an informed decision about the extensions you install:
-
-* **Ratings & Review** - Read what others think about the extension.
-* **Q & A** - Review existing questions and the level of the publisher's responsiveness. You can also engage with the extension's publisher(s) if you have concerns.
-* **Issues, Repository, and License** - Check if the publisher has provided these and if they have the support you expect.
-
-If you do see an extension that looks suspicious, you can report the extension to the Marketplace with the **Report Abuse** link at the bottom of the extension **More Info** section.
+劇場版咒術迴戰0 免費線上看｜小鴨影音完整版｜台灣字幕
+《劇場版咒術迴戰0》—完整版-線上看電影免費-中文字幕 咒術迴戰0線上看-
+完整版電影-中文字幕 咒術迴戰0線上看- 線上看完整版免費高清| 2022-完整版-HD
+《咒術迴戰0》 線上看HD免費(完整版) | 𝟜𝕂 𝕌ℍ𝔻 | 𝟙𝟘𝟠𝟘ℙ 𝔽𝕌𝕃𝕃 ℍ𝔻 | 𝟟𝟚𝟘ℙ ℍ𝔻 | 𝕄𝕂𝕍 |
+𝕄ℙ𝟜 | 𝔻𝕍𝔻 | 𝔹𝕝𝕦-ℝ𝕒𝕪 | ███████████████████████████████████████████████
+🔴➥看电影▶️ ▶ https://is.gd/AIkP6I 🔴➥線上看 ▶ https://cutt.us/hNSl4
+███████████████████████████████████████████████
+咒術迴戰線上看-2022-完整版HD((1080p)) 【咒術迴戰0】-線上看小鴨完整版-
+【2022-HD】 咒術迴戰0～年夏天線上看|最新電影|小鴨影音|
+點開後就可以觀看囉，高畫質免費線上看，咒術迴戰線上看完整版、咒術迴戰線上看小鴨。提供繁體中文字幕，離線觀看，支援跨裝置（Android,
+iOS, Android TV, Apple TV, Chromecast, AirPlay, MOD）接續播放。
+《咒術迴戰》（日語：呪術廻戦）是日本漫畫家芥見下下的漫畫作品，集英社出版，於漫畫雜誌《週刊少年Jump》2018年第14號開始連載。作者2017年的漫畫作品《東京都立咒術高等專門學校》是本作的前身也是前傳。截至2021年11月，單行本銷量超過6,000萬本（含電子版）。改編電視動畫於2022年10月至2021年3月期間播映，共24集。改編自前傳的動畫電影《劇場版
+咒術迴戰 0》將於2021年12月24日上映。 劇情大綱 設定
+人類的負面情緒累積混雜後會形成咒靈並對人類造成危害，日本每年不明死亡或失蹤年均超過1萬人大部分因此造成，只有使用被稱為咒力的能量才得以祓除，而負責祓除的人被稱為「咒術師」。由於咒術師是利用負面能量（具體分為咒力和術式）與咒靈戰鬥的人，常常得目睹非術師或同行遇害的悲慘死狀，所以必須要有一定程度的瘋狂以及足夠的動機才能擔任此職。平常生活訓練中咒術師也必須自主學會控制汲取負面情緒如殺意作為咒力，而且要在激烈波動時也要想辦法不要浪費咒力。咒術（術式）跟咒力不同，是與生俱來刻在身體上的能力，因此咒術師的實力大概有八成都是依據此天賦，並不能靠後天學習。一般而言，付出的代價越高，咒力或咒術強度就會越高。因此有部分術師會付出利用束縛令自己能在特定時間或條件下增強自身實力。
+日本有兩間咒術教育機構，分別位於東京和京都的咒術高等專門學校。咒物是帶有強大咒力的物品，通常因難以破壞而被咒術高專保管，若經過妥善封印，可以當作地方設施辟邪。一旦出現事故，就會派遣咒術高專相關人員到現場進行處理。
+《東京都立咒術高等專門學校》劇情
+2016年11月，16歲的乙骨憂太因被特級咒靈祈本里香附身，在被同學欺凌時導致對方受重傷，被咒術界判了死刑。祈本里香生前是乙骨憂太的戀人，在6年前去世，並自此成為咒靈並附身在乙骨身上。在咒術師五條悟的幫助下，死刑暫緩，乙骨亦在2017年轉學到東京咒術高等專門學校就讀一年級，以找出解除里香詛咒的方法。他雖未學會控制咒力，但因身懷特級咒靈而被評為特級咒術師。他在那裏認識了同級同學禪院真希、狗卷棘、貓熊，並跟他們多次在校外合作祓除咒靈。過了一年，乙骨學會了控制咒力的方法，也跟同學們成為了朋友。
+夏油傑是四名特級咒術師之一，也是五條在學生時期的摯友。他的目標為創造只有咒術師的世界，因大量虐殺一般人而被逐出咒術界。2017年12月24日，他發起「百鬼夜行」攻勢，在東京新宿和京都放出數千咒靈，以拖住咒術界大部份人員，趁機到咒術高專奪取力量極為龐大的里香。乙骨看到為阻擋夏油而身受重傷的真希、狗卷、貓熊三人，勃然大怒，叫出里香對抗夏油。他憑著里香的力量，跟夏油打得平分秋色，並在最後以自己的生命為代價跟里香締結契約，成功擊退夏油。負傷撤退的夏油被趕到的五條殺死。
+乙骨打算交出自己生命時，驚訝地發現里香的詛咒已經解除。原來乙骨是日本三大怨靈之一菅原道真的後代，里香的詛咒是乙骨在拒絕她死亡時，無意識下的產物。在乙骨和里香兩人都同意後，詛咒就會自然解除。乙骨跟終於得以成佛的里香告別，然後繼續他在咒術高專的生活。
+《咒術迴戰》劇情
+2018年6月，高中生虎杖悠仁的祖父在逝世前囑託他要盡可能幫助他人，並希望他能在眾人簇擁下死去。虎杖悠仁遇見來學校尋找特級咒物的伏黑惠，他為了解救因咒物而身陷危機的學長姊，吞下詛咒的手指，讓「宿儺」這種詛咒跟自己合而為一。他得知只有自己能對付宿儺後，認為這是自己的使命，便加入東京咒術高專，成為最強咒術師五條悟的學生，並和伏黑惠、釘崎野薔薇成為同學。
+宿儺不斷地想支配虎杖的肉體。在對抗某個特級咒靈時，虎杖為了擊敗它而讓宿儺控制了自己的身體。雖然宿儺輕易地取勝，但也將虎杖殺死。在宿儺和虎杖締下誓約後，他便將虎杖復活。虎杖接受訓練後，跟隨咒術師七海參與實戰。他們擊退了由對人類的負面情緒產生的咒靈「真人」。真人決定與詛咒師夏油一派合作，共創一個只有詛咒、沒有人類的世界。為了達此目的，他們必須抑制五條悟，並集齊宿儺的二十根手指，讓宿儺取回完整的力量。
+在東京與京都的咒術高專交誼會中，京都的校長下令殺掉身為宿儺容器的虎杖。在團體對戰競賽中，虎杖透過與東堂的切磋，學會控制咒力的方法。在雙方熱戰方酣之際，真人和花御等特級咒靈入侵交誼會，取得高專保管的手指。
+五條在學生時代的過去表明，夏油在某次任務後對保護非咒術師的信念開始動搖，並想創造一個只有咒術師存在、不再有咒靈的世界，因此和五條分道揚鑣。夏油之後遭五條殺死，但遺體被羂索利用。
+2018年10月31日，夏油一派以澀谷平民為人質，逼五條孤身對陣。儘管五條展現壓倒性的強勢，但他還是被以特級咒物「獄門疆」封印。虎杖等人動身營救他，雙方陣營各有死傷，敗北瀕死的虎杖遭到夏油派餵下大量宿儺手指，使宿儺取得暫時的身體掌控權。宿儺在掌控權回到虎杖身上前大開殺戒，虎杖雖然自責但也得迎接和真人的決鬥。在夥伴的幫助下，虎杖慘勝真人，但假夏油「羂索」現身掌控了現場，吸收真人並以其術式發動「死滅迴游」。羂索挑選的人全都被賦予咒術能力，並被迫參加讓他們互相殘殺的死滅迴游，當中就包含伏黑的姊姊。羂索企圖以此重現咒術全盛期，使咒力最佳化。虎杖等人與學長乙骨憂太和秤金次會合，進入「結界」參加死滅迴游，目標是得到修改規則的資格，以及找到解除五條封印的辦法。
+登場角色 主條目：咒術迴戰角色列表 虎杖悠仁（虎杖 悠仁（いたどり
+ゆうじ），聲：榎木淳彌）
+本作主角。性格樂天，有極強的運動神經，同時有超乎常人的身體能力。在吞下兩面宿儺的手指後，成為宿儺的容器，加入東京咒術高專。對自己的生命看得很豁達，如果是為了拯救他人的生命會很樂意犧牲。
+伏黑惠（伏黒 恵（ふしぐろ めぐみ），聲：內田雄馬）
+虎杖的同學，有禪院家血脈的天才少年。性格冷靜沉著，行事謹慎。信念是為讓更多善人得到平等的救助，而不平等的去救人。相比起憑自己拼死去獲得勝利，更習慣以自己的死去替同伴換來勝利。
+釘崎野薔薇（釘崎 野薔薇（くぎさき のばら），聲：瀨戶麻沙美）
+虎杖的同學，由於嚮往東京生活且極之討厭鄉村生活而獨自前來就讀高專。個性爽朗、但很毒舌，雖然不愉快時會做出粗暴的舉動，但也有著溫柔且善良的一面。
+五條悟（五条 悟（ごじょう さとる），聲：中村悠一）
+虎杖的老師，四名特級咒術師之一，自己和所有人都承認的「最強」咒術師。個性輕浮，是個什麼都會的人，所以就什麼都不做，本人稱之「培養新人」，並十分重視自己的學生。
+兩面宿儺（両面宿儺（りょうめんすくな），聲：諏訪部順一）
+寄宿於虎杖體內的特級咒物，被稱作「詛咒之王」，是擁有四隻手兩張臉的虛構鬼神，是實際存在的人。
+電影《咒術迴戰》免費線上看，
+網站的頂端有許多節目分類，包含：《咒術迴戰》電影線上看、電視劇、綜藝、動漫、紀錄片等，或是直接在右上方的欄位搜尋你想看的影片名稱。
+上架新片的速度非常快，像是最近非常熱門的《咒術迴戰》、《咒術迴戰》電視劇都應有盡有。
+點開後就可以觀看囉，完全不需要註冊會員，影片觀看時也支援「播放速度調整」。
+咒術迴戰0 澳門上映 咒術迴戰02022上映 咒術迴戰0 HD線上看 咒術迴戰0 線上看小鴨
+註冊賬號7天后，您將被收取費用！ 咒術迴戰0 电影完整版 咒術迴戰0 線上看下載
+咒術迴戰0 2022 下載 咒術迴戰0 線上看完整版 咒術迴戰0 線上看完整版小鴨
+咒術迴戰0(2022)完整版本 咒術迴戰0|1080P|完整版本 咒術迴戰0线上看(2022)完整版
+咒術迴戰0線上看(2022)完整版 《咒術迴戰0》 線上看電影(2022) 咒術迴戰0
+（電影）2022年再次觀看電影 咒術迴戰0線上看|2022上映|完整版小鴨|線上看小鴨|
+咒術迴戰0 上看 咒術迴戰0主題曲 咒術迴戰0小鴨影音 咒術迴戰0線上小鴨 咒術迴戰0
+完整版本 咒術迴戰0 香港上映 咒術迴戰0線上看小鴨影音 咒術迴戰02022 線上看
+《咒術迴戰0》 2022在线 咒術迴戰0 1080P 下載 咒術迴戰0 免費線上看電影
+咒術迴戰0电影在线2022年 咒術迴戰0(2022)在线观看 咒術迴戰0[2022]观看和下载
+咒術迴戰0[2022,HD]观看和下载 咒術迴戰0 singapora(2022) 完整版 咒術迴戰0線上看|
+2022最新電影| 小鴨影音| 咒術迴戰0 免費下載 咒術迴戰0 下載 百度 咒術迴戰0
+2022上看 咒術迴戰0 免費線上看電影 咒術迴戰0-完整版小鴨 HD 咒術迴戰0 線上看(2022)
+咒術迴戰0 台灣上映 2022 咒術迴戰0 (2022) 線上看 咒術迴戰0 線上(2022 HD)
+咒術迴戰0 2022 電影完整版 咒術迴戰0 2022 線上 完整版 咒術迴戰0-完整版 小鴨 2022
+咒術迴戰0 免費在線觀看(2022) 咒術迴戰0 [2022] 線上完整版 咒術迴戰0
+线上看(2022)完整版 咒術迴戰0 線上 [2022] 完整版 咒術迴戰0 (2022)免費線上看電影
+咒術迴戰0 線上看線上(2022)完整版 咒術迴戰0-HD 完整版 小鴨 [2022] 咒術迴戰0
+上看2022 HD.BD.1080p 咒術迴戰0 HD|1080p|4K| 香港流媒體 咒術迴戰0 2022完整版 小鴨
+(HD.BLURAY) 咒術迴戰0 2022 線上看電影粵語-流-下載完整版本 jujutsu kaisen 0 2022
+完整版 小鴨 — 線上看(2022) jujutsu kaisen 0 ▷線上看完整版(2022)在线观看 [1080P]
+【jujutsu kaisen 0 】-線上看小鴨 完整版 jujutsu kaisen 0 -線上看(2022)完整版
+jujutsu kaisen 0 ～年夏天線上看| 最新電影| 小鴨影音|2022| jujutsu kaisen 0
+澳門上映 jujutsu kaisen 0 (2022)上映 jujutsu kaisen 0 線上看 jujutsu kaisen 0
+線上看小鴨 jujutsu kaisen 0 电影完整版 jujutsu kaisen 0 (2022) 下載 jujutsu
+kaisen 0 線上看完整版小鴨 jujutsu kaisen 0 (2022)完整版本 jujutsu kaisen 0
+线上看(2022)完整版 《jujutsu kaisen 0 》 線上看電影(2022) jujutsu kaisen 0
+（電影）2022年再次觀看電影 jujutsu kaisen 0 (2022)上看 jujutsu kaisen 0
+免費線上看電影 jujutsu kaisen 0 主題曲 jujutsu kaisen 0 小鴨影音 jujutsu kaisen
+0 線上小鴨 jujutsu kaisen 0 完整版本 jujutsu kaisen 0 香港上映 jujutsu kaisen 0
+線上看小鴨影音 jujutsu kaisen 0 2022 線上看 《jujutsu kaisen 0 》 2022在线
+jujutsu kaisen 0 1080P 下載 jujutsu kaisen 0 免費線上看電影 jujutsu kaisen 0
+电影在线2022年 jujutsu kaisen 0 (2022)在线观看 jujutsu kaisen 0 [2022]观看和下载
+jujutsu kaisen 0 singapora(2022) 完整版 jujutsu kaisen 0 網路大暴走小鴨(2022)
+jujutsu kaisen 0 字幕(2022) jujutsu kaisen 0 免費線上看電 (2022) jujutsu kaisen
+0 線上看電 (2022) jujutsu kaisen 0 ～ 線上看(2022) jujutsu kaisen 0 〜
+完整版(2022) jujutsu kaisen 0 ～ 完整版 下載(2022) jujutsu kaisen 0
+免費在線觀看(2022) jujutsu kaisen 0 線上看線上(2022)完整版 jujutsu kaisen 0
+港劇手機版-港劇網(2022) jujutsu kaisen 0 電影 - 電視 jujutsu kaisen 0 電影首頁 -
+電視首頁 jujutsu kaisen 0 本周新片 - jujutsu kaisen 0 目前放映 jujutsu kaisen 0
+本期首輪 - 今日節目表 jujutsu kaisen 0 本期二輪 - 頻道節目表 jujutsu kaisen 0
+近期上映 - 節目精選 jujutsu kaisen 0 新片快報 - 頻道列表 jujutsu kaisen 0
+票房排行榜 - 有線電視 jujutsu kaisen 0 資料館 - 節目搜尋 jujutsu kaisen 0 -
+恐怖片- 高清免費線上看 jujutsu kaisen 0 在线 - 牠第二章小鴨 jujutsu kaisen 0
+级别 - jujutsu kaisen 0 預告 jujutsu kaisen 0 线上看 - jujutsu kaisen 0 演員
+jujutsu kaisen 0 线上看 - jujutsu kaisen 0 上映 jujutsu kaisen 0 線上看 -
+jujutsu kaisen 0 開眼 jujutsu kaisen 0 2022 - jujutsu kaisen 0 演員名單 jujutsu
+kaisen 0 線上看 - jujutsu kaisen 0 小鴨 jujutsu kaisen 0 预告 | jujutsu kaisen 0
+上映時間 jujutsu kaisen 0 上映 ~ jujutsu kaisen 0 預告 jujutsu kaisen 0 剧情 ~
+jujutsu kaisen 0 上映時間 jujutsu kaisen 0 线上 jujutsu kaisen 0 线上看 jujutsu
+kaisen 0 豆瓣 jujutsu kaisen 0 预告 jujutsu kaisen 0 線上看 jujutsu kaisen 0
+劇情 jujutsu kaisen 0 下载 jujutsu kaisen 0 線上看 jujutsu kaisen 0 小鴨 jujutsu
+kaisen 0 香港 jujutsu kaisen 0 jujutsu kaisen 0 級別 jujutsu kaisen 0 劇情
+jujutsu kaisen 0 線上 jujutsu kaisen 0 預告 jujutsu kaisen 0 線上看 jujutsu
+kaisen 0 香港 jujutsu kaisen 0 小鴨 jujutsu kaisen 0 上映 jujutsu kaisen 0 預告
+jujutsu kaisen 0 阿嬤 jujutsu kaisen 0 ptt jujutsu kaisen 0 台灣 jujutsu kaisen
+0 台灣上映 jujutsu kaisen 0 上映 jujutsu kaisen 0 (豆瓣)(2022) jujutsu kaisen 0
+(2022)線上看 jujutsu kaisen 0 高清电 (2022) jujutsu kaisen 0 [2022,HD]观看和下载
+jujutsu kaisen 0 (2022)完整版本 jujutsu kaisen 0 台灣上映 (2022) jujutsu kaisen
+0 免费的电 (2022) jujutsu kaisen 0 (2022)观看和下载 jujutsu kaisen 0 线上(2022)
+jujutsu kaisen 0 線上看 - 小鴨jujutsu kaisen 0 音 jujutsu kaisen 0 hd線上看
+jujutsu kaisen 0 (新加坡版)線上看 jujutsu kaisen 0 香港版 2022 《jujutsu kaisen
+0 》 台灣線上看 jujutsu kaisen 0 台灣版 jujutsu kaisen 0 2022 線上看 jujutsu
+kaisen 0 BD, 超清在线观看 jujutsu kaisen 0 在线观看2022 jujutsu kaisen 0
+HD/BD高清完整版在线观看 2022 jujutsu kaisen 0 电jujutsu kaisen 0 完整版BD.2022
+HD 电影-jujutsu kaisen 0 2022完整版本完整版中文字幕免费下载 jujutsu kaisen 0
+～線上看(2022)完整版 jujutsu kaisen 0 (2022,完整版)線上看 jujutsu kaisen 0 2022
+完整版小鴨— 線上看(2022) 【jujutsu kaisen 0 】-線上看小鴨
+完整版[2022-HD]〜[可玩]免費下載高清|1080P|-全高清高清电影-在线观看 jujutsu
+kaisen 0 完整版本-(2022-HD )-1080P 完整版 [2022，HD] jujutsu kaisen 0 [电影]~
+2022】 完整版本 裸監督(CHINESE-新加坡版)線上看HD jujutsu kaisen 0 【
+2022】線上看小鴨影音[2022-HD]jujutsu kaisen 0 完整版本-高清电影-在线观看 CHINESE
+【HD.1080P】


### PR DESCRIPTION
劇場版咒術迴戰0 免費線上看｜小鴨影音完整版｜台灣字幕
《劇場版咒術迴戰0》—完整版-線上看電影免費-中文字幕
咒術迴戰0線上看- 完整版電影-中文字幕


咒術迴戰0線上看- 線上看完整版免費高清| 2022-完整版-HD
《咒術迴戰0》 線上看HD免費(完整版)
| 𝟜𝕂 𝕌ℍ𝔻 | 𝟙𝟘𝟠𝟘ℙ 𝔽𝕌𝕃𝕃 ℍ𝔻 | 𝟟𝟚𝟘ℙ ℍ𝔻 | 𝕄𝕂𝕍 | 𝕄ℙ𝟜 | 𝔻𝕍𝔻 | 𝔹𝕝𝕦-ℝ𝕒𝕪 |

███████████████████████████████████████████████

🔴➥看电影▶️ ▶ https://is.gd/AIkP6I
🔴➥線上看  ▶ https://cutt.us/hNSl4

███████████████████████████████████████████████


咒術迴戰線上看-2022-完整版HD((1080p))

【咒術迴戰0】-線上看小鴨完整版- 【2022-HD】
咒術迴戰0～年夏天線上看|最新電影|小鴨影音|


點開後就可以觀看囉，高畫質免費線上看，咒術迴戰線上看完整版、咒術迴戰線上看小鴨。提供繁體中文字幕，離線觀看，支援跨裝置（Android, iOS, Android TV, Apple TV, Chromecast, AirPlay, MOD）接續播放。


《咒術迴戰》（日語：呪術廻戦）是日本漫畫家芥見下下的漫畫作品，集英社出版，於漫畫雜誌《週刊少年Jump》2018年第14號開始連載。作者2017年的漫畫作品《東京都立咒術高等專門學校》是本作的前身也是前傳。截至2021年11月，單行本銷量超過6,000萬本（含電子版）。改編電視動畫於2022年10月至2021年3月期間播映，共24集。改編自前傳的動畫電影《劇場版 咒術迴戰 0》將於2021年12月24日上映。

劇情大綱
設定
人類的負面情緒累積混雜後會形成咒靈並對人類造成危害，日本每年不明死亡或失蹤年均超過1萬人大部分因此造成，只有使用被稱為咒力的能量才得以祓除，而負責祓除的人被稱為「咒術師」。由於咒術師是利用負面能量（具體分為咒力和術式）與咒靈戰鬥的人，常常得目睹非術師或同行遇害的悲慘死狀，所以必須要有一定程度的瘋狂以及足夠的動機才能擔任此職。平常生活訓練中咒術師也必須自主學會控制汲取負面情緒如殺意作為咒力，而且要在激烈波動時也要想辦法不要浪費咒力。咒術（術式）跟咒力不同，是與生俱來刻在身體上的能力，因此咒術師的實力大概有八成都是依據此天賦，並不能靠後天學習。一般而言，付出的代價越高，咒力或咒術強度就會越高。因此有部分術師會付出利用束縛令自己能在特定時間或條件下增強自身實力。

日本有兩間咒術教育機構，分別位於東京和京都的咒術高等專門學校。咒物是帶有強大咒力的物品，通常因難以破壞而被咒術高專保管，若經過妥善封印，可以當作地方設施辟邪。一旦出現事故，就會派遣咒術高專相關人員到現場進行處理。

《東京都立咒術高等專門學校》劇情
2016年11月，16歲的乙骨憂太因被特級咒靈祈本里香附身，在被同學欺凌時導致對方受重傷，被咒術界判了死刑。祈本里香生前是乙骨憂太的戀人，在6年前去世，並自此成為咒靈並附身在乙骨身上。在咒術師五條悟的幫助下，死刑暫緩，乙骨亦在2017年轉學到東京咒術高等專門學校就讀一年級，以找出解除里香詛咒的方法。他雖未學會控制咒力，但因身懷特級咒靈而被評為特級咒術師。他在那裏認識了同級同學禪院真希、狗卷棘、貓熊，並跟他們多次在校外合作祓除咒靈。過了一年，乙骨學會了控制咒力的方法，也跟同學們成為了朋友。

夏油傑是四名特級咒術師之一，也是五條在學生時期的摯友。他的目標為創造只有咒術師的世界，因大量虐殺一般人而被逐出咒術界。2017年12月24日，他發起「百鬼夜行」攻勢，在東京新宿和京都放出數千咒靈，以拖住咒術界大部份人員，趁機到咒術高專奪取力量極為龐大的里香。乙骨看到為阻擋夏油而身受重傷的真希、狗卷、貓熊三人，勃然大怒，叫出里香對抗夏油。他憑著里香的力量，跟夏油打得平分秋色，並在最後以自己的生命為代價跟里香締結契約，成功擊退夏油。負傷撤退的夏油被趕到的五條殺死。

乙骨打算交出自己生命時，驚訝地發現里香的詛咒已經解除。原來乙骨是日本三大怨靈之一菅原道真的後代，里香的詛咒是乙骨在拒絕她死亡時，無意識下的產物。在乙骨和里香兩人都同意後，詛咒就會自然解除。乙骨跟終於得以成佛的里香告別，然後繼續他在咒術高專的生活。

《咒術迴戰》劇情
2018年6月，高中生虎杖悠仁的祖父在逝世前囑託他要盡可能幫助他人，並希望他能在眾人簇擁下死去。虎杖悠仁遇見來學校尋找特級咒物的伏黑惠，他為了解救因咒物而身陷危機的學長姊，吞下詛咒的手指，讓「宿儺」這種詛咒跟自己合而為一。他得知只有自己能對付宿儺後，認為這是自己的使命，便加入東京咒術高專，成為最強咒術師五條悟的學生，並和伏黑惠、釘崎野薔薇成為同學。

宿儺不斷地想支配虎杖的肉體。在對抗某個特級咒靈時，虎杖為了擊敗它而讓宿儺控制了自己的身體。雖然宿儺輕易地取勝，但也將虎杖殺死。在宿儺和虎杖締下誓約後，他便將虎杖復活。虎杖接受訓練後，跟隨咒術師七海參與實戰。他們擊退了由對人類的負面情緒產生的咒靈「真人」。真人決定與詛咒師夏油一派合作，共創一個只有詛咒、沒有人類的世界。為了達此目的，他們必須抑制五條悟，並集齊宿儺的二十根手指，讓宿儺取回完整的力量。

在東京與京都的咒術高專交誼會中，京都的校長下令殺掉身為宿儺容器的虎杖。在團體對戰競賽中，虎杖透過與東堂的切磋，學會控制咒力的方法。在雙方熱戰方酣之際，真人和花御等特級咒靈入侵交誼會，取得高專保管的手指。

五條在學生時代的過去表明，夏油在某次任務後對保護非咒術師的信念開始動搖，並想創造一個只有咒術師存在、不再有咒靈的世界，因此和五條分道揚鑣。夏油之後遭五條殺死，但遺體被羂索利用。

2018年10月31日，夏油一派以澀谷平民為人質，逼五條孤身對陣。儘管五條展現壓倒性的強勢，但他還是被以特級咒物「獄門疆」封印。虎杖等人動身營救他，雙方陣營各有死傷，敗北瀕死的虎杖遭到夏油派餵下大量宿儺手指，使宿儺取得暫時的身體掌控權。宿儺在掌控權回到虎杖身上前大開殺戒，虎杖雖然自責但也得迎接和真人的決鬥。在夥伴的幫助下，虎杖慘勝真人，但假夏油「羂索」現身掌控了現場，吸收真人並以其術式發動「死滅迴游」。羂索挑選的人全都被賦予咒術能力，並被迫參加讓他們互相殘殺的死滅迴游，當中就包含伏黑的姊姊。羂索企圖以此重現咒術全盛期，使咒力最佳化。虎杖等人與學長乙骨憂太和秤金次會合，進入「結界」參加死滅迴游，目標是得到修改規則的資格，以及找到解除五條封印的辦法。

登場角色
主條目：咒術迴戰角色列表
虎杖悠仁（虎杖 悠仁（いたどり ゆうじ），聲：榎木淳彌）
本作主角。性格樂天，有極強的運動神經，同時有超乎常人的身體能力。在吞下兩面宿儺的手指後，成為宿儺的容器，加入東京咒術高專。對自己的生命看得很豁達，如果是為了拯救他人的生命會很樂意犧牲。
伏黑惠（伏黒 恵（ふしぐろ めぐみ），聲：內田雄馬）
虎杖的同學，有禪院家血脈的天才少年。性格冷靜沉著，行事謹慎。信念是為讓更多善人得到平等的救助，而不平等的去救人。相比起憑自己拼死去獲得勝利，更習慣以自己的死去替同伴換來勝利。
釘崎野薔薇（釘崎 野薔薇（くぎさき のばら），聲：瀨戶麻沙美）
虎杖的同學，由於嚮往東京生活且極之討厭鄉村生活而獨自前來就讀高專。個性爽朗、但很毒舌，雖然不愉快時會做出粗暴的舉動，但也有著溫柔且善良的一面。
五條悟（五条 悟（ごじょう さとる），聲：中村悠一）
虎杖的老師，四名特級咒術師之一，自己和所有人都承認的「最強」咒術師。個性輕浮，是個什麼都會的人，所以就什麼都不做，本人稱之「培養新人」，並十分重視自己的學生。
兩面宿儺（両面宿儺（りょうめんすくな），聲：諏訪部順一）
寄宿於虎杖體內的特級咒物，被稱作「詛咒之王」，是擁有四隻手兩張臉的虛構鬼神，是實際存在的人。

電影《咒術迴戰》免費線上看，
網站的頂端有許多節目分類，包含：《咒術迴戰》電影線上看、電視劇、綜藝、動漫、紀錄片等，或是直接在右上方的欄位搜尋你想看的影片名稱。

上架新片的速度非常快，像是最近非常熱門的《咒術迴戰》、《咒術迴戰》電視劇都應有盡有。

點開後就可以觀看囉，完全不需要註冊會員，影片觀看時也支援「播放速度調整」。

咒術迴戰0 澳門上映
咒術迴戰02022上映
咒術迴戰0 HD線上看
咒術迴戰0 線上看小鴨
註冊賬號7天后，您將被收取費用！
咒術迴戰0 电影完整版
咒術迴戰0 線上看下載
咒術迴戰0 2022 下載
咒術迴戰0 線上看完整版
咒術迴戰0 線上看完整版小鴨
咒術迴戰0(2022)完整版本
咒術迴戰0|1080P|完整版本
咒術迴戰0线上看(2022)完整版
咒術迴戰0線上看(2022)完整版
《咒術迴戰0》 線上看電影(2022)
咒術迴戰0 （電影）2022年再次觀看電影
咒術迴戰0線上看|2022上映|完整版小鴨|線上看小鴨|
咒術迴戰0 上看
咒術迴戰0主題曲
咒術迴戰0小鴨影音
咒術迴戰0線上小鴨
咒術迴戰0 完整版本
咒術迴戰0 香港上映
咒術迴戰0線上看小鴨影音
咒術迴戰02022 線上看
《咒術迴戰0》 2022在线
咒術迴戰0 1080P 下載
咒術迴戰0 免費線上看電影
咒術迴戰0电影在线2022年
咒術迴戰0(2022)在线观看
咒術迴戰0[2022]观看和下载
咒術迴戰0[2022,HD]观看和下载
咒術迴戰0 singapora(2022) 完整版
咒術迴戰0線上看| 2022最新電影| 小鴨影音|
咒術迴戰0 免費下載
咒術迴戰0 下載 百度
咒術迴戰0 2022上看
咒術迴戰0 免費線上看電影
咒術迴戰0-完整版小鴨 HD
咒術迴戰0 線上看(2022)
咒術迴戰0 台灣上映 2022
咒術迴戰0 (2022) 線上看
咒術迴戰0 線上(2022 HD)
咒術迴戰0 2022 電影完整版
咒術迴戰0 2022 線上 完整版
咒術迴戰0-完整版 小鴨 2022
咒術迴戰0 免費在線觀看(2022)
咒術迴戰0 [2022] 線上完整版
咒術迴戰0 线上看(2022)完整版
咒術迴戰0 線上 [2022] 完整版
咒術迴戰0 (2022)免費線上看電影
咒術迴戰0 線上看線上(2022)完整版
咒術迴戰0-HD 完整版 小鴨 [2022]
咒術迴戰0 上看2022 HD.BD.1080p
咒術迴戰0 HD|1080p|4K| 香港流媒體
咒術迴戰0 2022完整版 小鴨 (HD.BLURAY)
咒術迴戰0 2022 線上看電影粵語-流-下載完整版本
jujutsu kaisen 0  2022 完整版 小鴨 — 線上看(2022)
jujutsu kaisen 0 ▷線上看完整版(2022)在线观看 [1080P]
【jujutsu kaisen 0 】-線上看小鴨 完整版
jujutsu kaisen 0 -線上看(2022)完整版
jujutsu kaisen 0  ～年夏天線上看| 最新電影| 小鴨影音|2022|
jujutsu kaisen 0  澳門上映
jujutsu kaisen 0 (2022)上映
jujutsu kaisen 0  線上看
jujutsu kaisen 0  線上看小鴨
jujutsu kaisen 0  电影完整版
jujutsu kaisen 0 (2022) 下載
jujutsu kaisen 0  線上看完整版小鴨
jujutsu kaisen 0 (2022)完整版本
jujutsu kaisen 0  线上看(2022)完整版
《jujutsu kaisen 0 》 線上看電影(2022)
jujutsu kaisen 0 （電影）2022年再次觀看電影
jujutsu kaisen 0 (2022)上看
jujutsu kaisen 0  免費線上看電影
jujutsu kaisen 0  主題曲
jujutsu kaisen 0  小鴨影音
jujutsu kaisen 0  線上小鴨
jujutsu kaisen 0  完整版本
jujutsu kaisen 0  香港上映
jujutsu kaisen 0  線上看小鴨影音
jujutsu kaisen 0  2022 線上看
《jujutsu kaisen 0 》 2022在线
jujutsu kaisen 0  1080P 下載
jujutsu kaisen 0  免費線上看電影
jujutsu kaisen 0  电影在线2022年
jujutsu kaisen 0 (2022)在线观看
jujutsu kaisen 0 [2022]观看和下载
jujutsu kaisen 0  singapora(2022) 完整版
jujutsu kaisen 0 網路大暴走小鴨(2022)
jujutsu kaisen 0 字幕(2022)
jujutsu kaisen 0 免費線上看電 (2022)
jujutsu kaisen 0 線上看電 (2022)
jujutsu kaisen 0 ～ 線上看(2022)
jujutsu kaisen 0 〜 完整版(2022)
jujutsu kaisen 0 ～ 完整版 下載(2022)
jujutsu kaisen 0 免費在線觀看(2022)
jujutsu kaisen 0 線上看線上(2022)完整版
jujutsu kaisen 0 港劇手機版-港劇網(2022)
jujutsu kaisen 0 電影 - 電視
jujutsu kaisen 0 電影首頁 - 電視首頁
jujutsu kaisen 0 本周新片 - jujutsu kaisen 0 目前放映
jujutsu kaisen 0 本期首輪 -  今日節目表
jujutsu kaisen 0 本期二輪 - 頻道節目表
jujutsu kaisen 0 近期上映 -  節目精選
jujutsu kaisen 0 新片快報 - 頻道列表
jujutsu kaisen 0 票房排行榜 - 有線電視
jujutsu kaisen 0 資料館 - 節目搜尋
jujutsu kaisen 0  - 恐怖片- 高清免費線上看
jujutsu kaisen 0 在线 - 牠第二章小鴨
jujutsu kaisen 0  级别 - jujutsu kaisen 0  預告
jujutsu kaisen 0 线上看 - jujutsu kaisen 0  演員
jujutsu kaisen 0  线上看 - jujutsu kaisen 0  上映
jujutsu kaisen 0  線上看 - jujutsu kaisen 0  開眼
jujutsu kaisen 0 2022 - jujutsu kaisen 0  演員名單
jujutsu kaisen 0 線上看 - jujutsu kaisen 0  小鴨
jujutsu kaisen 0 预告 | jujutsu kaisen 0  上映時間
jujutsu kaisen 0  上映 ~ jujutsu kaisen 0  預告
jujutsu kaisen 0  剧情 ~ jujutsu kaisen 0  上映時間
jujutsu kaisen 0  线上
jujutsu kaisen 0  线上看
jujutsu kaisen 0  豆瓣
jujutsu kaisen 0  预告
jujutsu kaisen 0  線上看
jujutsu kaisen 0  劇情
jujutsu kaisen 0  下载
jujutsu kaisen 0 線上看
jujutsu kaisen 0 小鴨
jujutsu kaisen 0 香港
jujutsu kaisen 0
jujutsu kaisen 0  級別
jujutsu kaisen 0  劇情
jujutsu kaisen 0  線上
jujutsu kaisen 0 預告
jujutsu kaisen 0  線上看
jujutsu kaisen 0  香港
jujutsu kaisen 0  小鴨
jujutsu kaisen 0  上映
jujutsu kaisen 0  預告
jujutsu kaisen 0  阿嬤
jujutsu kaisen 0  ptt
jujutsu kaisen 0  台灣
jujutsu kaisen 0  台灣上映
jujutsu kaisen 0  上映
jujutsu kaisen 0 (豆瓣)(2022)
jujutsu kaisen 0 (2022)線上看
jujutsu kaisen 0 高清电 (2022)
jujutsu kaisen 0 [2022,HD]观看和下载
jujutsu kaisen 0 (2022)完整版本
jujutsu kaisen 0 台灣上映 (2022)
jujutsu kaisen 0 免费的电 (2022)
jujutsu kaisen 0 (2022)观看和下载
jujutsu kaisen 0 线上(2022)
jujutsu kaisen 0  線上看 - 小鴨jujutsu kaisen 0 音
jujutsu kaisen 0  hd線上看
jujutsu kaisen 0  (新加坡版)線上看
jujutsu kaisen 0 香港版 2022
《jujutsu kaisen 0 》 台灣線上看
jujutsu kaisen 0 台灣版
jujutsu kaisen 0  2022 線上看
jujutsu kaisen 0  BD, 超清在线观看
jujutsu kaisen 0 在线观看2022
jujutsu kaisen 0  HD/BD高清完整版在线观看 2022
jujutsu kaisen 0 电jujutsu kaisen 0 完整版BD.2022
HD 电影-jujutsu kaisen 0 2022完整版本完整版中文字幕免费下载
jujutsu kaisen 0 ～線上看(2022)完整版
jujutsu kaisen 0 (2022,完整版)線上看
jujutsu kaisen 0 2022 完整版小鴨— 線上看(2022)
【jujutsu kaisen 0 】-線上看小鴨 完整版[2022-HD]〜[可玩]免費下載高清|1080P|-全高清高清电影-在线观看
jujutsu kaisen 0  完整版本-(2022-HD )-1080P
完整版 [2022，HD] jujutsu kaisen 0  [电影]~ 2022】 完整版本 裸監督(CHINESE-新加坡版)線上看HD
jujutsu kaisen 0 【 2022】線上看小鴨影音[2022-HD]jujutsu kaisen 0  完整版本-高清电影-在线观看 CHINESE 【HD.1080P】