### PR TITLE
Round two of fixing language names

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -201,7 +201,7 @@ In our example, the condition has three checks:
 
 GitLab CI can be used to test and publish the extension in headless Docker containers. This can be done by pulling a preconfigured Docker image, or installing `xvfb` and the libraries required to run Visual Studio Code during the pipeline.
 
-```yml
+```yaml
 image: node:12-buster
 
 before_script:

--- a/blogs/2017/01/15/connect-nina-e2e.md
+++ b/blogs/2017/01/15/connect-nina-e2e.md
@@ -266,13 +266,13 @@ Select the `Docker: Add docker files to workspace` command,  select `Node.js` as
 
 The Docker extension also provides auto-completion for your `Dockerfiles` and `docker-compose.yml` files, which makes authoring your Docker assets a lot simpler. For example, open up the `Dockerfile` and change line 2 from:
 
-```dockerfile
+```docker
 FROM node:latest
 ```
 
 To:
 
-```dockerfile
+```docker
 FROM mhart
 ```
 

--- a/blogs/2020/02/18/optimizing-ci.md
+++ b/blogs/2020/02/18/optimizing-ci.md
@@ -39,7 +39,7 @@ In order to share cache results across build agents, we needed platform-independ
 
 Here's how VS Code uses the `platformIndependent` parameter:
 
-```yml
+```yaml
 - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
   inputs:
     keyfile: keyfile
@@ -54,7 +54,7 @@ Another missing feature was the ability to create multiple caches per build job.
 
 And here's how we use the `alias` parameter:
 
-```yml
+```yaml
 - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
   inputs:
     keyfile: "yarn.lock"
@@ -74,7 +74,7 @@ There was still room for one final optimization, given a specific use case: buil
 
 Using the `dryRun` parameter in our build looks like this:
 
-```yml
+```yaml
 - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
   inputs:
     keyfile: commit

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -37,7 +37,7 @@ To enable SSL (using the HTTPS protocol), you will need to make a few changes to
 
 1. In the Dockerfile, add an `EXPOSE` line to the base section to define a separate port for HTTPS / SSL. Keep a separate `EXPOSE` line with a different port for HTTP requests.
 
-   ```Dockerfile
+   ```docker
    FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
    WORKDIR /app
    EXPOSE 5000

--- a/docs/containers/debug-node.md
+++ b/docs/containers/debug-node.md
@@ -209,7 +209,7 @@ Dockerfiles are often arranged in such a way as to optimize either image build t
 
 The solution is to remove that optimization from the `Dockerfile`:
 
-```dockerfile
+```docker
 FROM node:10.13-alpine
 ENV NODE_ENV=production
 WORKDIR /usr/src/app

--- a/docs/containers/debug-python.md
+++ b/docs/containers/debug-python.md
@@ -115,7 +115,7 @@ When you select **Docker: Add Docker Files to Workspace** for Django or Flask, w
 
 1. In the Dockerfile, comment out the line that adds app code to the container.
 
