### PR TITLE
add applocker note when running as admin

### DIFF
--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -103,3 +103,9 @@ Using the Registry Editor (regedit):
 3. Find the `.svg` key.
 4. Set its `Content Type` Data value to `image/svg+xml`.
 5. Exit `regedit`.
+
+### Unable to run as admin when AppLocker is enabled
+
+With the introduction of process sandboxing (see our [blog](https://code.visualstudio.com/blogs/2022/11/28/vscode-sandbox)) running as administrator is currently unsupported when AppLocker is configured on the system. Please run with your normal user account if possible.
+
+Subscribe to issue [122951](https://github.com/microsoft/vscode/issues/122951) for receiving updates on this matter.

--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -106,6 +106,6 @@ Using the Registry Editor (regedit):
 
 ### Unable to run as admin when AppLocker is enabled
 
-With the introduction of process sandboxing (see our [blog](https://code.visualstudio.com/blogs/2022/11/28/vscode-sandbox)) running as administrator is currently unsupported when AppLocker is configured on the system. Please run with your normal user account if possible.
+With the introduction of process sandboxing (see our [blog](https://code.visualstudio.com/blogs/2022/11/28/vscode-sandbox)) running as administrator is currently unsupported when AppLocker is configured on the system due to a limitation of the runtime sandbox, please refer to https://bugs.chromium.org/p/chromium/issues/detail?id=740132 for additional context. If your work requires to run the application from a elevated terminal, then you can launch with `--no-sandbox --disable-gpu-sandbox` as a workaround.
 
 Subscribe to issue [122951](https://github.com/microsoft/vscode/issues/122951) for receiving updates on this matter.


### PR DESCRIPTION
@deepak1556 I suggest to make an FAQ entry for running as admin on AppLocker that we can link to from the error message in the command line. Could you see if there are more details to fill in?

//cc @gregvanl 