### PR TITLE
update vuejs docs to work well with the latest version of Vue (v3)

### DIFF
--- a/docs/nodejs/images/vuejs/directive-suggestions.png
+++ b/docs/nodejs/images/vuejs/directive-suggestions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4606834866e46dea9dce4a2c254d9d3f9c0581d23cca25dccbeecd9a716ed698
+size 456468

--- a/docs/nodejs/images/vuejs/hello-world.png
+++ b/docs/nodejs/images/vuejs/hello-world.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27a255640e45c23d83f09739f0abe8e4cd95a61eab0c87799154f2f8e7edda67
-size 3484

--- a/docs/nodejs/images/vuejs/hmr-hello-world.png
+++ b/docs/nodejs/images/vuejs/hmr-hello-world.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d006db7fb3240a2ed9a27715162168ce5e9a75523767332c416122e64b812cd8
+size 158628

--- a/docs/nodejs/images/vuejs/javascript-suggestions.png
+++ b/docs/nodejs/images/vuejs/javascript-suggestions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87ef89abb53692caf82fa445d826da12ddd409641452f5c35a4c18bf67fd4cbd
-size 12407

--- a/docs/nodejs/images/vuejs/linting-with-eslint.png
+++ b/docs/nodejs/images/vuejs/linting-with-eslint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1599776669f8bacb20ebe687923933f7078852cc511d29dba9d1a400a3974cd
+size 343748

--- a/docs/nodejs/images/vuejs/macro-suggestions.png
+++ b/docs/nodejs/images/vuejs/macro-suggestions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62f2c26cb0b146625f969065c80d99b20d9c6c5551b480b96367fe9b5dc843e6
+size 433545

--- a/docs/nodejs/images/vuejs/peek-definition.png
+++ b/docs/nodejs/images/vuejs/peek-definition.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a33950d850a8b38c8e018e2d9a1addee14cb601d4e6dbbddee9298574b89e38
-size 18263

--- a/docs/nodejs/images/vuejs/suggestions.png
+++ b/docs/nodejs/images/vuejs/suggestions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90486f7e04e89e55445485ef3d54914c3bdf54f994c57cb65bcdbb16478ba67b
-size 15757

--- a/docs/nodejs/images/vuejs/syntax-highlighting.png
+++ b/docs/nodejs/images/vuejs/syntax-highlighting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e5244f781f5b37e53903917ac024a663c80e0c59c46d58fdafdbcaf4133962
+size 605114

--- a/docs/nodejs/images/vuejs/vetur-extension-recommendation.png
+++ b/docs/nodejs/images/vuejs/vetur-extension-recommendation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ed143da058d5db42a4bf3aafd57431cbc050334745bc42e9298724c70af1e42
-size 32375

--- a/docs/nodejs/images/vuejs/vetur-extension.png
+++ b/docs/nodejs/images/vuejs/vetur-extension.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:891336f320b3fd8aa37b3c5ef53cd6687d958432e7eeea8ff5088c21cbdb0ec2
-size 6633

--- a/docs/nodejs/images/vuejs/volar-extension.png
+++ b/docs/nodejs/images/vuejs/volar-extension.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea4e0ca2b2e4df53b5de022fece06aea86f1d7c35e718c7d0eb1435cab989e90
+size 421635

--- a/docs/nodejs/images/vuejs/volar-recommended.png
+++ b/docs/nodejs/images/vuejs/volar-recommended.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:844fc3cb397700b02668bbfb0e5ad9e3d5b21f6ce24d82813fb01d203dd53ef1
+size 438205

--- a/docs/nodejs/images/vuejs/vue-boilerplate-running-in-browser.png
+++ b/docs/nodejs/images/vuejs/vue-boilerplate-running-in-browser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3f07d175b3e1debdfb08fe3f970d2590ec133f3750233e322a0303b57605777
+size 379012

--- a/docs/nodejs/images/vuejs/vue-extension-pack.png
+++ b/docs/nodejs/images/vuejs/vue-extension-pack.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:403206d244bfde3725c1c173c5853762216cbc394805aa08930b3d7c9482cdc3
-size 9474

--- a/docs/nodejs/images/vuejs/vue-language-features.png
+++ b/docs/nodejs/images/vuejs/vue-language-features.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a2d32dab29dfcf004677489f88c08d03e5af6f042bfb34f00df27af260710a9
-size 25747

