### PR TITLE
Fix language names

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -83,7 +83,7 @@ HTML | `html`
 Ini | `ini`
 Java | `java`
 JavaScript | `javascript`
-JavaScript React | `javascriptreact`
+JavaScript JSX | `javascriptreact`
 JSON | `json`
 JSON with Comments | `jsonc`
 LaTeX | `latex`
@@ -111,7 +111,7 @@ SQL | `sql`
 Stylus | `stylus`
 Swift | `swift`
 TypeScript | `typescript`
-TypeScript React | `typescriptreact`
+TypeScript JSX | `typescriptreact`
 TeX | `tex`
 Visual Basic | `vb`
 Vue | `vue`

--- a/release-notes/v1_75.md
+++ b/release-notes/v1_75.md
@@ -473,7 +473,7 @@ If you run into problems such as breakpoints not being hit, please [file an issu
 
 ### JavaScript React language label is now JavaScript JSX
 
-The `JavaScript React` language mode has been renamed to `JavaScript JSX` to reflect that JSX syntax is used by more than just React. `TypeScript React` has also been renamed to `TypeScript TSX`.
+The `JavaScript React` language mode has been renamed to `JavaScript JSX` to reflect that JSX syntax is used by more than just React. `TypeScript React` has also been renamed to `TypeScript JSX`.
 
 Note that only the language names shown in the UI have been changed. The internal language IDs (`javascriptreact` and `typescriptreact`) remain unchanged for compatibility reasons.
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/173332

It's `JavaScript JSX` and `TypeScript JSX` now