### PR TITLE
Remove mentions of Python 2

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -142,10 +142,6 @@ The following settings apply to the individual formatters. The Python extension 
 | black (see note) | pip install black | blackArgs | blackPath |
 | yapf | pip install yapf | yapfArgs | yapfPath |
 
-> **Note**: By default, the Black formatter can't be installed when a Python 2 environment is active. Attempting to do so may display the message "Formatter black is not installed. Install?". If you try to install Black in response, another message appears saying "Could not find a version that satisfies the requirement black' No matching distribution found for black."
->
-> To work around this issue and use the Black formatter with Python 2, first install Black in a Python 3 environment. Then set the `python.formatting.blackPath` setting to that install location.
-
 When using custom arguments, each top-level element of an argument string that's separated by space on the command line must be a separate item in the args list. For example:
 
 ```json

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -52,7 +52,7 @@ If an interpreter hasn't been specified, then the Python extension automatically
 
   1. Virtual environments located directly under the workspace folder.
   2. Virtual environments related to the workspace but stored globally. For example, [Pipenv](https://pypi.org/project/pipenv/) or [Poetry](https://python-poetry.org/) environments that are located outside of the workspace folder.
-  3. Globally installed interpreters. For example, the ones found in `/usr/local/bin`, `C:\\python27`, `C:\\python38`, etc.
+  3. Globally installed interpreters. For example, the ones found in `/usr/local/bin`, `C:\\python38`, etc.
 
 > **Note**: The interpreter selected may differ from what `python` refers to in your terminal.
 
@@ -62,7 +62,7 @@ If Visual Studio Code doesn't locate your interpreter automatically, you can [ma
 
 The extension automatically looks for interpreters in the following locations, in no particular order:
 
-- Standard install paths such as `/usr/local/bin`, `/usr/sbin`, `/sbin`, `c:\\python27`, `c:\\python36`, etc.
+- Standard install paths such as `/usr/local/bin`, `/usr/sbin`, `/sbin`, `c:\\python36`, etc.
 - Virtual environments located directly under the workspace (project) folder.
 - Virtual environments located in the folder identified by the `python.venvPath` setting (see [General Python settings](/docs/python/settings-reference.md#general-python-settings)), which can contain multiple virtual environments. The extension looks for virtual environments in the first-level subfolders of `venvPath`.
 - Virtual environments located in a `~/.virtualenvs` folder for [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/).

--- a/learn/develop-cloud/overview.md
+++ b/learn/develop-cloud/overview.md
@@ -23,7 +23,7 @@ Remote development has benefits such as:
 
 ### Example scenario
 
-As an example scenario, you could have different dev environments for Python 2.7 and 3.7. Rather than having to worry about managing different versions of Python on your computer, you can connect to separate environments with the appropriate versions of Python already set up for you.
+As an example scenario, you could have different dev environments for different versions of Python. Rather than having to worry about managing different versions of Python on your computer, you can connect to separate environments with the appropriate versions of Python already set up for you.
 
 Since you may be working with teammates using Linux or deploying to a Linux production environment, you could also connect to development environments that use a different operating system than your own, or harness the power of the Windows Subsystem for Linux.
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docs/issues/5954

I think the only explicit mention was in the Black formatter section but cleaned up a couple Python versioning examples as well.