### PR TITLE
Make flask sample code style more Pythonic

### DIFF
--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -154,15 +154,18 @@ Debugging gives you the opportunity to pause a running program on a particular l
 1. Replace the contents of `app.py` with the following code, which adds a second route and function that you can step through in the debugger:
 
     ```python
-    from flask import Flask
-    from datetime import datetime
     import re
+    from datetime import datetime
+
+    from flask import Flask
 
     app = Flask(__name__)
+
 
     @app.route("/")
     def home():
         return "Hello, Flask!"
+
 
     @app.route("/hello/<name>")
     def hello_there(name):


### PR DESCRIPTION
I noticed the imports were out of order, so I ran [shed](https://github.com/Zac-HD/shed) on the sample code. It fixed the imports and also added the standard 2 lines between definitions at the global layer.
I think it's nice when sample code follows Pythonic conventions so that people don't get warnings from linters running in their editor when they try to use a sample.

Perhaps the ordering is intentional, however, given you later describe how to sort imports? That's on views.py file though, so that learning goal could still be achieved. Up to you!