### PR TITLE
Java: Update description and demos for language status item

### DIFF
--- a/api/references/icons-in-labels.md
+++ b/api/references/icons-in-labels.md
@@ -330,6 +330,7 @@ VS Code extensions can use these icons in labels, views, and trees.
 |<i class="codicon codicon-bold"></i>|bold|
 |<i class="codicon codicon-book"></i>|book|
 |<i class="codicon codicon-bookmark"></i>|bookmark|
+|<i class="codicon codicon-bracket-dot"></i>|bracket-dot|
 |<i class="codicon codicon-briefcase"></i>|briefcase|
 |<i class="codicon codicon-broadcast"></i>|broadcast|
 |<i class="codicon codicon-browser"></i>|browser|

--- a/docs/java/images/java-project/java.build.status.mp4
+++ b/docs/java/images/java-project/java.build.status.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69c907c81ecc2521741ed44a38a30aed7035641944beae190fc0f7faf40ff462
-size 285348
+oid sha256:44ab639f1e8f447fbafcc9166b180dfed0962e0c4d2ba32c3734124f14f9bdfa
+size 899007

--- a/docs/java/images/java-project/switch-to-standard.gif
+++ b/docs/java/images/java-project/switch-to-standard.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59ed7f935f6bd0d77ec29f83e721cc2e75eb44555ab0bf8864803a0831f8eb0c
-size 179479
+oid sha256:b21a092155e0adb4541bdaf164b19326f45bc1e5728169c0cf65b973c5a01f74
+size 560545

--- a/docs/java/images/java-tutorial/JavaHelloWorld.Standalone.mp4
+++ b/docs/java/images/java-tutorial/JavaHelloWorld.Standalone.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a16dc5eb2a553f3abf89cfd284bd12a092c552934970f4ffc6cf77db94e1892
-size 1010221
+oid sha256:a9b8b1aee34fb9b0090fe8a842adfa24cd01f084f6166805c2110aea3825fe71
+size 1572880

--- a/docs/java/java-project.md
+++ b/docs/java/java-project.md
@@ -198,27 +198,27 @@ Lightweight mode doesn't resolve imported dependencies nor build the project, so
 
 You can control which mode to launch with by configuring `java.server.launchMode` with the options below:
 
-- `Hybrid` (default) - Firstly, a workspace is opened with lightweight mode. You will be asked whether to switch to standard mode if your workspace contains unresolved Java projects. If you choose **Later**, it will stay in lightweight mode. You can click the server mode icon on the Status bar to manually switch to standard mode.
+- `Hybrid` (default) - Firstly, a workspace is opened with lightweight mode. You will be asked whether to switch to standard mode if your workspace contains unresolved Java projects. If you choose **Later**, it will stay in lightweight mode. You can click the language status item on the Status bar to manually switch to standard mode.
 - `Standard` - A workspace is opened with standard mode.
-- `LightWeight` - A workspace is opened with lightweight mode. You can click the server mode icon on the Status bar to manually switch to standard mode.
+- `LightWeight` - A workspace is opened with lightweight mode. You can click the language status item on the Status bar to manually switch to standard mode.
 
-The Status bar indicates which mode the current workspace is in using different icons.
+The language status item indicates which mode the current workspace is in using different icons.
 
 <div id="codicon-listing">
 
-- <i class="codicon codicon-rocket"></i> - workspace opened with lightweight mode.
+- <i class="codicon codicon-bracket-dot"></i> - workspace opened with lightweight mode.
 - <i class="codicon codicon-sync"></i> - workspace in the process of being opened with standard mode.
-- <i class="codicon codicon-thumbsup"></i> - workspace opened with standard mode.
+- <i class="codicon codicon-symbol-namespace"></i> - workspace opened with standard mode.
 
 </div>
 
-Clicking the lightweight mode icon switches to standard mode.
+Clicking the language status item switches to standard mode.
 
 ![Switch to Standard](images/java-project/switch-to-standard.gif)
 
 ## Build Status
 
-When you edit Java source code in Visual Studio Code, the Java language server is building your workspace to provide you with the necessary language features. You can see the detailed build task status and watch what is happening behind the scene by clicking the language server Status bar icon in the lower right.
+When you edit Java source code in Visual Studio Code, the Java language server is building your workspace to provide you with the necessary language features. You can see the detailed build task status and watch what is happening behind the scene by clicking the language status item in the Status bar. You can also click `check details` when a notification shows the language server is opening Java projects to see the build task status.
 
 <video autoplay loop muted playsinline controls>
   <source src="/docs/java/java-project/java.build.status.mp4" type="video/mp4">

--- a/docs/java/java-tutorial.md
+++ b/docs/java/java-tutorial.md
@@ -76,7 +76,7 @@ If you have never installed a JDK before and need to install one, we recommend y
 
 ## Creating a source code file
 
-Create a folder for your Java program and open the folder with VS Code. Then in VS Code, create a new file and save it with the name `Hello.java`. When you open that file, the Java Language Server automatically starts loading, and you should see a loading icon on the right side of the Status Bar. After it finishes loading, you will see a thumbs-up icon.
+Create a folder for your Java program and open the folder with VS Code. Then in VS Code, create a new file and save it with the name `Hello.java`. When you open that file, the Java Language Server automatically starts loading, and you should see a language status item with a loading icon on the right side of the Status Bar showing the language status is busy. After it finishes loading, you can hover on the language status item and find the loading process has been finished successfully. You can also choose to pin the status item in the status bar.
 
 <video autoplay loop muted playsinline controls>
   <source src="/docs/java/java-tutorial/JavaHelloWorld.Standalone.mp4" type="video/mp4">


### PR DESCRIPTION
Since vscode-java has [adopted](https://github.com/redhat-developer/vscode-java/pull/2363) the language status item, we'd better update our tutorial here.

cc: @nickzhums 

Signed-off-by: CsCherrYY <chenshi@microsoft.com>