### PR TITLE
Remove node pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ The history of this repo before we adopted LFS can be found at [microsoft/vscode
 ## Publishing
 
 Steps for how to publish documentation changes can be found [here](https://github.com/microsoft/vscode-website#publishing-a-documentation-change) in the (private) repository of the VS Code website.
+
+Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on https://code.visualstudio.com but the intent is that they will usually be live within 24 hours.

--- a/docs/azure/extensions.md
+++ b/docs/azure/extensions.md
@@ -21,8 +21,6 @@ There are many VS Code extensions on the [Marketplace](https://marketplace.visua
 
 > **Tip:** Click on an extension tile above to read the description and reviews in the Marketplace.
 
-There is also a [Node Pack for Azure](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack) extension pack which bundles useful Azure extensions for Node.js developers into a single installation.
-
 ## Searching for extensions
 
 You can also search for Azure or cloud extensions in the VS Code Extensions view (`kb(workbench.view.extensions)`) and type 'azure'.


### PR DESCRIPTION
The "Node Pack for Azure" actually points to the Azure Tools extension pack, now mentioned above in the article after a recent PR.