### PR TITLE
Update devcontainer-cli topic for new CLI

### DIFF
--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -296,9 +296,9 @@ The **Remote-Containers: Configure Container Features** command allows you to up
 
 We recommend pre-building images with the tools you need rather than creating and building a container image each time you open your project in a dev container. Using pre-built images will result in a faster container startup,  simpler configuration, and allows you to pin to a specific version of tools to improve supply-chain security and avoid potential breaks. You can automate pre-building your image by scheduling the build using a DevOps or continuous integration (CI) service like GitHub Actions.
 
-We recommend using the [VS Code devcontainer CLI](/docs/remote/devcontainer-cli.md) to pre-build your images since it is kept in sync with the Remote - Container extension's latest capabilities - including [dev container features](#dev-container-features-preview). Once you've built your image, you can push it to a container registry (like the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images), or [Docker Hub](https://docs.docker.com/engine/reference/commandline/push)) and reference it directly.
+We recommend using the [devcontainer CLI](/docs/remote/devcontainer-cli.md) to pre-build your images since it is kept in sync with the Remote - Container extension's latest capabilities - including [dev container features](#dev-container-features-preview). Once you've built your image, you can push it to a container registry (like the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images), or [Docker Hub](https://docs.docker.com/engine/reference/commandline/push)) and reference it directly.
 
-See the [VS Code devcontainer CLI article on pre-building images](/docs/remote/devcontainer-cli.md#building-a-dev-container-image) for more information.
+See the [devcontainer CLI article on pre-building images](/docs/remote/devcontainer-cli.md#building-a-dev-container-image) for more information.
 
 ## Inspecting volumes
 
@@ -701,7 +701,7 @@ The following articles may help answer your question:
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
 * Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
-* Help [shape the direction](https://github.com/microsoft/dev-container-spec) of development containers and the dev container CLI.
+* Help [shape the direction](https://github.com/devcontainers/spec) of development containers and the dev container CLI.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -701,7 +701,7 @@ The following articles may help answer your question:
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
 * Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
-* Help [shape the direction](https://github.com/devcontainers/spec) of development containers and the dev container CLI.
+* Review and provide feedback on the [Development Containers Specification](https://github.com/devcontainers/spec).
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.
 

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -1,220 +1,140 @@
 ---
-Order: 13
+Order: 14
 Area: remote
 TOCTitle: devcontainer CLI
 PageTitle: Installing and working with the devcontainer CLI
 ContentId: 8946213d-716e-41ca-955f-944a41c70353
-MetaDescription: Documentation on using the VS Code development container (devcontainer) command line interface with the Visual Studio Code Remote - Containers extension
+MetaDescription: Documentation on using the development container (devcontainer) command-line interface
 DateApproved: 7/7/2022
 ---
 # Development container CLI
 
-When we refer to a command line interface (CLI) for development containers, there are two varieties:
+This topic covers the development container command-line interface (devcontainer CLI), which allows you to build and manage development containers, and is a companion to the [Development Containers Specification](https://containers.dev).
 
-* "dev container CLI" - A reference implementation for the open dev container specification. The [current proposal](https://github.com/microsoft/dev-container-spec/issues/9) is to make a CLI available that can take a `devcontainer.json` and create and configure a development container from it. It could be available in any IDE or editor.
-* "Visual Studio Code `devcontainer` CLI" - A CLI that can be installed and used via the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or through an external terminal.
+## Development containers
 
-The former is in-progress. The latter, VS Code `devcontainer` CLI, is available today and the focus of this document.
+A consistent, predictable environment is key to a productive and enjoyable software development experience.
 
-## Visual Studio Code devcontainer CLI
+Containers (such as [Docker](https://www.docker.com)) have historically been used to standardize apps when they're deployed, but there's a great opportunity to support additional scenarios, including continuous integration (CI), test automation, and full-featured coding environments. A **development container** provides this working environment and ensures your project has the tools and software it needs, whether it's complex and distributed or just has a few requirements.
 
-Given the growing number of use cases for dev containers, there is a companion `devcontainer` CLI that can be used independent of the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or GitHub Codespaces. This article will walk you through its installation and how to use it in different scenarios.
+![Diagram comparing dev versus production containers](images/devcontainer-cli/dev-container-stages.png)
+
+Develop containers are supported in Visual Studio Code via the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and in [GitHub Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers). This support is backed by [devcontainer.json](/docs/remote/devcontainerjson-reference.md), a structured JSON with Comments (jsonc) metadata format to configure a containerized environment.
+
+As containerizing production workloads becomes commonplace, dev containers have become broadly useful for scenarios beyond VS Code. To promote dev containers, work has started on the [Development Containers Specification](https://github.com/devcontainers/spec), which empowers anyone in any tool to configure a consistent dev environment. As a companion to the specification, there is the open-source **dev container CLI**.
+
+## The dev container CLI
+
+The dev container CLI is a reference implementation for the dev container specification.
+
+When tools like VS Code and Codespaces detect a `devcontainer.json` file in a user's project, they use a CLI to configure a dev container. The devcontainer CLI is a reference implementation so that individual users and other tools can read in `devcontainer.json` metadata and create dev containers from it.
+
+This CLI can either be used directly or integrated into product experiences, similar to how it's integrated with Remote - Containers and Codespaces today. It currently supports both a simple single container option and integrates with [Docker Compose](https://docs.docker.com/compose/) for multi-container scenarios.
+
+The CLI is available for review in a new [devcontainers/cli](https://github.com/devcontainers/cli) repository and you can read more about its development in [this issue in the spec repo](https://github.com/devcontainers/spec/issues/9).
 
 ## System requirements
 
 To use the VS Code `devcontainer` CLI, you'll need the following on your system or CI/DevOps environment:
 
-1. [Node.js 14+](https://nodejs.org).
+1. [Node.js (version 14 or greater)](https://nodejs.org).
 1. [The `docker` CLI](/docs/remote/containers#installation).
+1. [Python](https://www.python.org/downloads)
+1. C/C++ compiler
+
+The VS Code [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-Contribute) wiki has details about the recommended toolsets.
 
 ## Installation
 
-### Install using VS Code
+You can try out the devcontainer CLI, either by installing its npm package or building the CLI repo from sources.
 
-1. Ensure you have the latest version of the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed (must be at least `v0.188.0`).
+To learn more about building the CLI from sources, go to the [CLI repo's README](https://github.com/devcontainers/cli#try-it-out).
 
-2. Launch Visual Studio Code and select  **Remote-Containers: Install devcontainer CLI** from the Command Palette (`kbstyle(F1)`).
-
-    ![The "Install devcontainer CLI" command](images/devcontainer-cli/install.png)
-
-* **Windows**: You will be prompted to automatically add the devcontainer CLI to your `PATH` or to copy the devcontainer CLI path to your clipboard for you to add to your `PATH`.
-* **macOS/Linux**: If the extension detects a `bin` folder (or `.local/bin` folder) in your user home folder and in your `PATH`, then you will have the option of adding a symlink to the devcontainer CLI to this location. You will also have the option to copy the devcontainer CLI path to your clipboard for you to add to your `PATH`.
-
-3. From an external terminal (one not inside Visual Studio Code), run `devcontainer --help` to test the installation and see the CLI's built-in help. Note that you may need to restart your shell for `PATH` changes to take effect.
-
-    ```bash
-    $ devcontainer --help
-    devcontainer <command>
-
-    Commands:
-      devcontainer open [path]   Open a dev container in VS Code
-      devcontainer build [path]  Build a dev container image
-
-    Options:
-      -h, --help               Show help  [boolean]
-          --disable-telemetry  Disable telemetry  [boolean] [default: false]
-    ```
-
-### Install from the command line
-
-You may also install the CLI from the command line. Currently this doesn't support the command `devcontainer open [path]`.
-
-Global install:
+### npm install
 
 ```bash
-npm install -g @vscode/dev-container-cli
-devcontainer --help
+npm install -g @devcontainers/cli
 ```
 
-Local install:
+Verify you can run the CLI and see its help text:
 
 ```bash
-npm install @vscode/dev-container-cli
-npx @vscode/dev-container-cli --help
+devcontainer <command>
+
+Commands:
+  devcontainer up                   Create and run dev container
+  devcontainer build [path]         Build a dev container image
+  devcontainer run-user-commands    Run user commands
+  devcontainer read-configuration   Read configuration
+  devcontainer exec <cmd> [args..]  Execute a command on a running dev container
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 
-## Opening a folder directly within a dev container
+## Running the CLI
 
-Visual Studio Code has many [command line options](/docs/editor/command-line.md), including `code .` that opens Visual Studio Code with the current folder. When you do this with a folder containing a dev container, Visual Studio Code will prompt you to reopen the folder within a dev container.
+Once you have the CLI, you can try it out with a sample project, like this [Rust sample](https://github.com/microsoft/vscode-remote-try-rust).
 
-![Prompt to reopen folder within a dev container](images/devcontainer-cli/reopen-in-container.png)
+Clone the Rust sample to your machine, and start a dev container with the CLI's `up` command:
 
-With the VS Code `devcontainer` CLI, you can use the `devcontainer open` command to open the current folder straight into dev container mode, skipping the prompt.
-
-You can optionally specify the path to the folder to open, for example `devcontainer open /source/my-folder` to open the `/source/my-folder` folder within a dev container.
-
-## Building a dev container image
-
-The `devcontainer build` command allows you to quickly build dev container images following the same steps as the Remote - Containers extension or GitHub Codespaces. This is useful when you want to pre-build a dev container image using a CI or DevOps product like GitHub Actions.
-
-As with the `open` command, `build` accepts a path to the folder containing a `.devcontainer` folder or `.devcontainer.json` file. If omitted, the current working folder is used. For example, `devcontainer build` will build the dev container image for the current folder and `devcontainer build /source/my-folder` will build the container image for the `/source/my-folder` folder.
-
-### Example of building and publishing an image
-
-For example, you may want to pre-build several images that you then reuse across multiple projects or repositories. To do so, follow these steps:
-
-1. [Create](/docs/editor/versioncontrol.md#initialize-a-repository) a source code repository.
-
-1. Create a dev container configuration for each image you want to pre-build, customizing as you wish (including [dev container features](/docs/remote/containers.md#dev-container-features-preview)). For example, consider this `devcontainer.json` file:
-
-    ```json
-    {
-        "build": {
-            "dockerfile": "Dockerfile"
-        },
-        "features": {
-            "docker-in-docker": "latest"
-        }
-    }
-    ```
-
-1. Use the `devcontainer build` command to build the image. See documentation for your image registry (like the [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-get-started-docker-cli?tabs=azure-cli), [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images), or [Docker Hub](https://docs.docker.com/engine/reference/commandline/push)) for information on image naming and additional steps like authentication.
-
-    ```bash
-    devcontainer build \
-        --image-name ghcr.io/your-org/your-repo/your-image-name \
-        change-me-to-repository-folder-with-dot-devcontainer
-    ```
-
-1. Next [push](https://docs.docker.com/engine/reference/commandline/push/) the image to your registry.
-
-    ```bash
-    docker push ghcr.io/your-org/your-image-name
-    ```
-
-1. Finally, for each project or repository that will use your image, craft a simplified `devcontainer.json` file that either uses the `image` property or references it in a Docker Compose file. Include any dev container features you added in your pre-build configuration in step 2. For example:
-
-    ```json
-    {
-        "image": "ghcr.io/your-org/your-image-name",
-        "features": {
-            "docker-in-docker": "latest"
-        }
-    }
-    ```
-
-That's it!
-
-### Adding automation
-
-Steps to automate pre-building your image will vary by CI/DevOps system, but here's an example GitHub Actions workflow that will automate the process for a subfolder called `change-me` and push it to GitHub Container Registry once a month and whenever the dev container folder is modified in the `main` branch:
-
-```yaml
-name: Generate Dev Container Image
-on:
-  schedule:
-    - cron: '0 0 1 * *'
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'change-me/.devcontainer/**/*'
-permissions:
-  contents: read
-  packages: write
-jobs:
-  devcontainer:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -e
-
-          # Update this based on your image name and the path of the .devcontainer folder in your repository
-          FOLDER_WITH_DOT_DEVCONTAINER="change-me"
-          IMAGE_NAME="your-image-name"
-          IMAGE_REPOSITORY="$(echo "ghcr.io/$\{{ github.repository_owner }}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
-
-          # [Optional] Enable buildkit, set output to plain text for logging
-          export DOCKER_BUILDKIT=1
-          export BUILDKIT_PROGRESS=plain
-
-          # Do the build - update
-          npm install -g "@vscode/dev-container-cli"
-          devcontainer build --no-cache --image-name "${IMAGE_REPOSITORY}" "${FOLDER_WITH_DOT_DEVCONTAINER}"
-
-          # Push image to GitHub Container Registry
-          echo "$\{{ github.token }}" | docker login ghcr.io -u "$\{{ github.actor }}" --password-stdin
-          docker push "${IMAGE_REPOSITORY}"
+```bash
+git clone https://github.com/microsoft/vscode-remote-try-rust
+devcontainer up --workspace-folder <path-to-vscode-remote-try-rust>
 ```
 
-### CLI build options
+This will download the container image from a container registry and start the container. Your Rust container should now be running:
 
-The following options can be used with the `build` command:
-
-* `--no-cache` : By default, building a Docker container image reuses layers from previous image builds. The `--no-cache` option prevents the cache being used and forces the image to be rebuilt.
-* `--image-name` : The Remote - Containers extension typically determines its own name for the images it builds. You can specify the name to use for the built image using the `--image-name` option.
-
-You can also type `devcontainer build --help` to see a full list of available options.
-
-### **Optional:** Avoiding problems with images built using Docker
-
-Given Dockerfiles and Docker Compose files can be used without VS Code or the VS Code `devcontainer` CLI, you may want to let users know that they should not try to build the image directly if it will not work as expected. To solve this problem, you can add a build argument that needs to be specified for things to work.
-
-For example, you could add the following to your Dockerfile:
-
-```Dockerfile
-ARG vscode
-RUN if [[ -z "$vscode" ]] ; then printf "\nERROR: This Dockerfile needs to be built with VS Code !" && exit 1; else printf "VS Code is detected: $vscode"; fi
+```bash
+[88 ms] dev-containers-cli 0.1.0.
+[165 ms] Start: Run: docker build -f /home/node/vscode-remote-try-rust/.devcontainer/Dockerfile -t vsc-vscode-remote-try-rust-89420ad7399ba74f55921e49cc3ecfd2 --build-arg VARIANT=bullseye /home/node/vscode-remote-try-rust/.devcontainer
+[+] Building 0.5s (5/5) FINISHED
+ => [internal] load build definition from Dockerfile                       0.0s
+ => => transferring dockerfile: 38B                                        0.0s
+ => [internal] load .dockerignore                                          0.0s
+ => => transferring context: 2B                                            0.0s
+ => [internal] load metadata for mcr.microsoft.com/vscode/devcontainers/r  0.4s
+ => CACHED [1/1] FROM mcr.microsoft.com/vscode/devcontainers/rust:1-bulls  0.0s
+ => exporting to image                                                     0.0s
+ => => exporting layers                                                    0.0s
+ => => writing image sha256:39873ccb81e6fb613975e11e37438eee1d49c963a436d  0.0s
+ => => naming to docker.io/library/vsc-vscode-remote-try-rust-89420ad7399  0.0s
+[1640 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/home/node/vscode-remote-try-rust,target=/workspaces/vscode-remote-try-rust -l devcontainer.local_folder=/home/node/vscode-remote-try-rust --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --entrypoint /bin/sh vsc-vscode-remote-try-rust-89420ad7399ba74f55921e49cc3ecfd2-uid -c echo Container started
+Container started
+{"outcome":"success","containerId":"f0a055ff056c1c1bb99cc09930efbf3a0437c54d9b4644695aa23c1d57b4bd11","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/vscode-remote-try-rust"}
 ```
 
-And the following in your `devcontainer.json`:
+You can then run commands in this dev container:
 
-```json
- "build": {
-      "dockerfile": "Dockerfile",
-      "args": {
-          // set vscode arg for Dockerfile
-          "vscode": "true"
-      },
-    }
+```bash
+devcontainer exec --workspace-folder <path-to-vscode-remote-try-rust> cargo run
 ```
 
-In the Docker Compose case, you can add this argument to a separate [override file to extend your configuration](/docs/remote/create-dev-container.md#extend-your-docker-compose-file-for-development) that is located in a different place in your source tree than the primary Docker Compose file.
+This will compile and run the Rust sample, outputting:
+
+```bash
+[33 ms] dev-containers-cli 0.1.0.
+   Compiling hello_remote_world v0.1.0 (/workspaces/vscode-remote-try-rust)
+    Finished dev [unoptimized + debuginfo] target(s) in 1.06s
+     Running `target/debug/hello_remote_world`
+Hello, VS Code Remote - Containers!
+{"outcome":"success"}
+```
+
+These steps above are also provided in the CLI repo's [README](https://github.com/devcontainers/cli/blob/main/README.md).
+
+## Automation
+
+If you'd like to use the devcontainer CLI in your CI/CD builds or test automation, you can find examples of GitHub Actions and Azure DevOps Tasks in the [devcontainers/ci](https://github.com/devcontainers/ci) repository.
+
+## Feedback
+
+The devcontainer CLI and specification are under active development and we welcome your feedback, which you can provide in [this issue](https://github.com/devcontainers/cli/issues/7), or through new issues and pull requests in the [devcontainers/cli](https://github.com/devcontainers/cli) repository.
 
 ## Next steps
 
+* [Dev container specification repository](https://github.com/devcontainers/spec) - File and review issues to shape the direction of development containers and the dev container CLI.
+* [devcontainer.json reference](/docs/remote/devcontainerjson-reference.md) - Review the `devcontainer.json` schema.
 * [Create a Development Container](/docs/remote/create-dev-container.md) - Create a custom container for your work environment.
 * [Advanced Containers](/remote/advancedcontainers/overview.md) - Find solutions to advanced container scenarios.
-* [devcontainer.json reference](/docs/remote/devcontainerjson-reference.md) - Review the `devcontainer.json` schema.
-* [Dev container specification repository](https://github.com/microsoft/dev-container-spec) - File and review issues to shape the direction of development containers and the dev container CLI.

--- a/docs/remote/devcontainer-cli.md
+++ b/docs/remote/devcontainer-cli.md
@@ -4,30 +4,28 @@ Area: remote
 TOCTitle: devcontainer CLI
 PageTitle: Installing and working with the devcontainer CLI
 ContentId: 8946213d-716e-41ca-955f-944a41c70353
-MetaDescription: Documentation on using the development container (devcontainer) command-line interface
+MetaDescription: Documentation on using the development container (dev container) command-line interface
 DateApproved: 7/7/2022
 ---
 # Development container CLI
 
-This topic covers the development container command-line interface (devcontainer CLI), which allows you to build and manage development containers, and is a companion to the [Development Containers Specification](https://containers.dev).
+This topic covers the development container command-line interface (dev container CLI), which allows you to build and manage development containers, and is a companion to the [Development Containers Specification](https://containers.dev).
 
 ## Development containers
 
 A consistent, predictable environment is key to a productive and enjoyable software development experience.
 
-Containers (such as [Docker](https://www.docker.com)) have historically been used to standardize apps when they're deployed, but there's a great opportunity to support additional scenarios, including continuous integration (CI), test automation, and full-featured coding environments. A **development container** provides this working environment and ensures your project has the tools and software it needs, whether it's complex and distributed or just has a few requirements.
+Containers (for example [Docker](https://www.docker.com) containers) have historically been used to standardize apps when they're deployed, but there's a great opportunity to support additional scenarios, including continuous integration (CI), test automation, and full-featured coding environments. A **development container** provides this working environment and ensures your project has the tools and software it needs, whether it's complex and distributed or just has a few requirements.
 
 ![Diagram comparing dev versus production containers](images/devcontainer-cli/dev-container-stages.png)
 
-Develop containers are supported in Visual Studio Code via the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and in [GitHub Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers). This support is backed by [devcontainer.json](/docs/remote/devcontainerjson-reference.md), a structured JSON with Comments (jsonc) metadata format to configure a containerized environment.
+Development containers are supported in Visual Studio Code via the [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and in [GitHub Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers). This support is backed by [devcontainer.json](/docs/remote/devcontainerjson-reference.md), a structured JSON with Comments (jsonc) metadata format to configure a containerized environment.
 
-As containerizing production workloads becomes commonplace, dev containers have become broadly useful for scenarios beyond VS Code. To promote dev containers, work has started on the [Development Containers Specification](https://github.com/devcontainers/spec), which empowers anyone in any tool to configure a consistent dev environment. As a companion to the specification, there is the open-source **dev container CLI**.
+As containerizing production workloads becomes commonplace, dev containers have become broadly useful for scenarios beyond VS Code. To promote dev containers in any environment, work has started on the [Development Containers Specification](https://github.com/devcontainers/spec), which empowers anyone in any tool to configure a consistent dev environment. The open-source **dev container CLI** serves as the reference implementation of the specification.
 
 ## The dev container CLI
 
-The dev container CLI is a reference implementation for the dev container specification.
-
-When tools like VS Code and Codespaces detect a `devcontainer.json` file in a user's project, they use a CLI to configure a dev container. The devcontainer CLI is a reference implementation so that individual users and other tools can read in `devcontainer.json` metadata and create dev containers from it.
+When tools like VS Code and Codespaces detect a `devcontainer.json` file in a user's project, they use a CLI to configure a dev container. The dev container CLI is a reference implementation so that individual users and other tools can read in `devcontainer.json` metadata and create dev containers from it.
 
 This CLI can either be used directly or integrated into product experiences, similar to how it's integrated with Remote - Containers and Codespaces today. It currently supports both a simple single container option and integrates with [Docker Compose](https://docs.docker.com/compose/) for multi-container scenarios.
 
@@ -35,7 +33,7 @@ The CLI is available for review in a new [devcontainers/cli](https://github.com/
 
 ## System requirements
 
-To use the VS Code `devcontainer` CLI, you'll need the following on your system or CI/DevOps environment:
+To use the VS Code dev container CLI, you'll need the following on your system or CI/DevOps environment:
 
 1. [Node.js (version 14 or greater)](https://nodejs.org).
 1. [The `docker` CLI](/docs/remote/containers#installation).
@@ -46,7 +44,7 @@ The VS Code [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-
 
 ## Installation
 
-You can try out the devcontainer CLI, either by installing its npm package or building the CLI repo from sources.
+You can try out the dev container CLI, either by installing its npm package or building the CLI repo from sources.
 
 To learn more about building the CLI from sources, go to the [CLI repo's README](https://github.com/devcontainers/cli#try-it-out).
 
@@ -126,15 +124,15 @@ These steps above are also provided in the CLI repo's [README](https://github.co
 
 ## Automation
 
-If you'd like to use the devcontainer CLI in your CI/CD builds or test automation, you can find examples of GitHub Actions and Azure DevOps Tasks in the [devcontainers/ci](https://github.com/devcontainers/ci) repository.
+If you'd like to use the dev container CLI in your CI/CD builds or test automation, you can find examples of GitHub Actions and Azure DevOps Tasks in the [devcontainers/ci](https://github.com/devcontainers/ci) repository.
 
 ## Feedback
 
-The devcontainer CLI and specification are under active development and we welcome your feedback, which you can provide in [this issue](https://github.com/devcontainers/cli/issues/7), or through new issues and pull requests in the [devcontainers/cli](https://github.com/devcontainers/cli) repository.
+The dev container CLI and specification are under active development and we welcome your feedback, which you can provide in [this issue](https://github.com/devcontainers/cli/issues/7), or through new issues and pull requests in the [devcontainers/cli](https://github.com/devcontainers/cli) repository.
 
 ## Next steps
 
-* [Dev container specification repository](https://github.com/devcontainers/spec) - File and review issues to shape the direction of development containers and the dev container CLI.
+* [Dev container specification repository](https://github.com/devcontainers/spec) - Read and contribute to the open specification.
 * [devcontainer.json reference](/docs/remote/devcontainerjson-reference.md) - Review the `devcontainer.json` schema.
 * [Create a Development Container](/docs/remote/create-dev-container.md) - Create a custom container for your work environment.
 * [Advanced Containers](/remote/advancedcontainers/overview.md) - Find solutions to advanced container scenarios.

--- a/docs/remote/devcontainerjson-reference.md
+++ b/docs/remote/devcontainerjson-reference.md
@@ -1,5 +1,5 @@
 ---
-Order: 14
+Order: 13
 Area: remote
 TOCTitle: devcontainer.json
 PageTitle: devcontainer.json reference

--- a/docs/remote/images/devcontainer-cli/dev-container-stages.png
+++ b/docs/remote/images/devcontainer-cli/dev-container-stages.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91fa228815927cd9ed9a6805a7c1d47e70d195a5e2deac9a77074af767519bb7
+size 46234

--- a/docs/remote/images/devcontainer-cli/install.png
+++ b/docs/remote/images/devcontainer-cli/install.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a407008345dd4caf3f6c96179a46478707f3575221993f2b737963b4a9eed95d
-size 2228

--- a/docs/remote/images/devcontainer-cli/reopen-in-container.png
+++ b/docs/remote/images/devcontainer-cli/reopen-in-container.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3a44828138b232e256f40c33e1597d41f1b3fda471efd9bc1715540db05f746
-size 3958


### PR DESCRIPTION
Update docs/remote/devcontainer-cli topic for new devcontainer CLI.
Much of the content came from the announcement blog post.