### PR TITLE
Update remote indicator images

### DIFF
--- a/docs/devcontainers/images/tutorial/dev-containers-commands-simple.png
+++ b/docs/devcontainers/images/tutorial/dev-containers-commands-simple.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f8f6b2e305661d9a8f661c7d7f3a1efd8876bea738d6b3540d822467bfb7890
-size 124048
+oid sha256:80e5a5af7e19f968ab779f269257708eb90766bc2c71fe334f9c89a058b895ec
+size 111090

--- a/docs/remote/images/ssh-tutorial/remote-commands-simple.png
+++ b/docs/remote/images/ssh-tutorial/remote-commands-simple.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:064337e4882be0cbc1ad3da0ce7e5739632e6e5e94107ece9d9ee5dd91f4e557
-size 253366
+oid sha256:7573e967c36700e4c244a65e0359a99dce18b23634bdbdb120e382d779f43f15
+size 116059

--- a/docs/remote/images/wsl-tutorial/wsl-commands.png
+++ b/docs/remote/images/wsl-tutorial/wsl-commands.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2dc8d672e8f8ab146f1beff3e6d1a7b696486a8e42fa06eb3db91de4a1b36de
-size 25762
+oid sha256:44713a50118af9dce4e001979132c884faa0bbfac2d8fc9c25885108bea87e46
+size 26176


### PR DESCRIPTION
Based on endgame feedback I made a change to the remote indicator to only show the `Install Additional Remote Extensions` command if there are additional recommended remote extensions to be installed. 

In our docs screenshots we always show all 6 extensions' commands, so I'm updating them again to reflect the latest (one less item in the remote indicator).