### PR TITLE
Improve description of the `contributes.viewContainers` id property

### DIFF
--- a/api/extension-guides/tree-view.md
+++ b/api/extension-guides/tree-view.md
@@ -289,7 +289,7 @@ To contribute a View Container, you should first register it using [contributes.
 
 You have to specify the following required fields:
 
-- `id` - The name of the new view container you're creating.
+- `id` - The id of the new view container you're creating.
 - `title` - The name that will show up at the top of the view container.
 - `icon` - An image that will be displayed for the view container when in the Activity Bar.
 


### PR DESCRIPTION
Describing the `id` field as `the name of the new view container` is imprecise. Instead, it should be `the id of the new view container`.