### PR TITLE
Fixed the description above the text sync example

### DIFF
--- a/api/language-extensions/language-server-extension-guide.md
+++ b/api/language-extensions/language-server-extension-guide.md
@@ -217,7 +217,7 @@ The source code for the Language Server is at `/server`. The interesting section
 
 This pulls in the `vscode-languageserver` libraries.
 
-Below is a server implementation that uses the provided simple text document manager that synchronizes text documents by always sending the file's full content from VS Code to the server.
+Below is a server implementation that uses the provided text document manager that synchronizes text documents by always sending incremental deltas from VS Code to the server.
 
 ```typescript
 import {
@@ -269,6 +269,7 @@ connection.onInitialize((params: InitializeParams) => {
 
   const result: InitializeResult = {
     capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
       // Tell the client that this server supports code completion.
       completionProvider: {
         resolveProvider: true

--- a/api/language-extensions/language-server-extension-guide.md
+++ b/api/language-extensions/language-server-extension-guide.md
@@ -269,7 +269,6 @@ connection.onInitialize((params: InitializeParams) => {
 
   const result: InitializeResult = {
     capabilities: {
-      textDocumentSync: TextDocumentSyncKind.Incremental,
       // Tell the client that this server supports code completion.
       completionProvider: {
         resolveProvider: true


### PR DESCRIPTION
Since the description above this code is this:
> Below is a server implementation that uses the provided simple text document manager that synchronizes text documents by always sending the file's full content from VS Code to the server

I think that this line was misleading here. Or perhaps this description is not accurate