### PR TITLE
Update "Keymaps" menu item to current text label

### DIFF
--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -26,7 +26,7 @@ For doing more advanced keyboard shortcut customization, read [Advanced Customiz
 
 ## Keymap extensions
 
-Keyboard shortcuts are vital to productivity and changing keyboarding habits can be tough. To help with this, **File** > **Preferences** > **Keymaps** shows you a list of popular keymap extensions. These extensions modify the VS Code shortcuts to match those of other editors so you don't need to learn new keyboard shortcuts. There is also a [Keymaps category](https://marketplace.visualstudio.com/search?target=VSCode&category=Keymaps&sortBy=Installs) of extensions in the Marketplace.
+Keyboard shortcuts are vital to productivity and changing keyboarding habits can be tough. To help with this, **File** > **Preferences** > **Migrate Keyboard Shortcuts from...** shows you a list of popular keymap extensions. These extensions modify the VS Code shortcuts to match those of other editors so you don't need to learn new keyboard shortcuts. There is also a [Keymaps category](https://marketplace.visualstudio.com/search?target=VSCode&category=Keymaps&sortBy=Installs) of extensions in the Marketplace.
 
 <div class="marketplace-extensions-curated-keymaps"></div>
 


### PR DESCRIPTION
In VSCode 1.69.2, the menu item for retrieving popular keymap extensions is **File > Preferences > Migrate Keyboard Shortcuts from...**, not **File > Preferences > Keymaps**.