### PR TITLE
Various debugger UI updates

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -43,7 +43,7 @@ Follow these steps:
 
 2. While the default image for GitHub Codespaces should have all the needed prerequisites for most extensions, you can install any other required dependencies (for example, using `yarn install` or `sudo apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`).
 
-3. Finally, press `kb(workbench.action.debug.start)` or use the **Run view** to launch the extension inside in the codespace.
+3. Finally, press `kb(workbench.action.debug.start)` or use the **Run and Debug** view to launch the extension inside in the codespace.
 
     > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the codespace.
 
@@ -63,7 +63,7 @@ Follow these steps:
 
 5. Run `yarn install` or `npm install` in a new VS Code terminal window (`kb(workbench.action.terminal.new)`) to ensure the Linux versions Node.js native dependencies are installed. You can also install other OS or runtime dependencies, but you may want to add these to `.devcontainer/Dockerfile` as well so they are available if you rebuild the container.
 
-6. Finally, press `kb(workbench.action.debug.start)` or use the **Run view** to launch the extension inside this same container and attach the debugger.
+6. Finally, press `kb(workbench.action.debug.start)` or use the **Run and Debug** view to launch the extension inside this same container and attach the debugger.
 
     > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the container.
 
@@ -79,7 +79,7 @@ Follow steps:
 
 3. Install any required dependencies that might be missing (for example using `yarn install` or `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`).
 
-4. Finally, press `kb(workbench.action.debug.start)` or use the **Run view** to launch the extension inside on the remote host and attach the debugger.
+4. Finally, press `kb(workbench.action.debug.start)` or use the **Run and Debug** view to launch the extension inside on the remote host and attach the debugger.
 
     > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else on the SSH host.
 
@@ -97,7 +97,7 @@ Follow these steps:
 
 3. Install any required dependencies that might be missing (for example using `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`). You will at least want to run `yarn install` or `npm install` to ensure Linux versions of native Node.js dependencies are available.
 
-4. Finally, press `kb(workbench.action.debug.start)` or use the **Run view** to launch the extension and attach the debugger as you would locally.
+4. Finally, press `kb(workbench.action.debug.start)` or use the **Run and Debug** view to launch the extension and attach the debugger as you would locally.
 
     > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in WSL.
 

--- a/api/extension-guides/debugger-extension.md
+++ b/api/extension-guides/debugger-extension.md
@@ -82,9 +82,9 @@ To try Mock Debug:
 
 - Create a new empty folder `mock test` and open it in VS Code.
 - Create a file `readme.md` and enter several lines of arbitrary text.
-- Switch to the Run view and press the gear icon.
-- VS Code will let you select an "environment" in order to create a default launch configuration. Pick "Mock Debug".
-- Press the green Start button and then Enter to confirm the suggested file `readme.md`.
+- Switch to the Run and Debug view (`kb(workbench.view.debug)`) and select the **create a launch.json file** link.
+- VS Code will let you select an "debugger" in order to create a default launch configuration. Pick "Mock Debug".
+- Press the green **Start** button and then `kbstyle(Enter)` to confirm the suggested file `readme.md`.
 
 A debug session starts and you can "step" through the readme file, set and hit breakpoints, and run into exceptions (if the word `exception` appears in a line).
 
@@ -298,7 +298,7 @@ Since VS Code runs on different platforms, we have to make sure that the DA prog
 
 **configurationAttributes** declares the schema for the `launch.json` attributes that are available for this debugger. This schema is used for validating the `launch.json` and supporting IntelliSense and hover help when editing the launch configuration.
 
-The **initialConfigurations** define the initial content of the default `launch.json` for this debugger. This information is used when a project does not have a `launch.json` and a user starts a debug session or clicks on the gear icon in the Run view. In this case VS Code lets the user pick a debug environment and then creates the corresponding `launch.json`:
+The **initialConfigurations** define the initial content of the default `launch.json` for this debugger. This information is used when a project does not have a `launch.json` and a user starts a debug session or selects the **create a launch.json file** link in the Run and Debug view. In this case VS Code lets the user pick a debug environment and then creates the corresponding `launch.json`:
 
 ![Debugger Quickpick](images/debugger-extension/debug-init-config.png)
 

--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -66,7 +66,7 @@ Here are some ideas for things for you to try:
 
 ## Debugging the extension
 
