### PR TITLE
Update built-in commands

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -107,17 +107,23 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 
 * _uri_ - Uri of a text document
 * _position_ - A position in a text document
-* _(returns)_ - A CallHierarchyItem or undefined
+* _(returns)_ - A promise that resolves to an array of CallHierarchyItem-instances
 
 `vscode.provideIncomingCalls` - Compute incoming calls for an item
 
 * _item_ - A call hierarchy item
-* _(returns)_ - A CallHierarchyItem or undefined
+* _(returns)_ - A promise that resolves to an array of CallHierarchyIncomingCall-instances
 
 `vscode.provideOutgoingCalls` - Compute outgoing calls for an item
 
 * _item_ - A call hierarchy item
-* _(returns)_ - A CallHierarchyItem or undefined
+* _(returns)_ - A promise that resolves to an array of CallHierarchyOutgoingCall-instances
+
+`vscode.prepareRename` - Execute the prepareRename of rename provider
+
+* _uri_ - Uri of a text document
+* _position_ - A position in a text document
+* _(returns)_  A promise that resolves to a range and placeholder text.
 
 `vscode.executeDocumentRenameProvider` - Execute rename provider.
 
@@ -203,6 +209,12 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 
 * _(returns)_ - A promise that resolves to an array of NotebookContentProvider static info objects.
 
+`vscode.executeInlineValueProvider` - Execute inline value provider
+
+* _uri_ - Uri of a text document
+* _range_ - A range in a text document
+* _(returns)_ - A promise that resolves to an array of InlineValue objects
+
 `vscode.open` - Opens the provided resource in the editor. Can be a text or binary file, or an http(s) URL. If you need more control over the options for opening a text file, use vscode.window.showTextDocument instead.
 
 * _uri_ - Uri of a text document
@@ -225,7 +237,27 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 * _columnOrOptions_ - (optional) Either the column in which to open or editor options, see vscode.TextDocumentShowOptions
 * _(returns)_ - no result
 
-`vscode.removeFromRecentlyOpened` - Removes an entry with the given path from the recently opened list.
+`vscode.prepareTypeHierarchy` - Prepare type hierarchy at a position inside a document
+
+* _uri_ - Uri of a text document
+* _position_ - A position in a text document
+* _(returns)_ - A promise that resolves to an array of TypeHierarchyItem-instances
+
+`vscode.provideSupertypes` - Compute supertypes for an item
+
+* _item_ - A type hierarchy item
+* _(returns)_ - A promise that resolves to an array of TypeHierarchyItem-instances
+
+`vscode.provideSubtypes` - Compute subtypes for an item
+
+* _item_ - A type hierarchy item
+* _(returns)_ - A promise that resolves to an array of TypeHierarchyItem-instances
+
+`vscode.revealTestInExplorer` - Reveals a test instance in the explorer
+
+* _testItem_ - A VS Code TestItem.
+
+`vscode.removeFromRecentlyOpened` - Removes an entry with the given path from the recently opened list
 
 * _path_ - Path to remove from recently opened.
 


### PR DESCRIPTION
This patch improve built-in commands description, including:

- Update description for call hierarchy since https://github.com/microsoft/vscode/issues/167717 fixed
- Add new API description for `type hierarchy`
- Update other APIs according to [API file](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostApiCommands.ts)

fix #5826 