### PR TITLE
Rebrand .NET Core > .NET

### DIFF
--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -100,11 +100,11 @@ Alternatively, you can install just the Docker CLI inside your development envir
 
 ## Debugging in a container
 
-The Docker extension supports debugging .NET Core-based and Node.js-based services running inside a container. Other programming languages are not supported at this time.
+The Docker extension supports debugging .NET and Node.js-based services running inside a container. Other programming languages are not supported at this time.
 
 Debugging in a container may be harder to set up than regular debugging because a container is a stronger isolation mechanism than a process. In particular:
 
-- The debug engine running inside VS Code process needs to communicate with the service process being debugged. In the case of a service running inside a container, this implies network communication via a common network (typically Docker host network). The container needs to have appropriate ports exposed via the Docker host network for the debug engine to connect to the service process (Node.js), or debugger proxy running inside the container (.NET Core).
+- The debug engine running inside VS Code process needs to communicate with the service process being debugged. In the case of a service running inside a container, this implies network communication via a common network (typically Docker host network). The container needs to have appropriate ports exposed via the Docker host network for the debug engine to connect to the service process (Node.js), or debugger proxy running inside the container (.NET).
 - Source file information generated during build time is valid in the context of the build environment (where VS Code is running). The container filesystem is different from the build environment filesystem, and paths to source files need to be re-mapped in order for the debugger to display correct source file when a breakpoint is hit.
 
 Because of the concerns above, it is generally recommended to use regular debugging, and employ debugging in a container when necessary.
