### PR TITLE
Fix instructions to show builtin extensions

### DIFF
--- a/docs/getstarted/images/themes/built-in-themes.png
+++ b/docs/getstarted/images/themes/built-in-themes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd1e401b712f40b77dccdce5b0ac9781d81ba7800e31bdef1b75b00a0e44c9b3
-size 36403
+oid sha256:9534f3dd43402284c837bfa26d11dc20c417da9a408bd974a26458fbafdabbd1
+size 94624

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -181,7 +181,7 @@ See the [Create a new Color Theme](/api/extension-guides/color-theme.md#create-a
 
 ## Remove default Color Themes
 
-If you'd like to remove some of the default themes shipped with VS Code from the Color Theme picker, you can disable them from the Extensions view (`kb(workbench.view.extensions)`). Open the `...` **More Actions** dropdown menu from the top of the Extensions view, select **Show Built-in Extensions**, and you'll see a **THEMES** section listing the default themes.
+If you'd like to remove some of the default themes shipped with VS Code from the Color Theme picker, you can disable them from the Extensions view (`kb(workbench.view.extensions)`). Click the **Filter Extensions** button from the top of the Extensions view, select the **Built-in** option, and you'll see a **THEMES** section listing the default themes.
 
 ![built-in themes](images/themes/built-in-themes.png)
 


### PR DESCRIPTION
On macOS, there isn't **Show Built-in Extensions** button. I need to search for `@builtin` to show them. So I added a separate instruction for the OS.

I can't verify whether the button is still there on Windows and Linux versions (no environment sorry).