### PR TITLE
Update Rust Linting Check on Save Command

### DIFF
--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -195,7 +195,7 @@ The Rust toolset includes linting, provided by rustc and clippy, to detect issue
 
 ![linter warning about an unused variable](images/rust/linter-warning.png)
 
-The rustc linter, enabled by default, detects basic Rust errors, but you can use [clippy](https://github.com/rust-lang/rust-clippy) to get more lints. To enable clippy integration in rust-analyzer, change the **Rust-analyzer > Check on Save: Command** (`rust-analyzer.check.command`) setting to `clippy` instead of the default `check`. The rust-analyzer extension will now run `cargo clippy` when you save a file and display clippy warnings and errors directly in the editor and Problems view.
+The rustc linter, enabled by default, detects basic Rust errors, but you can use [clippy](https://github.com/rust-lang/rust-clippy) to get more lints. To enable clippy integration in rust-analyzer, change the **Rust-analyzer > Check: Command** (`rust-analyzer.check.command`) setting to `clippy` instead of the default `check`. The rust-analyzer extension will now run `cargo clippy` when you save a file and display clippy warnings and errors directly in the editor and Problems view.
 
 ## Quick Fixes
 

--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -195,7 +195,7 @@ The Rust toolset includes linting, provided by rustc and clippy, to detect issue
 
 ![linter warning about an unused variable](images/rust/linter-warning.png)
 
-The rustc linter, enabled by default, detects basic Rust errors, but you can use [clippy](https://github.com/rust-lang/rust-clippy) to get more lints. To enable clippy integration in rust-analyzer, change the **Rust-analyzer > Check on Save: Command** (`rust-analyzer.checkOnSave.command`) setting to `clippy` instead of the default `check`. The rust-analyzer extension will now run `cargo clippy` when you save a file and display clippy warnings and errors directly in the editor and Problems view.
+The rustc linter, enabled by default, detects basic Rust errors, but you can use [clippy](https://github.com/rust-lang/rust-clippy) to get more lints. To enable clippy integration in rust-analyzer, change the **Rust-analyzer > Check on Save: Command** (`rust-analyzer.check.command`) setting to `clippy` instead of the default `check`. The rust-analyzer extension will now run `cargo clippy` when you save a file and display clippy warnings and errors directly in the editor and Problems view.
 
 ## Quick Fixes
 


### PR DESCRIPTION
# Summary
- The old command: `rust-analyzer.checkOnSave.command` is no longer a valid command with the current version of the rust-analyzer vscode extension.
- To achieve the desired result without a invalid type error the command used must be: `rust-analyzer.check.command`