@@ -116,4 +116,4 @@ For more information about how to set up debugging inside a container see [ASP.N
 Read on to learn more about
 
 - [Build and run a Node.js app in a container](/docs/containers/quickstart-node.md)
-- [Build and run a .NET Core app in a container](/docs/containers/quickstart-aspnet-core.md)
+- [Build and run a ASP.NET Core app in a container](/docs/containers/quickstart-aspnet-core.md)

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -13,7 +13,7 @@ With version 0.9.0 and later, the Docker extension provides more support for deb
 
 The Docker extension provides a `docker` debug configuration provider that manages how VS Code will launch an application and/or attach a debugger to the application in a running Docker container. This provider is configured via entries within `launch.json`, with configuration being specific to each application platform supported by the provider.
 
-The Docker extension currently supports debugging [Node.js](#node-js), [Python](#python), and [.NET](#net-core) applications within Docker containers.
+The Docker extension currently supports debugging [Node.js](#node-js), [Python](#python), and [.NET](#net) applications within Docker containers.
 
 ## Requirements
 

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -13,7 +13,7 @@ With version 0.9.0 and later, the Docker extension provides more support for deb
 
 The Docker extension provides a `docker` debug configuration provider that manages how VS Code will launch an application and/or attach a debugger to the application in a running Docker container. This provider is configured via entries within `launch.json`, with configuration being specific to each application platform supported by the provider.
 
-The Docker extension currently supports debugging [Node.js](#node-js), [Python](#python), and [.NET Core](#net-core) applications within Docker containers.
+The Docker extension currently supports debugging [Node.js](#node-js), [Python](#python), and [.NET](#net-core) applications within Docker containers.
 
 ## Requirements
 
@@ -74,13 +74,13 @@ Example `launch.json` configuration for debugging a Python application:
 }
 ```
 
-## .NET Core
+## .NET
 
-More information about debugging .NET Core applications within Docker containers can be found in [Debug .NET Core within Docker containers](/docs/containers/debug-netcore.md).
+More information about debugging .NET applications within Docker containers can be found in [Debug .NET within Docker containers](/docs/containers/debug-netcore.md).
 
-> The previous (Preview) .NET Core Docker debugging support (utilizing `"type": "docker-coreclr"` instead of the current preview's `"type": "docker"`) is being deprecated. You can still find documentation on that support at [Debug .NET Core - Deprecated](https://github.com/microsoft/vscode-docker/wiki/Debug-NetCore-Deprecated).
+> The previous (Preview) .NET Docker debugging support (utilizing `"type": "docker-coreclr"` instead of the current preview's `"type": "docker"`) is being deprecated. You can still find documentation on that support at [Debug .NET Core - Deprecated](https://github.com/microsoft/vscode-docker/wiki/Debug-NetCore-Deprecated).
 
-Example `launch.json` configuration for debugging a .NET Core application:
+Example `launch.json` configuration for debugging a .NET application:
 
 ```json
 {
@@ -107,7 +107,7 @@ Example `launch.json` configuration for debugging a .NET Core application:
 | `dockerServerReadyAction` | Options for launching a browser to the Docker container. Similar to serverReadyAction, but replaces container ports with host ports. |
 | `removeContainerAfterDebug` | Whether to remove the debug container after debugging. |
 | `platform` | The target platform for the application. Can be `netCore` or `node`. |
-| `netCore` | Options for debugging .NET Core projects in Docker. |
+| `netCore` | Options for debugging .NET projects in Docker. |
 | `node` | Options for debugging Node.js projects in Docker. |
 | `python` | Options for debugging Python projects in Docker. |
 
@@ -154,11 +154,11 @@ Example `launch.json` configuration for debugging a .NET Core application:
 
 ### netCore object properties
 
-> Properties passed in the `netCore` object are generally passed on to the .NET Core debug adaptor, even if not specifically listed below. The complete list of debugger properties is in the [OmniSharp VS Code extension documentation](https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md).
+> Properties passed in the `netCore` object are generally passed on to the .NET debug adaptor, even if not specifically listed below. The complete list of debugger properties is in the [OmniSharp VS Code extension documentation](https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md).
 
 | Property | Description |
 | --- | --- |
-| `appProject` | The .NET Core project (.csproj, .fsproj, etc.) to debug. |
+| `appProject` | The .NET project (.csproj, .fsproj, etc.) to debug. |
 
 ## Next steps
 
@@ -166,6 +166,6 @@ Read on to learn more about:
 
 - [Debugging Node.js within Docker containers](/docs/containers/debug-node.md)
 - [Debugging Python within Docker containers](/docs/containers/debug-python.md)
-- [Debugging .NET Core within Docker containers](/docs/containers/debug-netcore.md)
+- [Debugging .NET within Docker containers](/docs/containers/debug-netcore.md)
 - [Debugging with Docker Compose](/docs/containers/docker-compose.md#debug)
 - [Troubleshooting](/docs/containers/troubleshooting.md)

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -1,17 +1,17 @@
 ---
 Area: containers
 ContentId: B1DF33C0-400C-413D-B60B-D1AA278F6DE3
-PageTitle: Debug a .NET Core app running in a Docker container
+PageTitle: Debug a .NET app running in a Docker container
 DateApproved: 04/15/2021
-MetaDescription: Debug a .NET Core app running in a Docker container, using Visual Studio Code.
+MetaDescription: Debug a .NET app running in a Docker container, using Visual Studio Code.
 ---
-# Debug .NET Core within a container
+# Debug .NET within a container
 
 ## Prerequisites
 
-1. Install the [.NET Core SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET Core debugger.
+1. Install the [.NET SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET debugger.
 
-1. Install the Visual Studio Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp), which includes support for attaching to the .NET Core debugger with VS Code.
+1. Install the Visual Studio Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp), which includes support for attaching to the .NET debugger with VS Code.
 
 1. macOS users only: Add `/usr/local/share/dotnet/sdk/NuGetFallbackFolder` as a shared folder in your Docker preferences.
 
@@ -19,7 +19,7 @@ MetaDescription: Debug a .NET Core app running in a Docker container, using Visu
 
 ## Walkthrough
 
-1. If needed, create a .NET Core project with `dotnet new`.
+1. If needed, create a .NET project with `dotnet new`.
 1. Open the project folder in VS Code.
 1. Wait until a notification appears asking if you want to add required assets for debugging. Select **Yes**:
 

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -9,7 +9,7 @@ MetaDescription: Develop a multi-container app running in a Docker containers us
 ---
 # Use Docker Compose
 
-Docker Compose provides a way to orchestrate multiple containers that work together. Examples include a service that processes requests and a front-end web site, or a service that uses a supporting function such as a Redis cache. If you are using the microservices model for your app development, you can use Docker Compose to factor the app code into several independently running services that communicate using web requests. This article helps you enable Docker Compose for your apps, whether they are Node.js, Python, or .NET Core, and also helps you configure debugging in Visual Studio Code for these scenarios.
+Docker Compose provides a way to orchestrate multiple containers that work together. Examples include a service that processes requests and a front-end web site, or a service that uses a supporting function such as a Redis cache. If you are using the microservices model for your app development, you can use Docker Compose to factor the app code into several independently running services that communicate using web requests. This article helps you enable Docker Compose for your apps, whether they are Node.js, Python, or .NET, and also helps you configure debugging in Visual Studio Code for these scenarios.
 
 Also, for single-container scenarios, using Docker Compose provides tool-independent configuration in a way that a single Dockerfile does not. Configuration settings such as volume mounts for the container, port mappings, and environment variables can be declared in the docker-compose YML files.
 
@@ -49,11 +49,11 @@ First, refer to the debugging documentation for your target platform, to underst
 
 - [Node.js debugging](/docs/containers/debug-node.md)
 - [Python Docker debugging](/docs/containers/debug-python.md)
-- [.NET Core debugging](/docs/containers/debug-netcore.md)
+- [.NET debugging](/docs/containers/debug-netcore.md)
 
 If you want to debug in Docker Compose, run the command **Docker Compose Up** using one of the two Docker Compose files as described in the previous section, and then attach using the appropriate **Attach** launch configuration. Launching directly using the normal launch configuration does not use Docker Compose.
 
-Create an **Attach** [launch configuration](/docs/editor/debugging.md#launch-configurations). This is a section in `launch.json`. The process is mostly manual, but in some cases, the Docker extension can help by adding a pre-configured launch configuration that you can use as a template and customize. The process for each platform (Node.js, Python, and .NET Core) is described in the following sections.
+Create an **Attach** [launch configuration](/docs/editor/debugging.md#launch-configurations). This is a section in `launch.json`. The process is mostly manual, but in some cases, the Docker extension can help by adding a pre-configured launch configuration that you can use as a template and customize. The process for each platform (Node.js, Python, and .NET) is described in the following sections.
 
 ### Node.js
 
@@ -187,7 +187,7 @@ For debugging Python with Docker Compose, follow these steps:
 
    ![Screenshot of starting debugging](images/compose/docker-compose-attach.png)
 
-1. If you try to attach to a .NET Core app running in a container, you'll see a prompt ask to select your app's container.
+1. If you try to attach to a .NET app running in a container, you'll see a prompt ask to select your app's container.
 
    ![Screenshot of container selection](images/compose/select-container.png)
 
@@ -201,13 +201,13 @@ For debugging Python with Docker Compose, follow these steps:
 
    ![Screenshot of debugger prompt](images/compose/docker-compose-netcore-debugger-prompt.png)
 
-If everything is configured correctly, the debugger should be attached to your .NET Core app.
+If everything is configured correctly, the debugger should be attached to your .NET app.
 
 ![Screenshot of debug session](images/compose/docker-compose-debugging.png)
 
 ## Volume mounts
 
-By default, the Docker extension does not do any volume mounting for debugging components. There's no need for it in .NET Core or Node.js, since the required components are built into the runtime. If your app requires volume mounts, specify them by using the `volumes` tag in the `docker-compose*.yml` files.
+By default, the Docker extension does not do any volume mounting for debugging components. There's no need for it in .NET or Node.js, since the required components are built into the runtime. If your app requires volume mounts, specify them by using the `volumes` tag in the `docker-compose*.yml` files.
 
 ```yml
 volumes:

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -98,7 +98,7 @@ Read on to learn more about
 
 - [Choosing your development environment](/docs/containers/choosing-dev-environment.md)
 - [Build and run a Node.js app in a container](/docs/containers/quickstart-node.md)
-- [Build and run a .NET Core app in a container](/docs/containers/quickstart-aspnet-core.md)
+- [Build and run a .NET app in a container](/docs/containers/quickstart-aspnet-core.md)
 - [Debug apps within Docker containers](/docs/containers/debug-common.md)
 - [Docker application development](https://docs.docker.com/develop)
 - [Troubleshooting](/docs/containers/troubleshooting.md)

--- a/docs/containers/quickstart-aspnet-core.md
+++ b/docs/containers/quickstart-aspnet-core.md
@@ -18,10 +18,10 @@ In this guide you will learn how to:
 ## Prerequisites
 
 - Docker and the VS Code Docker extension must be installed as described on the [overview](/docs/containers/overview.md#installation).
-- For .NET development, install [.NET Core SDK](https://dotnet.microsoft.com/download).
+- For .NET development, install [.NET SDK](https://dotnet.microsoft.com/download).
 - Microsoft [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension.
 
-## Create a .NET Core Web API project
+## Create a .NET Web API project
 
 1. Create a folder for the project.
 1. Open developer command prompt in the project folder and initialize the project:
@@ -54,15 +54,18 @@ In this guide you will learn how to:
 
    ``` output
    ~/code/scratch/netcorerest$ dotnet build
-   Microsoft (R) Build Engine version 16.3.0+0f4c62fea for .NET Core
+   Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
    Copyright (C) Microsoft Corporation. All rights reserved.
 
-   Restore completed in 18.97 ms for ~/code/scratch/netcorerest/netcorerest.csproj.
-   netcorerest -> ~/code/scratch/netcorerest/bin/Debug/netcoreapp3.0/netcorerest.dll
+     Determining projects to restore...
+     All projects are up-to-date for restore.
+     nettest -> c:\source\repos\nettest\bin\Debug\net6.0\nettest.dll
 
-    Build succeeded.
-        0 Warning(s)
-        0 Error(s)
+   Build succeeded.
+       0 Warning(s)
+       0 Error(s)
+
+   Time Elapsed 00:00:03.78
    ```
 
 ## Add an environment variable to the image
@@ -169,7 +172,7 @@ You can use specific port on the host by changing the Docker run options used by
 
 You're done! Now that your container is ready, you may want to:
 
-- [Learn about debugging .NET Core in a container](/docs/containers/debug-netcore.md)
+- [Learn about debugging .NET in a container](/docs/containers/debug-netcore.md)
 - [Customize your Docker build and run tasks](/docs/containers/reference.md)
 - [Push your image to a container registry](/docs/containers/quickstart-container-registries.md#push-an-image-to-a-container-registry)
 - [Deploy a containerized app to Azure App Service](/docs/containers/app-service.md)

--- a/docs/containers/reference.md
+++ b/docs/containers/reference.md
@@ -11,7 +11,7 @@ MetaDescription: Reference for Docker build and Docker run tasks and properties 
 
 The Docker extension includes several Visual Studio Code tasks to control the behavior of Docker [build](#docker-build-task) and [run](#docker-run-task), and form the basis of container startup for debugging.
 
-The tasks allow for a great deal of control and customization. The final configuration is a combination of general defaults, platform-specific defaults (such as Node.js, Python, or .NET Core), and user input. User input takes precedence when it conflicts with defaults.
+The tasks allow for a great deal of control and customization. The final configuration is a combination of general defaults, platform-specific defaults (such as Node.js, Python, or .NET), and user input. User input takes precedence when it conflicts with defaults.
 
 All common features of Visual Studio Code tasks (for example, grouping tasks into compound tasks) are supported by Docker extension tasks. For more information on common task features and properties, see the Visual Studio Code [custom task](/docs/editor/tasks.md#custom-tasks) documentation.
 
@@ -88,11 +88,11 @@ For Python Docker images, the `docker-build` task infers the following options:
 | `dockerBuild.tag` | The base name of the root workspace folder. |
 | `dockerBuild.pull` | Defaults to true in order to pull new base images before building. |
 
-### .NET Core (docker-build)
+### .NET (docker-build)
 
 **Minimal configuration using defaults**
 
-When you build a .NET Core-based Docker image, you can omit the `platform` property and just set the `netCore` object (`platform` is implicitly set to `netcore` when `netCore` object is present). Note that `appProject` is a required property:
+When you build a .NET-based Docker image, you can omit the `platform` property and just set the `netCore` object (`platform` is implicitly set to `netcore` when `netCore` object is present). Note that `appProject` is a required property:
 
 ```json
 {
@@ -111,7 +111,7 @@ When you build a .NET Core-based Docker image, you can omit the `platform` prope
 
 **Platform defaults**
 
-For .NET Core-based images, the `docker-build` task infers the following options:
+For .NET-based images, the `docker-build` task infers the following options:
 
 | Property | Inferred Value |
 | --- | --- |
@@ -126,10 +126,10 @@ Here are all properties available for configuring `docker-build` task. All prope
 | Property | Description |
 | --- | --- |
 | `dockerBuild` | Options for controlling the `docker build` command executed ([see below](#dockerbuild-object-properties)). <br/> Required unless `platform` is set. |
-| `platform` | Determines the platform: .NET Core (`netcore`) or Node.js (`node`) and default settings for `docker build` command. |
+| `platform` | Determines the platform: .NET (`netcore`) or Node.js (`node`) and default settings for `docker build` command. |
 | `node` | Determines options specific for Node.js projects ([see below](#node-object-properties-dockerbuild-task)). |
 | `python` | There are no object properties for Python in the `docker-build` task. |
-| `netCore` | Determines options specific for .NET Core projects ([see below](#netcore-object-properties-dockerbuild-task)). |
+| `netCore` | Determines options specific for .NET projects ([see below](#netcore-object-properties-dockerbuild-task)). |
 
 ### dockerBuild object properties
 
@@ -154,7 +154,7 @@ Here are all properties available for configuring `docker-build` task. All prope
 
 | Property | Description |
 | --- | --- |
-| `appProject` | The .NET Core project file (`.csproj`, `.fsproj`, etc.) associated with the Dockerfile and `docker-build` task. <br/> Required always.  |
+| `appProject` | The .NET project file (`.csproj`, `.fsproj`, etc.) associated with the Dockerfile and `docker-build` task. <br/> Required always.  |
 
 ## Docker run task
 
@@ -169,7 +169,7 @@ See [property reference](#run-task-reference) for full list of all task properti
 
 ### Docker run platform support
 
-While the `docker-run` task can be used to run any Docker image, the extension has explicit support (and simplified configuration) for Node.js, Python, and .NET Core.
+While the `docker-run` task can be used to run any Docker image, the extension has explicit support (and simplified configuration) for Node.js, Python, and .NET.
 
 ### Node.js (docker-run)
 
@@ -277,11 +277,11 @@ For Python-based Docker images, the `docker-run` task infers the following optio
 | `dockerRun.containerName` | Derived from the base name of the root workspace folder. |
 | `dockerRun.image` | The tag from a dependent docker-build task (if one exists) or derived from the base name of the root workspace folder. |
 
-### .NET Core (docker-run)
+### .NET (docker-run)
 
 **Minimal configuration using defaults**
 
-When building a .NET Core-based Docker image, you can omit the `platform` property and just set the `netCore` object (`platform` is implicitly set to `netcore` when `netCore` object is present). Note that `appProject` is a required property:
+When building a .NET-based Docker image, you can omit the `platform` property and just set the `netCore` object (`platform` is implicitly set to `netcore` when `netCore` object is present). Note that `appProject` is a required property:
 
 ```json
 {
@@ -300,7 +300,7 @@ When building a .NET Core-based Docker image, you can omit the `platform` proper
 
 **Platform defaults**
 
-For .NET Core-based images, the `docker-run` task infers the following options:
+For .NET-based images, the `docker-run` task infers the following options:
 
 | Property | Inferred Value |
 | --- | --- |
@@ -317,10 +317,10 @@ Here are all properties available for configuring `docker-run` task. All propert
 | Property | Description |
 | --- | --- |
 | `dockerRun` | Options for controlling the `docker run` command executed ([see below](#dockerrun-object-properties)). <br/> Required unless `platform` is set. |
-| `platform` | Determines the platform: .NET Core (`netcore`) or Node.js (`node`) and default settings for `docker run` command. |
+| `platform` | Determines the platform: .NET (`netcore`) or Node.js (`node`) and default settings for `docker run` command. |
 | `node` | For Node.js projects, this controls various options ([see below](#node-object-properties-dockerrun-task)). |
 | `python` | For Python projects, this controls various options ([see below](#python-object-properties-dockerrun-task)). |
-| `netCore` | For .NET Core projects, this controls various options ([see below](#netcore-object-properties-dockerrun-task)). |
+| `netCore` | For .NET projects, this controls various options ([see below](#netcore-object-properties-dockerrun-task)). |
 
 ### dockerRun object properties
 
@@ -388,7 +388,7 @@ Here are all properties available for configuring `docker-run` task. All propert
 
 | Property | Description |
 | --- | --- |
-| `appProject` | The .NET Core project file (`.csproj`, `.fsproj`, etc.) associated with `docker-run` task. <br/> Required. |
+| `appProject` | The .NET project file (`.csproj`, `.fsproj`, etc.) associated with `docker-run` task. <br/> Required. |
 | `configureSsl` | Whether to configure ASP.NET Core SSL certificates and other settings to enable SSL on the service in the container. |
 | `enableDebugging` | Whether to enable the started container for debugging. This will infer additional volume mappings and other options necessary for debugging. |
 


### PR DESCRIPTION
.NET 5 and later drop the "Core" and just use the brand ".NET"
ASP.NET Core still uses the "Core" name 
Product UI still uses .NET Core in places, so those refs are not updated
@ucheNkadiCode @gregvanl 