### PR TITLE
Fixed angular-tutorial.md `React` section

### DIFF
--- a/docs/nodejs/angular-tutorial.md
+++ b/docs/nodejs/angular-tutorial.md
@@ -160,7 +160,7 @@ If you'd like to see a full MEAN (MongoDB, Express, Angular, Node.js) stack exam
 
 ### React
 
-[React](https://facebook.github.io/react/) is another popular web framework. If you'd like to see an example of React working with VS Code, check out the [Using React in VS Code](/docs/nodejs/reactjs-tutorial.md) tutorial. It will walk you through creating an React application and configuring the `launch.json` file for the JavaScript debugger.
+[React](https://reactjs.org) is a library for building ui and it is more minimal than angular. If you'd like to see an example of React working with VS Code, check out the [Using React in VS Code](/docs/nodejs/reactjs-tutorial.md) tutorial. It will walk you through creating an React application and configuring the `launch.json` file for the JavaScript debugger.
 
 ## Angular Extensions
 


### PR DESCRIPTION
Changed the link of react website to `https://reactjs.org` from `https://facebook.github.io/react` and changed the term `web framework` to `library for building ui`