-VS Code's built-in debugging functionality makes it easy to debug extensions. Set a breakpoint by clicking the gutter next to a line, and VS Code will hit the breakpoint. You can hover over variables in the editor or use the Run view in the left to check a variable's value. The Debug Console allows you to evaluate expressions.
+VS Code's built-in debugging functionality makes it easy to debug extensions. Set a breakpoint by clicking the gutter next to a line, and VS Code will hit the breakpoint. You can hover over variables in the editor or use the **Run and Debug** view in the left to check a variable's value. The Debug Console allows you to evaluate expressions.
 
 <video loop muted playsinline controls title="Debug VS Code extension video">
   <source src="/api/get-started/your-first-extension/debug.mp4" type="video/mp4">

--- a/api/language-extensions/language-server-extension-guide.md
+++ b/api/language-extensions/language-server-extension-guide.md
@@ -531,7 +531,7 @@ Debugging the client code is as easy as debugging a normal extension. Set a brea
 
 ![Debugging the client](images/language-server-extension-guide/debugging-client.png)
 
-Since the server is started by the `LanguageClient` running in the extension (client), we need to attach a debugger to the running server. To do so, switch to the Run view and select the launch configuration **Attach to Server** and press `kb(workbench.action.debug.start)`. This will attach the debugger to the server.
+Since the server is started by the `LanguageClient` running in the extension (client), we need to attach a debugger to the running server. To do so, switch to the **Run and Debug** view and select the launch configuration **Attach to Server** and press `kb(workbench.action.debug.start)`. This will attach the debugger to the server.
 
 ![Debugging the server](images/language-server-extension-guide/debugging-server.png)
 

--- a/api/references/icons-in-labels.md
+++ b/api/references/icons-in-labels.md
@@ -242,7 +242,7 @@ The ID of the icon identifies the location where the icon is used. The default c
 |<i class="codicon codicon-issues"></i>|remote-explorer-review-issues|issues|Review issue icon in the remote explorer view.|
 |<i class="codicon codicon-remote-explorer"></i>|remote-explorer-view-icon|remote-explorer|View icon of the remote explorer view.|
 |<i class="codicon codicon-chevron-up"></i>|review-comment-collapse|chevron-up|Icon to collapse a review comment.|
-|<i class="codicon codicon-debug-alt"></i>|run-view-icon|debug-alt|View icon of the run view.|
+|<i class="codicon codicon-debug-alt"></i>|run-view-icon|debug-alt|View icon of the Run and Debug view.|
 |<i class="codicon codicon-clear-all"></i>|search-clear-results|clear-all|Icon for clear results in the search view.|
 |<i class="codicon codicon-collapse-all"></i>|search-collapse-results|collapse-all|Icon for collapse results in the search view.|
 |<i class="codicon codicon-ellipsis"></i>|search-details|ellipsis|Icon to make search details visible.|

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -26,7 +26,7 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
    ![csharpPrompt](images/debug/csharp-prompt.png)
 
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and enter **Docker: Add Docker Files to Workspace...**. If you have already dockerized your app, you can instead do **Docker: Initialize for Docker debugging**. Follow the prompts.
-1. Switch to the Run view (`kb(workbench.view.debug)`).
+1. Switch to the **Run and Debug** view (`kb(workbench.view.debug)`).
 1. Select the **Docker .NET Core Launch** launch configuration.
 1. Optionally, set a breakpoint.
 1. Start debugging! (`kb(workbench.action.debug.start)`)

--- a/docs/cpp/config-clang-mac.md
+++ b/docs/cpp/config-clang-mac.md
@@ -217,7 +217,7 @@ Before you start stepping through the code, let's take a moment to notice severa
 
    ![Initial breakpoint](images/msvc/stopAtEntry.png)
 
-- The Run view on the left shows debugging information. You'll see an example later in the tutorial.
+- The **Run and Debug** view on the left shows debugging information. You'll see an example later in the tutorial.
 
 - At the top of the code editor, a debugging control panel appears. You can move this around the screen by grabbing the dots on the left side.
 

--- a/docs/cpp/config-linux.md
+++ b/docs/cpp/config-linux.md
@@ -215,7 +215,7 @@ Before you start stepping through the code, let's take a moment to notice severa
 
    ![Initial breakpoint](images/playbutton/breakpoint-debug.png)
 
-- The Run view on the left shows debugging information. You'll see an example later in the tutorial.
+- The **Run and Debug** view on the left shows debugging information. You'll see an example later in the tutorial.
 
 - At the top of the code editor, a debugging control panel appears. You can move this around the screen by grabbing the dots on the left side.
 

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -222,7 +222,7 @@ Before you start stepping through the code, let's take a moment to notice severa
 
    ![Initial breakpoint](images/playbutton/breakpoint-debug.png)
 
