### PR TITLE
Use double quote to prevent globbing and word splitting

### DIFF
--- a/remote/advancedcontainers/persist-bash-history.md
+++ b/remote/advancedcontainers/persist-bash-history.md
@@ -17,7 +17,7 @@ If you have a root user, update your `Dockerfile` with the following:
 
 ```Dockerfile
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && echo $SNIPPET >> "/root/.bashrc"
+    && echo "$SNIPPET" >> "/root/.bashrc"
 ```
 
 If you have a non-root user, update your `Dockerfile` with the following. Replace `user-name-goes-here` with the name of a [non-root user](/remote/advancedcontainers/add-nonroot-user.md) in the container.
@@ -29,7 +29,7 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
     && mkdir /commandhistory \
     && touch /commandhistory/.bash_history \
     && chown -R $USERNAME /commandhistory \
-    && echo $SNIPPET >> "/home/$USERNAME/.bashrc"
+    && echo "$SNIPPET" >> "/home/$USERNAME/.bashrc"
 ```
 
 Next, add a local volume to store the command history. This step varies depending on whether or not you are using Docker Compose.


### PR DESCRIPTION
Hi!

I just copy/pasted the recipe to persist bash history in my Dockerfile, and [`hadolint`](https://github.com/hadolint/hadolint) (which is a linter for Dockerfile) raised a warning (SC2086).

In this specific case, double-quotes does not matter much, but at least it will avoid the warning to be raised by default for people copy/pasting this documented recipe and using Hadolint. :+1: 