### PR TITLE
setup/linux.md: fix broken Nixpkgs link

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -115,7 +115,7 @@ To get more information about the installation from the AUR, please consult the 
 
 ### Nix package for NixOS (or any Linux distribution using Nix package manager)
 
-There is a community maintained [VS Code Nix package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/default.nix) in the nixpkgs repository. In order to install it using Nix, set `allowUnfree` option to true in your `config.nix` and execute:
+There is a community maintained [VS Code Nix package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/vscode.nix) in the nixpkgs repository. In order to install it using Nix, set `allowUnfree` option to true in your `config.nix` and execute:
 
 ```bash
 nix-env -i vscode


### PR DESCRIPTION
We moved to https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/vscode.nix in this [Nixpkgs pull request](https://github.com/NixOS/nixpkgs/pull/60423/commits/5c85979f78d4dee02cd0cb8be42f0953e7d71a18), let's update the Nixpkgs link to reflect the change.

Thanks for reviewing this!