### PR TITLE
Should reference engines.vscode not vscode.engine

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -313,7 +313,7 @@ Because of this we recommend that extensions use `major.EVEN_NUMBER.patch` for r
 
 If extension authors do not want their pre-release users to be updated to the release version, we recommend to always increment and publish a new pre-release version before publishing a release version in order to make sure that the pre-release version is always higher. Note that while pre-release users will be updated to a release version if it is higher, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version.
 
-Pre-release extensions are supported after VS Code version `1.63.0` and so all pre-release extensions needs to set `vscode.engine` value in their `package.json` to `>= 1.63.0`.
+Pre-release extensions are supported after VS Code version `1.63.0` and so all pre-release extensions needs to set `engines.vscode` value in their `package.json` to `>= 1.63.0`.
 
 > **Note:** Extensions that already have a separate stand alone pre-release extension should reach out to the VS Code team to enable the automatic uninstall of the outdated separate extension and install of the pre-release version of the main extension.
 


### PR DESCRIPTION
The extension manifest shows `engines.vscode` https://code.visualstudio.com/api/get-started/extension-anatomy#extension-manifest. `vscode.engine` does not exist.