### PR TITLE
Added VS build tools are required for omnisharp to function properly

### DIFF
--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -31,6 +31,12 @@ From [Using .NET in Visual Studio Code](/docs/languages/dotnet.md):
 
 1. In the VS Code Settings editor (`kb(workbench.action.openSettings)`), uncheck the C# extension's **Omnisharp: Use Modern Net** [setting](/docs/getstarted/settings.md) (`"omnisharp.useModernNet": false`).
 
+## Install Tools for Visual Studio [Windows Only]
+The C# Extension no longer ships with microsoft build tools so they must be installed manually.
+
+1. Download the [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
+1. Install the .Net desktop build tools workload. No other components are required.
+
 ## Setup VS Code as Unity Script Editor
 
 Open up **Unity Preferences**, **External Tools**, then browse for the Visual Studio Code executable as **External Script Editor**.


### PR DESCRIPTION
For intellisense to work with .net5, VS build tools now need to be downloaded and installed manually.  Added a section to that effect