### PR TITLE
Update to latest dev container repos and terms

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -611,6 +611,6 @@ There are a few extension problems that could be resolved with some added functi
 - See [Tips and Tricks](/docs/remote/troubleshooting) or the [FAQ](/docs/remote/faq).
 - Search for answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 - [Upvote a feature or request a new one](https://aka.ms/vscode-remote/feature-requests), search [existing issues](https://aka.ms/vscode-remote/issues), or [report a problem](https://aka.ms/vscode-remote/issues/new).
-- Contribute a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+- Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 - Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code](https://github.com/microsoft/vscode).
 - See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -238,7 +238,7 @@ This implies trusting [the machine the Docker daemon runs on](/remote/advancedco
 
 VS Code's container configuration is stored in a [devcontainer.json](https://containers.dev/implementors/json_reference) file. This file is similar to the `launch.json` file for debugging configurations, but is used for launching (or attaching to) your development container instead. You can also specify any extensions to install once the container is running or post-create commands to prepare the environment. The dev container configuration is either located under `.devcontainer/devcontainer.json` or stored as a `.devcontainer.json` file (note the dot-prefix) in the root of your project.
 
-You can use any image, Dockerfile, or set of Docker Compose files as a starting point. Here is a simple example that uses one of the pre-built [Development Container images](https://hub.docker.com/_/microsoft-devcontainers):
+You can use any image, Dockerfile, or set of Docker Compose files as a starting point. Here is a simple example that uses one of the pre-built [Development Container images](https://github.com/devcontainers/images):
 
 ```json
 {

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -101,7 +101,7 @@ This quick start covers how to set up a dev container for an existing project to
 
     > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 
-    ![Select a node dev container Template](images/containers/select-dev-container-def.png)
+    ![Select a node Dev Container Template](images/containers/select-dev-container-def.png)
 
     The list will be automatically sorted based on the contents of the folder you open.
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -97,17 +97,17 @@ This quick start covers how to set up a dev container for an existing project to
 
     ![Quick actions Status bar item](images/containers/remote-dev-status-bar.png)
 
-2. Now pick a starting point for your dev container. You can either select a base **dev container definition** from a filterable list, or use an existing [Dockerfile](https://docs.docker.com/engine/reference/builder/) or [Docker Compose file](https://docs.docker.com/compose/compose-file/#compose-file-structure-and-examples) if one exists in the folder you selected.
+2. Now pick a starting point for your dev container. You can either select a base **dev container Template** from a filterable list, or use an existing [Dockerfile](https://docs.docker.com/engine/reference/builder/) or [Docker Compose file](https://docs.docker.com/compose/compose-file/#compose-file-structure-and-examples) if one exists in the folder you selected.
 
     > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 
-    ![Select a node dev container definition](images/containers/select-dev-container-def.png)
+    ![Select a node dev container Template](images/containers/select-dev-container-def.png)
 
     The list will be automatically sorted based on the contents of the folder you open.
 
     You may be able to customize your dev container with additional Features, which [you can read more about below](#dev-container-features).
 
-    The dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
+    The dev container Templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 3. After picking the starting point for your container, VS Code will add the dev container configuration files to your project (`.devcontainer/devcontainer.json`).
 
@@ -181,9 +181,9 @@ For example, follow these steps to open one of the "try" repositories in a Repos
 
     > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 
-    ![Select a node dev container definition](images/containers/select-dev-container-def.png)
+    ![Select a node dev container Template](images/containers/select-dev-container-def.png)
 
-    The list will be automatically sorted based on the contents of the folder you open. Note the dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
+    The list will be automatically sorted based on the contents of the folder you open. The dev container Templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 4. The VS Code window (instance) will reload, clone the source code, and start building the dev container. A progress notification provides status updates.
 
@@ -238,11 +238,11 @@ This implies trusting [the machine the Docker daemon runs on](/remote/advancedco
 
 VS Code's container configuration is stored in a [devcontainer.json](https://containers.dev/implementors/json_reference) file. This file is similar to the `launch.json` file for debugging configurations, but is used for launching (or attaching to) your development container instead. You can also specify any extensions to install once the container is running or post-create commands to prepare the environment. The dev container configuration is either located under `.devcontainer/devcontainer.json` or stored as a `.devcontainer.json` file (note the dot-prefix) in the root of your project.
 
-You can use any image, Dockerfile, or set of Docker Compose files as a starting point. Here is a simple example that uses one of the pre-built [VS Code Development Container images](https://hub.docker.com/_/microsoft-vscode-devcontainers):
+You can use any image, Dockerfile, or set of Docker Compose files as a starting point. Here is a simple example that uses one of the pre-built [Development Container images](https://hub.docker.com/_/microsoft-devcontainers):
 
 ```json
 {
-    "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-12",
     "forwardPorts": [ 3000 ],
     "customizations": {
         // Configure properties specific to VS Code.
@@ -651,7 +651,7 @@ In addition, while Alpine support is available, some extensions installed in the
 * See [Tips and Tricks](/docs/devcontainers/tips-and-tricks.md) or the [FAQ](/docs/devcontainers/faq.md).
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
-* Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Review and provide feedback on the [Development Containers Specification](https://github.com/devcontainers/spec).
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -97,7 +97,7 @@ This quick start covers how to set up a dev container for an existing project to
 
     ![Quick actions Status bar item](images/containers/remote-dev-status-bar.png)
 
-2. Now pick a starting point for your dev container. You can either select a base **dev container Template** from a filterable list, or use an existing [Dockerfile](https://docs.docker.com/engine/reference/builder/) or [Docker Compose file](https://docs.docker.com/compose/compose-file/#compose-file-structure-and-examples) if one exists in the folder you selected.
+2. Now pick a starting point for your dev container. You can either select a base **Dev Container Template** from a filterable list, or use an existing [Dockerfile](https://docs.docker.com/engine/reference/builder/) or [Docker Compose file](https://docs.docker.com/compose/compose-file/#compose-file-structure-and-examples) if one exists in the folder you selected.
 
     > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -107,7 +107,7 @@ This quick start covers how to set up a dev container for an existing project to
 
     You may be able to customize your dev container with additional Features, which [you can read more about below](#dev-container-features).
 
-    The dev container Templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
+    The dev container Templates displayed come from our [first-party and community index](https://containers.dev/templates), which is part of the [Dev Container Specification](https://containers.dev/). We host a set of Templates as part of the spec in the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 3. After picking the starting point for your container, VS Code will add the dev container configuration files to your project (`.devcontainer/devcontainer.json`).
 
@@ -183,7 +183,7 @@ For example, follow these steps to open one of the "try" repositories in a Repos
 
     ![Select a node dev container Template](images/containers/select-dev-container-def.png)
 
-    The list will be automatically sorted based on the contents of the folder you open. The dev container Templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
+    The list will be automatically sorted based on the contents of the folder you open. The dev container Templates displayed come from our [first-party and community index](https://containers.dev/templates), which is part of the [Dev Container Specification](https://containers.dev/). We host a set of Templates as part of the spec in the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 4. The VS Code window (instance) will reload, clone the source code, and start building the dev container. A progress notification provides status updates.
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -181,7 +181,7 @@ For example, follow these steps to open one of the "try" repositories in a Repos
 
     > **Note:** When using Alpine Linux containers, some extensions may not work due to `glibc` dependencies in native code inside the extension.
 
-    ![Select a node dev container Template](images/containers/select-dev-container-def.png)
+    ![Select a node Dev Container Template](images/containers/select-dev-container-def.png)
 
     The list will be automatically sorted based on the contents of the folder you open. The dev container Templates displayed come from our [first-party and community index](https://containers.dev/templates), which is part of the [Dev Container Specification](https://containers.dev/). We host a set of Templates as part of the spec in the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -651,7 +651,7 @@ In addition, while Alpine support is available, some extensions installed in the
 * See [Tips and Tricks](/docs/devcontainers/tips-and-tricks.md) or the [FAQ](/docs/devcontainers/faq.md).
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
-* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
+* Create a [Dev Container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Review and provide feedback on the [Development Containers Specification](https://github.com/devcontainers/spec).
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -28,11 +28,11 @@ After any of the steps above, you'll have a fully functioning dev container, and
 
 VS Code's container configuration is stored in a [devcontainer.json](https://containers.dev/implementors/json_reference) file. This file is similar to the `launch.json` file for debugging configurations, but is used for launching (or attaching to) your development container instead. The dev container configuration is either located under `.devcontainer/devcontainer.json` or stored as a `.devcontainer.json` file (note the dot-prefix) in the root of your project.
 
-You can use an image as a starting point for your `devcontainer.json`. An image is like a mini-disk drive with various tools and an operating system pre-installed. You can pull images from a container registry, which is a collection of repositories that store images. Here is a simple example `devcontainer.json` that uses a pre-built TypeScript and Node.js VS Code Development Container image from the popular container registry [Docker Hub](https://hub.docker.com/_/microsoft-vscode-devcontainers):
+You can use an image as a starting point for your `devcontainer.json`. An image is like a mini-disk drive with various tools and an operating system pre-installed. You can pull images from a container registry, which is a collection of repositories that store images. Here is a simple example `devcontainer.json` that uses a pre-built TypeScript and Node.js VS Code Development Container image from the popular container registry [Docker Hub](https://hub.docker.com/_/microsoft-devcontainers):
 
 ```json
 {
-    "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12"
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-12"
 }
 ```
 
@@ -49,7 +49,7 @@ For this example, if you'd like to install the [ESLint extension](https://market
 
 ```json
 {
-    "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-12",
 
     "customizations": {
         "vscode": {
@@ -115,19 +115,19 @@ sudo apt-get update
 sudo apt-get install git
 ```
 
-You may also use the `"features"` property in the `devcontainer.json` to install tools and languages from a pre-defined set of [scripts](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library/docs) or even your own.
-
-> **Note:** Features support is in preview.
+You may also use the `"features"` property in the `devcontainer.json` to install tools and languages from a pre-defined set of [Features](https://github.com/devcontainers/features) or even your own.
 
 For example, you could install the latest version of the Azure CLI with the following:
 
 ```json
 "features": {
-    "azure-cli": "latest"
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+        "version": "latest"
+    }
   }
 ```
 
-See the article on [dev container features](/docs/devcontainers/containers.md#dev-container-features-preview) for more details.
+See the [dev container Features specification](https://containers.dev/implementors/features/) for more details.
 
 ### Rebuild
 
@@ -197,9 +197,9 @@ Rather than creating a `.devcontainer` by hand, selecting the **Dev Containers: 
 
 The command lets you pick a pre-defined container configuration from a list based on your folder's contents:
 
-![Add a dev container definition](images/create-dev-container/select-dev-container-def-all.png)
+![Add a dev container config](images/create-dev-container/select-dev-container-def-all.png)
 
-All of the predefined container configurations you can pick from come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers), which has examples of `devcontainer.json` and Dockerfiles for different scenarios.
+The predefined container configurations you can pick from come from our [first-party and community index](https://containers.dev/templates).
 
 At the end of using **Dev Containers: Add Dev Container Configuration Files...**, you'll be shown the list of available features, which are tools and languages you can easily drop into your dev container. **Dev Containers: Configure Container Features** allows you to update an existing configuration.
 
@@ -256,12 +256,12 @@ To get started quickly, **open the folder** you want to work with in VS Code and
 
 ![Select Docker Compose File](images/create-dev-container/select-docker-compose.png)
 
-You'll be asked to either select an existing Docker Compose file (if one exists), or pick a pre-defined container configuration from the [vscode-dev-containers repository](https://github.com/microsoft/vscode-dev-containers) in a filterable list sorted based on your folder's contents. Many of these "dev container definitions" use a Dockerfile, so select one of the following definitions as a starting point for Docker Compose:
+You'll be asked to either select an existing Docker Compose file (if one exists), or pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. Many of these "dev container Templates" use a Dockerfile, so select one of the following Templates as a starting point for Docker Compose:
 
-* [Existing Docker Compose](https://aka.ms/vscode-remote/samples/existing-docker-compose)
-* [Node.js & MongoDB](https://aka.ms/vscode-remote/samples/node-mongo)
-* [Python & PostgreSQL](https://aka.ms/vscode-remote/samples/python-postgres)
-* [Docker-from-Docker Compose](https://aka.ms/vscode-remote/samples/docker-from-docker-compose).
+* [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose)
+* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo)
+* [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres)
+* [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose).
 
 After you make your selection, VS Code will add the appropriate `.devcontainer/devcontainer.json` (or `.devcontainer.json`) file to the folder.
 
@@ -350,7 +350,7 @@ You can add other services to your `docker-compose.yml` file as described in [Do
 network_mode: service:db
 ```
 
-You can see an example of `network_mode: service:db` in the [Node.js and Mongo DB example dev container](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/javascript-node-mongo/.devcontainer/docker-compose.yml#L20).
+You can see an example of `network_mode: service:db` in the [Node.js and Mongo DB example dev container](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo).
 
 ### Extend your Docker Compose file for development
 
@@ -427,20 +427,20 @@ services:
       command: /bin/sh -c "while sleep 1000; do :; done"
 ```
 
-### Docker Compose dev container definitions
+### Docker Compose dev container Templates
 
-The following are dev container definitions that use Docker Compose:
+The following are dev container Templates that use Docker Compose:
 
-* [Existing Docker Compose](https://aka.ms/vscode-remote/samples/existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
-* [Node.js & MongoDB](https://aka.ms/vscode-remote/samples/node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.
-* [Python & PostgreSQL](https://aka.ms/vscode-remote/samples/python-postgres) -  A Python container that connects to PostgreSQL in a different container.
-* [Docker-from-Docker Compose](https://aka.ms/vscode-remote/samples/docker-from-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
+* [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
+* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.
+* [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres) -  A Python container that connects to PostgreSQL in a different container.
+* [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
 
 Congratulations! You've now configured a dev container in Visual Studio Code. Continue reading to learn how to share container configurations among teammates and various projects.
 
 ## Add configuration files to a repository
 
-You can easily share a customized dev container definition for your project by adding `devcontainer.json` files to source control. By including these files in your repository, anyone that opens a local copy of your repo in VS Code will be automatically prompted to reopen the folder in a container, provided they have the Dev Containers extension installed.
+You can easily share a customized dev container Template for your project by adding `devcontainer.json` files to source control. By including these files in your repository, anyone that opens a local copy of your repo in VS Code will be automatically prompted to reopen the folder in a container, provided they have the Dev Containers extension installed.
 
 ![Dev container configuration file reopen notification](images/create-dev-container/dev-container-reopen-prompt.png)
 
@@ -472,12 +472,12 @@ In the Settings editor, you can search for 'dev containers repo' to find the set
 
 ![Repository container folders setting](images/create-dev-container/repo-container-folder-setting.png)
 
-Next, place your `.devcontainer/devcontainer.json` (and related files) in a sub folder that mirrors the remote location of the repository. For example, if you wanted to create a configuration for `github.com/microsoft/vscode-dev-containers`, you would create the following folder structure:
+Next, place your `.devcontainer/devcontainer.json` (and related files) in a sub folder that mirrors the remote location of the repository. For example, if you wanted to create a configuration for `github.com/devcontainers/templates`, you would create the following folder structure:
 
 ```
 📁 github.com
-    📁 microsoft
-        📁 vscode-dev-containers
+    📁 devcontainers
+        📁 templates
            📁 .devcontainer
 ```
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -427,7 +427,7 @@ services:
       command: /bin/sh -c "while sleep 1000; do :; done"
 ```
 
-### Docker Compose dev container Templates
+### Docker Compose Dev Container Templates
 
 The following are dev container Templates that use Docker Compose:
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -254,14 +254,12 @@ VS Code can be configured to **automatically start any needed containers** for a
 
 To get started quickly, **open the folder** you want to work with in VS Code and run the **Dev Containers: Add Dev Container Configuration Files...** command in the Command Palette (`kbstyle(F1)`).
 
-![Select Docker Compose File](images/create-dev-container/select-docker-compose.png)
+You'll be prompted to pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. From the VS Code UI, you may select one of the following Templates as a starting point for Docker Compose:
 
-You'll be asked to either select an existing Docker Compose file (if one exists), or pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. You may choose to select one of the following Templates as a starting point for Docker Compose:
-
-* [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose)
-* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo)
-* [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres)
-* [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose).
+* [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
+* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.
+* [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres) -  A Python container that connects to PostgreSQL in a different container.
+* [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
 
 After you make your selection, VS Code will add the appropriate `.devcontainer/devcontainer.json` (or `.devcontainer.json`) file to the folder.
 
@@ -426,15 +424,6 @@ services:
         - .:/workspace:cached
       command: /bin/sh -c "while sleep 1000; do :; done"
 ```
-
-### Docker Compose Dev Container Templates
-
-The following are Dev Container Templates that use Docker Compose:
-
-* [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
-* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.
-* [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres) -  A Python container that connects to PostgreSQL in a different container.
-* [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
 
 Congratulations! You've now configured a dev container in Visual Studio Code. Continue reading to learn how to share container configurations among teammates and various projects.
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -199,7 +199,7 @@ The command lets you pick a pre-defined container configuration from a list base
 
 ![Add a dev container config](images/create-dev-container/select-dev-container-def-all.png)
 
-The predefined container configurations you can pick from come from our [first-party and community index](https://containers.dev/templates).
+The predefined container configurations you can pick from come from our [first-party and community index](https://containers.dev/templates), which is part of the [Dev Container Specification](https://containers.dev/). We host a set of Templates as part of the spec in the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 At the end of using **Dev Containers: Add Dev Container Configuration Files...**, you'll be shown the list of available features, which are tools and languages you can easily drop into your dev container. **Dev Containers: Configure Container Features** allows you to update an existing configuration.
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -440,7 +440,7 @@ Congratulations! You've now configured a dev container in Visual Studio Code. Co
 
 ## Add configuration files to a repository
 
-You can easily share a customized dev container Template for your project by adding `devcontainer.json` files to source control. By including these files in your repository, anyone that opens a local copy of your repo in VS Code will be automatically prompted to reopen the folder in a container, provided they have the Dev Containers extension installed.
+You can easily share a customized Dev Container Template for your project by adding `devcontainer.json` files to source control. By including these files in your repository, anyone that opens a local copy of your repo in VS Code will be automatically prompted to reopen the folder in a container, provided they have the Dev Containers extension installed.
 
 ![Dev container configuration file reopen notification](images/create-dev-container/dev-container-reopen-prompt.png)
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -28,7 +28,7 @@ After any of the steps above, you'll have a fully functioning dev container, and
 
 VS Code's container configuration is stored in a [devcontainer.json](https://containers.dev/implementors/json_reference) file. This file is similar to the `launch.json` file for debugging configurations, but is used for launching (or attaching to) your development container instead. The dev container configuration is either located under `.devcontainer/devcontainer.json` or stored as a `.devcontainer.json` file (note the dot-prefix) in the root of your project.
 
-You can use an image as a starting point for your `devcontainer.json`. An image is like a mini-disk drive with various tools and an operating system pre-installed. You can pull images from a container registry, which is a collection of repositories that store images. Here is a simple example `devcontainer.json` that uses a pre-built TypeScript and Node.js VS Code Development Container image from the popular container registry [Docker Hub](https://hub.docker.com/_/microsoft-devcontainers):
+You can use an image as a starting point for your `devcontainer.json`. An image is like a mini-disk drive with various tools and an operating system pre-installed. You can pull images from a container registry, which is a collection of repositories that store images. Here is a simple example `devcontainer.json` that uses a pre-built TypeScript and Node.js VS Code Development Container [image](https://github.com/devcontainers/images):
 
 ```json
 {
@@ -257,7 +257,7 @@ To get started quickly, **open the folder** you want to work with in VS Code and
 You'll be prompted to pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. From the VS Code UI, you may select one of the following Templates as a starting point for Docker Compose:
 
 * [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
-* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.
+* [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a MongoDB database in a different container.
 * [Python & PostgreSQL](https://github.com/devcontainers/templates/tree/main/src/postgres) -  A Python container that connects to PostgreSQL in a different container.
 * [Docker-from-Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-from-docker-compose) - Includes the Docker CLI and illustrates how you can use it to access your local Docker install from inside a dev container by volume mounting the Docker Unix socket.
 
@@ -348,7 +348,7 @@ You can add other services to your `docker-compose.yml` file as described in [Do
 network_mode: service:db
 ```
 
-You can see an example of `network_mode: service:db` in the [Node.js and Mongo DB example dev container](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo).
+You can see an example of `network_mode: service:db` in the [Node.js and MongoDB example dev container](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo).
 
 ### Extend your Docker Compose file for development
 

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -256,7 +256,7 @@ To get started quickly, **open the folder** you want to work with in VS Code and
 
 ![Select Docker Compose File](images/create-dev-container/select-docker-compose.png)
 
-You'll be asked to either select an existing Docker Compose file (if one exists), or pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. Many of these "dev container Templates" use a Dockerfile, so select one of the following Templates as a starting point for Docker Compose:
+You'll be asked to either select an existing Docker Compose file (if one exists), or pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. You may choose to select one of the following Templates as a starting point for Docker Compose:
 
 * [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose)
 * [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo)

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -429,7 +429,7 @@ services:
 
 ### Docker Compose Dev Container Templates
 
-The following are dev container Templates that use Docker Compose:
+The following are Dev Container Templates that use Docker Compose:
 
 * [Existing Docker Compose](https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose) - Includes a set of files that you can drop into an existing project that will reuse a `docker-compose.yml` file in the root of your project.
 * [Node.js & MongoDB](https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo) -  A Node.js container that connects to a Mongo DB in a different container.

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -127,7 +127,7 @@ For example, you could install the latest version of the Azure CLI with the foll
   }
 ```
 
-See the [dev container Features specification](https://containers.dev/implementors/features/) for more details.
+See the [Dev Container Features specification](https://containers.dev/implementors/features/) for more details.
 
 ### Rebuild
 

--- a/docs/remote/linux.md
+++ b/docs/remote/linux.md
@@ -160,6 +160,6 @@ RUN  wget -q https://copr-be.cloud.fedoraproject.org/results/mosquito/myrepo-el6
 * See [Tips and Tricks](/docs/remote/troubleshooting.md) or the [FAQ](/docs/remote/faq.md).
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
-* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
+* Create a [Dev Container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/docs/remote/linux.md
+++ b/docs/remote/linux.md
@@ -160,6 +160,6 @@ RUN  wget -q https://copr-be.cloud.fedoraproject.org/results/mosquito/myrepo-el6
 * See [Tips and Tricks](/docs/remote/troubleshooting.md) or the [FAQ](/docs/remote/faq.md).
 * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/vscode-remote).
 * Add a [feature request](https://aka.ms/vscode-remote/feature-requests) or [report a problem](https://aka.ms/vscode-remote/issues/new).
-* Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/remote/advancedcontainers/configure-separate-containers.md
+++ b/remote/advancedcontainers/configure-separate-containers.md
@@ -38,7 +38,7 @@ Let's set up a container for use with all of the Python projects in the `./Repos
 
     ![Select a python dev container definition](images/configure-separate-containers/select-dev-container-def-python.png)
 
-    The list will be automatically sorted based on the contents of the folder you open. Note the dev container definitions displayed come from the [vscode-dev-containers repository](https://aka.ms/vscode-dev-containers). You can browse the `containers` folder of that repository to see the contents of each definition.
+    The list will be automatically sorted based on the contents of the folder you open. Note the dev container templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each definition.
 
 3. After picking the starting point for your container, VS Code will add the dev container configuration files to the `./Repos/python/.devcontainer` folder.
 

--- a/remote/advancedcontainers/configure-separate-containers.md
+++ b/remote/advancedcontainers/configure-separate-containers.md
@@ -38,7 +38,7 @@ Let's set up a container for use with all of the Python projects in the `./Repos
 
     ![Select a python dev container definition](images/configure-separate-containers/select-dev-container-def-python.png)
 
-    The list will be automatically sorted based on the contents of the folder you open. Note the dev container templates displayed come from the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each definition.
+    The list will be automatically sorted based on the contents of the folder you open. The dev container Templates displayed come from our [first-party and community index](https://containers.dev/templates), which is part of the [Dev Container Specification](https://containers.dev/). We host a set of Templates as part of the spec in the [devcontainers/templates repository](https://github.com/devcontainers/templates). You can browse the `src` folder of that repository to see the contents of each Template.
 
 3. After picking the starting point for your container, VS Code will add the dev container configuration files to the `./Repos/python/.devcontainer` folder.
 

--- a/remote/advancedcontainers/questions-feedback.md
+++ b/remote/advancedcontainers/questions-feedback.md
@@ -22,6 +22,6 @@ The links below can provide you with more help configuring your development cont
 
 ## Contributing
 
-* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
+* Create a [Dev Container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/remote/advancedcontainers/questions-feedback.md
+++ b/remote/advancedcontainers/questions-feedback.md
@@ -22,6 +22,6 @@ The links below can provide you with more help configuring your development cont
 
 ## Contributing
 
-* Create a [development container definition](https://aka.ms/vscode-dev-containers) for others to use.
+* Create a [development container Template](https://containers.dev/templates) or [Feature](https://containers.dev/features) for others to use.
 * Contribute to [our documentation](https://github.com/microsoft/vscode-docs) or [VS Code itself](https://github.com/microsoft/vscode).
 * See our [CONTRIBUTING](https://aka.ms/vscode-remote/contributing) guide for details.

--- a/remote/advancedcontainers/use-docker-kubernetes.md
+++ b/remote/advancedcontainers/use-docker-kubernetes.md
@@ -13,7 +13,9 @@ While you can build, deploy, and debug your application inside a dev container, 
 
 Once the needed CLIs are in place, you can also work with the appropriate container cluster using the [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) extension or the [Kubernetes](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) extension.
 
-See the following example dev container definitions for additional information on a specific scenario:
+See the following example Dev Container Templates for additional information on a specific scenario. To add them to your project, **open the folder** you want to work with in VS Code and run the **Dev Containers: Add Dev Container Configuration Files...** command in the Command Palette (`kbstyle(F1)`).
+
+You'll be prompted to pick a pre-defined container configuration from our [first-party and community index](https://containers.dev/templates) in a filterable list sorted based on your folder's contents. From the VS Code UI, you may select one of the Templates described in the sections below.
 
 **Running Docker or Minikube in a development container**
 

--- a/remote/advancedcontainers/use-docker-kubernetes.md
+++ b/remote/advancedcontainers/use-docker-kubernetes.md
@@ -29,7 +29,7 @@ See the following example dev container definitions for additional information o
 
 * [Kubernetes - Local Configuration](https://aka.ms/vscode-remote/samples/kubernetes-helm) - Takes the Docker-from-Docker model and adds kubectl and Helm to illustrate how you can access a local Minikube or Docker provided Kubernetes cluster.
 
-There is also documentation on the [Docker-in-Docker](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md), [Docker-from-Docker](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md), and [Kubernetes](https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md) install scripts that you can reuse and are referenced by the samples above.
+There is also documentation on the [Docker-in-Docker](https://github.com/devcontainers/features/tree/main/src/docker-in-docker), [Docker-from-Docker](https://github.com/devcontainers/features/tree/main/src/docker-from-docker), and [Kubernetes](https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube) install scripts that you can reuse and are referenced by the samples above.
 
 ## Mounting host volumes with Docker from inside a container
 


### PR DESCRIPTION
- Remove mentions of vscode-dev-containers, point users to devcontainers/templates, devcontainers/features, and self-hosting
- Update terminology: "definition" -> "Template"
- Use latest syntax for referencing Features
- Remove mentions of Features being in preview

Fixes https://github.com/microsoft/vscode-docs/issues/5736