### PR TITLE
Update tips-and-tricks.md - fix typo

### DIFF
--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -345,7 +345,8 @@ or a custom schema
                 }
             }
         }
-    },
+    }
+]
 ```
 
 See more in the [JSON](/docs/languages/json.md) documentation.


### PR DESCRIPTION
Fixed a typo in the description JSON schema in section 'Add JSON validation'.