### PR TITLE
c-cpp-properties-schema-reference.md: configurationProvider: mention vscode-cpptools-api

### DIFF
--- a/docs/cpp/c-cpp-properties-schema-reference.md
+++ b/docs/cpp/c-cpp-properties-schema-reference.md
@@ -94,6 +94,8 @@ For more information about changing these settings, see [Customizing Default Set
 - `configurationProvider`
   The ID of a VS Code extension that can provide IntelliSense configuration information for source files. For example, use the VS Code extension ID `ms-vscode.cmake-tools` to provide configuration information from the CMake Tools extension.
 
+  A `configurationProvider` candidate extension must implement [vscode-cpptools-api](https://github.com/microsoft/vscode-cpptools-api).
+
 - `windowsSdkVersion`
   The versions of the Windows SDK include path to use on Windows, for example `10.0.17134.0`.
 


### PR DESCRIPTION
This PR enhances the documentation about the `configurationProvider` option specified inside `c-cpp-properties.json` by introducing the requirement for an extension to become a `configurationProvider` candidate.

Not sure how to name https://github.com/microsoft/vscode-cpptools-api properly, so I just call it vscode-cpptools-api.

Fixes #5816 