### PR TITLE
Add pytest fixtures support with Pylance

### DIFF
--- a/docs/python/images/testing/pytest-annotation-code-action.png
+++ b/docs/python/images/testing/pytest-annotation-code-action.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0fefca5c6adf65d5eea704621a0537b3d58dab05b648b1c7510883e10cdb201
+size 80688

--- a/docs/python/images/testing/pytest-fixture-autocomplete.png
+++ b/docs/python/images/testing/pytest-fixture-autocomplete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acc0284dae62d2ae2dc9f15d2b0a4f184e882d99af9eaa72ee1add5d46b3f2b7
+size 544029

--- a/docs/python/images/testing/pytest-inferred-parametrized-argument.png
+++ b/docs/python/images/testing/pytest-inferred-parametrized-argument.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca715d8350c9d51452824e3ad62230595139be7aead984f0a643593c59009c35
+size 79583

--- a/docs/python/images/testing/pytest-inferred-parametrized-argument.png
+++ b/docs/python/images/testing/pytest-inferred-parametrized-argument.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca715d8350c9d51452824e3ad62230595139be7aead984f0a643593c59009c35
-size 79583
+oid sha256:96c4fa372d7c8d3d7fdb04d414b2741264ea08127a49a3eaf0b749bd8078bd18
+size 148568

--- a/docs/python/images/testing/pytest-inferred-parametrized-argument.png
+++ b/docs/python/images/testing/pytest-inferred-parametrized-argument.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96c4fa372d7c8d3d7fdb04d414b2741264ea08127a49a3eaf0b749bd8078bd18
-size 148568
+oid sha256:7cdddcf9057ce70b5a7502628ec502f491802eee01a3ac8e2d8ac6daba13641d
+size 132887

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -66,6 +66,7 @@ The language server settings apply when `python.languageServer` is `Pylance` or 
 | importFormat | `absolute`| Defines the default format when auto importing modules. Accepted values are `absolute` or `relative`. |
 | inlayHints.variableTypes | false | Whether to display inlay hints for variable types. Accepted values are `true` or `false`. |
 | inlayHints.functionReturnTypes | false |  Whether to display inlay hints for function return types.  Accepted values are `true` or `false`. |
+| inlayHints.pytestParameters | false | Whether to display inlay hints for pytest fixture argument types. Accepted values are `true` or `false`. |
 | diagnosticSeverityOverrides | {} | Allows a user to override the severity levels for individual diagnostics. <br> For each rule, the available severity levels are `error` (red squiggle), `warning` (yellow squiggle), `information` (blue squiggle), and `none` (rule disabled). <br> For information about the keys to use for the diagnostic severity rules, see the **Diagnostic severity rules** section below. |
 
 **Diagnostic severity rules**

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -324,17 +324,13 @@ When hovering over a fixture reference or a parameterized argument reference, Py
 
 ![Pylance type inference based on the types of arguments passed to the paramaterization decorator.](/docs/python/images/testing/pytest-inferred-parametrized-argument.png)
 
