### PR TITLE
Add rehydrated Node.js deploy topic to sitemap

### DIFF
--- a/build/sitemap.xml
+++ b/build/sitemap.xml
@@ -486,6 +486,11 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://code.visualstudio.com/docs/nodejs/nodejs-deployment</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
         <loc>https://code.visualstudio.com/docs/nodejs/reactjs-tutorial</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>


### PR DESCRIPTION
https://github.com/microsoft/vscode-docs/pull/5725 added content back to Deploy Node.js Apps topic at https://code.visualstudio.com/docs/nodejs/nodejs-deployment.
This PR adds it to the sitemap so search crawlers will see it