### PR TITLE
Three-way-merge-to-cli-options

### DIFF
--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -44,7 +44,8 @@ Argument|Description
 `-n` or `--new-window`| Opens a new session of VS Code instead of restoring the previous session (default).
 `-r` or `--reuse-window` | Forces opening a file or folder in the last active window.
 `-g` or `--goto` | When used with *file:line{:character}*, opens a file at a specific line and optional character position. This argument is provided since some operating systems permit `:` in a file name.
-`-d` or `--diff` | Open a file difference editor. Requires two file paths as arguments.
+`-d` or `--diff <file> <file>` | Open a file difference editor. Requires two file paths as arguments.
+`-m` or `--merge  <path1> <path2> <base> <result>` | Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions, and the output file to save merge results.
 `-w` or `--wait` | Wait for the files to be closed before returning.
 `--locale <locale>` | Set the [display language](/docs/getstarted/locales.md) (locale) for the VS Code session. (for example, `en-US` or `zh-TW`)
 

--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -44,7 +44,7 @@ Argument|Description
 `-n` or `--new-window`| Opens a new session of VS Code instead of restoring the previous session (default).
 `-r` or `--reuse-window` | Forces opening a file or folder in the last active window.
 `-g` or `--goto` | When used with *file:line{:character}*, opens a file at a specific line and optional character position. This argument is provided since some operating systems permit `:` in a file name.
-`-d` or `--diff <file> <file>` | Open a file difference editor. Requires two file paths as arguments.
+`-d` or `--diff <file1> <file2>` | Open a file difference editor. Requires two file paths as arguments.
 `-m` or `--merge  <path1> <path2> <base> <result>` | Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions, and the output file to save merge results.
 `-w` or `--wait` | Wait for the files to be closed before returning.
 `--locale <locale>` | Set the [display language](/docs/getstarted/locales.md) (locale) for the VS Code session. (for example, `en-US` or `zh-TW`)


### PR DESCRIPTION
In line with the https://code.visualstudio.com/updates/v1_70#_command-line-option-merge this documentation needed to include the new `---merge`