### PR TITLE
Fixed typo

### DIFF
--- a/api/language-extensions/semantic-highlight-guide.md
+++ b/api/language-extensions/semantic-highlight-guide.md
@@ -163,7 +163,7 @@ In the example above, an extension declares a new type `templateType` and a new 
 }
 ```
 
-The `semanticTokenColors` value `#ff0011"` shown above applies to both `type` and all it's subtypes, including `templateType`.
+The `semanticTokenColors` value `"#ff0011"` shown above applies to both `type` and all it's subtypes, including `templateType`.
 
 Along with custom token types, extensions can define how these are mapped to TextMate scopes. This is described in the [Custom Mappings](#custom-textmate-scope-mappings) section. Note that custom mapping rules are not automatically inherited from the super type. Instead, subtypes need to redefine the mapping, preferably to more specific scopes.
 


### PR DESCRIPTION
Fixed a missing quote (perhaps a copy-paste mistake).
See images below.

Current:
<img width="762" alt="Screen Shot 2022-07-04 at 10 35 34 AM" src="https://user-images.githubusercontent.com/43240003/177175881-d958a2a5-4a18-4d4b-9929-f0dcb9229012.png">

Fix: 
<img width="733" alt="Screen Shot 2022-07-04 at 10 36 27 AM" src="https://user-images.githubusercontent.com/43240003/177176041-eda07c1a-bd24-478a-8a18-51ba82bbd4e3.png">
