### PR TITLE
3947 Added Search Editor Documentation

### DIFF
--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -217,7 +217,7 @@ Below is a search for the word 'SearchEditor' with two lines of text before and 
 The **Open Search Editor** command opens an existing search editor if one exists, or to otherwise create a new one. The **New Search Editor** command will always create a new Search Editor.
 
 
-In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
+In the Search Editor, results can be navigated to using Go to Definition actions, such as `kb(editor.action.revealDefinition)` to open the source location in the current editor group, or `kb(editor.action.revealDefinitionAside)` to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
 
 ![search editor triggers](images/codebasics/search-editor-triggers.gif)
 

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -206,6 +206,37 @@ Example:
 
 The modifiers can also be stacked - for example, `\u\u\u$1` will uppercase the first three characters of the group, or `\l\U$1` will lowercase the first character, and uppercase the rest. The capture group is referenced by `$n` in the replacement string, where `n` is the order of the capture group.
 
+## Search Editor
+Search Editors let you view workspace search results in a full-sized editor, complete with syntax highlighting and optional lines of surrounding context.
+
+- ** Insert image from Feb 2020 release??
+
+The Open Search Editor command opens an existing search editor if one exists, or to otherwise create a new one. The pre-existing command Open new Search Editor has been renamed to New Search Editor, and will always create a new Search Editor.
+
+** Insert image or gif?
+
+In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
+
+** Insert image or gif
+
+### Search editor command arguments
+* `search.action.openNewEditor` - Opens the search editor in a new tab.
+- `search.action.openInEditor` - Copy the current Search results into a new Search editor
+* `search.action.openNewEditorToSide` - Opens the search editor in a new window next to the window you currently have opened.
+- Should we insert images here?
+
+You can also use the Open New Search Editor button at the top of the Search view. (TODO: See where this is) You can also copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
+- **insert image?
+
+
+Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true
+### Search editor context default
+The `search.searchEditor.defaultNumberOfContextLines` setting has a default value of 1, meaning one context line will be shown before and after each result line in the Search editor.
+
+### Options for configuring how Search Editors are created
+- `search.searchEditor.defaultNumberOfContextLines` - Configure how many context lines a Search Editor shows by default.
+- `search.searchEditor.reusePriorSearchConfiguration` - Reuse the last active Search Editor's configuration when creating a new Search Editor.
+
 ## IntelliSense
 
 We'll always offer word completion, but for the rich [languages](/docs/languages/overview.md), such as JavaScript, JSON, HTML, CSS, SCSS, Less, C# and TypeScript, we offer a true IntelliSense experience. If a language service knows possible completions, the IntelliSense suggestions will pop up as you type. You can always manually trigger it with `kb(editor.action.triggerSuggest)`.  By default, `kbstyle(Tab)` or `kbstyle(Enter)` are the accept keyboard triggers but you can also [customize these key bindings](/docs/getstarted/keybindings.md).

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -214,7 +214,7 @@ Below is a search for the word 'SearchEditor' with two lines of text before and 
 
 ![search editor overview](images/codebasics/search-editor-overview.png)
 
-The Open Search Editor command opens an existing search editor if one exists, or to otherwise create a new one. The pre-existing command Open new Search Editor has been renamed to New Search Editor, and will always create a new Search Editor.
+The **Open Search Editor** command opens an existing search editor if one exists, or to otherwise create a new one. The **New Search Editor** command will always create a new Search Editor.
 
 
 In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -216,7 +216,7 @@ Below is a search for the word 'SearchEditor' with two lines of text before and 
 
 The Open Search Editor command opens an existing search editor if one exists, or to otherwise create a new one. The pre-existing command Open new Search Editor has been renamed to New Search Editor, and will always create a new Search Editor.
 
-** Insert image or gif showing how to open it?
+<b>** Insert image or gif showing how to open it?</b>
 
 In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
 
@@ -226,10 +226,10 @@ In the Search Editor, results can be navigated to using Go to Definition actions
 * `search.action.openNewEditor` - Opens the search editor in a new tab.
 - `search.action.openInEditor` - Copy the current Search results into a new Search editor
 * `search.action.openNewEditorToSide` - Opens the search editor in a new window next to the window you currently have opened.
-- Should we insert images here?
+- <b>Should we insert images here?</b>
 
 You can also use the Open New Search Editor button at the top of the Search view. (TODO: See where this is) You can also copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
-- **Dont insert image from Feb 2020 release? Thats for an extenssion
+- <b>**Dont insert image from Feb 2020 release? Thats for an extenssion</b>
 
 
 Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -232,7 +232,7 @@ You can also use the Open New Search Editor button at the top of the Search view
 
 Search editor was opened by clicking the **Open New Search Editor** button (third button) on the top of the search view
 
-Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/)
+
 ### Search editor context default
 The `search.searchEditor.defaultNumberOfContextLines` setting has a default value of 1, meaning one context line will be shown before and after each result line in the Search editor.
 

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -209,15 +209,18 @@ The modifiers can also be stacked - for example, `\u\u\u$1` will uppercase the f
 ## Search Editor
 Search Editors let you view workspace search results in a full-sized editor, complete with syntax highlighting and optional lines of surrounding context.
 
-- ** Insert image from Feb 2020 release??
+Below is a search for the word 'SearchEditor' with two lines of text before and after the match for context:
+
+
+![search editor overview](images/codebasics/search-editor-overview.png)
 
 The Open Search Editor command opens an existing search editor if one exists, or to otherwise create a new one. The pre-existing command Open new Search Editor has been renamed to New Search Editor, and will always create a new Search Editor.
 
-** Insert image or gif?
+** Insert image or gif showing how to open it?
 
 In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
 
