### PR TITLE
Use full path to target keyring file

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -34,7 +34,7 @@ Installing the .deb package will automatically install the apt repository and si
 ```bash
 sudo apt-get install wget gpg
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings
+sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
 rm -f packages.microsoft.gpg
 ```


### PR DESCRIPTION
This makes the install command place the file in the expected location whether the keyrings directory exists previously or not.