### PR TITLE
Updating the deprecated storagePath to storageUri

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -186,7 +186,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             const workspaceData = vscode.Uri.joinPath(context.storageUri, 'workspace-data.json');
-            const writeData = Buffer.from(JSON.stringify({ now: Date.now() }), 'utf8');
+            const writeData = new TextEncoder().encode(JSON.stringify({ now: Date.now() }));
             vscode.workspace.fs.writeFile(workspaceData, writeData);
         }
     ));

--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -162,7 +162,7 @@ In some cases, your extension may need to persist state information that does no
 
 However, if your extension relies on current VS Code pathing conventions (for example `~/.vscode`) or the presence of certain OS folders (for example `~/.config/Code` on Linux) to persist data, you may run into problems. Fortunately, it should be simple to update your extension and avoid these challenges.
 
-If you are persisting simple key-value pairs, you can store workspace specific or global state information using `vscode.ExtensionContext.workspaceState` or `vscode.ExtensionContext.globalState` respectively. If your data is more complicated than key-value pairs, the  `globalStoragePath` and `storagePath` properties provide "safe" paths that you can use to read/write global workspace-specific information in a file.
+If you are persisting simple key-value pairs, you can store workspace specific or global state information using `vscode.ExtensionContext.workspaceState` or `vscode.ExtensionContext.globalState` respectively. If your data is more complicated than key-value pairs, the  `globalStorageUri` and `storageUri` properties provide "safe" paths that you can use to read/write global workspace-specific information in a file.
 
 To use the APIs:
 
@@ -176,13 +176,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('myAmazingExtension.persistWorkspaceData', () => {
 
         // Create the extension's workspace storage folder if it doesn't already exist
-        if (!fs.existsSync(context.storagePath)) {
-            fs.mkdirSync(context.storagePath);
+        if (!fs.existsSync(context.storageUri)) {
+            fs.mkdirSync(context.storageUri);
         }
 
         // Write a file to the workspace storage folder
         fs.writeFileSync(
-            path.join(context.storagePath, 'workspace-data.json'),
+            path.join(context.storageUri, 'workspace-data.json'),
             JSON.stringify({ now: Date.now() }));
     }));
 
@@ -190,13 +190,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('myAmazingExtension.persistGlobalData', () => {
 
         // Create the extension's global (cross-workspace) folder if it doesn't already exist
-        if (!fs.existsSync(context.globalStoragePath)) {
-            fs.mkdirSync(context.globalStoragePath);
+        if (!fs.existsSync(context.globalStorageUri)) {
+            fs.mkdirSync(context.globalStorageUri);
         }
 
         // Write a file to the global storage folder for the extension
         fs.writeFileSync(
-            path.join(context.globalStoragePath, 'global-data.json'),
+            path.join(context.globalStorageUri, 'global-data.json'),
             JSON.stringify({ now: Date.now() }));
     }));
 }

--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -207,7 +207,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         const workspaceData = vscode.Uri.joinPath(context.globalStorageUri, 'global-data.json');
-        const writeData = Buffer.from(JSON.stringify({ now: Date.now() }), 'utf8');
+        const writeData = new TextEncoder().encode(JSON.stringify({ now: Date.now() }));
         vscode.workspace.fs.writeFile(workspaceData, writeData);
     ));
 }

--- a/api/extension-capabilities/common-capabilities.md
+++ b/api/extension-capabilities/common-capabilities.md
@@ -40,8 +40,8 @@ There are four options for storing data:
 
 - [`ExtensionContext.workspaceState`](/api/references/vscode-api#ExtensionContext.workspaceState): A workspace storage where you can write key/value pairs. VS Code manages the storage and will restore it when the same workspace is opened again.
 - [`ExtensionContext.globalState`](/api/references/vscode-api#ExtensionContext.globalState): A global storage where you can write key/value pairs. VS Code manages the storage and will restore it for each extension activation. You can selectively synchronize key/value pairs in global storage by setting the keys for sync using `setKeysForSync` method on `globalState`.
-- [`ExtensionContext.storageUri`](/api/references/vscode-api#ExtensionContext.storageUri): A workspace specific storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible only from the current workspace.
-- [`ExtensionContext.globalStorageUri`](/api/references/vscode-api#ExtensionContext.globalStorageUri): A global storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible from all workspaces.
+- [`ExtensionContext.storageUri`](/api/references/vscode-api#ExtensionContext.storageUri): A workspace specific storage URI pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible only from the current workspace.
+- [`ExtensionContext.globalStorageUri`](/api/references/vscode-api#ExtensionContext.globalStorageUri): A global storage URI pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible from all workspaces.
 
 The extension context is available to the `activate` function in the [Extension Entry File](/api/get-started/extension-anatomy#extension-entry-file).
 

--- a/api/extension-capabilities/common-capabilities.md
+++ b/api/extension-capabilities/common-capabilities.md
@@ -40,8 +40,8 @@ There are four options for storing data:
 
 - [`ExtensionContext.workspaceState`](/api/references/vscode-api#ExtensionContext.workspaceState): A workspace storage where you can write key/value pairs. VS Code manages the storage and will restore it when the same workspace is opened again.
 - [`ExtensionContext.globalState`](/api/references/vscode-api#ExtensionContext.globalState): A global storage where you can write key/value pairs. VS Code manages the storage and will restore it for each extension activation. You can selectively synchronize key/value pairs in global storage by setting the keys for sync using `setKeysForSync` method on `globalState`.
-- [`ExtensionContext.storagePath`](/api/references/vscode-api#ExtensionContext.storagePath): A workspace specific storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible only from the current workspace.
-- [`ExtensionContext.globalStoragePath`](/api/references/vscode-api#ExtensionContext.globalStoragePath): A global storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible from all workspaces.
+- [`ExtensionContext.storageUri`](/api/references/vscode-api#ExtensionContext.storageUri): A workspace specific storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible only from the current workspace.
+- [`ExtensionContext.globalStorageUri`](/api/references/vscode-api#ExtensionContext.globalStorageUri): A global storage path pointing to a local directory where your extension has read/write access. This is a good option if you need to store large files that are accessible from all workspaces.
 
 The extension context is available to the `activate` function in the [Extension Entry File](/api/get-started/extension-anatomy#extension-entry-file).
 

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -798,7 +798,7 @@ If you are trying to connect to a localhost port from an external application, t
 
 Extensions may try to persist global data by looking for the `~/.config/Code` folder on Linux. This folder may not exist, which can cause the extension to throw errors like `ENOENT: no such file or directory, open '/root/.config/Code/User/filename-goes-here`.
 
-**Resolution:** Extensions can use the `context.globalStoragePath` or `context.storagePath` property to resolve this problem. See the [extension author's guide](/api/advanced-topics/remote-extensions#persisting-extension-data-or-state) for details.
+**Resolution:** Extensions can use the `context.globalStorageUri` or `context.storageUri` property to resolve this problem. See the [extension author's guide](/api/advanced-topics/remote-extensions#persisting-extension-data-or-state) for details.
 
 ### Cannot sign in / have to sign in each time I connect to a new endpoint
 


### PR DESCRIPTION
As the `globalStoragePath` and `storagePath` properties are deprecated, I've updated it to use the new `globalStorageUri` and `storageUri` properties.