### PR TITLE
update jupyter command

### DIFF
--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -33,7 +33,7 @@ If you attempt to open a notebook when VS Code is in an untrusted workspace runn
 
 ## Create or open a Jupyter Notebook
 
-You can create a Jupyter Notebook by running the **Jupyter: Create New Jupyter Notebook** command from the Command Palette (`kb(workbench.action.showCommands)`) or by creating a new `.ipynb` file in your workspace.
+You can create a Jupyter Notebook by running the **Create: New Jupyter Notebook** command from the Command Palette (`kb(workbench.action.showCommands)`) or by creating a new `.ipynb` file in your workspace.
 
 ![Blank Jupyter Notebook](images/jupyter/native-code-cells-01.png)
 


### PR DESCRIPTION
You can see the command here without the `Jupyter:` category prefix:

![image](https://user-images.githubusercontent.com/4307307/205182358-917dabfe-f4e6-4fba-80ef-223b2b859b7e.png)

But if you type in the command as it appears in the docs, the command palette will return empty:

![image](https://user-images.githubusercontent.com/4307307/205182433-33c81e3d-7520-476e-a0e9-d2589f1e5808.png)