--- a/docs/nodejs/images/vuejs/vue-linting.png
+++ b/docs/nodejs/images/vuejs/vue-linting.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a04f3e4fcd9bf1f4ce37cda746b7012323e6a97f7ef0eb036940644c98eaa98f
-size 5002

--- a/docs/nodejs/vuejs-tutorial.md
+++ b/docs/nodejs/vuejs-tutorial.md
@@ -9,133 +9,127 @@ MetaDescription: Vue JavaScript tutorial showing IntelliSense, debugging, and co
 ---
 # Using Vue in Visual Studio Code
 
-[Vue.js](https://vuejs.org/) is a popular JavaScript library for building web application user interfaces and  Visual Studio Code has built-in support for the Vue.js building blocks of [HTML](/docs/languages/html.md), [CSS](/docs/languages/css.md), and [JavaScript](/docs/languages/javascript.md). For a richer Vue.js development environment, you can install the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension which supports Vue.js IntelliSense, code snippets, formatting, and more.
+[Vue.js](https://vuejs.org/) is a popular JavaScript library for building web application user interfaces and  Visual Studio Code has built-in support for the Vue.js building blocks of [HTML](https://code.visualstudio.com/docs/languages/html), [CSS](https://code.visualstudio.com/docs/languages/css), and [JavaScript](https://code.visualstudio.com/docs/languages/javascript). For a richer Vue.js development environment, you can install the [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extension which supports Vue.js IntelliSense, formatting, and more.
 
 ---
 
-![welcome to Vue](images/vuejs/welcome-to-vue.png)
+![welcome to vue](./images/vuejs/welcome-to-vue.png)
 
 ---
 
 ## Welcome to Vue
 
-We'll be using the [Vue CLI](https://cli.vuejs.org/) for this tutorial. If you are new to the Vue.js framework, you can find great documentation and tutorials on the [vuejs.org](https://vuejs.org) website.
+We'll be using the [official Vue scaffolding tool](https://vuejs.org/guide/quick-start.html#with-build-tools) for this tutorial. If you are new to the Vue.js framework, you can find great documentation and tutorials on the [vuejs.org](https://vuejs.org/) website.
 
-To install and use the Vue CLI as well as run the Vue application server, you'll need the [Node.js](https://nodejs.org/) JavaScript runtime and [npm](https://www.npmjs.com/) (the Node.js package manager) installed. npm is included with Node.js which you can install from [Node.js downloads](https://nodejs.org/en/download/).
+To use the scaffolding tool as well as run the Vue application server, you'll need the [Node.js](https://nodejs.org/) JavaScript runtime and [npm](https://www.npmjs.com/) (the Node.js package manager) installed. npm is included with Node.js which you can install from [Node.js downloads](https://nodejs.org/en/download/).
 
->**Tip**: To test that you have Node.js and npm correctly installed on your machine, you can type `node --version` and `npm --version`.
+> Tip: To test that you have Node.js and npm correctly installed on your machine, you can type node --version and npm --version.
+>
 
-To install the `vue/cli` , in a terminal or command prompt type:
+You can now create a new Vue.js application by typing:
 
-```bash
-npm install -g @vue/cli
+```
+npm init vue@3
 ```
 
-This may take a few minutes to install. You can now create a new Vue.js application by typing:
+You will be prompted with several questions to setup the project. For our purposes you can answer the prompts as follows:
 
-```bash
-vue create my-app
+```jsx
+Project name: … my-app
+✔ Add TypeScript? … No
+✔ Add JSX Support? … No
+✔ Add Vue Router for Single Page Application development? … No
+✔ Add Pinia for state management? … No
+✔ Add Vitest for Unit testing? … No
+✔ Add Cypress for both Unit and End-to-End testing? … No
+✔ Add ESLint for code quality? … Yes
+✔ Add Prettier for code formatting? … No
 ```
 
-where `my-app` is the name of the folder for your application. You will be prompted to select a preset and you can keep the default `(babel, eslint)`, which will use [Babel](https://babeljs.io) to transpile the JavaScript to browser compatible ES5 and install the [ESLint](https://eslint.org/) linter to detect coding errors. It may take a few minutes to create the Vue application and install its dependencies.
+Let's quickly run our Vue application by navigating to the new folder, installing the dependencies, and typing `npm run dev` to start the web server and open the application in a browser:
 
-Let's quickly run our Vue application by navigating to the new folder and typing `npm run serve` to start the web server and open the application in a browser:
-
-```bash
+```
 cd my-app
-npm run serve
+npm install
+npm run dev
 ```
 
-You should see "Welcome to your Vue.js App" on [http://localhost:8080](http://localhost:8080) in your browser. You can press `kbstyle(Ctrl+C)` to stop the `vue-cli-service` server.
+You should see the Vue.js welcome page that says “You did it!” on [http://localhost:5173/](http://localhost:5173/) in your browser.
+
+![screenshot of vue app up and running](./images/vuejs/vue-boilerplate-running-in-browser.png)
+
+You can press Ctrl+C to stop the dev server.
 
 To open your Vue application in VS Code, from a terminal (or command prompt), navigate to the `my-app` folder and type `code .`:
 
-```bash
+```
 cd my-app
 code .
 ```
 
 VS Code will launch and display your Vue application in the File Explorer.
 
-## Vetur extension
+## Volar extension
 
-Now expand the `src` folder and select the `App.vue` file. You'll notice that VS Code doesn't show any syntax highlighting and it treats the file as **Plain Text** as you can see in the lower right Status Bar. You'll also see a notification recommending the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension for the `.vue` file type.
+Now expand the `src` folder and select the `App.vue` file. You'll notice that VS Code doesn't show any syntax highlighting and it treats the file as **Plain Text** as you can see in the lower right Status Bar. You’ll also see a notification recommending you install a couple extensions.
 
-![vetur extension recommendation](images/vuejs/vetur-extension-recommendation.png)
+![Volar extension recommended](./images/vuejs/volar-recommended.png)
 
-The Vetur extension supplies Vue.js language features (syntax highlighting, IntelliSense, snippets, formatting) to VS Code.
+The Volar extension supplies Vue.js language features (syntax highlighting, IntelliSense, formatting) to VS Code. The TypeScript Vue Plugin is not necessary for this tutorial.
 
-![vetur extension](images/vuejs/vetur-extension.png)
+![Volar extension](./images/vuejs/volar-extension.png)
 
-From the notification, press **Install** to download and install the Vetur extension. You should see the Vetur extension **Installing** in the Extensions view. Once the installation is complete (may take several minutes), the **Install** button will change to the **Manage** gear button.
+From the notification, press **Install** to download and install the Volar extension.
 
 Now you should see that `.vue` is a recognized file type for the Vue language and you have language features such as syntax highlighting, bracket matching, and hover descriptions.
 
-![vue language features](images/vuejs/vue-language-features.png)
+![Volar syntax highlighting](./images/vuejs/syntax-highlighting.png)
+
+You can learn more about Volar [with this FREE video lesson from Vue School](https://vueschool.io/lessons/volar-the-official-language-feature-extension-for-vs-code?friend=vscode).
 
 ## IntelliSense
 
 As you start typing in `App.vue`, you'll see smart suggestions or completions both for HTML and CSS but also for Vue.js specific items like declarations (`v-bind`, `v-for`) in the Vue `template` section:
 
-![Vue.js suggestions](images/vuejs/suggestions.png)
+![vue directive suggestions](./images/vuejs/directive-suggestions.png)
 
-and Vue properties (`methods`, `computed`) in the `scripts` section:
+and some Vue compiler micros in the script setup section:
 
-![Vue.js JavaScript suggestions](images/vuejs/javascript-suggestions.png)
-
-### Go to Definition, Peek definition
-
-VS Code through the Vue extension language service can also provide type definition information in the editor through **Go to Definition** (`kb(editor.action.revealDefinition)`) or **Peek Definition** (`kb(editor.action.peekDefinition)`). Put the cursor over the `App`, right click and select **Peek Definition**. A [Peek window](/docs/editor/editingevolved.md#peek) will open showing the `App` definition from `App.js`.
-
-![Vue.js peek definition](images/vuejs/peek-definition.png)
-
-Press `kbstyle(Escape)` to close the Peek window.
+![vue macro suggestions](./images/vuejs/macro-suggestions.png)
 
 ## Hello World
 
 Let's update the sample application to "Hello World!". In `App.vue` replace the HelloWorld component `msg` custom attribute text with "Hello World!".
 
-```html
-<template>
-  <div id="app">
-    <img src="./assets/logo.png">
-    <HelloWorld msg="Hello World!"/>
-  </div>
-</template>
+```
+<HelloWorld msg="Hello World" />
 ```
 
-Once you save the `App.vue` file (`kb(workbench.action.files.save)`), restart the server with `npm run serve` and you'll see "Hello World!". Leave the server running while we go on to learn about Vue.js client side debugging.
+Once you save the `App.vue` file (⌘S), the page will auto update in the browser via Hot Module Reloading.
 
->**Tip**: VS Code supports Auto Save, which by default saves your files after a delay. Check the **Auto Save** option in the **File** menu to turn on Auto Save or directly configure the `files.autoSave` user [setting](/docs/getstarted/settings.md).
+> Tip: VS Code supports Auto Save, which by default saves your files after a delay. Check the Auto Save option in the File menu to turn on Auto Save or directly configure the files.autoSave user setting.
+>
 
----
-
-![hello world](images/vuejs/hello-world.png)
-
----
+![page updates with HMR](./images/vuejs/hmr-hello-world.png)
 
 ## Linting
 
-Linters analyze your source code and can warn you about potential problems before you run your application. The Vue ESLint plugin ([eslint-plugin-vue](https://www.npmjs.com/package/eslint-plugin-vue)) checks for Vue.js specific syntax errors which are shown in the editor as red squigglies and are also displayed in the **Problems** panel (**View** > **Problems** `kb(workbench.actions.view.problems)`).
+Linters analyze your source code and can warn you about potential problems before you run your application. The Vue ESLint plugin ([eslint-plugin-vue](https://www.npmjs.com/package/eslint-plugin-vue)) checks for Vue.js specific syntax errors which are shown in the editor as red squigglies and are also displayed in the **Problems** panel (**View** > **Problems** ⇧⌘M).
 
-Below you can see an error when the Vue linter detects more than one root element in a template:
+Below you can see an error when the Vue linter detects the use of v-for without a key defined:
 
-![Vue linting](images/vuejs/vue-linting.png)
+![lint with ESLint](./images/vuejs/linting-with-eslint.png)
 
 ## Debugging
 
-You can debug client side Vue.js code with the built-in JavaScript debugger. You can learn more from the [Vue.js debugging in VS Code](https://github.com/microsoft/vscode-recipes/tree/main/vuejs-cli) recipe on the VS Code debugging [recipes](https://github.com/microsoft/vscode-recipes) site.
-
->Note: There are currently issues with the sourcemaps generated by vue-cli, which cause issues with the debugging experience in VS Code. See [https://github.com/vuejs/vue-loader/issues/1163](https://github.com/vuejs/vue-loader/issues/1163).
+You can debug client side Vue.js code with the built-in JavaScript debugger. You can learn more about debugging Vue.js apps with this [FREE video lesson from Vue School](https://vueschool.io/lessons/debugging-vue-apps-in-vs-code?friend=vscode).
 
 Another popular tool for debugging Vue.js is the [vue-devtools](https://github.com/vuejs/vue-devtools) plug-in.
 
 ## Other extensions
 
-Vetur is only one of many Vue.js extensions available for VS Code. You can search in the Extensions view (`kb(workbench.view.extensions)`) by typing 'vue'.
+Volar is only one of many Vue.js extensions available for VS Code. You can search in the Extensions view (⇧⌘X) by typing 'vue'.
 
-![Vue.js extensions](images/vuejs/vue-extensions.png)
+![other vue extensions](./images/vuejs/vue-extensions.png)
 
 There are also Extension Packs which bundle extensions that other people have found useful for Vue.js development.
-
-![Vue.js extension pack](images/vuejs/vue-extension-pack.png)


### PR DESCRIPTION
The current guide for Vue is outdated. It targets Vue 2.
This PR updates the guide to work well for the latest version Vue 3. 

We also created some video content at Vue School teaching how to work with VS Code + Vue. There are some links in this PR to some of pertinent and free lessons from the premium course. 

Thanks!