### PR TITLE
add new topic to sitemap, update milestone query

### DIFF
--- a/build/sitemap.xml
+++ b/build/sitemap.xml
@@ -516,6 +516,11 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://code.visualstudio.com/docs/nodejs/profiling</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
         <loc>https://code.visualstudio.com/docs/nodejs/extensions</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>

--- a/release-notes/v1_75.md
+++ b/release-notes/v1_75.md
@@ -9,14 +9,12 @@ DownloadVersion: 1.75.0
 ---
 # January 2023 (version 1.75)
 
-<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
-
 Welcome to the Insiders build. These are the preliminary notes for the January 1.75 release of Visual Studio Code. As we get closer to the release date, you'll find details below about new features and important fixes.
 
 Until the January milestone release notes are available, you can still track our progress:
 
 * **[Commit log](https://github.com/Microsoft/vscode/commits/main)** - GitHub commits to the vscode open-source repository.
-* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22January+2023%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
+* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22December+2022%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
 
 We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
 


### PR DESCRIPTION
Also take out the download links from the Insiders snapshot since 1.75 isn't available yet but people still seem to find the page