### PR TITLE
Update linux.md

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -34,7 +34,7 @@ Installing the .deb package will automatically install the apt repository and si
 ```bash
 sudo apt-get install wget gpg
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings
+sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings
 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
 rm -f packages.microsoft.gpg
 ```

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -34,8 +34,8 @@ Installing the .deb package will automatically install the apt repository and si
 ```bash
 sudo apt-get install wget gpg
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
-sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
+sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings
+sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
 rm -f packages.microsoft.gpg
 ```
 


### PR DESCRIPTION
Place keyring in `/etc/apt/keyrings/` instead of `/etc/apt/trusted.gpg.d/`. This follows the official recommendation in https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-key.8.html#deprecation.