### PR TITLE
Remove mention to outdated command in the inlay hints section of the Rust tutorial

### DIFF
--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -135,7 +135,7 @@ One of the first things you may notice is rust-analyzer providing [inlay hints](
 
 ![Rust program with inlay hints displayed](images/rust/inlay-hints.png)
 
-While inlay hints can be helpful for understanding your code, you can also disable the feature via the **Editor > Inlay Hints: Enabled** setting (`editor.inlayHints.enabled`) or use the **Rust Analyzer: Toggle Inlay Hints** command to hide or display this extra information.
+While inlay hints can be helpful for understanding your code, you can also configure the feature via the **Editor > Inlay Hints: Enabled** setting (`editor.inlayHints.enabled`).
 
 ### Hover information
 


### PR DESCRIPTION
This was removed in favour of the `onUnlessPressed` and `offUnlessPressed` options in Code.