### PR TITLE
Fix broken anchor and correcting link text to match other link texts

### DIFF
--- a/api/extension-capabilities/common-capabilities.md
+++ b/api/extension-capabilities/common-capabilities.md
@@ -80,7 +80,7 @@ With the [`vscode.QuickPick`](/api/references/vscode-api#QuickPick) API, you can
 
 ## File Picker
 
-Extensions can use the [`vscode.window.showOpenDialog`](/api/references/vscode-api#vscode.window.showOpenDialog) API to open the system file picker and select files or folders.
+Extensions can use the [`window.showOpenDialog`](/api/references/vscode-api#window.showOpenDialog) API to open the system file picker and select files or folders.
 
 ## Output Channel
 


### PR DESCRIPTION
Link `/api/references/vscode-api#vscode.window.showOpenDialog` on current page points to a non-existent anchor `#vscode.window.showOpenDialog` on page `/api/references/vscode-api`.  Correcting it to point to an existing anchor: `#window.showOpenDialog`.

Also fixing link text `vscode.window.showOpenDialog` to be similar to other names on the page like `window.showInformationMessage`, `window.createOutputChannel`, etc.

Although it might be better to return all texts to the prefix `vscode.` for clarity.