### PR TITLE
extension telemetry page

### DIFF
--- a/api/extension-guides/telemetry.md
+++ b/api/extension-guides/telemetry.md
@@ -1,20 +1,34 @@
 # Telemetry
 
-For reporting telemetry your extension can use the VS Code telemetry infrastructure for reporting through the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module. This module provides a consistent way for extensions to report telemetry over [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/). The module respects the user's decision about whether or not to send telemetry data via the `telemetry.telemetryLevel` setting. Additionally, this module guarantees backwards compatability against previous versions of VS Code.
+## Telemetry Module
+
+The VS Code team maintains the [vscode-extension-telemetry](https://www.npmjs.com/package/@vscode/extension-telemetry) npm module which provides a consistent and safe way to collect telemetry within VS Code. The module reports telemetry to [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/) and guarantees backwards compatability against previous versios of VS Code.
 
 Follow this guide to set up [Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/learn/nodejs-quick-start) and get your Application Insights instrumentation key.
 
-If you would prefer to not utilize the npm module, it is still recommended that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API. By doing this users will have one centralised place to control their telemetry settings.
+## Without the teleemtry module
 
-If your extension would like to give control to the user if telemetry for your extension is collected independent of VS Code telemetry then we suggest that you introduce a specific extension setting to control this and to always ask user for consent before any data is reported.
+Extension authors who wish not to use Application Insights can utilize their own custom solution to send telemetry. When deciding not to utilize the npm module, it is still required that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API. By doing this users will have one centralised place to control their telemetry settings.
 
-Additionally, telemetry authors can add a `telemetry.json` file to their root build directory for their telemetry to show up in the `--telemetry` dump that VS Code produces.
+## Custom telemetry setting
 
+Extension may wish to give control to the user regarding extension specific telemetry independent of VS Code telemetry. In this case we suggest that you introduce a specific extension setting. Custom telemetry settings are recommended to be tagged with `telemetry` and `usesOnlineServices ` so that users can more easily query them in the settings UI. Adding a custom telemetry setting is not an exemption from respecting a users decision and the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` flag must always be respected. If `isTelemetryEnabled` reports false, even if your setting is enabled, telemetry must not be sent.
+
+## Telemetry.json
+
+VS Code understands that telemetry can be a sensitive topic for many and aims to be as transparent as possible. The core VS code product and most first party extensions ship with a `telemetry.json` file in their root. This allows for a user to use the VS Code CLI with the `--telemetry` flag to receive a dump of all telemetry which VS Code produces. Extension authors may include a `telemetry.json` file in their root and it will also appear in the CLI dump.
+
+## Do's and Don'ts
 **✔️ Do**
 
 * Use the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module if using application insights works for you.
 * Otherwise, respect the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API.
+* Tag your custom telemetry setting with `telemetry` and `usesOnlineServices ` if you have one.
+* Collect as little telemetry as possible
+* Be as transparent as possible to your users about what you collect
 
 ❌ Don't
 * Introduce a custom telemetry collection solution that does not ask for user consent.
 * Collect Personally identifable information.
+* Collect more telemetry than necessary
+* Use just the `telemetry.telemetryLevel` setting as it can sometimes be incorrect compared to `isTelemetryEnabled`.

--- a/api/extension-guides/telemetry.md
+++ b/api/extension-guides/telemetry.md
@@ -1,0 +1,20 @@
+# Telemetry
+
+For reporting telemetry your extension can use the VS Code telemetry infrastructure for reporting through the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module. This module provides a consistent way for extensions to report telemetry over [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/). The module respects the user's decision about whether or not to send telemetry data via the `telemetry.telemetryLevel` setting. Additionally, this module guarantees backwards compatability against previous versions of VS Code.
+
+Follow this guide to set up [Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/learn/nodejs-quick-start) and get your Application Insights instrumentation key.
+
+If you would prefer to not utilize the npm module, it is still recommended that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API. By doing this users will have one centralised place to control their telemetry settings.
+
+If your extension would like to give control to the user if telemetry for your extension is collected independent of VS Code telemetry then we suggest that you introduce a specific extension setting to control this and to always ask user for consent before any data is reported.
+
+Additionally, telemetry authors can add a `telemetry.json` file to their root build directory for their telemetry to show up in the `--telemetry` dump that VS Code produces.
+
+**✔️ Do**
+
+* Use the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module if using application insights works for you.
+* Otherwise, respect the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API.
+
+❌ Don't
+* Introduce a custom telemetry collection solution that does not ask for user consent.
+* Collect Personally identifable information.

--- a/api/extension-guides/telemetry.md
+++ b/api/extension-guides/telemetry.md
@@ -2,21 +2,21 @@
 
 ## Telemetry Module
 
-The VS Code team maintains the [vscode-extension-telemetry](https://www.npmjs.com/package/@vscode/extension-telemetry) npm module which provides a consistent and safe way to collect telemetry within VS Code. The module reports telemetry to [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/) and guarantees backwards compatability against previous versios of VS Code.
+The VS Code team maintains the [vscode-extension-telemetry](https://www.npmjs.com/package/@vscode/extension-telemetry) npm module which provides a consistent and safe way to collect telemetry within VS Code. The module reports telemetry to [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/) and guarantees backwards compatability against previous versions of VS Code.
 
 Follow this guide to set up [Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/learn/nodejs-quick-start) and get your Application Insights instrumentation key.
 
-## Without the teleemtry module
+## Without the telemetry module
 
-Extension authors who wish not to use Application Insights can utilize their own custom solution to send telemetry. When deciding not to utilize the npm module, it is still required that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API. By doing this users will have one centralised place to control their telemetry settings.
+Extension authors who wish not to use Application Insights can utilize their own custom solution to send telemetry. In this case, it is still required that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API. By doing this users will have one centralised place to control their telemetry settings.
 
 ## Custom telemetry setting
 
-Extension may wish to give control to the user regarding extension specific telemetry independent of VS Code telemetry. In this case we suggest that you introduce a specific extension setting. Custom telemetry settings are recommended to be tagged with `telemetry` and `usesOnlineServices ` so that users can more easily query them in the settings UI. Adding a custom telemetry setting is not an exemption from respecting a users decision and the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` flag must always be respected. If `isTelemetryEnabled` reports false, even if your setting is enabled, telemetry must not be sent.
+Extension may wish to give user control for extension specific telemetry independent of VS Code telemetry. In this case we suggest that you introduce a specific extension setting. Custom telemetry settings are recommended to be tagged with `telemetry` and `usesOnlineServices ` so that users can more easily query them in the settings UI. Adding a custom telemetry setting is not an exemption from respecting a users decision and the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` flag must always be respected. If `isTelemetryEnabled` reports false, even if your setting is enabled, telemetry must not be sent.
 
 ## Telemetry.json
 
-VS Code understands that telemetry can be a sensitive topic for many and aims to be as transparent as possible. The core VS code product and most first party extensions ship with a `telemetry.json` file in their root. This allows for a user to use the VS Code CLI with the `--telemetry` flag to receive a dump of all telemetry which VS Code produces. Extension authors may include a `telemetry.json` file in their root and it will also appear in the CLI dump.
+We understand that telemetry can be a sensitive topic for many users and we aim to be as transparent as possible. The core VS Code product and most first party extensions ship with a `telemetry.json` file in their root. This allows a user to use the VS Code CLI with the `--telemetry` flag to receive a dump of all telemetry which VS Code produces. Extension authors may include a `telemetry.json` file in their root and it will also appear in the CLI dump.
 
 ## Do's and Don'ts
 **✔️ Do**
@@ -24,11 +24,11 @@ VS Code understands that telemetry can be a sensitive topic for many and aims to
 * Use the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module if using application insights works for you.
 * Otherwise, respect the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API.
 * Tag your custom telemetry setting with `telemetry` and `usesOnlineServices ` if you have one.
-* Collect as little telemetry as possible
-* Be as transparent as possible to your users about what you collect
+* Collect as little telemetry as possible.
+* Be as transparent as possible to your users about what you collect.
 
 ❌ Don't
 * Introduce a custom telemetry collection solution that does not ask for user consent.
 * Collect Personally identifable information.
-* Collect more telemetry than necessary
+* Collect more telemetry than necessary.
 * Use just the `telemetry.telemetryLevel` setting as it can sometimes be incorrect compared to `isTelemetryEnabled`.

--- a/api/toc.json
+++ b/api/toc.json
@@ -40,7 +40,8 @@
       ["Debugger Extension", "/api/extension-guides/debugger-extension"],
       ["Markdown Extension", "/api/extension-guides/markdown-extension"],
       ["Test Extension", "/api/extension-guides/testing"],
-      ["Custom Data Extension", "/api/extension-guides/custom-data-extension"]
+      ["Custom Data Extension", "/api/extension-guides/custom-data-extension"],
+      ["Telemetry", "/api/extension-guides/telemetry"]
     ]
   },
   {

--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -126,7 +126,7 @@ When you open a file type for which VS Code does not have any precomputed recomm
 
 ## For extension authors
 
-Please read the [extension guides telemetry document](../../api/extension-guides/telemetry.md).
+Please read the [extension guides telemetry document](/api/extension-guides/telemetry.md).
 
 ## Next steps
 

--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -124,6 +124,9 @@ Some precomputed recommendations are shipped as part of the product while additi
 
 When you open a file type for which VS Code does not have any precomputed recommendation, it asks the Extension Marketplace for extensions that declare that they support this file type. If the query returns extensions you don't have installed, VS Code will provide a notification.
 
+## For extension authors
+
+Please read the [extension guides telemetry document](../../api/extension-guides/telemetry.md).
 
 ## Next steps
 

--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -124,15 +124,6 @@ Some precomputed recommendations are shipped as part of the product while additi
 
 When you open a file type for which VS Code does not have any precomputed recommendation, it asks the Extension Marketplace for extensions that declare that they support this file type. If the query returns extensions you don't have installed, VS Code will provide a notification.
 
-## For extension authors
-
-If you have created a VS Code extension, you can use the VS Code telemetry infrastructure for reporting through the [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry) npm module. This module provides a consistent way for extensions to report telemetry over [Azure Monitor and Application Insights](https://azure.microsoft.com/services/monitor/). The module respects the user's decision about whether or not to send telemetry data via the `telemetry.telemetryLevel` setting. Additionally, this module guarantees backwards compatability against previous versions of VS Code.
-
-Follow this guide to set up [Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/learn/nodejs-quick-start) and get your Application Insights instrumentation key.
-
-If you would prefer to not utilize the npm module, it is still recommended that extension authors respect the user's choice by utilizing the `isTelemetryEnabled` and `onDidChangeTelemetryEnabled` API.
-
-Additionally, telemetry authors can add a `telemetry.json` file to their root build directory for their telemetry to show up in the `--telemetry` dump that VS Code produces.
 
 ## Next steps
 


### PR DESCRIPTION
This PR adds a new Telemetry page to the extension guides.

This is a first cut @lramos15 please add what you had in mind directly in the PR. Thanks!

@gregvanl can you give this a quick review and add the page header as all the other pages seem to have that and I am not sure how to generate it. Thanks!