### PR TITLE
Update tips-and-tricks.md - fix keybinding

### DIFF
--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -449,7 +449,7 @@ You can quickly open a file or image or create a new file by moving the cursor t
 
 ### Close the currently opened folder
 
-Keyboard Shortcut: `kb(workbench.action.closeActiveEditor)`
+Keyboard Shortcut: `kb(workbench.action.closeFolder)`
 
 ### Navigation history
 


### PR DESCRIPTION
The section title says about the folder, so keybinding should be `kb(workbench.action.closeFolder)`, not `kb(workbench.action.closeActiveEditor)`.