### PR TITLE
Update .NET getting started instructions

### DIFF
--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -11,13 +11,37 @@ MetaDescription: Get started writing and debugging .NET apps with Visual Studio 
 
 [.NET](https://dotnet.microsoft.com) provides a fast and modular platform for creating many different types of applications that run on Windows, Linux, and macOS. Use Visual Studio Code with the C# and F# extensions to get a powerful editing experience with [C# IntelliSense](https://docs.microsoft.com/visualstudio/ide/visual-csharp-intellisense), F# IntelliSense (smart code completion), and debugging.
 
-## Prerequisites
+## Setting up VS Code for .NET development
 
-Install the following:
+### Coding Pack for .NET
 
-* [.NET SDK](https://dotnet.microsoft.com/download). The SDK also includes the Runtime.
-* The [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) from the VS Code Marketplace.
-* The [F# extension (Ionide)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp) from the VS Code Marketplace.
+To help you set up quickly, you can install the **Coding Pack for .NET**, which includes VS Code, the .NET Software Development Kit, and essential .NET extensions. The Coding Pack can be used as a clean installation, or to update or repair an existing development environment.
+
+<a class="tutorial-install-extension-btn" onclick="pushCodingPackEvent('dotnet', 'win')" href="https://aka.ms/dotnet-coding-pack-win">Install the Coding Pack for .NET - Windows</a>
+
+<a class="tutorial-install-extension-btn" onclick="pushCodingPackEvent('dotnet', 'mac')" href="https://aka.ms/dotnet-coding-pack-mac">Install the Coding Pack for .NET - macOS</a><br>
+
+> **Note**: The Coding Pack for .NET is only available for Windows and macOS. For other operating systems, you will need to manually install the .NET SDK, VS Code, and .NET extensions.
+
+### Installing extensions
+
+If you are an existing VS Code user, you can also add .NET support by installing the [Extension Pack for .NET](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-pack), which includes these extensions:
+
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+* [Ionide for F#](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
+* [Jupyter Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter)
+* [.NET Interactive Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+
+<a class="tutorial-install-extension-btn" href="vscode:extension/ms-dotnettools.vscode-dotnet-pack">Install the Extension Pack for .NET</a>
+
+You can also install extensions separately.
+
+## Installing and setting up the .NET Software Development Kit
+
+If you download the extensions separately, ensure that you also have the .NET SDK on your local environment. The .NET SDK is a software development environment used for developing .NET applications.
+
+<a class="tutorial-install-extension-btn" href="https://aka.ms/vscDocs/dotnet/download">Install the .NET SDK</a>
+
 
 ## Create a C# "Hello World" app
 


### PR DESCRIPTION
Updated the .NET getting started instructions to include the [.NET coding pack](https://code.visualstudio.com/learn/educators/installers) and the [.NET extension pack](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscode-dotnet-pack).