-    ``` dockerfile
+    ```docker
     #ADD . /app
     ```
 
@@ -169,7 +169,7 @@ When you select **Docker: Add Docker Files to Workspace** for Django or Flask, w
 
 1. In the Dockerfile, comment out the line that adds app code to the container.
 
-    ``` dockerfile
+    ```docker
     #ADD . /app
     ```
 

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -61,7 +61,7 @@ Create an **Attach** [launch configuration](/docs/editor/debugging.md#launch-con
 
 1. Configure the debugging port in `docker-compose.debug.yml`. This is set when you create the file, so you might not need to change it. In the example below, port 9229 is used for debugging on both the host and the container.
 
-   ```yml
+   ```yaml
     version: '3.4'
 
     services:
@@ -138,7 +138,7 @@ For debugging Python with Docker Compose, follow these steps:
 
 1. Right-click on the `docker-compose.debug.yml` file (example shown below) and choose **Compose Up**.
 
-    ```yml
+    ```yaml
     version: '3.4'
 
     services:
@@ -209,7 +209,7 @@ If everything is configured correctly, the debugger should be attached to your .
 
 By default, the Docker extension does not do any volume mounting for debugging components. There's no need for it in .NET or Node.js, since the required components are built into the runtime. If your app requires volume mounts, specify them by using the `volumes` tag in the `docker-compose*.yml` files.
 
-```yml
+```yaml
 volumes:
     - /host-folder-path:/container-folder-path
 ```

--- a/docs/containers/quickstart-aspnet-core.md
+++ b/docs/containers/quickstart-aspnet-core.md
@@ -52,7 +52,7 @@ In this guide you will learn how to:
 1. Open terminal prompt (`kb(workbench.action.terminal.toggleTerminal)`).
 1. Issue `dotnet build` command to build the application:
 
-   ``` output
+   ```
    ~/code/scratch/netcorerest$ dotnet build
    Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
    Copyright (C) Microsoft Corporation. All rights reserved.

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -88,7 +88,7 @@ To give Python Web Developers a great starting point, we chose to use [Gunicorn]
 
 To use Gunicorn, it must bind to an application callable (what the application server uses to communicate with your code) as an entry point. This callable is declared in the `wsgi.py` file of a Django application. To accomplish this binding, the final line in the Dockerfile says:
 
-```dockerfile
+```docker
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "{workspace_folder_name}.wsgi"]
 ```
 
@@ -107,7 +107,7 @@ app = Flask(__name__) # Flask instance named app
 
 To accomplish this binding, the final line in the Dockerfile says:
 
-```dockerfile
+```docker
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "{subfolder}.{module_file}:app"]
 ```
 

--- a/docs/containers/troubleshooting.md
+++ b/docs/containers/troubleshooting.md
@@ -19,7 +19,7 @@ If you select a port less than 1024 when adding Dockerfiles to the workspace, th
 
 The **Add Dockerfiles to Workspace** command sets up non-root privileges if you choose a non-system port. If your current Dockerfile and `tasks.json` is not set up for non-root usage, try running the command **Add Dockerfiles to Workspace**, and select a port **greater than** 1023. This command overwrites your current Dockerfile and `tasks.json`. For some project types, such as **Python: General**, you might still need to modify your Dockerfile and `tasks.json`. Within the Dockerfile, you must expose a **non-system port**, create a working directory for your app code, and then add a non-root user with access to the app directory. Ensure that your exposed port is updated wherever it is referenced. In the example below, the Gunicorn port had to be updated to match the exposed port:
 
-``` dockerfile
+```docker
 # 1024 or higher
 EXPOSE 1024
 

--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -152,7 +152,7 @@ If the keychain throws the error "Not enough memory resources are available to p
 
 If you're not sure what credentials to delete, try deleting all of the vscode specific credentials which all start with `vscode`. Here is a PowerShell one-liner that does exactly that:
 
-```pwsh
+```powershell
 cmdkey /list | Select-String -Pattern "LegacyGeneric:target=(vscode.+)" | ForEach-Object { cmdkey.exe /delete $_.Matches.Groups[1].Value }
 ```
 

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -265,7 +265,7 @@ A best practice among Python developers is to avoid installing packages into a g
    current system.", then you need to temporarily change the PowerShell execution policy to allow scripts to
    run (see [About Execution Policies](https://go.microsoft.com/fwlink/?LinkID=135170) in the PowerShell documentation):
 
-   ```pwsh
+   ```powershell
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
    ```
 

--- a/docs/remote/containers.md
+++ b/docs/remote/containers.md
@@ -550,13 +550,13 @@ Next, install `gnupg2` in your container by updating your Dockerfile.
 
 For example:
 
-```bash
+```docker
 RUN apt-get update && apt-get install gnupg2 -y
 ```
 
 Or if running as a [non-root user](/remote/advancedcontainers/add-nonroot-user.md):
 
-```bash
+```docker
 RUN sudo apt-get update && sudo apt-get install gnupg2 -y
 ```
 

--- a/docs/remote/create-dev-container.md
+++ b/docs/remote/create-dev-container.md
@@ -183,7 +183,7 @@ When you make changes like installing new software, changes made in the Dockerfi
 
 In your Dockerfile, use `FROM` to designate the image, and the `RUN` instruction to install any software. You can use `&&` to string together multiple commands.
 
-```Dockerfile
+```docker
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install git

--- a/docs/remote/linux.md
+++ b/docs/remote/linux.md
@@ -123,7 +123,7 @@ sudo rpm -Uh \
 
 In a container environment, you can add similar contents to a Dockerfile:
 
-```Dockerfile
+```docker
 FROM centos:6
 
 RUN yum -y install wget tar

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -143,7 +143,7 @@ Finally, you'll be asked to pick a config file to use. You can also set the `"re
 
 For example, entering `ssh -i ~/.ssh/id_rsa-remote-ssh yourname@remotehost.yourcompany.com` in the input box would generate this entry:
 
-```sshconfig
+```ssh-config
 Host remotehost.yourcompany.com
     User yourname
     HostName another-host-fqdn-or-ip-goes-here
@@ -244,7 +244,7 @@ If you have ports that you **always want to forward**, you can use the `LocalFor
 
 For example, if you wanted to forward ports 3000 and 27017, you could update the file as follows:
 
-```sshconfig
+```ssh-config
 Host remote-linux-machine
     User myuser
     HostName remote-linux-machine.mydomain

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -437,7 +437,7 @@ brew install --cask macfuse
 brew install gromgit/fuse/sshfs-mac
 brew link --overwrite sshfs-mac
 ```
-    
+
 In addition, if you would prefer not to use the command line to mount the remote filesystem, you can also install [SSHFS GUI](https://github.com/dstuecken/sshfs-gui).
 
 To use the command line, run the following commands from a local terminal (replacing `user@hostname` with the remote user and hostname / IP):
@@ -714,7 +714,7 @@ There are two ways to resolve this error:
 
 * **Option 2**: If you don't want to delete your containers or images, add this line into your Dockerfile before any `apt` or `apt-get` command. It adds the needed source lists for Jessie:
 
-    ```Dockerfile
+    ```docker
     # Add archived sources to source list if base image uses Debian 8 / Jessie
     RUN cat /etc/*-release | grep -q jessie && printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
     ```

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -223,13 +223,13 @@ You can always manually switch the default distro by using [wslconfig.exe](https
 
 For example:
 
-```bash
+```bat
 wslconfig /setdefault Ubuntu
 ```
 
 You can see which distributions you have installed using:
 
-```bash
+```bat
 wslconfig /l
 ```
 

--- a/docs/sourcecontrol/overview.md
+++ b/docs/sourcecontrol/overview.md
@@ -178,7 +178,7 @@ Now you can run `git config --global -e` and use VS Code as editor for configuri
 
 You can use VS Code's diff and merge capabilities even when using Git from command-line. Add the following to your Git configurations to use VS Code as the diff and merge tool:
 
-```bash
+```ini
 [diff]
     tool = default-difftool
 [difftool "default-difftool"]

--- a/docs/terminal/shell-integration.md
+++ b/docs/terminal/shell-integration.md
@@ -45,7 +45,7 @@ Add the following to your `~/.bashrc` file. Run `code ~/.bashrc` in bash to open
 
 Add the following to your [PowerShell profile](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.2). Run `code $Profile` in pwsh to open the file in VS Code.
 
-```pwsh
+```powershell
 if ($env:TERM_PROGRAM -eq "vscode") { . "$(code --locate-shell-integration-path pwsh)" }
 ```
 

--- a/release-notes/v1_70.md
+++ b/release-notes/v1_70.md
@@ -102,7 +102,7 @@ You can now use command line options to bring up the merge editor in VS Code:
 
 This enables you to use VS Code as a merge tool for Git, for example, if you configure this in `.gitconfig`:
 
-```gitconfig
+```toml
 [merge]
   tool = code
 [mergetool "code"]

--- a/release-notes/v1_70.md
+++ b/release-notes/v1_70.md
@@ -102,7 +102,7 @@ You can now use command line options to bring up the merge editor in VS Code:
 
 This enables you to use VS Code as a merge tool for Git, for example, if you configure this in `.gitconfig`:
 
-```toml
+```ini
 [merge]
   tool = code
 [mergetool "code"]

--- a/remote/advancedcontainers/add-nonroot-user.md
+++ b/remote/advancedcontainers/add-nonroot-user.md
@@ -53,7 +53,7 @@ While any images or Dockerfiles that come from the Remote - Containers extension
 
 Running your application as a non-root user is recommended even in production (since it is more secure), so this is a good idea even if you're reusing an existing Dockerfile. For example, this snippet for a Debian/Ubuntu container will create a user called `user-name-goes-here`, give it the ability to use `sudo`, and set it as the default:
 
-```Dockerfile
+```docker
 ARG USERNAME=user-name-goes-here
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -84,7 +84,7 @@ In either case, if you've already built the container and connected to it, run *
 
 While the `remoteUser` property tries to automatically update the UID/GID as appropriate on Linux when using a **Dockerfile or image**, you can use this snippet in your Dockerfile to manually change the UID/GID of a user instead. Update the `ARG` values as appropriate.
 
-```Dockerfile
+```docker
 ARG USERNAME=user-name-goes-here
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -96,6 +96,6 @@ RUN groupmod --gid $USER_GID $USERNAME \
 
 Note that on Alpine Linux, you'll need to install the `shadow` package first.
 
-```Dockerfile
+```docker
 RUN apk add --no-cache shadow
 ```

--- a/remote/advancedcontainers/avoid-extension-reinstalls.md
+++ b/remote/advancedcontainers/avoid-extension-reinstalls.md
@@ -20,7 +20,7 @@ To create the named local volume, follow these steps:
 
 1. **If you are running as a non-root user**, you'll need to ensure your Dockerfile creates `~/.vscode-server/extensions` and/or `~/.vscode-server-insiders/extensions` in the container with this non-root user as the owner. If you do not do this, the folder will be owned by root and your connection will fail with a permissions issue. See [Adding a non-root user to your dev container](/remote/advancedcontainers/add-nonroot-user.md) for full details, but you can use this snippet in your Dockerfile to create the folders. Replace `user-name-goes-here` with the actual user name:
 
-    ```Dockerfile
+    ```docker
     ARG USERNAME=user-name-goes-here
 
     RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \

--- a/remote/advancedcontainers/avoid-extension-reinstalls.md
+++ b/remote/advancedcontainers/avoid-extension-reinstalls.md
@@ -48,7 +48,7 @@ To create the named local volume, follow these steps:
 
     Update (or [extend](/docs/remote/create-dev-container.md#extend-your-docker-compose-file-for-development)) your `docker-compose.yml` with the following for the appropriate service. Replacing `/root` with the home directory in the container if not root (for example `/home/user-name-goes-here`) and `unique-vol-name-here` with a unique name for the volume.
 
-    ```yml
+    ```yaml
     services:
       your-service-name-here:
         volumes:

--- a/remote/advancedcontainers/docker-options.md
+++ b/remote/advancedcontainers/docker-options.md
@@ -49,7 +49,7 @@ You may use a [Cloud-Init](https://cloud-init.io/) file (which is an industry st
 
 `cloud-init.txt` file:
 
-``` bash
+```yaml
 #cloud-config
 
 apt:

--- a/remote/advancedcontainers/persist-bash-history.md
+++ b/remote/advancedcontainers/persist-bash-history.md
@@ -15,14 +15,14 @@ First, update your `Dockerfile` so that each time a command is used in `bash`, t
 
 If you have a root user, update your `Dockerfile` with the following:
 
-```Dockerfile
+```docker
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
     && echo "$SNIPPET" >> "/root/.bashrc"
 ```
 
 If you have a non-root user, update your `Dockerfile` with the following. Replace `user-name-goes-here` with the name of a [non-root user](/remote/advancedcontainers/add-nonroot-user.md) in the container.
 
-```Dockerfile
+```docker
 ARG USERNAME=user-name-goes-here
 
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \

--- a/remote/advancedcontainers/reduce-docker-warnings.md
+++ b/remote/advancedcontainers/reduce-docker-warnings.md
@@ -15,7 +15,7 @@ The following are some tips for eliminating warnings that may be appearing in yo
 
 This error can typically be safely ignored and is tricky to get rid of completely. However, you can reduce it to one message in stdout when installing the needed package by adding the following to your Dockerfile:
 
-```Dockerfile
+```docker
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
@@ -29,14 +29,14 @@ This occurs in Dockerfiles because the `apt-key` command is not running from a t
 
 For example:
 
-```Dockerfile
+```docker
 # (OUT=$(apt-key add - 2>&1) || echo $OUT) will only print the output with non-zero exit code is hit
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
 ```
 
 You can also set the `APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE` environment variable to suppress the warning, but it looks a bit scary so be sure to add comments in your Dockerfile if you use it:
 
-```Dockerfile
+```docker
 # Suppress an apt-key warning about standard out not being a terminal. Use in this script is safe.
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ```
@@ -49,7 +49,7 @@ If the messages are harmless, you can pipe the output of the command from standa
 
 For example:
 
-```Dockerfile
+```docker
 RUN apt-get -y install --no-install-recommends apt-utils dialog 2>&1
 ```
 

--- a/remote/advancedcontainers/start-processes.md
+++ b/remote/advancedcontainers/start-processes.md
@@ -65,7 +65,7 @@ The `overrideCommand` property defaults to `true` because many images will immed
 
 Next, consider this Dockerfile:
 
-```Dockerfile
+```docker
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-focal
 
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
We use shiki as the highlighter, so the actual reference list is at [shiki/languages.md](https://github.com/shikijs/shiki/blob/main/docs/languages.md).
One thing to note is that the ssh-config name currently isn't recognized locally, but I'm hoping that updating shiki would help.