### PR TITLE
Add info about deployment to ACA from Docker

### DIFF
--- a/docs/containers/app-service.md
+++ b/docs/containers/app-service.md
@@ -3,17 +3,17 @@ Order: 8
 Area: containers
 TOCTitle: Deploy to Azure
 ContentId: 044913F5-F99D-4228-A916-0443260AB7FB
-PageTitle: Deploy a containerized app to Azure App Service
+PageTitle: Deploy a containerized app to Azure App Service or Azure Container Apps
 DateApproved: 01/17/2023
-MetaDescription: Using Visual Studio Code, build a container image for your application, push the image to a container registry, and deploy to Azure App Service.
+MetaDescription: Using Visual Studio Code, build a container image for your application, push the image to a container registry, and deploy to Azure App Service or Azure Container Apps.
 ---
-# Deploy to Azure App Service
+# Deploy to Azure App Service or Azure Container Apps
 
 In this guide you will learn how to:
 
 - Create a container image for your application.
 - Push the image to a container registry.
-- Deploy the image to Azure App Service.
+- Deploy the image to Azure App Service or Azure Container Apps.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ If you already have an image, skip this step and proceed to [Push the image to a
 
 ## Push the image to a container registry
 
-Before deploying the image to an App Service, the image must be uploaded to a container registry. The image can be uploaded to either [Azure Container Registry (ACR)](https://learn.microsoft.com/azure/container-registry/container-registry-get-started-portal) or [Docker Hub](https://hub.docker.com/).
+Before deploying the image to an App Service or a Container App, the image must be uploaded to a container registry. The image can be uploaded to either [Azure Container Registry (ACR)](https://learn.microsoft.com/azure/container-registry/container-registry-get-started-portal) or [Docker Hub](https://hub.docker.com/).
 
 1. Open the Docker Explorer and select **Connect Registry...** icon under **Registries** group and follow the prompt. Choose the provider (Azure or Docker Hub) and provide the credential to connect to the registry.
 
@@ -64,15 +64,15 @@ Before deploying the image to an App Service, the image must be uploaded to a co
 
     ![Refresh registry](images/app-service/explorer-refresh-registry.png)
 
-## Deploy the image to Azure App Service
+## Deploy the image to Azure App Service or Azure Container Apps
 
-In the previous section, the image is pushed to a remote container registry. Now deploy this image to Azure App Service.
+In the previous section, the image is pushed to a remote container registry. Now deploy this image to Azure App Service or Azure Container Apps.
 
-1. In Docker Explorer, navigate to your image under Registries, right-click on the tag, and select **Deploy Image To Azure App Service...**.
+1. In Docker Explorer, navigate to your image under Registries, right-click on the tag, and select **Deploy Image To Azure App Service...** or **Deploy Image to Azure Container Apps...**.
 
     ![Deploy to Azure App Service](images/app-service/explorer-deploy-to-app-service.png)
 
-2. When prompted, provide the values for the App Service.
+2. When prompted, provide the values for the App Service or Container App.
     - New web app name: The name must be unique across Azure.
     - Resource group: Select an existing resource group or create a new one.
     - App Service plan: Select an existing App Service Plan or create a new one. (An App Service Plan defines the physical resources that host the website; you can use a basic or free plan tier for this tutorial).
@@ -85,7 +85,7 @@ In the previous section, the image is pushed to a remote container registry. Now
 
     ![Deployment complete output](images/app-service/output-appservice-deployment.png)
 
-5. To browse the deployed website, you can use `kbstyle(Ctrl+click)` to open the URL in the Output panel. You might need to wait a little while for the app to be live in Azure. The new App Service also appears in the Azure view in Visual Studio Code under the App Service section, where you can right-click the website and select **Browse Website**.
+5. To browse the deployed website, you can use `kbstyle(Ctrl+click)` to open the URL in the Output panel. You might need to wait a little while for the app to be live in Azure. The new App Service or Container App also appears in the Azure view in Visual Studio Code, where you can right-click the website and select **Browse Website**.
 
     ![Web Application](images/app-service/webapp-homepage.png)
 

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -81,7 +81,7 @@ You can display the content and push, pull, or delete images from [Azure Contain
 
 ![Azure Container Registry content](images/overview/container-registry.png)
 
-An image in an Azure Container Registry can be deployed to Azure App Service directly from VS Code. See [Deploy to Azure App Service](/docs/containers/app-service.md) to get started. For more information about how to authenticate to and work with registries, see [Using container registries](/docs/containers/quickstart-container-registries.md).
+An image in an Azure Container Registry can be deployed to Azure App Service or Azure Container Apps directly from VS Code. See [Deploy to Azure](/docs/containers/app-service.md) to get started. For more information about how to authenticate to and work with registries, see [Using container registries](/docs/containers/quickstart-container-registries.md).
 
 ## Debugging services running inside a container
 

--- a/docs/containers/quickstart-aspnet-core.md
+++ b/docs/containers/quickstart-aspnet-core.md
@@ -58,12 +58,12 @@ In this guide you will learn how to:
      Determining projects to restore...
      All projects are up-to-date for restore.
      net -> C:\source\repos\net\bin\Debug\net7.0\net.dll
-   
+
    Build succeeded.
        0 Warning(s)
        0 Error(s)
-   
-   Time Elapsed 00:00:08.96   
+
+   Time Elapsed 00:00:08.96
    ```
 
 ## Add an environment variable to the image
@@ -173,5 +173,5 @@ You're done! Now that your container is ready, you may want to:
 - [Learn about debugging .NET in a container](/docs/containers/debug-netcore.md)
 - [Customize your Docker build and run tasks](/docs/containers/reference.md)
 - [Push your image to a container registry](/docs/containers/quickstart-container-registries.md#push-an-image-to-a-container-registry)
-- [Deploy a containerized app to Azure App Service](/docs/containers/app-service.md)
+- [Deploy a containerized app to Azure App Service or Azure Container Apps](/docs/containers/app-service.md)
 - [Learn about using Docker Compose](/docs/containers/docker-compose.md)

--- a/docs/containers/quickstart-container-registries.md
+++ b/docs/containers/quickstart-container-registries.md
@@ -94,7 +94,8 @@ For each tagged image in a repository, here are the actions that can be performe
 - **Pull Image**: copies the latest version of the image locally
 - **Copy Full Tag**: copies the full tag to the clipboard
 - **Copy Image Digest**: copies the image digest, which is a SHA256 hash identifier that Docker uses, to the clipboard. See [Docker Docs](https://docs.docker.com/engine/reference/commandline/images/#list-image-digests) for more info on image digests
-- **Deploy Image to Azure App Service**: deploys the image to Azure App Service, see [Deploy images to Azure App Service](/docs/containers/app-service.md) page
+- **Deploy Image to Azure App Service**: deploys the image to Azure App Service, see [Deploy images to Azure](/docs/containers/app-service.md) page
+- **Deploy Image to Azure Container Apps**: deploys the image to Azure Container Apps, see [Deploy images to Azure](/docs/containers/app-service.md) page
 - **Untag Image**: untags the image
 - **Delete Image**: deletes the image permanently
 
@@ -115,4 +116,4 @@ For each tagged image in a repository, here are the actions that can be performe
 
 ## Next steps
 
-- [Deploy to Azure App Service](/docs/containers/app-service.md)
+- [Deploy to Azure](/docs/containers/app-service.md)

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -156,7 +156,7 @@ The Docker Explorer provides an interactive experience to examine and manage Doc
 
 ## Build the image in Azure
 
-You can use the command **Azure Container Registry: Build Image in Azure** to build an image that you can then deploy to Azure App Service.
+You can use the command **Azure Container Registry: Build Image in Azure** to build an image that you can then deploy to Azure App Service or Azure Container Apps.
 
 1. Install the [Azure account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account). Open the **Command Palette** (`kb(workbench.action.showCommands)`) and search for the command **Azure: Sign In**. If you don't have an Azure account, you can sign up for a [free trial](https://azure.microsoft.com/free/?utm_source=campaign&utm_campaign=vscode-azure-account&mktingSource=vscode-azure-account).
 
@@ -178,11 +178,11 @@ You can use the command **Azure Container Registry: Build Image in Azure** to bu
 
 The process of building the image might take a few minutes. You can track progress in the terminal. If you encounter an error (`Error: failed to download context.`), try using the **Refresh** option on the container registry and then request another build. Before rebuilding, manually delete the old image.
 
-## Deploy to Azure App Service
+## Deploy to Azure App Service or Azure Container Apps
 
-Once the container image is built, it should appear in the Container Registry with the tag you specified. Now that it's built, you can deploy it to Azure App Service. You don't need to install the Azure App Service extension to get started, although it might be useful for managing the app service. You can install it from [Azure App Service](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice), but we recommend you install the [Azure Tools extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack), which includes a package of tools for a wide range of Azure development scenarios.
+Once the container image is built, it should appear in the Container Registry with the tag you specified. Now that it's built, you can deploy it to Azure App Service or Azure Container Apps. The [Azure App Service](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) extension is recommended for deployments to Azure App Service, and the [Azure Container Apps](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurecontainerapps) extension is required for deployments to Azure Container Apps. You can obtain both if you install the [Azure Tools extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack), which includes a package of tools for a wide range of Azure development scenarios.
 
-1. Right-click on the image tag and choose **Deploy Image to to Azure App Service**.
+1. Right-click on the image tag and choose **Deploy Image to Azure App Service** or **Deploy Image to Azure Container Apps**.
 
    ![Deploy image to Azure App Service](images/app-service/deploy-image-to-azure-app-service.png)
 


### PR DESCRIPTION
/cc @ghogen @gregvanl. Adding some docs for the new [Deploy to ACA feature](https://github.com/microsoft/vscode-docker/issues/3535) in the Docker extension. Whereas the "Deploy to App Service" feature does _not_ require the AppSvc extension, the "Deploy to ACA" feature _does_ require the ACA extension. If it is not present, you'll be prompted to install it, and taken to the extension install page automatically if you accept. I tried my best to phrase the prose talking about that to make the distinction clear.

Please hold off on merging until our 1.24.0 release, tentatively planned for 22 Feb.