### PR TITLE
Updated docs to use deploy stage instead of after_script

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -277,24 +277,23 @@ cache: yarn
 }
 ```
 
-4. Add an `after_script` stage to the job that calls `npm run deploy` with the secret variable.
+4. Add `deploy` stage that calls `npm run deploy` with the secret variable.
 
 ```yaml
-after_script:
-- |
-  echo ">>> Publish"
-  yarn deploy
-
-stages:
-- name: after_script
-  if: env(TRAVIS_TAG) =~ ^v
+deploy:
+  provider: script
+  script: "npm run deploy"
+  skip_cleanup: true
+  on:
+    tags: true
 ```
 
-The [stages](https://docs.travis-ci.com/user/conditional-builds-stages-jobs#conditional-stages) property tells the CI to include stages when certain conditions are met.
+The [deploy](https://docs.travis-ci.com/user/deployment) property tells the CI to deploy artifacts to a given provider if a set of conditions are met. The deploy stage does not get triggered on pull requests
 
-In our example, the condition has one check:
+In our example, the condition that is checked:
 
-- `env(TRAVIS_TAG) =~ ^v` - Publish only if a tagged (release) build that starts with the letter `v`.
+- `tags: true` - Publish only if the build is triggered from a git tag (releast) 
+- `skip_cleanup: true` - Prevents travis from removing any files created during the build that may be needed for deployment.
 
 ## Common questions
 


### PR DESCRIPTION
**Context**: The use of the `after_script` for deployment may not be the best usecase for deployment. Since [2012](https://blog.travis-ci.com/after_script_behavior_changes), the `after_script` will **always** run regardless if the result of the test result.  Using the `after_script` will lead to attempts at publishing a new version of an extension in every build. 

The condition `env(TRAVIS_TAG) =~ ^v` has no effect so on each build it will still try to publish a new version.

I think a better solution is to use the `deploy` script which is design for deploy artifacts to a repository, such as the Azure Marketplace. 
