### PR TITLE
Prefer keeping all videos in Git LFS

### DIFF
--- a/blogs/2016/12/12/roundup-customize.md
+++ b/blogs/2016/12/12/roundup-customize.md
@@ -54,13 +54,7 @@ Here are two File Icon themes I really like:
 
 ## Snippets Aplenty
 
-Do you use snippets while writing code? Many snippets come built into VS Code and are shown in the IntelliSense suggest window while you type.
-
-<video id="snippets-showcase" src="https://az754404.vo.msecnd.net/public/snippets_showcase.mp4" placeholder="/images/userdefinedsnippets_snippets_placeholder.png" autoplay loop controls muted>
-    Sorry you're browser doesn't support HTML 5 video.
-</video>
-
-When you start using a new library or framework, check the Marketplace to see if there is a snippet pack for it. There are snippet packs for many popular JavaScript frameworks.
+Do you use snippets while writing code? Many snippets come built into VS Code and are shown in the IntelliSense suggest window while you type. When you start using a new library or framework, check the Marketplace to see if there is a snippet pack for it. There are snippet packs for many popular JavaScript frameworks.
 
 - [Bootstrap 3](https://marketplace.visualstudio.com/items?itemName=wcwhitehead.bootstrap-3-snippets) from [William Whitehead](https://marketplace.visualstudio.com/search?term=publisher%3A%22William%20Whitehead%22&target=VSCode&sortBy=Relevance)
 - [Angular 2](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2) from [John Papa](https://marketplace.visualstudio.com/search?term=publisher%3A%22johnpapa%22&target=VSCode&sortBy=Relevance)

--- a/docs/languages/images/python/feature_showcase.mp4
+++ b/docs/languages/images/python/feature_showcase.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:212369f0efa523948e75ba0f071529d0ea5ab3b789a0e367b7892c2ee44abdf7
-size 7393889

--- a/docs/languages/images/python/python-snippets.mp4
+++ b/docs/languages/images/python/python-snippets.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:739d6734eb75516e44dd03c2c2422919091b45dfae6ad70b6cd12d30cc24de84
-size 252592

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -69,7 +69,7 @@ Linting analyzes your Python code for potential errors, making it easy to naviga
 The Python extension can apply a number of different linters including Pylint, pycodestyle, Flake8, mypy, pydocstyle, prospector, and pylama. See [Linting](/docs/python/linting.md).
 
 <video autoplay loop muted playsinline controls title="Python linting video">
-  <source src="https://az754404.vo.msecnd.net/public/python-linting.mp4" type="video/mp4">
+  <source src="/docs/languages/python/python-linting.mp4" type="video/mp4">
 </video>
 
 ## Debugging
@@ -79,7 +79,7 @@ No more `print` statement debugging! Set breakpoints, inspect data, and use the 
 For Python-specific details, including setting up your `launch.json` configuration and remote debugging, see [Debugging](/docs/python/debugging.md). General VS Code debugging information is found in the [debugging document](/docs/editor/debugging.md). The [Django](/docs/python/tutorial-django.md) and [Flask](/docs/python/tutorial-flask.md) tutorials also demonstrate debugging in the context of those web apps, including debugging Django page templates.
 
 <video autoplay loop muted playsinline controls title="Python debugging video">
-  <source src="https://az754404.vo.msecnd.net/public/python-debugging.mp4" type="video/mp4">
+  <source src="/docs/languages/python/python-debugging.mp4" type="video/mp4">
 </video>
 
 ## Environments

--- a/docs/nodejs/images/nodejs-debugging/restartFrame.gif
+++ b/docs/nodejs/images/nodejs-debugging/restartFrame.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a38e533e8d85ed61544547d0c19fde97282a05560e8209c45c5c001cea2f00d
+size 1653001

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -523,9 +523,7 @@ Alternatively you can start your program `server.js` via **nodemon** directly wi
 
 The Node debugger supports restarting execution at a stack frame. This can be useful in situations where you have found a problem in your source code and you want to rerun a small portion of the code with modified input values. Stopping and then restarting the full debug session can be time-consuming. The **Restart Frame** action allows you to reenter the current function after you have changed variables with the **Set Value** action:
 
-<p>
-  <img alt="restart frame" src="https://az754404.vo.msecnd.net/public/restartFrame.gif" />
-</p>
+![Restart frame](images/nodejs-debugging/restartFrame.gif)
 
 **Restart Frame** won't roll back mutation to state outside of the function, so it may not always work as expected.
 


### PR DESCRIPTION
Just remove a video from an old 2016 blog post (100 page views since November).
The python videos were already in Git LFS (?) so update the links (tested building the site locally).
Also remove a couple unused .mp4's
