### PR TITLE
Update git config.followTagsWhenSync definition

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -4209,7 +4209,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // When enabled, fetch all branches when pulling. Otherwise, fetch just the current one.
     "git.fetchOnPull": false,
 
-    // Follow push all tags when running the sync command.
+    // Push all annotated tags when running the sync command.
     "git.followTagsWhenSync": false,
 
     // List of git repositories to ignore.


### PR DESCRIPTION
Relates to https://github.com/microsoft/vscode/pull/155914

This updates the definition for the [Git extension](https://code.visualstudio.com/docs/editor/versioncontrol) setting `followTagsWhenSync`. The current definition is somewhat ambiguous, so this updates it to more closely reflect the description for `--follow-tags` [in the Git documentation](https://git-scm.com/docs/git-push#Documentation/git-push.txt---follow-tags).