### PR TITLE
Update mingw toolset instructions

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -29,10 +29,8 @@ To successfully complete this tutorial, you must do the following steps:
 
 1. Follow the **Installation** instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64. Take care to run each required Start menu and `pacman` command.
 
-1. Install the Mingw-w64 toolset:
-   1. Have an open MSYS2 terminal. (Run "MSYS2 MinGW x64" from the Start menu.)
-   1. Run the `pacman` command (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`).
-      - Note: Leave the "members in group" prompt blank to install all missing packages in the group.
+1. Install the Mingw-w64 toolchain (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`). Run the `pacman` command in a MSYS2 terminal.
+   - Note: Leave the "members in group" prompt blank to install all missing packages in the group.
 
 1. Add the path to your Mingw-w64 `bin` folder to the Windows `PATH` environment variable by using the following steps:
    1. In the Windows search bar, type 'settings' to open your Windows Settings.
@@ -51,8 +49,8 @@ g++ --version
 gdb --version
 ```
 
-- If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located. If the compilers do not exist at that PATH entry, make sure you followed the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
-- If `gcc` has the correct output but not `gdb` then you need to install the packages you are missing from the Mingw-w64 toolset.
+1. If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located. If the compilers do not exist at that PATH entry, make sure you followed the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
+2. If `gcc` has the correct output but not `gdb` then you need to install the packages you are missing from the Mingw-w64 toolset.
    - Missing the `mingw-w64-gdb` package is one cause of the "The value of miDebuggerPath is invalid." message upon attempted compilation if your PATH is correct.
 
 ## Create Hello World

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -25,9 +25,14 @@ To successfully complete this tutorial, you must do the following steps:
 
     ![C/C++ extension](images/cpp/cpp-extension.png)
 
-1. Get the latest version of Mingw-w64 via [MSYS2](https://www.msys2.org/), which provides up-to-date native builds of GCC, Mingw-w64, and other helpful C++ tools and libraries. You can download the latest installer from the MSYS2 page or use this [link to the installer](https://github.com/msys2/msys2-installer/releases/download/2022-01-18/msys2-x86_64-20220118.exe).
+1. Get the latest version of Mingw-w64 via [MSYS2](https://www.msys2.org/), which provides up-to-date native builds of GCC, Mingw-w64, and other helpful C++ tools and libraries. You can download the latest installer from the MSYS2 page or use this [link to the installer](https://github.com/msys2/msys2-installer/releases/download/2022-06-03/msys2-x86_64-20220603.exe).
 
-1. Follow the **Installation** instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64. Take care to run each required Start menu and `pacman` command, especially Step 7, when you will install the actual Mingw-w64 toolset (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`).
+1. Follow the **Installation** instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64. Take care to run each required Start menu and `pacman` command.
+
+1. Install the Mingw-w64 toolset:
+   1. Have an open MSYS2 terminal. (Run "MSYS2 MinGW x64" from the Start menu.)
+   1. Run the `pacman` command (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`).
+      - Note: Leave the "members in group" prompt blank to install all missing packages in the group.
 
 1. Add the path to your Mingw-w64 `bin` folder to the Windows `PATH` environment variable by using the following steps:
    1. In the Windows search bar, type 'settings' to open your Windows Settings.
@@ -41,11 +46,14 @@ To successfully complete this tutorial, you must do the following steps:
 To check that your Mingw-w64 tools are correctly installed and available, open a **new** Command Prompt and type:
 
 ```bash
+gcc --version
 g++ --version
 gdb --version
 ```
 
-If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located. If the compilers do not exist at that PATH entry, make sure you followed the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
+- If you don't see the expected output or `g++` or `gdb` is not a recognized command, make sure your PATH entry matches the Mingw-w64 binary location where the compilers are located. If the compilers do not exist at that PATH entry, make sure you followed the instructions on the [MSYS2 website](https://www.msys2.org/) to install Mingw-w64.
+- If `gcc` has the correct output but not `gdb` then you need to install the packages you are missing from the Mingw-w64 toolset.
+   - Missing the `mingw-w64-gdb` package is one cause of the "The value of miDebuggerPath is invalid." message upon attempted compilation if your PATH is correct.
 
 ## Create Hello World
 


### PR DESCRIPTION
Updating the "Using GCC with MinGW" instructions page.  

Accounts for the removal of steps on MSYS2's Getting Started page, which is a dependency that these instructions rely on.
Without this change users following these instructions would be unable to compile C++ when using the default launcher specified by these instructions.  As these instructions acknowledge this is not meant to teach anything about GDB, MinGW, etc. so we can't expect the people using this page to correct this small gap on their own when following the instructions.  

Not sure if VS Code depends on all of these packages.  Might be able to get by on some minimal subset of packages but just including all of them simplifies the instructions.  One issue this resolves is that VS Code expects gdb.exe to be in the bin folder specified by `miDebuggerPath` but just installing `mingw-w64-x86_64-gcc` as [MSYS2's page](https://www.msys2.org/) specifies does not install `mingw-w64-x86_64-gdb`.

(Students are expecting to just download the prompted extension & be able to run C++...they are frustrated that this is not just dynamically bundled together & give up on VS Code when these instructions fail.) 