### PR TITLE
Update Approved Badges

### DIFF
--- a/api/references/extension-manifest.md
+++ b/api/references/extension-manifest.md
@@ -202,10 +202,11 @@ We allow badges from the following URL prefixes:
 - travis-ci.com
 - travis-ci.org
 - visualstudio.com
-- vsmarketplacebadge.apphb.com
+- vsmarketplacebadges.dev
 - www.bithound.io
 - www.versioneye.com
 
+Note : Replace vsmarketplacebadge.apphb.com with vsmarketplacebadges.dev
 If you have other badges you would like to use, please open a GitHub [issue](https://github.com/microsoft/vscode/issues) and we're happy to take a look.
 
 ## Combining Extension Contributions

--- a/api/references/extension-manifest.md
+++ b/api/references/extension-manifest.md
@@ -206,7 +206,8 @@ We allow badges from the following URL prefixes:
 - www.bithound.io
 - www.versioneye.com
 
-Note : Replace vsmarketplacebadge.apphb.com with vsmarketplacebadges.dev
+Note : Replace vsmarketplacebadge.apphb.com badge with vsmarketplacebadges.dev badge.
+
 If you have other badges you would like to use, please open a GitHub [issue](https://github.com/microsoft/vscode/issues) and we're happy to take a look.
 
 ## Combining Extension Contributions


### PR DESCRIPTION
vsmarketplacebadge.apphb.com is currently not supported and is replaced with vsmarketplacebadges.dev . More details in microsoft/vscode-vsce#799 . Updating the document due to this change.