-** Insert image or gif
+![search editor triggers](images/codebasics/search-editor-triggers.gif)
 
 ### Search editor command arguments
 * `search.action.openNewEditor` - Opens the search editor in a new tab.
@@ -226,7 +229,7 @@ In the Search Editor, results can be navigated to using Go to Definition actions
 - Should we insert images here?
 
 You can also use the Open New Search Editor button at the top of the Search view. (TODO: See where this is) You can also copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
-- **insert image?
+- **Dont insert image from Feb 2020 release? Thats for an extenssion
 
 
 Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -226,11 +226,11 @@ In the Search Editor, results can be navigated to using Go to Definition actions
 - `search.action.openInEditor` - Copy the current Search results into a new Search editor
 * `search.action.openNewEditorToSide` - Opens the search editor in a new window next to the window you currently have opened.
 
-You can also use the Open New Search Editor button at the top of the Search view, and can copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
+You can also use the Open New Search Editor button at the top of the Search view, and can copy your existing results from a Search view over to a Search Editor with the **Open in Editor link** added to the top of the results tree, or the **Search Editor: Open Results** in Editor command.
 
 ![Search Editor Button](images/codebasics/search-editor-button.png)
 
-Search editor was opened by clicking the Open New Search Editor button (third button) on the top of the search view
+Search editor was opened by clicking the **Open New Search Editor** button (third button) on the top of the search view
 
 Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true
 ### Search editor context default

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -226,11 +226,8 @@ In the Search Editor, results can be navigated to using Go to Definition actions
 * `search.action.openNewEditor` - Opens the search editor in a new tab.
 - `search.action.openInEditor` - Copy the current Search results into a new Search editor
 * `search.action.openNewEditorToSide` - Opens the search editor in a new window next to the window you currently have opened.
-- <b>Should we insert images here?</b>
 
-You can also use the Open New Search Editor button at the top of the Search view. (TODO: See where this is) You can also copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
-- <b>**Dont insert image from Feb 2020 release? Thats for an extenssion</b>
-
+You can also use the Open New Search Editor button at the top of the Search view, and can copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
 
 Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true
 ### Search editor context default

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -216,7 +216,6 @@ Below is a search for the word 'SearchEditor' with two lines of text before and 
 
 The Open Search Editor command opens an existing search editor if one exists, or to otherwise create a new one. The pre-existing command Open new Search Editor has been renamed to New Search Editor, and will always create a new Search Editor.
 
-<b>** Insert image or gif showing how to open it?</b>
 
 In the Search Editor, results can be navigated to using Go to Definition actions, such as F12 to open the source location in the current editor group, or Ctrl+K F12 to open the location in an editor to the side. Additionally, double-clicking can optionally open the source location, configurable with the `search.searchEditor.doubleClickBehaviour` setting.
 
@@ -228,6 +227,10 @@ In the Search Editor, results can be navigated to using Go to Definition actions
 * `search.action.openNewEditorToSide` - Opens the search editor in a new window next to the window you currently have opened.
 
 You can also use the Open New Search Editor button at the top of the Search view, and can copy your existing results from a Search view over to a Search Editor with the <b>Open in Editor link</b> added to the top of the results tree, or the <b>Search Editor: Open Results </b> in Editor command.
+
+![Search Editor Button](images/codebasics/search-editor-button.png)
+
+Search editor was opened by clicking the Open New Search Editor button (third button) on the top of the search view
 
 Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true
 ### Search editor context default

--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -232,7 +232,7 @@ You can also use the Open New Search Editor button at the top of the Search view
 
 Search editor was opened by clicking the **Open New Search Editor** button (third button) on the top of the search view
 
-Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/), and can be opted into in Stable by setting search.enableSearchEditorPreview to true
+Note: Search Editors are enabled by default in [Insiders](https://code.visualstudio.com/insiders/)
 ### Search editor context default
 The `search.searchEditor.defaultNumberOfContextLines` setting has a default value of 1, meaning one context line will be shown before and after each result line in the Search editor.
 

--- a/docs/editor/images/codebasics/search-editor-button.png
+++ b/docs/editor/images/codebasics/search-editor-button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197f0603b3eeffd5863e5f0b01ac1355f99e1779eadf346f7633ea004fd35ba5
+size 181527

--- a/docs/editor/images/codebasics/search-editor-overview.png
+++ b/docs/editor/images/codebasics/search-editor-overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa09893358f248046ac1522dab1d331082d7b291db8e1a57c4b75e2464e5d56f
+size 272704

--- a/docs/editor/images/codebasics/search-editor-triggers.gif
+++ b/docs/editor/images/codebasics/search-editor-triggers.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d171be1a070e2326de849c8b4d0755ba5ae02e6c811d013eaa6759d3a3dcac0
+size 4775383


### PR DESCRIPTION
Fixes issue #3947 Added documentation for the search editor feature. Please let me know how this looks, and if there is anything else I should add. I am looking forward to making my first contribution. 
You can view how the md file looks <a href="https://github.com/joey2031/vscode-docs/blob/3947-searchEditorDoc/docs/editor/codebasics.md#search-editor">here</a>

List of sources (VS code blog posts)
- [January 2020 (v1.42)](https://code.visualstudio.com/updates/v1_42#_search-editor)
- [February 2020 (v1.43)](https://code.visualstudio.com/updates/v1_43#_search-editors)
- [May 2020 (v1.46)](https://code.visualstudio.com/updates/v1_46#_search-editor)
- [June 2020 (v1.47)](https://code.visualstudio.com/updates/v1_47#_new-search-editor-command-arguments)
- [July 2020 (v1.48)](https://code.visualstudio.com/updates/v1_48#_search-editor)
