### PR TITLE
Fix language names

### DIFF
--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -42,7 +42,7 @@ First, make sure Docker CLI is installed into your development container. The ex
 
 Here is an example for Ubuntu-based distros (from a `.devcontainer/Dockerfile`):
 
-```cli
+```sh
     ...
     && apt-get -y install software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 2>/dev/null \

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -63,7 +63,7 @@ The Docker extension helps you author Dockerfiles by using [IntelliSense](/docs/
 1. Open a terminal (`kb(workbench.action.terminal.toggleTerminal)`).
 1. Enter `npm run start` to start the application:
 
-   ```output
+   ```
    > express-app@0.0.0 start /Users/user/code/scratch/express-app
    > node ./bin/www
    ```

--- a/docs/cpp/cmake-linux.md
+++ b/docs/cpp/cmake-linux.md
@@ -76,7 +76,7 @@ If you have an existing CMake project that already has a `CMakeLists.txt` file i
 
 Otherwise, create a folder for a new project. From the Terminal window, create an empty folder called `cmakeQuickStart`, navigate into it, and open VS Code in that folder by entering the following commands:
 
-```cmd
+```bash
 mkdir cmakeQuickStart
 cd cmakeQuickStart
 code .

--- a/docs/cpp/config-clang-mac.md
+++ b/docs/cpp/config-clang-mac.md
@@ -43,7 +43,7 @@ xcode-select --install
 
 From the macOS Terminal, create an empty folder called `projects` where you can store all your VS Code projects, then create a subfolder called `helloworld`, navigate into it, and open VS Code in that folder by entering the following commands:
 
-```cmd
+```bash
 mkdir projects
 cd projects
 mkdir helloworld

--- a/docs/cpp/config-linux.md
+++ b/docs/cpp/config-linux.md
@@ -50,7 +50,7 @@ sudo apt-get install build-essential gdb
 
 From the terminal window, create an empty folder called `projects` to store your VS Code projects. Then create a subfolder called `helloworld`, navigate into it, and open VS Code in that folder by entering the following commands:
 
-```cmd
+```bash
 mkdir projects
 cd projects
 mkdir helloworld

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -56,7 +56,7 @@ gdb --version
 
 From a Windows command prompt, create an empty folder called `projects` where you can place all your VS Code projects. Then create a sub-folder called `helloworld`, navigate into it, and open VS Code in that folder by entering the following commands:
 
-```cmd
+```bat
 mkdir projects
 cd projects
 mkdir helloworld

--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -59,7 +59,7 @@ If the Developer Command Prompt is using the BuildTools location as the starting
 
 From the Developer Command Prompt, create an empty folder called "projects" where you can store all your VS Code projects, then create a subfolder called "helloworld", navigate into it, and open VS Code (`code`) in that folder (`.`) by entering the following commands:
 
-```cmd
+```bat
 mkdir projects
 cd projects
 mkdir helloworld

--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -303,7 +303,7 @@ To have a variable in the pasted script, you need to escape the '$' of the `$var
 
 This results in the pasted snippet as:
 
-```text
+```
 $MyVar = 2
 ```
 

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -43,9 +43,9 @@ On startup the best matching projects are loaded automatically but you can also 
 
 The available options include:
 
-* Selecting a ```project.json``` file will open a .NET project and VS Code will load that project plus the referenced projects.
-* Selecting a ```*.sln``` file opens a MSBuild-project. It will load the referenced ```*.csproj``` projects and sibling or descendant ```project.json``` files but no other project files that are referenced from the solution file.
-* Selecting a ```folder``` will make VS Code scan for ```*.sln```, ```project.json``` and ```*.csx``` files (C# scripts) and VS Code will attempt to load them all.
+* Selecting a `project.json` file will open a .NET project and VS Code will load that project plus the referenced projects.
+* Selecting a `*.sln` file opens a MSBuild-project. It will load the referenced `*.csproj` projects and sibling or descendant `project.json` files but no other project files that are referenced from the solution file.
+* Selecting a `folder` will make VS Code scan for `*.sln`, `project.json` and `*.csx` files (C# scripts) and VS Code will attempt to load them all.
 
 Once the project is loaded the enhanced experiences light up...
 

--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -49,7 +49,7 @@ If you download the extensions separately, ensure that you also have the .NET SD
    * Open a terminal/command prompt and navigate to the folder in which you'd like to create the app.
    * Enter the following command in the command shell:
 
-   ```cmd
+   ```bat
      dotnet new console
    ```
 
@@ -60,7 +60,7 @@ If you download the extensions separately, ensure that you also have the .NET SD
 
 3. Run the app by entering the following command in the command shell:
 
-   ```cmd
+   ```bat
    dotnet run
    ```
 
@@ -71,19 +71,19 @@ If you download the extensions separately, ensure that you also have the .NET SD
    * Open a terminal/command prompt and navigate to the folder in which you'd like to create the app.
    * Enter the following command in the command shell:
 
-   ```cmd
+   ```bat
    dotnet new console -lang "F#"
    ```
 
 2. Once it completes, open the project in Visual Studio Code:
 
-   ```cmd
+   ```bat
    code .
    ```
 
 3. Run the app by entering the following command in the command shell:
 
-   ```cmd
+   ```bat
     dotnet run
    ```
 

--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -80,7 +80,7 @@ code .
 
 `cargo new` creates a simple Hello World project with a `main.rs` source code file and `Cargo.toml` [Cargo manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) file.
 
-```plaintext
+```
 src\
     main.rs
 .gitignore

--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -187,7 +187,7 @@ Before|After
 
 To edit this directly within VS Code Settings editor, go to **File** > **Preferences** > **Settings** (**Code** > **Preferences** > **Settings** on macOS). Switch to the **Workspace** tab and then type "files exclude" into the Settings editor search bar.  Add a glob pattern similar to the pattern shown below by clicking the **Add Pattern** button for the **Files: Exclude** setting.  You will need to add each pattern separately.
 
-```glob
+```
 **/.git
 **/*.fbx
 **/*.FBX

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -323,7 +323,7 @@ An example of when to use PYTHONPATH would be if you have source code in a `src`
 
 To solve this problem, you could add the path to `src` to PYTHONPATH by creating an `.env` file within your VS Code workspace.
 
-```cmd
+```bat
 PYTHONPATH=src
 ```
 

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -141,7 +141,7 @@ pylint --generate-rcfile > .pylintrc
 
 If you are running Pylint in PowerShell, you have to explicitly specify a UTF-8 output encoding. This file contains sections for all the Pylint options, along with documentation in the comments.
 
-```ps
+```powershell
 pylint --generate-rcfile | Out-File -Encoding utf8 .pylintrc
 ```
 

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -77,7 +77,7 @@ To verify that you've installed Python successfully on your machine, run one of 
 
 - Windows: open a command prompt and run the following command:
 
-    ```ps
+    ```bat
     py -3 --version
     ```
 
@@ -256,7 +256,7 @@ A best practice among Python developers is to avoid installing packages into a g
 
    **Virtual environment creation for Windows**
 
-   ```cmd
+   ```bat
    py -3 -m venv .venv
    .venv\scripts\activate
    ```
@@ -265,7 +265,7 @@ A best practice among Python developers is to avoid installing packages into a g
    current system.", then you need to temporarily change the PowerShell execution policy to allow scripts to
    run (see [About Execution Policies](https://go.microsoft.com/fwlink/?LinkID=135170) in the PowerShell documentation):
 
-   ```cmd
+   ```pwsh
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
    ```
 

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -204,7 +204,7 @@ Support for running tests in parallel with pytest is available through the `pyte
 
    **For Windows**
 
-   ```cmd
+   ```bat
    py -3 -m pip install pytest-xdist
    ```
 
@@ -267,9 +267,9 @@ You can also change the default behavior of clicking on the gutter decoration to
 
 The debugger works the same for tests as for other Python code, including breakpoints, variable inspection, and so on. To customize settings for debugging tests, you can specify `"purpose": ["debug-test"]` in the `launch.json` file in the `.vscode` folder from your workspace. This configuration will be used when you run **Test: Debug All Tests**, **Test: Debug Tests in Current File** and **Test: Debug Test at Cursor** commands.
 
-For example, the configuration below in the ```launch.json``` file disables the ```justMyCode``` setting for debugging tests:
+For example, the configuration below in the `launch.json` file disables the `justMyCode` setting for debugging tests:
 
-```py
+```json
 {
     "name": "Python: Debug Tests",
     "type": "python",

--- a/docs/remote/create-dev-container.md
+++ b/docs/remote/create-dev-container.md
@@ -474,7 +474,7 @@ In the Settings editor:
 
 Next, place your `.devcontainer/devcontainer.json` (and related files) in a sub folder that mirrors the remote location of the repository. For example, if you wanted to create a configuration for `github.com/microsoft/vscode-dev-containers`, you would create the following folder structure:
 
-```text
+```
 📁 github.com
     📁 microsoft
         📁 vscode-dev-containers

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -143,7 +143,7 @@ Finally, you'll be asked to pick a config file to use. You can also set the `"re
 
 For example, entering `ssh -i ~/.ssh/id_rsa-remote-ssh yourname@remotehost.yourcompany.com` in the input box would generate this entry:
 
-```text
+```sshconfig
 Host remotehost.yourcompany.com
     User yourname
     HostName another-host-fqdn-or-ip-goes-here
@@ -244,7 +244,7 @@ If you have ports that you **always want to forward**, you can use the `LocalFor
 
 For example, if you wanted to forward ports 3000 and 27017, you could update the file as follows:
 
-```text
+```sshconfig
 Host remote-linux-machine
     User myuser
     HostName remote-linux-machine.mydomain

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -202,7 +202,7 @@ A fix has been merged so this problem should be resolved in a version of the ser
 
 Remote - SSH extension makes use of an SSH tunnel to facilitate communication with the host. In some cases, this may be disabled on your SSH server. To see if this is the problem, open the **Remote - SSH** category in the output window and check for the following message:
 
-```text
+```
 open failed: administratively prohibited: open failed
 ```
 
@@ -699,7 +699,7 @@ docker ps -a --filter="label=vsch.quality" --format "table \{{.ID}}\t\{{.Status}
 
 When building containers that use images based on Debian 8/Jessie — such as older versions of the `node:8` image — you may encounter the following error:
 
-```text
+```
 ...
 W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
 E: Some index files failed to download. They have been ignored, or old ones used instead.

--- a/release-notes/v1_17.md
+++ b/release-notes/v1_17.md
@@ -330,7 +330,7 @@ Fenced code blocks in Markdown files now set the language mode for their content
 
 Reference links and reference link definitions are now detected as links in the editor:
 
-```md
+```markdown
 Some text with a [link][link definition] in it
 
 [link definition]: /path/to/link

--- a/release-notes/v1_60.md
+++ b/release-notes/v1_60.md
@@ -252,7 +252,7 @@ Notebooks now support links between Markdown cells:
 
 You can create a link to a header in a Markdown cell using:
 
-```md
+```markdown
 [Link text](#header-slug)
 ```
 

--- a/release-notes/v1_69.md
+++ b/release-notes/v1_69.md
@@ -414,7 +414,7 @@ Previously, there was no way to review changes that would have been applied by a
 
 Markdown lets you use angle brackets to write link destinations that contain spaces or other special characters:
 
-```md
+```markdown
 [Some link](<path to file with spaces.md>)
 ```
 

--- a/release-notes/v1_70.md
+++ b/release-notes/v1_70.md
@@ -102,7 +102,7 @@ You can now use command line options to bring up the merge editor in VS Code:
 
 This enables you to use VS Code as a merge tool for Git, for example, if you configure this in `.gitconfig`:
 
-```properties
+```gitconfig
 [merge]
   tool = code
 [mergetool "code"]

--- a/remote-release-notes/v1_70.md
+++ b/remote-release-notes/v1_70.md
@@ -16,7 +16,7 @@ We've also merged an [updated proposal for distributing features and templates](
 
 The CLI [now supports](https://github.com/devcontainers/cli/pull/61) multiple `--image-name` parameters, such as:
 
-```console
+```sh
 devcontainer build --workspace-folder ./ --image-name alpine3 --image-name alpine3.0
 ```
 

--- a/remote/advancedcontainers/configure-separate-containers.md
+++ b/remote/advancedcontainers/configure-separate-containers.md
@@ -13,7 +13,7 @@ While development containers often are tied to a single folder, repository, or p
 
 For example:
 
-```text
+```
 📁 Repos
    📁 node
    📁 python

--- a/remote/advancedcontainers/connect-multiple-containers.md
+++ b/remote/advancedcontainers/connect-multiple-containers.md
@@ -15,7 +15,7 @@ If you'd prefer to use `devcontainer.json` instead and are using Docker Compose,
 
 To see how this works, consider this example source tree:
 
-```text
+```
 📁 project-root
     📁 .git
     📁 container1-src

--- a/remote/advancedcontainers/environment-variables.md
+++ b/remote/advancedcontainers/environment-variables.md
@@ -71,7 +71,7 @@ If you have a large number of environment variables that you need to set, you ca
 
 First, create an environment file somewhere in your source tree. Consider this `.devcontainer/devcontainer.env` file:
 
-```text
+```
 YOUR_ENV_VAR_NAME=your-value-goes-here
 ANOTHER_ENV_VAR_NAME=your-value-goes-here
 ```


### PR DESCRIPTION
I kept seeing warnings related to invalid language names while building the website, and so I took a look at what language names were being used and changed them to fit ones listed in [linguist/languages.yml](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml).

For plain text, one can just use three backticks without specifying a language. 