### PR TITLE
Extend description of running tests in parallel to include pyproject.toml example

### DIFF
--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -221,6 +221,12 @@ Support for running tests in parallel with pytest is available through the `pyte
     addopts=-n4
    ```
 
+   Or, if you are using a `pyproject.toml` file
+   ```toml
+    [tool.pytest.ini_options]
+    addopts="-n 4"
+   ```
+
 3. Run your tests, which will now be run in parallel.
 
 ## Debug tests


### PR DESCRIPTION
The `pyproject.toml` file is becoming more widely used in projects and requires a slightly different approach and syntax, with quotation marks and a specific header section.

This PR includes a minimum viable example for that use case that will be picked up by VS Code and cause the tests to run in parallel when triggered by the editor.