### PR TITLE
Avoid gerund and shorten header

### DIFF
--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -187,7 +187,7 @@ The key bindings shown below are the default key bindings. You can change these 
 ]
 ```
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 In VS Code, you can enhance your coding with artificial intelligence (AI), such as suggestions for lines of code or entire functions, fast documentation creation, and help creating code-related artifacts like tests.
 

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -179,7 +179,7 @@ To install support for Remote Development:
 1. If you are connecting to a remote machine with SSH, use the **Remote - SSH** extension.
 1. If the remote source files are hosted in a container (for example, Docker), use the **Dev Containers** extension.
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -65,7 +65,7 @@ IntelliSense just works: hit `kb(editor.action.triggerSuggest)` at any time to g
 
 ![IntelliSense](images/csharp/intellisense.png)
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -151,7 +151,7 @@ One of the key advantages of VS Code is speed. When you open your Java source fi
   <source src="/docs/languages/java/intellisense.mp4" type="video/mp4">
 </video>
 
-### Enhancing completions with AI
+### Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -247,7 +247,7 @@ VS Code automatically suggests some common code simplifications such as converti
 
 Set `"javascript.suggestionActions.enabled"` to `false` to disable suggestions.
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 

--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -49,7 +49,7 @@ You can fold regions of source code using the folding icons on the gutter betwee
 
 In addition to the default JSON mode following the [JSON specification](https://www.json.org/), VS Code also has a **JSON with Comments** (jsonc) mode. This mode is used for the VS Code configuration files such as `settings.json`, `tasks.json`, or `launch.json`. When in the **JSON with Comments** mode, you can use single line (`//`) as well as block comments (`/* */`) as used in JavaScript. The mode also accepts trailing commas, but they are discouraged and the editor will display a warning.
 
-The current editor mode is indicated in the editor's Status Bar. Select the mode indicator to change the mode and to configure how file extensions are associated to modes. You can also directly modify the `files.associations` [setting](/docs/languages/overview.md#adding-a-file-extension-to-a-language) to associate file names or file name patterns to `jsonc`.
+The current editor mode is indicated in the editor's Status Bar. Select the mode indicator to change the mode and to configure how file extensions are associated to modes. You can also directly modify the `files.associations` [setting](/docs/languages/overview.md#add-a-file-extension-to-a-language) to associate file names or file name patterns to `jsonc`.
 
 ## JSON schemas and settings
 

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -39,7 +39,7 @@ The richness of support varies across the different languages and their extensio
 * Debugging
 * Refactoring
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 In VS Code, you can enhance your coding with artificial intelligence (AI), such as suggestions for lines of code or entire functions, fast documentation creation, and help creating code-related artifacts like tests.
 
@@ -49,7 +49,7 @@ In VS Code, you can enhance your coding with artificial intelligence (AI), such 
 
 You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
 
-## Changing the language for the selected file
+## Change the language for the selected file
 
 In VS Code, we default the language support for a file based on its filename extension. However, at times you may want to change language modes, to do this click on the language indicator - which is located on the right hand of the Status Bar. This will bring up the **Select Language Mode** dropdown where you can select another language for the current file.
 
@@ -69,7 +69,7 @@ You can see the list of currently installed languages and their identifiers in t
 
 You can find a list of known identifiers in the [language identifier reference](/docs/languages/identifiers.md).
 
-## Adding a file extension to a language
+## Add a file extension to a language
 
 You can add new file extensions to an existing language with the `files.associations` [setting](/docs/getstarted/settings.md).
 

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -52,7 +52,7 @@ IntelliSense quickly shows methods, class members, and documentation as you type
 
 > **Tip**: Check out the [IntelliCode extension for VS Code (preview)](https://go.microsoft.com/fwlink/?linkid=2006060). IntelliCode provides a set of AI-assisted capabilities for IntelliSense in Python, such as inferring the most relevant auto-completions based on the current code context.
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -71,7 +71,7 @@ For autocomplete and IntelliSense issues, check the following causes:
 | The path to the python interpreter is incorrect | Make sure you selected a valid interpreter path by running the **Python: Select Interpreter** command (see [Environments](/docs/python/environments.md)). |
 | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
 
-## Enhancing completions with AI
+## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
 


### PR DESCRIPTION
This helps avoid a line break in the pages right navigation list and also recommended writing practice to avoid gerunds in headers