### PR TITLE
Add info on logical lines

### DIFF
--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -55,6 +55,25 @@ Here's an example of expanding the selection with `kb(editor.action.smartSelect.
 
 ![Expand selection](images/codebasics/expandselection.gif)
 
+### Insert cursors on Logical Lines
+
+If you'd like to ignore line wraps when adding cursors above or below your current selection, you can pass in `{ "logicalLine": true }` to `args` on the keybinding like this:
+
+```json
+{
+  "key": "shift+alt+down",
+  "command": "editor.action.insertCursorBelow",
+  "when": "textInputFocus",
+  "args": { "logicalLine": true },
+},
+{
+  "key": "shift+alt+up",
+  "command": "editor.action.insertCursorAbove",
+  "when": "textInputFocus",
+  "args": { "logicalLine": true },
+},
+```
+
 ## Column (box) selection
 
 Place the cursor in one corner and then hold `kbstyle(Shift+Alt)` while dragging to the opposite corner:


### PR DESCRIPTION
This issue was raised in #26393 and fixed  in #135805. 

It got a shout out in the [October 2021 release notes](https://code.visualstudio.com/updates/v1_62#_thank-you:%7E:text=InsertCursorAbove/Below), but was never documented anywhere on the site.

Since it's not configured via a setting, has even less discoverability that someone would know to add this specific command to the keybind args.

Also asked about on Stack Overflow [How to avoid multi cursor on wrapped lines in VS Code?](https://stackoverflow.com/q/53283020/1366033)