### PR TITLE
1.76 release notes placeholder for Insiders

### DIFF
--- a/release-notes/v1_76.md
+++ b/release-notes/v1_76.md
@@ -1,0 +1,26 @@
+---
+Order:
+TOCTitle: February 2023
+PageTitle: Visual Studio Code February 2023
+MetaDescription: Learn what is new in the Visual Studio Code February 2023 Release (1.76)
+MetaSocialImage: 1_76/release-highlights.png
+Date: 2023-3-2
+DownloadVersion: 1.76.0
+---
+# February 2023 (version 1.76)
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+Welcome to the Insiders build. These are the preliminary notes for the February 1.76 release of Visual Studio Code. As we get closer to the release date, you'll find details below about new features and important fixes.
+
+Until the February milestone release notes are available, you can still track our progress:
+
+* **[Commit log](https://github.com/Microsoft/vscode/commits/main)** - GitHub commits to the vscode open-source repository.
+* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22February+2023%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
+
+We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>


### PR DESCRIPTION
This adds a 1.76 release notes placeholder for the Insiders build but not shown in the website TOC (Order: is empty). 