### PR TITLE
Fix indent fail to unbreak CI

### DIFF
--- a/.pipelines/templates/jobs/build.yml
+++ b/.pipelines/templates/jobs/build.yml
@@ -56,8 +56,8 @@ jobs:
       displayName: Setup NPM Authentication
 
   - script: npm install
-      displayName: Install Dist dependencies
-      workingDirectory: $(Pipeline.Workspace)/vscode-website/dist
+    displayName: Install Dist dependencies
+    workingDirectory: $(Pipeline.Workspace)/vscode-website/dist
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize


### PR DESCRIPTION
CI broke at https://dev.azure.com/monacotools/Monaco/_build/results?buildId=203868&view=results due to an indentation issue.