### PR TITLE
Updated incorrect information

### DIFF
--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -143,10 +143,10 @@ x               source.abc
     )           punctuation.paren.close, expression.group, expression.group, source.abc
 )               punctuation.paren.close, expression.group, source.abc
 (               punctuation.paren.open, expression.group, source.abc
-a               keyword.letter, source.abc
+a               keyword.letter, expression.group, source.abc
 ```
 
-Note that text that is not matched by one of the rules, such as the string `xyz`, is included in the current scope. The last parenthesis at the end of the file is not part of the `expression.group` since the `end` rule is not matched.
+Note that text that is not matched by one of the rules, such as the string `xyz`, is included in the current scope. The last parenthesis at the end of the file is part of the `expression.group` even if the `end` rule is not matched, as `end-of-document` was found before the `end` rule was.
 
 ### Embedded languages
 


### PR DESCRIPTION
The `end` rule mustn't be found for the scope to be applied. The `end` rule will be overruled by the `end-of-document` by the grammar engine, and the scope will apply to any token between `begin` and `end-of-document`.

You can validate this yourself by opening a [begin, end] match rule and inspect it using the scope inspector in VS Code.

See Image below (using both tmLanguage and file provided in the example):
<img width="487" alt="Screen Shot 2022-06-01 at 11 28 46 AM" src="https://user-images.githubusercontent.com/43240003/171442024-623c7e28-c99d-4cbd-99f7-f99fd0bbe1b4.png">

