### PR TITLE
Update '/docs/introvideos/basics.md' - fix 2 typos

### DIFF
--- a/docs/introvideos/basics.md
+++ b/docs/introvideos/basics.md
@@ -41,7 +41,7 @@ Pick another video from the list: [Introductory Videos](/docs/getstarted/introvi
 * Debug Console
   * **View** > **Debug Console** (`kb(workbench.debug.action.toggleRepl)`)
 * Problems panel
-  * **View** > **Problems** (`kbworkbench.actions.view.problems)`)
+  * **View** > **Problems** (`kb(workbench.actions.view.problems)`)
 * Integrated Terminal
   * **View** > **Terminal** (`kb(workbench.action.terminal.toggleTerminal)`)
 * Create a new file
@@ -51,7 +51,7 @@ Pick another video from the list: [Introductory Videos](/docs/getstarted/introvi
 * Auto Save
   * **File** > **Auto Save**
 * Run
-  * **Run** > **Start Debugging** (`kb(workbench.action.debug.start))
+  * **Run** > **Start Debugging** (`kb(workbench.action.debug.start)`)
 * Programming language extensions
   * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) - IntelliSense, linting, debugging, code formatting, refactoring, and more.
   * [Live Preview](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) - Hosts a local server to preview your webpages.


### PR DESCRIPTION
Fix 2 typos in key bindings in 'Video outline': 1) for '**View** > **Problems**'; 2) for '**Run** > **Start Debugging**'.