### PR TITLE
Added classPaths options to java debugging

### DIFF
--- a/docs/java/java-debugging.md
+++ b/docs/java/java-debugging.md
@@ -167,6 +167,9 @@ Below are all the configurations available for `Launch` and `Attach`. For more i
 - `sourcePaths` - The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
 - `classPaths` - The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
+  - `$Auto` - Automatically resolve the classpaths of current project.
+  - `$Runtime` - The classpaths within 'runtime' scope of current project.
+  - `$Test` - The classpaths within 'test' scope of current project.
 - `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in [Supported Encodings](https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html).
 - `vmArgs` - The extra options and system properties for the JVM (for example -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple Java projects, otherwise the expression evaluation and conditional breakpoint may not work.

--- a/docs/java/java-debugging.md
+++ b/docs/java/java-debugging.md
@@ -166,10 +166,17 @@ Below are all the configurations available for `Launch` and `Attach`. For more i
 - `args` - The command-line arguments passed to the program. Use `"${command:SpecifyProgramArgs}"` to prompt for program arguments. It accepts a string or an array of string.
 - `sourcePaths` - The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
+  - `$Auto` - Automatically resolve the modulepaths of current project.
+  - `$Runtime` - The modulepaths within 'runtime' scope of current project.
+  - `$Test` - The modulepaths within 'test' scope of current project.
+  - `!/path/to/exclude` - Exclude the specified path from modulepaths.
+  - `/path/to/append` - Append the specified path to the modulepaths.
 - `classPaths` - The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
   - `$Auto` - Automatically resolve the classpaths of current project.
   - `$Runtime` - The classpaths within 'runtime' scope of current project.
   - `$Test` - The classpaths within 'test' scope of current project.
+  - `!/path/to/exclude` - Exclude the specified path from classpaths.
+  - `/path/to/append` - Append the specified path to the classpaths.
 - `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in [Supported Encodings](https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html).
 - `vmArgs` - The extra options and system properties for the JVM (for example -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple Java projects, otherwise the expression evaluation and conditional breakpoint may not work.


### PR DESCRIPTION
When adding custom folders to a Java project's classpath, via the `classPaths` field, it was un-clear on how to append the automatically resolved classPath to the list.

i.e. specifying the following resulted in a simple class-path of `-cp /usr/local/data/git/some-folder/`, instead of all my maven dependencies plus the folder:
```json
{
    "type": "java",
    "name": "some-service",
    "request": "launch",
    "mainClass": "com.sample.SomeService",
    "projectName": "some-service",
    "classPaths": [
        "/usr/local/data/git/some-folder/"
    ]
}
```

Had to dig around a bit to find an enum defined as `ClasspathVariable` under [microsoft/vscode-java-debug/src/constants.ts](https://github.com/microsoft/vscode-java-debug/blob/main/src/constants.ts) and saw that it was used [here](https://github.com/microsoft/vscode-java-debug/blob/c8738216f36859320afbd09dc766b5be98aeb272/src/configurationProvider.ts#L402) in determining the classpath.

i.e. in order to get the desired effect I had to do something like (which worked like a dream):
```json
{
    "type": "java",
    "name": "some-service",
    "request": "launch",
    "mainClass": "com.sample.SomeService",
    "projectName": "some-service",
    "classPaths": [
        "$Auto",
        "/usr/local/data/git/some-folder/"
    ]
}
```

I'm adding these enums to the documentation and am describing as described under [microsoft/vscode-java-debug/package.nls.json](https://github.com/microsoft/vscode-java-debug/blob/c8738216f36859320afbd09dc766b5be98aeb272/package.nls.json#L12)