### PR TITLE
Typo Docker Contexts: Use

### DIFF
--- a/docs/containers/ssh.md
+++ b/docs/containers/ssh.md
@@ -35,7 +35,7 @@ It is also possible to connect to the remote Docker engine directly using SSH tu
 
     Always include the user name in the Docker endpoint address, even if it is the same as the local user name. If you omit the port, it defaults to 22.
 
-1. Use the **Command Palette** (`kb(workbench.action.showCommands)`) to issue the **Docker Context: Use** command to activate the Docker context pointing to the remote machine. This command causes both VS Code and Docker CLI to use the remote machine context.
+1. Use the **Command Palette** (`kb(workbench.action.showCommands)`) to issue the **Docker Contexts: Use** command to activate the Docker context pointing to the remote machine. This command causes both VS Code and Docker CLI to use the remote machine context.
 
 1. It is recommended to change the refresh rate to something longer than the default with the `docker.explorerRefreshInterval` setting. The connection over SSH is slow, and it can result in trying to refresh again before the previous refresh even finished. We recommend at least 3000 ms.
 


### PR DESCRIPTION
In my instance of VSCode, the command category is called "Docker Context**s**", plural.