### PR TITLE
remote: update 'Kill VS Code Server on Host' command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
+*.md diff=markdown

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -516,8 +516,9 @@ The SSH extension provides a command for cleaning up the VS Code Server from the
 If you want to run these steps manually, or if the command isn't working for you, you can run a script like this:
 
 ```bash
-kill -9 `ps ax | grep "remoteExtensionHostAgent.js" | grep -v grep | awk '{print $1}'`
-kill -9 `ps ax | grep "watcherService" | grep -v grep | awk '{print $1}'`
+# Kill server processes
+kill -9 `ps aux | \grep vscode-server | \grep USER | \grep -v grep | awk '{print $2}'`
+# Delete related files and folder
 rm -rf ~/.vscode-server # Or ~/.vscode-server-insiders
 ```
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -519,7 +519,7 @@ If you want to run these steps manually, or if the command isn't working for you
 # Kill server processes
 kill -9 `ps aux | \grep vscode-server | \grep USER | \grep -v grep | awk '{print $2}'`
 # Delete related files and folder
-rm -rf ~/.vscode-server # Or ~/.vscode-server-insiders
+rm -rf $HOME/.vscode-server # Or ~/.vscode-server-insiders
 ```
 
 The VS Code Server was previously installed under `~/.vscode-remote` so you can check that location too.


### PR DESCRIPTION

   The current commands fail to show any processes corresponding to the VS Code server. Grep for `vscode-server` instead.
   
   Also add a separate command to clean up the most recent  `.$hash.{pid,log,token}` files.

For bonus points, mark Markdown files with the `diff=markdown` attribute in `.gitattributes`
