### PR TITLE
remove mentions of port forwarding from tunnels

### DIFF
--- a/blogs/2022/12/07/remote-even-better.md
+++ b/blogs/2022/12/07/remote-even-better.md
@@ -33,7 +33,7 @@ In addition to the new CLI, we've made the following updates to improve remote d
 
 ## Tunnel to anywhere, from one tool
 
-Tunneling, also known as port forwarding, securely transmits data from one network to another. You can use secure tunnels to develop against any machine of your choosing from a VS Code desktop or web client, without the hassle of setting up SSH or HTTPS (although you can do that if you want as well 😊).
+Tunneling securely transmits data from one network to another. You can use secure tunnels to develop against any machine of your choosing from a VS Code desktop or web client, without the hassle of setting up SSH or HTTPS (although you can do that if you want as well 😊).
 
 You have two great options for tunneling to remote machines from VS Code:
 

--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -109,7 +109,7 @@ Argument|Description
 
 VS Code integrates with other [remote environments](/docs/remote/remote-overview.md) to become even more powerful and flexible. Our goal is to provide a cohesive experience that allows you to manage both local and remote machines from one, unified CLI.
 
-The Visual Studio Code [Remote - Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-server)  extension lets you connect to a remote machine, like a desktop PC or VM, via a secure tunnel. Tunneling, also known as port forwarding, securely transmits data from one network to another. You can then securely connect to that machine from anywhere, without the requirement of SSH.
+The Visual Studio Code [Remote - Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-server)  extension lets you connect to a remote machine, like a desktop PC or VM, via a secure tunnel. Tunneling securely transmits data from one network to another. You can then securely connect to that machine from anywhere, without the requirement of SSH.
 
 We've built functionality into the `code` CLI that will initiate tunnels on remote machines. You can run:
 

--- a/docs/remote/tunnels.md
+++ b/docs/remote/tunnels.md
@@ -11,7 +11,7 @@ DateApproved: 12/7/2022
 
 The Visual Studio Code [Remote - Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-server) extension lets you connect to a remote machine, like a desktop PC or virtual machine (VM), via a secure tunnel. You can connect to that machine from a VS Code client anywhere, without the requirement of SSH.
 
-Tunneling, also known as port forwarding, securely transmits data from one network to another.
+Tunneling securely transmits data from one network to another.
 
 This can eliminate the need for source code to be on your VS Code client machine since the extension runs commands and other extensions directly on the remote machine.
 

--- a/docs/remote/vscode-server.md
+++ b/docs/remote/vscode-server.md
@@ -25,7 +25,7 @@ We want to provide a unified VS Code experience no matter how you use the editor
 
 Access to the VS Code Server is built in to the existing [`code` CLI](/docs/editor/command-line.md#launching-from-command-line).
 
-The CLI establishes a tunnel between a VS Code client and your remote machine. Tunneling, also known as port forwarding, securely transmits data from one network to another.
+The CLI establishes a tunnel between a VS Code client and your remote machine. Tunneling securely transmits data from one network to another.
 
 ![The VS Code Server architecture](images/vscode-server/server-arch-latest.png)
 


### PR DESCRIPTION
Commented this in an initial draft, but I didn't read carefully and it
seems to have survived. Port forwarding is different than tunnels (and
has no inherent security, where our tunnels do.)