### PR TITLE
Clarify pre-release to release update semantics

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -312,7 +312,7 @@ We only support `major.minor.patch` for extension versions and `semver` pre-rele
 VS Code will auto update extensions to the highest version available, so even if a user opted into a pre-release version and there is an extension release with a higher version, that user will be updated to the released version.
 Because of this we recommend that extensions use `major.EVEN_NUMBER.patch` for release versions and `major.ODD_NUMBER.patch` for pre-release versions. For example: `0.2.*` for release and `0.3.*` for pre-release.
 
-If extension authors do not want their pre-release users to be updated to the release version, we recommend to always increment and publish a new pre-release version before publishing a release version in order to make sure that the pre-release version is always higher.
+If extension authors do not want their pre-release users to be updated to the release version, we recommend to always increment and publish a new pre-release version before publishing a release version in order to make sure that the pre-release version is always higher. Note that while pre-release users will be updated to a release version if it is newer, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version.
 
 Pre-release extensions are supported after VS Code version `1.63.0` and so all pre-release extensions needs to set `vscode.engine` value in their `package.json` to `>= 1.63.0`.
 

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -312,7 +312,7 @@ We only support `major.minor.patch` for extension versions and `semver` pre-rele
 VS Code will auto update extensions to the highest version available, so even if a user opted into a pre-release version and there is an extension release with a higher version, that user will be updated to the released version.
 Because of this we recommend that extensions use `major.EVEN_NUMBER.patch` for release versions and `major.ODD_NUMBER.patch` for pre-release versions. For example: `0.2.*` for release and `0.3.*` for pre-release.
 
-If extension authors do not want their pre-release users to be updated to the release version, we recommend to always increment and publish a new pre-release version before publishing a release version in order to make sure that the pre-release version is always higher. Note that while pre-release users will be updated to a release version if it is newer, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version.
+If extension authors do not want their pre-release users to be updated to the release version, we recommend to always increment and publish a new pre-release version before publishing a release version in order to make sure that the pre-release version is always higher. Note that while pre-release users will be updated to a release version if it is higher, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version.
 
 Pre-release extensions are supported after VS Code version `1.63.0` and so all pre-release extensions needs to set `vscode.engine` value in their `package.json` to `>= 1.63.0`.
 


### PR DESCRIPTION
The existing documentation is ambiguous about what happens in this scenario:

- User has pre-release version 0.1.0 installed.
- Release version 0.2.0 is published. User automatically updates to this version.
- Pre-release version 0.3.0 is published. Is the user now stuck on the release version, or are they still eligible for pre-releases because they had a pre-release installed before?

I tried creating a dummy extension on the marketplace and published a few versions to test the functionality, and the user appears to still be eligible for newer pre-releases. What I've written is correct based on that testing, but I'd love to get some expert validation of this behavior.

@aleun FYI