### PR TITLE
api: document missing semantic highlighting contribution points

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -29,6 +29,9 @@ MetaDescription: To extend Visual Studio Code, your extension (plug-in) declares
 - [`problemPatterns`](/api/references/contribution-points#contributes.problemPatterns)
 - [`productIconThemes`](/api/references/contribution-points#contributes.productIconThemes)
 - [`resourceLabelFormatters`](/api/references/contribution-points#contributes.resourceLabelFormatters)
+- [`semanticTokenModifiers`](/api/references/contribution-points#contributes.semanticTokenModifiers)
+- [`semanticTokenScopes`](/api/references/contribution-points#contributes.semanticTokenScopes)
+- [`semanticTokenTypes`](/api/references/contribution-points#contributes.semanticTokenTypes)
 - [`snippets`](/api/references/contribution-points#contributes.snippets)
 - [`submenus`](/api/references/contribution-points#contributes.submenus)
 - [`taskDefinitions`](/api/references/contribution-points#contributes.taskDefinitions)
@@ -1019,6 +1022,66 @@ Contributes resource label formatters that specify how to display URIs everywher
 ```
 
 This means that all URIs that have a scheme `remotehub` will get rendered by showing only the `path` segment of the URI and the separator will be `/`. Workspaces which have the `remotehub` URI will have the GitHub suffix in their label.
+
+## contributes.semanticTokenModifiers
+
+Contributes new semantic token modifiers that can be highlighted via theme rules.
+
+```json
+{
+  "contributes": {
+    "semanticTokenModifiers": [
+      {
+        "id": "native",
+        "description": "Annotates a symbol that is implemented natively"
+      }
+    ]
+  }
+}
+```
+
+See the [Semantic Highlighting Guide](/api/language-extensions/semantic-highlight-guide) to read more about semantic highlighting.
+
+## contributes.semanticTokenScopes
+
+Contributes mapping between semantic token types & modifiers and scopes either as a fallback or to support language-specific themes.
+
+```json
+{
+  "contributes": {
+    "semanticTokenScopes": [
+      {
+        "language": "typescript",
+        "scopes": {
+          "property.readonly": ["variable.other.constant.property.ts"]
+        }
+      }
+    ]
+  }
+}
+```
+
+See the [Semantic Highlighting Guide](/api/language-extensions/semantic-highlight-guide) to read more about semantic highlighting.
+
+## contributes.semanticTokenTypes
+
+Contributes new semantic token types that can be highlighted via theme rules.
+
+```json
+{
+  "contributes": {
+    "semanticTokenTypes": [
+      {
+        "id": "templateType",
+        "superType": "type",
+        "description": "A template type."
+      }
+    ]
+  }
+}
+```
+
+See the [Semantic Highlighting Guide](/api/language-extensions/semantic-highlight-guide) to read more about semantic highlighting.
 
 ## contributes.snippets
 


### PR DESCRIPTION
Semantic highlighting is already documented in the linked page but it was missing in the reference overview page, so this PR addresses that.