### PR TITLE
Use transpiling over compiling

### DIFF
--- a/docs/typescript/typescript-compiling.md
+++ b/docs/typescript/typescript-compiling.md
@@ -9,7 +9,7 @@ MetaDescription: Learn about TypeScript compiling with Visual Studio Code.
 ---
 # Compiling TypeScript
 
-[TypeScript](https://www.typescriptlang.org) is a typed superset of JavaScript that compiles to plain JavaScript. It offers classes, modules, and interfaces to help you build robust components.
+[TypeScript](https://www.typescriptlang.org) is a typed superset of JavaScript that transpiles to plain JavaScript. It offers classes, modules, and interfaces to help you build robust components.
 
 ## Install the TypeScript compiler
 


### PR DESCRIPTION
Throughout the article it is written that `tsc` transpiles TypeScript source code to JavaScript. That's why I find it important to also state that in the beginning of the article.