-- The Run view on the left shows debugging information. You'll see an example later in the tutorial.
+- The **Run and Debug** view on the left shows debugging information. You'll see an example later in the tutorial.
 
 - At the top of the code editor, a debugging control panel appears. You can move this around the screen by grabbing the dots on the left side.
 

--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -233,7 +233,7 @@ Before you start stepping through the code, let's take a moment to notice severa
 
    ![Initial breakpoint](images/playbutton/breakpoint-debug.png)
 
-- The Run view on the left shows debugging information. You'll see an example later in the tutorial.
+- The **Run and Debug** view on the left shows debugging information. You'll see an example later in the tutorial.
 
 - At the top of the code editor, a debugging control panel appears. You can move this around the screen by grabbing the dots on the left side.
 

--- a/docs/cpp/config-wsl.md
+++ b/docs/cpp/config-wsl.md
@@ -260,7 +260,7 @@ Before you start stepping through the code, let's take a moment to notice severa
 
    ![Initial breakpoint](images/playbutton/breakpoint-debug.png)
 
-- The Run view on the left shows debugging information. You'll see an example later in the tutorial.
+- The **Run and Debug** view on the left shows debugging information. You'll see an example later in the tutorial.
 
 - At the top of the code editor, a debugging control panel appears. You can move this around the screen by grabbing the dots on the left side.
 

--- a/docs/editor/accessibility.md
+++ b/docs/editor/accessibility.md
@@ -179,7 +179,7 @@ The VS Code debugger UI is user accessible and has the following features:
 
 * Changes in debug state are read out (for example 'started', 'breakpoint hit', 'terminated', ...).
 * All debug actions are keyboard accessible.
