### PR TITLE
Add Dec plan, update Jan query

### DIFF
--- a/release-notes/v1_75.md
+++ b/release-notes/v1_75.md
@@ -13,8 +13,9 @@ Welcome to the Insiders build. These are the preliminary notes for the January 1
 
 Until the January milestone release notes are available, you can still track our progress:
 
+* **[December iteration plan](https://github.com/microsoft/vscode/issues/168000)** - Review what's planned for the December house-keeping milestone.
 * **[Commit log](https://github.com/Microsoft/vscode/commits/main)** - GitHub commits to the vscode open-source repository.
-* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22December+2022%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
+* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22January+2023%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
 
 We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
 


### PR DESCRIPTION
For the Insiders 1.75 release notes placeholder, add the December plan and update to the renamed January issue query.