-
 Pylance also offers [code actions](/docs/editor/refactoring.md#code-actions--quick-fixes-and-refactorings) to add type annotation to test functions that has  fixture parameters.  Inlay hints for inferred fixture parameter types can also be enabled by setting `python.analysis.inlayHints.pytestParameters` to `true` in your User settings.
 
 ![Code action to add type annotation when hoving over a test function with a fixture parameter](/docs/python/images/testing/pytest-annotation-code-action.png)
 
-
-
 ## Test configuration settings
 
 The behavior of testing with Python is driven by general UI settings provided by VS Code, and settings that are specific to Python and to whichever framework you've enabled.
-
 
 ### General UI settings
 

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -313,9 +313,28 @@ Below are all the supported commands for testing with the Python extension in VS
 |  **Testing: Focus on Test Explorer View** | Open the Test Explorer view. Similar to **Testing: Focus on Python View** on versions prior to 2021.9.
 |  **Test: Stop Refreshing Tests** | Cancel test discovery. |
 
+## IntelliSense for pytest fixtures and parameterization
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) offers IntelliSense features that can help you work more efficiently with [pytest fixtures](https://docs.pytest.org/en/6.2.x/fixture.html) and [parameterized tests](https://docs.pytest.org/en/6.2.x/parametrize.html).
+
+As you're typing the parameters for your test function, Pylance will offer you a list of [auto completions](/docs/python/editing.md#autocomplete-and-intellisense) that includes known parameters from arguments defined by `@pytest.mark.parametrize`, as well as existing pytest fixtures defined in your tests file or in `confest.py`. [Code navigation](/docs/python/editing.md#navigation) features such as **Go to Definition** and **Find All References** and [rename symbol refactoring](/docs/editor/refactoring.md#rename-symbol) are also supported.
+
+![Auto completion suggestion when passing a parameter to a test function in a Python test file. The suggestion is a fixture defined in conftest.py.](/docs/python/images/testing/pytest-fixture-autocomplete.png)
+
+When hovering over a fixture reference or a parameterized argument reference, Pylance will show the inferred type annotation, either based on the return values of the fixture, or based on the inferred types of the arguments passed by the parameterization decorator.
+
+![Pylance type inference based on the types of arguments passed to the paramaterization decorator.](/docs/python/images/testing/pytest-inferred-parametrized-argument.png)
+
+
+Pylance also offers [code actions](/docs/editor/refactoring.md#code-actions--quick-fixes-and-refactorings) to add type annotation to test functions that has  fixture parameters.  Inlay hints for inferred fixture parameter types can also be enabled by setting `python.analysis.inlayHints.pytestParameters` to `true` in your User settings.
+
+![Code action to add type annotation when hoving over a test function with a fixture parameter](/docs/python/images/testing/pytest-annotation-code-action.png)
+
+
+
 ## Test configuration settings
 
 The behavior of testing with Python is driven by general UI settings provided by VS Code, and settings that are specific to Python and to whichever framework you've enabled.
+
 
 ### General UI settings
 
@@ -359,6 +378,12 @@ You can also configure pytest using a `pytest.ini` file as described on [pytest 
 
 > **Note**
 > If you have the pytest-cov coverage module installed, VS Code doesn't stop at breakpoints while debugging because pytest-cov is using the same technique to access the source code being run. To prevent this behavior, include `--no-cov` in `pytestArgs` when debugging tests, for example by adding `"env": {"PYTEST_ADDOPTS": "--no-cov"}` to your debug configuration. (See [Debug Tests](#debug-tests) above about how to set up that launch configuration.) (For more information, see [Debuggers and PyCharm](https://pytest-cov.readthedocs.io/en/latest/debuggers.html) in the pytest-cov documentation.)
+
+### IntelliSense settings
+
+| Setting<br/>(python.analysis.) | Default | Description |
+| --- | --- | --- |
+| inlayHints.pytestParameters | false | Whether to display inlay hints for pytest fixture argument types. Accepted values are `true` or `false`. |
 
 ## See also
 

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -313,20 +313,20 @@ Below are all the supported commands for testing with the Python extension in VS
 |  **Testing: Focus on Test Explorer View** | Open the Test Explorer view. Similar to **Testing: Focus on Python View** on versions prior to 2021.9.
 |  **Test: Stop Refreshing Tests** | Cancel test discovery. |
 
-## IntelliSense for pytest fixtures and parameterization
+## IntelliSense for pytest
 [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) offers IntelliSense features that can help you work more efficiently with [pytest fixtures](https://docs.pytest.org/en/6.2.x/fixture.html) and [parameterized tests](https://docs.pytest.org/en/6.2.x/parametrize.html).
 
-As you're typing the parameters for your test function, Pylance will offer you a list of [auto completions](/docs/python/editing.md#autocomplete-and-intellisense) that includes known parameters from arguments defined by `@pytest.mark.parametrize`, as well as existing pytest fixtures defined in your tests file or in `confest.py`. [Code navigation](/docs/python/editing.md#navigation) features such as **Go to Definition** and **Find All References** and [rename symbol refactoring](/docs/editor/refactoring.md#rename-symbol) are also supported.
+As you're typing the parameters for your test function, Pylance will offer you a list of [completions](/docs/python/editing.md#autocomplete-and-intellisense) that includes argument names from `@pytest.mark.parametrize` decorators, as well as existing pytest fixtures defined in your tests file or in `conftest.py`. [Code navigation](/docs/python/editing.md#navigation) features such as **Go to Definition** and **Find All References** and [rename symbol refactoring](/docs/editor/refactoring.md#rename-symbol) are also supported.
 
-![Auto completion suggestion when passing a parameter to a test function in a Python test file. The suggestion is a fixture defined in conftest.py.](/docs/python/images/testing/pytest-fixture-autocomplete.png)
+![Auto completion suggestion when passing a parameter to a test function in a Python test file. The suggestion is a fixture defined in conftest.py.](images/testing/pytest-fixture-autocomplete.png)
 
-When hovering over a fixture reference or a parameterized argument reference, Pylance will show the inferred type annotation, either based on the return values of the fixture, or based on the inferred types of the arguments passed by the parameterization decorator.
+When hovering over a fixture reference or a parameterized argument reference, Pylance will show the inferred type annotation, either based on the return values of the fixture, or based on the inferred types of the arguments passed to the parameterization decorator.
 
-![Pylance type inference based on the types of arguments passed to the paramaterization decorator.](/docs/python/images/testing/pytest-inferred-parametrized-argument.png)
+![Pylance type inference based on the types of arguments passed to the paramaterization decorator.](images/testing/pytest-inferred-parametrized-argument.png)
 
-Pylance also offers [code actions](/docs/editor/refactoring.md#code-actions--quick-fixes-and-refactorings) to add type annotation to test functions that has  fixture parameters.  Inlay hints for inferred fixture parameter types can also be enabled by setting `python.analysis.inlayHints.pytestParameters` to `true` in your User settings.
+Pylance also offers [code actions](/docs/editor/refactoring.md#code-actions--quick-fixes-and-refactorings) to add type annotations to test functions that have fixture parameters.  Inlay hints for inferred fixture parameter types can also be enabled by setting `python.analysis.inlayHints.pytestParameters` to `true` in your User settings.
 
-![Code action to add type annotation when hoving over a test function with a fixture parameter](/docs/python/images/testing/pytest-annotation-code-action.png)
+![Code action to add type annotation when hoving over a test function with a fixture parameter](images/testing/pytest-annotation-code-action.png)
 
 ## Test configuration settings
 


### PR DESCRIPTION
This feature is now on the latest Pylance stable version: https://devblogs.microsoft.com/python/python-in-visual-studio-code-february-2023-release/#preview-improved-intellisense-support-for-pytest-with-pylance

  