-* Both the Run view and Debug Console support Tab navigation.
+* Both the Run and Debug view and Debug Console support Tab navigation.
 * Debug hover is keyboard accessible (`kb(editor.action.showHover)`).
 * Keyboard shortcuts can be created to set focus to each debugger area.
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -32,13 +32,13 @@ The following documentation is based on the built-in [Node.js](https://nodejs.or
 
 It is helpful to first create a sample Node.js application before reading about debugging. You can follow the [Node.js walkthrough](/docs/nodejs/nodejs-tutorial.md) to install Node.js and create a simple "Hello World" JavaScript application (`app.js`). Once you have a simple application set up, this page will take you through VS Code debugging features.
 
-## Run view
+## Run and Debug view
 
-To bring up the Run view, select the Run icon in the **Activity Bar** on the side of VS Code. You can also use the keyboard shortcut `kb(workbench.view.debug)`.
+To bring up the **Run and Debug** view, select the **Run and Debug** icon in the **Activity Bar** on the side of VS Code. You can also use the keyboard shortcut `kb(workbench.view.debug)`.
 
-![Debug icon](images/debugging/run.png)
+![Run and Debug icon](images/debugging/run.png)
 
-The Run view displays all information related to running and debugging and has a top bar with debugging commands and configuration settings.
+The **Run and Debug** view displays all information related to running and debugging and has a top bar with debugging commands and configuration settings.
 
 If running and debugging is not yet configured (no `launch.json` has been created), VS Code shows the Run start view.
 
@@ -119,7 +119,7 @@ To add a new configuration to an existing `launch.json`, use one of the followin
 
 VS Code also supports compound launch configurations for starting multiple configurations at the same time; for more details, please read this [section](#compound-launch-configurations).
 
-In order to start a debug session, first select the configuration named **Launch Program** using the **Configuration dropdown** in the Run view. Once you have your launch configuration set, start your debug session with `kb(workbench.action.debug.start)`.
+In order to start a debug session, first select the configuration named **Launch Program** using the **Configuration dropdown** in the **Run and Debug** view. Once you have your launch configuration set, start your debug session with `kb(workbench.action.debug.start)`.
 
 Alternatively, you can run your configuration through the **Command Palette** (`kb(workbench.action.showCommands)`) by filtering on **Debug: Select and Start Debugging** or typing `'debug '` and selecting the configuration you want to debug.
 
@@ -127,7 +127,7 @@ As soon as a debugging session starts, the **DEBUG CONSOLE** panel is displayed 
 
 ![debug session](images/debugging/debug-session.png)
 
-In addition, the **debug status** appears in the Status Bar showing the active debug configuration. By selecting the debug status, a user can change the active launch configuration and start debugging without needing to open the Run view.
+In addition, the **debug status** appears in the Status Bar showing the active debug configuration. By selecting the debug status, a user can change the active launch configuration and start debugging without needing to open the **Run and Debug** view.
 
 ![Debug status](images/debugging/debug-status.png)
 
@@ -144,7 +144,7 @@ Once a debug session starts, the **Debug toolbar** will appear on the top of the
 * Restart `kb(workbench.action.debug.restart)`
 * Stop `kb(workbench.action.debug.stop)`
 
->**Tip**: Use the setting `debug.toolBarLocation` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the Run view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area.
+>**Tip**: Use the setting `debug.toolBarLocation` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the **Run and Debug** view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area.
 
 ### Run mode
 
@@ -154,7 +154,7 @@ In addition to debugging a program, VS Code supports **running** the program. Th
 
 ## Breakpoints
 
-Breakpoints can be toggled by clicking on the **editor margin** or using `kb(editor.debug.action.toggleBreakpoint)` on the current line. Finer breakpoint control (enable/disable/reapply) can be done in the Run view's **BREAKPOINTS** section.
+Breakpoints can be toggled by clicking on the **editor margin** or using `kb(editor.debug.action.toggleBreakpoint)` on the current line. Finer breakpoint control (enable/disable/reapply) can be done in the **Run and Debug** view's **BREAKPOINTS** section.
 
 * Breakpoints in the editor margin are normally shown as red filled circles.
 * Disabled breakpoints have a filled gray circle.
@@ -184,13 +184,13 @@ Just like regular breakpoints, Logpoints can be enabled or disabled and can also
 
 ## Data inspection
 
-Variables can be inspected in the **VARIABLES** section of the Run view or by hovering over their source in the editor. Variable values and expression evaluation are relative to the selected stack frame in the **CALL STACK** section.
+Variables can be inspected in the **VARIABLES** section of the **Run and Debug** view or by hovering over their source in the editor. Variable values and expression evaluation are relative to the selected stack frame in the **CALL STACK** section.
 
 ![Debug Variables](images/debugging/variables.png)
 
 Variable values can be modified with the **Set Value** action from the variable's context menu. Additionally, you can use the **Copy Value** action to copy the variable's value, or **Copy as Expression** action to copy an expression to access the variable.
 
-Variables and expressions can also be evaluated and watched in the Run view's **WATCH** section.
+Variables and expressions can also be evaluated and watched in the **Run and Debug** view's **WATCH** section.
 
 ![Debug Watch](images/debugging/watch.png)
 
@@ -531,6 +531,6 @@ To write your own debugger extension, visit:
 
 Debugging of Node.js-based applications is supported on Linux, macOS, and Windows out of the box with VS Code. Many other scenarios are supported by [VS Code extensions](https://marketplace.visualstudio.com/vscode/Debuggers?sortBy=Installs) available in the Marketplace.
 
-### I do not see any launch configurations in the Run view dropdown. What is wrong?
+### I do not see any launch configurations in the Run and Debug view dropdown. What is wrong?
 
 The most common problem is that you did not set up `launch.json` or there is a syntax error in that file. Alternatively, you might need to open a folder, since no-folder debugging does not support launch configurations.

--- a/docs/editor/images/debugging/run.png
+++ b/docs/editor/images/debugging/run.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8cc1b709f5b078cf54ab8e8b9e359cca46a02c30ba4327cda0bcd6d7dbe41e4
-size 3530
+oid sha256:6bb271a687c4a6720c65c4f201b33b1b999ca2f60c9cc463f351bfd3350cfb81
+size 13518

--- a/docs/introvideos/debugging.md
+++ b/docs/introvideos/debugging.md
@@ -10,7 +10,7 @@ MetaSocialImage: images/opengraph/introvideos.png
 ---
 # Debugging in Visual Studio Code
 
-Debugging is a core feature of Visual Studio Code. In this tutorial, we will show you how to run and debug a program in VS Code. We’ll take a tour of the Run View, explore some debugging features, and end by setting a breakpoint.
+Debugging is a core feature of Visual Studio Code. In this tutorial, we will show you how to run and debug a program in VS Code. We'll take a tour of the **Run and Debug** view, explore some debugging features, and end by setting a breakpoint.
 
 > **Tip:** To use the debugging features demonstrated in this video for Node.js, you will need to first install [Node.js](https://nodejs.org/en/). To follow along with the Python portion of the video, you'll need to install [Python](https://www.python.org/downloads/).
 

--- a/docs/java/java-tutorial.md
+++ b/docs/java/java-tutorial.md
@@ -106,7 +106,7 @@ To learn more about editing Java, see [Java Editing](/docs/java/java-editing.md)
 
 ## Running and debugging your program
 
-To run and debug Java code, set a breakpoint, then either press `kb(workbench.action.debug.start)` on your keyboard or use the **Run** > **Start Debugging** menu item. You can also use the **Run|Debug** CodeLens option in the editor. After the code compiles, you can see all your variables and threads in the Run view.
+To run and debug Java code, set a breakpoint, then either press `kb(workbench.action.debug.start)` on your keyboard or use the **Run** > **Start Debugging** menu item. You can also use the **Run|Debug** CodeLens option in the editor. After the code compiles, you can see all your variables and threads in the **Run and Debug** view.
 
 <video autoplay loop muted playsinline controls>
   <source src="/docs/java/java-tutorial/run-debug.mp4" type="video/mp4">

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -37,7 +37,7 @@ There are several ways to run Julia code within VS Code. You can run a Julia fil
 
 ## Debugging
 
-You can start debugging by opening the Julia file that you would like to debug. Then, select the Debug view on the Activity bar (as shown below):
+You can start debugging by opening the Julia file that you would like to debug. Then, select the **Run and Debug** view on the Activity bar (as shown below):
 
 ![Getting started debugging Julia code](images/julia/debug1.png)
 

--- a/docs/nodejs/angular-tutorial.md
+++ b/docs/nodejs/angular-tutorial.md
@@ -107,7 +107,7 @@ Once you save the `app.component.ts` file, the running instance of the server wi
 
 To debug the client side Angular code, we'll use the built-in JavaScript debugger.
 
->Note: This tutorial assumes you have the Edge browser installed. If you want to debug using Chrome, replace the launch `type` with `pwa-chrome`. There is also a debugger for the [Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug) browser.
+>Note: This tutorial assumes you have the Edge browser installed. If you want to debug using Chrome, replace the launch `type` with `chrome`. There is also a debugger for the [Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug) browser.
 
 ### Set a breakpoint
 
@@ -117,7 +117,7 @@ To set a breakpoint in `app.component.ts`, click on the gutter to the left of th
 
 ### Configure the debugger
 
-We need to initially configure the [debugger](/docs/editor/debugging.md). To do so, go to the Run view (`kb(workbench.view.debug)`) and click on the gear button or **Create a launch.json** link to create a `launch.json` debugger configuration file. Choose **Edge: launch** from the **Select Environment** dropdown list. This will create a `launch.json` file in a new `.vscode` folder in your project which includes a configuration to launch the website.
+We need to initially configure the [debugger](/docs/editor/debugging.md). To do so, go to the **Run and Debug** view (`kb(workbench.view.debug)`) and select the **create a launch.json file** link to create a `launch.json` debugger configuration file. Choose **Web App (Edge)** from the **Select debugger** dropdown list. This will create a `launch.json` file in a new `.vscode` folder in your project which includes a configuration to launch the website.
 
 We need to make one change for our example: change the port of the `url` from `8080` to `4200`. Your `launch.json` should look like this:
 
@@ -126,7 +126,7 @@ We need to make one change for our example: change the port of the `url` from `8
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "name": "Launch Edge against localhost",
             "url": "http://localhost:4200",

--- a/docs/nodejs/browser-debugging.md
+++ b/docs/nodejs/browser-debugging.md
@@ -43,7 +43,7 @@ In most cases, you'll want to start a new instance of the browser to debug your 
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-msedge",
+      "type": "msedge",
       "request": "launch",
       "name": "Launch my cool app",
       "url": "http://localhost:8000"
@@ -52,7 +52,7 @@ In most cases, you'll want to start a new instance of the browser to debug your 
 }
 ```
 
-When you hit `kb(workbench.action.debug.start)` or the **Start** button in the Debug view, `http://localhost:8000` will be opened in debug mode. If you'd like to use Chrome instead of Edge, replace `pwa-msedge` with `pwa-chrome`.
+When you hit `kb(workbench.action.debug.start)` or the **Start** button in the **Run and Debug** view, `http://localhost:8000` will be opened in debug mode. If you'd like to use Chrome instead of Edge, replace `msedge` with `chrome`.
 
 You can also debug a single file without running a server, for example:
 
@@ -61,7 +61,7 @@ You can also debug a single file without running a server, for example:
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-msedge",
+      "type": "msedge",
       "request": "launch",
       "name": "Launch hello.html",
       "file": "${workspaceFolder}/hello.html"
@@ -87,7 +87,7 @@ Next, add a new section to the `vscode/launch.json` file as below:
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-msedge",
+      "type": "msedge",
       "request": "attach",
       "name": "Attach to browser",
       "port": 9222
@@ -96,7 +96,7 @@ Next, add a new section to the `vscode/launch.json` file as below:
 }
 ```
 
-Now, you can press `kb(workbench.action.debug.start)` or the **Start** button in the Debug view to attach to the running browser. You can even add a `host` property to debug a browser running on a different machine.
+Now, you can press `kb(workbench.action.debug.start)` or the **Start** button in the **Run and Debug** view to attach to the running browser. You can even add a `host` property to debug a browser running on a different machine.
 
 ## Launch configuration attributes
 

--- a/docs/nodejs/images/nodejs/debugicon.png
+++ b/docs/nodejs/images/nodejs/debugicon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:793ff3bab5901b01788fd8a2248b9f450ffb34a611dc3de62f15530a28d866f0
-size 1897
+oid sha256:c6aead9e4ed9e71de2cc860564181ec60d4767b11d43f0e715f501e1a04b3858
+size 7897

--- a/docs/nodejs/images/nodejs/hello-world-debugging.png
+++ b/docs/nodejs/images/nodejs/hello-world-debugging.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:567fdf3bd20d238ef36760895961402e4e04671582345fcda829e63881dde0c4
-size 53716
+oid sha256:1342d22aa854e3a698ddabbca529060dee6ee75b07ea5378fa12761c63f6963a
+size 166079

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -471,7 +471,7 @@ By default, VS Code will stream the debugged source from the remote Node.js fold
 
 ## Access Loaded Scripts
 
-If you need to set a breakpoint in a script that is not part of your workspace and therefore cannot be easily located and opened through normal VS Code file browsing, you can access the loaded scripts via the **LOADED SCRIPTS** view in the Run view:
+If you need to set a breakpoint in a script that is not part of your workspace and therefore cannot be easily located and opened through normal VS Code file browsing, you can access the loaded scripts via the **LOADED SCRIPTS** view in the **Run and Debug** view:
 
 ![Loaded Scripts Explorer](images/nodejs-debugging/loaded-scripts-explorer.gif)
 

--- a/docs/nodejs/nodejs-tutorial.md
+++ b/docs/nodejs/nodejs-tutorial.md
@@ -91,7 +91,7 @@ To set a breakpoint in `app.js`, put the editor cursor on the first line and pre
 
 ![app.js breakpoint set](images/nodejs/app-js-breakpoint-set.png)
 
-To start debugging, select the Run View in the Activity Bar:
+To start debugging, select the **Run and Debug** view in the Activity Bar:
 
 ![Run icon](images/nodejs/debugicon.png)
 
@@ -170,7 +170,7 @@ You can also write code that references modules in other files. For example, in 
 
 ## Debug your Express app
 
-You will need to create a debugger configuration file `launch.json` for your Express application. Click on the Run icon in the **Activity Bar** and then the Configure gear icon at the top of the Run view to create a default `launch.json` file.  Select the **Node.js** environment by ensuring that the `type` property in `configurations` is set to `"node"`.  When the file is first created, VS Code will look in `package.json` for a `start` script and will use that value as the `program` (which in this case is `"${workspaceFolder}\\bin\\www`) for the **Launch Program** configuration.
+You will need to create a debugger configuration file `launch.json` for your Express application. Click on **Run and Debug** in the **Activity Bar** (`kb(workbench.view.debug)`) and then select the **create a launch.json file** link to create a default `launch.json` file.  Select the **Node.js** environment by ensuring that the `type` property in `configurations` is set to `"node"`.  When the file is first created, VS Code will look in `package.json` for a `start` script and will use that value as the `program` (which in this case is `"${workspaceFolder}\\bin\\www`) for the **Launch Program** configuration.
 
 ```json
 {
@@ -186,7 +186,7 @@ You will need to create a debugger configuration file `launch.json` for your Exp
 }
 ```
 
-Save the new file and make sure **Launch Program** is selected in the configuration dropdown at the top of the Run view. Open `app.js` and set a breakpoint near the top of the file where the Express app object is created by clicking in the gutter to the left of the line number. Press `kb(workbench.action.debug.start)` to start debugging the application. VS Code will start the server in a new terminal and hit the breakpoint we set. From there you can inspect variables, create watches, and step through your code.
+Save the new file and make sure **Launch Program** is selected in the configuration dropdown at the top of the **Run and Debug** view. Open `app.js` and set a breakpoint near the top of the file where the Express app object is created by clicking in the gutter to the left of the line number. Press `kb(workbench.action.debug.start)` to start debugging the application. VS Code will start the server in a new terminal and hit the breakpoint we set. From there you can inspect variables, create watches, and step through your code.
 
 ![Debug session](images/nodejs/debugsession.png)
 

--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -111,7 +111,7 @@ Once you save the `index.js` file, the running instance of the server will updat
 
 To debug the client side React code, we'll use the built-in JavaScript debugger.
 
->Note: This tutorial assumes you have the Edge browser installed. If you want to debug using Chrome, replace the launch `type` with `pwa-chrome`. There is also a debugger for the [Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug) browser.
+>Note: This tutorial assumes you have the Edge browser installed. If you want to debug using Chrome, replace the launch `type` with `chrome`. There is also a debugger for the [Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug) browser.
 
 ### Set a breakpoint
 
@@ -121,7 +121,7 @@ To set a breakpoint in `index.js`, click on the gutter to the left of the line n
 
 ### Configure the debugger
 
-We need to initially configure the [debugger](/docs/editor/debugging.md). To do so, go to the Run view (`kb(workbench.view.debug)`) and click on the gear button or **Create a launch.json** link to create a `launch.json` debugger configuration file. Choose **Edge: launch** from the **Select Environment** dropdown list. This will create a `launch.json` file in a new `.vscode` folder in your project which includes a configuration to launch the website.
+We need to initially configure the [debugger](/docs/editor/debugging.md). To do so, go to the **Run and Debug** view (`kb(workbench.view.debug)`) and select the **create a launch.json file** link to create a `launch.json` debugger configuration file. Choose **Web App (Edge)** from the **Select debugger** dropdown list. This will create a `launch.json` file in a new `.vscode` folder in your project which includes a configuration to launch the website.
 
 We need to make one change for our example: change the port of the `url` from `8080` to `3000`. Your `launch.json` should look like this:
 
@@ -130,7 +130,7 @@ We need to make one change for our example: change the port of the `url` from `8
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "name": "Launch Edge against localhost",
             "url": "http://localhost:3000",

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -177,7 +177,7 @@ There may be instances where you need to debug a Python script that's invoked lo
 
 1. In the terminal, start Python with the script, for example, `python3 myscript.py`. You should see the "Waiting for debugger attach" message that's included in the code, and the script halts at the `debugpy.wait_for_client()` call.
 
-1. Switch to the Run view, select the appropriate configuration from the debugger dropdown list, and start the debugger.
+1. Switch to the **Run and Debug** view (`kb(workbench.view.debug)`), select the appropriate configuration from the debugger dropdown list, and start the debugger.
 
 1. The debugger should stop on the `debugpy.breakpoint()` call, from which point you can use the debugger normally. You also have the option of setting other breakpoints in the script code using the UI instead of using `debugpy.breakpoint()`.
 
@@ -269,7 +269,7 @@ Now that an SSH tunnel has been set up to the remote computer, you can begin you
     #debugpy.wait_for_client()
     ```
 
-1. Local computer: switch to the Run view in VS Code, select the **Python: Attach** configuration
+1. Local computer: switch to the **Run and Debug** view (`kb(workbench.view.debug)`) in VS Code, select the **Python: Attach** configuration
 
 1. Local computer: set a breakpoint in the code where you want to start debugging.
 

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -312,7 +312,7 @@ Debugging gives you the opportunity to pause a running program on a particular l
     'Friday, 07 September, 2018 at 07:46:32'
     ```
 
-    > **Tip**: The **Debug Console** also shows exceptions from within the app that may not appear in the terminal. For example, if you see a "Paused on exception" message in the **Call Stack** area of Run view, switch to the **Debug Console** to see the exception message.
+    > **Tip**: The **Debug Console** also shows exceptions from within the app that may not appear in the terminal. For example, if you see a "Paused on exception" message in the **Call Stack** area of **Run and Debug** view, switch to the **Debug Console** to see the exception message.
 
 1. Copy that line into the > prompt at the bottom of the debug console, and try changing the formatting:
 

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -262,7 +262,7 @@ Debugging gives you the opportunity to pause a running program on a particular l
     'Wednesday, 31 October, 2018 at 18:13:39'
     ```
 
-    > **Tip**: The **Debug Console** also shows exceptions from within the app that may not appear in the terminal. For example, if you see a "Paused on exception" message in the **Call Stack** area of Run view, switch to the **Debug Console** to see the exception message.
+    > **Tip**: The **Debug Console** also shows exceptions from within the app that may not appear in the terminal. For example, if you see a "Paused on exception" message in the **Call Stack** area of **Run and Debug** view, switch to the **Debug Console** to see the exception message.
 
 1. Copy that line into the > prompt at the bottom of the debug console, and try changing the formatting:
 

--- a/docs/typescript/typescript-debugging.md
+++ b/docs/typescript/typescript-debugging.md
@@ -31,9 +31,7 @@ For a simple example of source maps in action, see the [TypeScript tutorial](/do
 }
 ```
 
-For more advanced debugging scenarios, you can create your own debug configuration `launch.json` file. To see the default configuration, go to the Run view (`kb(workbench.view.debug)`) and press the gear icon or **Create a launch.json** link to **Configure or Fix 'launch.json'**.
-
-![configure launch.json](images/debugging/configure-debugging.png)
+For more advanced debugging scenarios, you can create your own debug configuration `launch.json` file. To see the default configuration, go to the **Run and Debug** view (`kb(workbench.view.debug)`) and select the **create a launch.json file** link. This will create a `launch.json` file in a `.vscode` folder with default values detected in your project.
 
 This will create a `launch.json` file in a `.vscode` folder with default values detected in your project.
 
@@ -112,7 +110,7 @@ tsconfig.json
 
 Run `tsc` to build the app and then test by opening `helloweb.html` in your browser (you can right-click `helloweb.html` in the File Explorer and select **Copy Path** to paste into your browser).
 
-In the Run view, press the gear icon to create a `launch.json` file selecting **Edge: launch** as the debugger, or **Chrome** if you prefer.
+In the Run and Debug view (`kb(workbench.view.debug)`), select **create a launch.json file** to create a `launch.json` file selecting **Web App (Edge)** as the debugger, or **Web App (Chrome)** if you prefer.
 
 Update the `launch.json` to specify the local file URL to `helloweb.html`:
 
@@ -121,17 +119,17 @@ Update the `launch.json` to specify the local file URL to `helloweb.html`:
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "pwa-msedge",
+            "type": "msedge",
             "request": "launch",
             "name": "Launch Edge against localhost",
-            "url": "file:///C:/Users/username/deleteMe/HelloWeb/helloweb.html",
+            "url": "file:///C:/Users/username/HelloWeb/helloweb.html",
             "webRoot": "${workspaceFolder}"
         }
     ]
 }
 ```
 
-The Run view configuration dropdown will now show the new configuration **Launch Edge against localhost**. If you run that configuration, your browser will launch with your web page. Open `helloweb.ts` in the editor and click the left gutter to add a breakpoint (it will be displayed as a red circle). Press `kb(workbench.action.debug.start)` to start the debug session, which launches the browser and hits your breakpoint in `helloweb.ts`.
+The **Run and Debug** view configuration dropdown will now show the new configuration **Launch Edge against localhost**. If you run that configuration, your browser will launch with your web page. Open `helloweb.ts` in the editor and click the left gutter to add a breakpoint (it will be displayed as a red circle). Press `kb(workbench.action.debug.start)` to start the debug session, which launches the browser and hits your breakpoint in `helloweb.ts`.
 
 ![client-side debug breakpoint](images/debugging/client-side-debug-breakpoint.png)
 

--- a/docs/typescript/typescript-tutorial.md
+++ b/docs/typescript/typescript-tutorial.md
@@ -152,7 +152,7 @@ The debugger will start a session, run your code, and display the "Hello World" 
 
 ![debug console output](images/tutorial/debug-console.png)
 
-In `helloworld.ts`, set a breakpoint by clicking on the left gutter of the editor. You will see a red circle if the breakpoint is set. Press `kb(workbench.action.debug.start)` again. Execution will stop when the breakpoint is hit and you'll be able to see debugging information such as variable values and the call stack in the Run view (`kb(workbench.view.debug)`).
+In `helloworld.ts`, set a breakpoint by clicking on the left gutter of the editor. You will see a red circle if the breakpoint is set. Press `kb(workbench.action.debug.start)` again. Execution will stop when the breakpoint is hit and you'll be able to see debugging information such as variable values and the call stack in the **Run and Debug** view (`kb(workbench.view.debug)`).
 
 ![debug breakpoint](images/tutorial/debug-breakpoint.png)
 


### PR DESCRIPTION
View is now called "Run and Debug"
"create a launch.json file" link instead of Gear icon if no launch.json is detected
Couple of stale screenshot update
Edge: launch -> Web App (Edge), Chrome: launch -> Web App (Chrome)
pwa-msedge -> msedge, pws-chrome -> chrome