### PR TITLE
Add task globs to release

### DIFF
--- a/release-notes/v1_68.md
+++ b/release-notes/v1_68.md
@@ -160,9 +160,9 @@ As a reminder, minimum contrast ratio can be disabled if you would prefer origin
 
 ## Tasks
 
-### Glob for default tasks
+### Glob pattern for default tasks
 
-Default build and test tasks can now be scoped to only be "default" when the active file matches a file glob:
+Default build and test tasks can now be scoped to only be "default" when the active file matches a filename glob pattern:
 
 ```jsonc
 {
@@ -174,7 +174,7 @@ Default build and test tasks can now be scoped to only be "default" when the act
             "command": "echo TextFile",
             "group": {
                 "kind": "build",
-                "isDefault": "**.txt" // This is a glob which will only match when the active file has a .txt extension.
+                "isDefault": "**.txt" // This is a glob pattern which will only match when the active file has a .txt extension.
             }
         },
         {
@@ -183,7 +183,7 @@ Default build and test tasks can now be scoped to only be "default" when the act
             "command": "echo JavascriptFile",
             "group": {
                 "kind": "build",
-                "isDefault": "**.js" // This is a glob which will only match when the active file has a .js extension.
+                "isDefault": "**.js" // This is a glob pattern which will only match when the active file has a .js extension.
             },
         }
     ]

--- a/release-notes/v1_68.md
+++ b/release-notes/v1_68.md
@@ -158,6 +158,38 @@ The find match background work added a lot more flexibility in how the terminal 
 
 As a reminder, minimum contrast ratio can be disabled if you would prefer original colors by setting `"terminal.integrated.minimumContrastRatio": 1`.
 
+## Tasks
+
+### Glob for default tasks
+
+Default build and test tasks can now be scoped to only be "default" when the active file matches a file glob:
+
+```jsonc
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "echo txt",
+            "type": "shell",
+            "command": "echo TextFile",
+            "group": {
+                "kind": "build",
+                "isDefault": "**.txt" // This is a glob which will only match when the active file has a .txt extension.
+            }
+        },
+        {
+            "label": "echo js",
+            "type": "shell",
+            "command": "echo JavascriptFile",
+            "group": {
+                "kind": "build",
+                "isDefault": "**.js" // This is a glob which will only match when the active file has a .js extension.
+            },
+        }
+    ]
+}
+```
+
 ## Source Control
 
 There have been a few updates to the Git extension that align with our new [pull request flow](#using-pull-requests).


### PR DESCRIPTION
This was part of the 1.68 release, but I missed adding it to the release notes.