### PR TITLE
Fixed the release notes extension link

### DIFF
--- a/release-notes/v1_68.md
+++ b/release-notes/v1_68.md
@@ -777,7 +777,7 @@ Last but certainly not least, a big _**Thank You**_ to the contributors of VS Co
 
 Extension authors for enabling extensions that run code as [web extensions](https://code.visualstudio.com/api/extension-guides/web-extensions) (the list below is between May 2 and June 6, 2022):
 
-* [Pipeline Editor](https://marketplace.visualstudio.com/items?itemName=x) ([Alexey Volkov](https://marketplace.visualstudio.com/publishers/Cloud-pipelines))
+* [Pipeline Editor](https://marketplace.visualstudio.com/items?itemName=Cloud-pipelines.pipeline-editor-vscode) ([Alexey Volkov](https://marketplace.visualstudio.com/publishers/Cloud-pipelines))
 * [Markdown Base64 Image ID](https://marketplace.visualstudio.com/items?itemName=amoxuk.markdown-base64-replace-by-id) ([amoxuk](https://marketplace.visualstudio.com/publishers/amoxuk))
 * [Apache Daffodil VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ASF.apache-daffodil-vscode) ([Apache Software Foundation](https://marketplace.visualstudio.com/publishers/asf))
 * [Web Search](https://marketplace.visualstudio.com/items?itemName=BenRogersWPG.websearchengine) ([Ben Rogers](https://marketplace.visualstudio.com/publishers/BenRogersWPG))


### PR DESCRIPTION
See https://github.com/microsoft/vscode-docs/issues/5452