### PR TITLE
docs: remove example reference from faq section

### DIFF
--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -212,7 +212,7 @@ For bugs, feature requests or to contact an extension author, you should use the
 
 VS Code does a background check to detect if the installation has been changed on disk and if so, you will see the text **[Unsupported]** in the title bar. This is done since some extensions directly modify (patch) the VS Code product in such a way that is semi-permanent (until the next update) and this can cause hard to reproduce issues. We are not trying to block VS Code patching, but we want to raise awareness that patching VS Code means you are running an unsupported version. [Reinstalling VS Code](/download) will replace the modified files and silence the warning.
 
-You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software (see issue [#94858](https://github.com/microsoft/vscode/issues/94858) for an example). Check your anti-virus software settings and reinstall VS Code to repair the missing files.
+You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software. Check your anti-virus software settings and reinstall VS Code to repair the missing files.
 
 ## Resolving shell environment fails
 

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -212,7 +212,7 @@ For bugs, feature requests or to contact an extension author, you should use the
 
 VS Code does a background check to detect if the installation has been changed on disk and if so, you will see the text **[Unsupported]** in Help > About. This is done since some extensions directly modify (patch) the VS Code product in such a way that is semi-permanent (until the next update) and this can cause hard to reproduce issues. We are not trying to block VS Code patching, but we want to raise awareness that patching VS Code means you are running an unsupported version. [Reinstalling VS Code](/download) will replace the modified files and silence the warning.
 
-You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software. Check your anti-virus software (see issue [#94858](https://github.com/microsoft/vscode/issues/94858) for an example) settings and reinstall VS Code to repair the missing files.
+You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software (see issue [#94858](https://github.com/microsoft/vscode/issues/94858) for an example). Check your anti-virus software settings and reinstall VS Code to repair the missing files.
 
 ## Resolving shell environment fails
 

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -210,9 +210,9 @@ For bugs, feature requests or to contact an extension author, you should use the
 
 ## Installation appears to be corrupt [Unsupported]
 
-VS Code does a background check to detect if the installation has been changed on disk and if so, you will see the text **[Unsupported]** in the title bar. This is done since some extensions directly modify (patch) the VS Code product in such a way that is semi-permanent (until the next update) and this can cause hard to reproduce issues. We are not trying to block VS Code patching, but we want to raise awareness that patching VS Code means you are running an unsupported version. [Reinstalling VS Code](/download) will replace the modified files and silence the warning.
+VS Code does a background check to detect if the installation has been changed on disk and if so, you will see the text **[Unsupported]** in Help > About. This is done since some extensions directly modify (patch) the VS Code product in such a way that is semi-permanent (until the next update) and this can cause hard to reproduce issues. We are not trying to block VS Code patching, but we want to raise awareness that patching VS Code means you are running an unsupported version. [Reinstalling VS Code](/download) will replace the modified files and silence the warning.
 
-You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software. Check your anti-virus software settings and reinstall VS Code to repair the missing files.
+You may also see the **[Unsupported]** message if VS Code files have been mistakenly quarantined or removed by anti-virus software. Check your anti-virus software (see issue [#94858](https://github.com/microsoft/vscode/issues/94858) for an example) settings and reinstall VS Code to repair the missing files.
 
 ## Resolving shell environment fails
 


### PR DESCRIPTION
Example reference from https://code.visualstudio.com/docs/supporting/faq#_installation-appears-to-be-corrupt-unsupported removed. 
Fixes #5380