### PR TITLE
Fix macOS settings.json location

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -157,7 +157,7 @@ If you prefer to always work directly with `settings.json`, you can set `"workbe
 Depending on your platform, the user settings file is located here:
 
 * **Windows** `%APPDATA%\Code\User\settings.json`
-* **macOS** `$HOME/Library/Application\ Support/Code/User/settings.json`
+* **macOS** `$HOME/Library/Application Support/Code/User/settings.json`
 * **Linux** `$HOME/.config/Code/User/settings.json`
 
 ### Reset all settings


### PR DESCRIPTION
This PR fixes the location of `settings.json` on macOS.

<img width="561" alt="Xnapper-2022-08-17-20 53 06" src="https://user-images.githubusercontent.com/17038330/185274854-5efc1340-35dc-48af-98a2-c52d38d8e4b1.png">

