### PR TITLE
Consistently capitalize 'Codespaces' in 1.71 release notes

### DIFF
--- a/release-notes/v1_71.md
+++ b/release-notes/v1_71.md
@@ -350,9 +350,9 @@ You can also create a temporary Settings Profile and associate it to a folder or
 
 When you are browsing a GitHub or Azure Repos repository such as [https://vscode.dev/github/microsoft/vscode](https://vscode.dev/github/microsoft/vscode), you can use the [**Continue Working On**](https://code.visualstudio.com/docs/editor/github#_continue-working-on) command to select a different development environment to use with your repository.
 
-Previously, if you had pending edits in your virtual workspace, you would need to push them to GitHub or Azure Repos to view them elsewhere. This milestone, we have added **Edit Sessions** integration to the **Continue Working On** feature, so that your uncommitted changes automatically travel with you to your target development environment, such as a GitHub codespace:
+Previously, if you had pending edits in your virtual workspace, you would need to push them to GitHub or Azure Repos to view them elsewhere. This milestone, we have added **Edit Sessions** integration to the **Continue Working On** feature, so that your uncommitted changes automatically travel with you to your target development environment, such as a GitHub codespace.
 
-In the video below, the user's changes to a TypeScript file that were made when using VS Code for the Web are applied when they create and switch to working in a new GitHub Codespace.
+In the video below, the user's changes to a TypeScript file that were made when using VS Code for the Web are applied when they create and switch to working in a new GitHub codespace.
 
 ![Continue On in GitHub Codespaces](images/1_71/continue-on-codespaces.gif)
 


### PR DESCRIPTION
'GitHub Codespaces' refers to the product as a whole, while 'a GitHub codespace' refers to a single instance