### PR TITLE
Fix return type from vscode.executeDefinitionProvider

### DIFF
--- a/api/extension-guides/command.md
+++ b/api/extension-guides/command.md
@@ -40,7 +40,7 @@ async function printDefinitionsForActiveEditor() {
     return;
   }
 
-  const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+  const definitions = await vscode.commands.executeCommand<vscode.LocationLink[]>(
     'vscode.executeDefinitionProvider',
     activeEditor.document.uri,
     activeEditor.selection.active


### PR DESCRIPTION
According to issue https://github.com/microsoft/vscode-docs/pull/4098 ，but not fix this file yet.