### PR TITLE
Describe remote indicator position correctly

### DIFF
--- a/release-notes/v1_76.md
+++ b/release-notes/v1_76.md
@@ -30,7 +30,7 @@ It is now possible to sort JSONC (JSON documents with comments) files by key. To
 
 ## Remote Development
 
-This milestone we made several usability improvements to the remote indicator (visible in the lower right of the Status bar):
+This milestone we made several usability improvements to the remote indicator (visible in the lower left of the Status bar):
 
 1. There is now a default keybinding to open the remote indicator menu: `kb(workbench.action.remote.showMenu)`.
 <!-- TODO@joyceerhl screencast mp4 -->


### PR DESCRIPTION
Remote indicator is a LEFT end of Status Bar, not the right end.