### PR TITLE
Add Node.js Deployment page and reconfigure Azure Deployment

### DIFF
--- a/docs/azure/deployment.md
+++ b/docs/azure/deployment.md
@@ -17,12 +17,12 @@ Whether your workflow is through the [Azure CLI](https://learn.microsoft.com/cli
 
 These tutorials from Microsoft Learn describe different ways of creating and deploying apps to Azure via Visual Studio Code:
 
-Tutorial | Description
---- | ---
-[Deploy Azure Functions](https://learn.microsoft.com/azure/developer/javascript/tutorial/azure-function-cosmos-db-mongo-api) | Build and manage Azure Functions serverless apps directly in VS Code with the Azure Functions extension.
-[Deploy using the App Service extension](https://learn.microsoft.com/azure/app-service/tutorial-nodejs-mongodb-app) | Manage Azure resources directly in VS Code with the Azure App Service extension.
-[Deploy using Docker](https://learn.microsoft.com/azure/developer/javascript/tutorial/tutorial-vscode-docker-node/tutorial-vscode-docker-node-01) | Deploy your website using a Docker container.
-[Deploy a static website](https://learn.microsoft.com/azure/static-web-apps/getting-started) | Create, deploy, and update a static website.
+Tutorial(s) | Description | Framework / Language
+--- | --- | ---
+[Deploy a static website](https://learn.microsoft.com/azure/static-web-apps/getting-started) | Create, deploy, and update a static website | Angular, Blazor, React, or Vue
+[Deploy Node.js web apps](https://code.visualstudio.com/docs/nodejs/nodejs-deployment) | Deploy web apps, containerized apps, or serverless code | Node.js
+[Deploy Python apps](https://code.visualstudio.com/docs/python/python-on-azure) | Deploy web apps, containerized apps, or serverless code | Python
+[Deploy Java apps](https://code.visualstudio.com/docs/java/java-on-azure) | Deploy web apps, Spring Boot apps, or serverless code | Java
 
 You can find additional tutorials and walkthroughs on the
 [Azure Developer Center](https://learn.microsoft.com/azure/developer), including language-specific articles for JavaScript and Node.js, Python, Java, and .NET.

--- a/docs/azure/deployment.md
+++ b/docs/azure/deployment.md
@@ -15,14 +15,14 @@ Whether your workflow is through the [Azure CLI](https://learn.microsoft.com/cli
 
 ## Deployment tutorials
 
-These tutorials from Microsoft Learn describe different ways of creating and deploying apps to Azure via Visual Studio Code:
+The tutorials and topics below describe different ways of creating and deploying apps to Azure via Visual Studio Code:
 
 Tutorial(s) | Description | Framework / Language
 --- | --- | ---
 [Deploy a static website](https://learn.microsoft.com/azure/static-web-apps/getting-started) | Create, deploy, and update a static website | Angular, Blazor, React, or Vue
-[Deploy Node.js web apps](https://code.visualstudio.com/docs/nodejs/nodejs-deployment) | Deploy web apps, containerized apps, or serverless code | Node.js
-[Deploy Python apps](https://code.visualstudio.com/docs/python/python-on-azure) | Deploy web apps, containerized apps, or serverless code | Python
-[Deploy Java apps](https://code.visualstudio.com/docs/java/java-on-azure) | Deploy web apps, Spring Boot apps, or serverless code | Java
+[Deploy Node.js web apps](/docs/nodejs/nodejs-deployment.md) | Deploy web apps, containerized apps, or serverless code | Node.js
+[Deploy Python apps](/docs/python/python-on-azure.md) | Deploy web apps, containerized apps, or serverless code | Python
+[Deploy Java apps](/docs/java/java-on-azure.md) | Deploy web apps, Spring Boot apps, or serverless code | Java
 
 You can find additional tutorials and walkthroughs on the
 [Azure Developer Center](https://learn.microsoft.com/azure/developer), including language-specific articles for JavaScript and Node.js, Python, Java, and .NET.

--- a/docs/nodejs/images/azure/azure-tools.png
+++ b/docs/nodejs/images/azure/azure-tools.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027c808d27ae82b77734a7fccc64d415e813ba77f6dc4bafda29c845c0275a56
+size 19510

--- a/docs/nodejs/nodejs-deployment.md
+++ b/docs/nodejs/nodejs-deployment.md
@@ -10,3 +10,15 @@ DateApproved: 10/6/2022
 # Deploy a Node.js Application to Azure
 
 This page is redirected to /docs/azure/deployment and only exists to create the "Node.js Deployment" TOC item.
+
+
+## Deployment tutorials
+
+These tutorials from Microsoft Learn describe different ways of creating and deploying apps to Azure via Visual Studio Code:
+
+Tutorial | Description | Related Tools
+--- | --- | ---
+[Deploy Azure Functions](https://learn.microsoft.com/azure/developer/javascript/tutorial/azure-function-cosmos-db-mongo-api) | Build and manage Azure Functions serverless apps directly in VS Code with the Azure Functions extension. | [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups) <br> [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) <br> [Azure Databases](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-cosmosdb)
+[Deploy using Azure Portal and App Service](https://learn.microsoft.com/azure/app-service/tutorial-nodejs-mongodb-app) | Manage Azure resources directly in VS Code with the Azure App Service extension. | [MongoDB](https://www.mongodb.com/docs/manual/installation/) <br> [Azure Portal](https://portal.azure.com/)
+[Deploy using Docker](https://learn.microsoft.com/azure/developer/javascript/tutorial/tutorial-vscode-docker-node/tutorial-vscode-docker-node-01) | Deploy your website using a Docker container. | [Docker](https://www.docker.com/) <br> [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) <br> [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) <br> [Azure Account Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) <br> [Azure App Service](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) <br> [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups)
+[Deploy a static website](https://learn.microsoft.com/azure/static-web-apps/getting-started) | Create, deploy, and update a static website. | [Git](https://www.git-scm.com/downloads) <br> [Azure Static Web Apps](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps)

--- a/docs/nodejs/nodejs-deployment.md
+++ b/docs/nodejs/nodejs-deployment.md
@@ -1,24 +1,24 @@
 ---
 Order: 4
 Area: nodejs
-TOCTitle: Node.js Deployment
+TOCTitle: Deploy Node.js Apps
 PageTitle: Node.js Deployment with Visual Studio Code
 ContentId: 856a4a73-a4b4-4418-b88d-1f65d0ba7824
 MetaDescription: Node.js Deployment to Azure with Visual Studio Code
 DateApproved: 10/6/2022
 ---
-# Deploy a Node.js Application to Azure
+# Deploy Node.js Web Apps
 
-This page is redirected to /docs/azure/deployment and only exists to create the "Node.js Deployment" TOC item.
+The [Azure Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack) extensions for Visual Studio Code make it easy to deploy Node.js applications.
 
+![Azure Tools extension](images/azure/azure-tools.png)
 
 ## Deployment tutorials
 
-These tutorials from Microsoft Learn describe different ways of creating and deploying apps to Azure via Visual Studio Code:
+These tutorials from Microsoft Learn describe different ways of creating and deploying Node.js apps to Azure via Visual Studio Code:
 
 Tutorial | Description | Related Tools
 --- | --- | ---
 [Deploy Azure Functions](https://learn.microsoft.com/azure/developer/javascript/tutorial/azure-function-cosmos-db-mongo-api) | Build and manage Azure Functions serverless apps directly in VS Code with the Azure Functions extension. | [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups) <br> [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) <br> [Azure Databases](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-cosmosdb)
 [Deploy using Azure Portal and App Service](https://learn.microsoft.com/azure/app-service/tutorial-nodejs-mongodb-app) | Manage Azure resources directly in VS Code with the Azure App Service extension. | [MongoDB](https://www.mongodb.com/docs/manual/installation/) <br> [Azure Portal](https://portal.azure.com/)
 [Deploy using Docker](https://learn.microsoft.com/azure/developer/javascript/tutorial/tutorial-vscode-docker-node/tutorial-vscode-docker-node-01) | Deploy your website using a Docker container. | [Docker](https://www.docker.com/) <br> [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) <br> [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) <br> [Azure Account Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) <br> [Azure App Service](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) <br> [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups)
-[Deploy a static website](https://learn.microsoft.com/azure/static-web-apps/getting-started) | Create, deploy, and update a static website. | [Git](https://www.git-scm.com/downloads) <br> [Azure Static Web Apps](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps)


### PR DESCRIPTION
@spboyer and I noticed that the Node.js deployment should be renamed to be in line with the names from #5660. We also think the current Azure deployment really should be the Node.js deployment page. So I moved that table to the Node.js page-- I think the TOC link still reroutes to the Azure page so that change still needs to be made.

Finally, tables were reformatted to match #5705 and #5714