### PR TITLE
Fix a broken hyperlink for "Language-specific editor settings"

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -99,7 +99,7 @@ Here are some of the filters available:
 * `@ext` - Settings specific to an extension. You provide the extension ID such as `@ext:ms-python.python`.
 * `@feature` - Settings specific to a **Features** subgroup. For example, `@feature:explorer` shows settings of the File Explorer.
 * `@id` - Find a setting based on the setting ID. For example, `@id:workbench.activityBar.visible`.
-* `@lang` - Apply a language filter based on a language ID. For example, `@lang:typescript`. See [Language-specific editor settings](#language-specific-editor-settings) for more details.
+* `@lang` - Apply a language filter based on a language ID. For example, `@lang:typescript`. See [Language-specific editor settings](#languagespecific-editor-settings) for more details.
 * `@tag` - Settings specific to a system of VS Code. For example, `@tag:workspaceTrust` for settings related to [Workspace Trust](/docs/editor/workspace-trust.md)
 
 The Search bar remembers your settings search queries and supports Undo/Redo (`kb(undo)`/`kb(redo)`). You can quickly clear a search term or filter with the **Clear Settings Search Input** button at the right of the Search bar.


### PR DESCRIPTION
In [this section](https://code.visualstudio.com/docs/getstarted/settings#_other-filters) of the docs, there's a broken hyperlink to "Language-specific editor settings".
The link points to  https://code.visualstudio.com/docs/getstarted/settings#_language-specific-editor-settings
The correct link is https://code.visualstudio.com/docs/getstarted/settings#_languagespecific-editor-settings