### PR TITLE
Add doc note to GitHub Repos blog

### DIFF
--- a/blogs/2021/06/10/remote-repositories.md
+++ b/blogs/2021/06/10/remote-repositories.md
@@ -10,7 +10,7 @@ Author: Brigit Murtaugh, Eric Amodio
 
 June 10, 2021 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh), Eric Amodio, [@eamodio](https://twitter.com/eamodio)
 
->**Note**: The Remote Repositories extension has been renamed to [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=github.remotehub) since this blog post was published.
+>**Note**: The Remote Repositories extension has been renamed to [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=github.remotehub) since this blog post was published. You can also check out the [latest documentation](/docs/sourcecontrol/github.md#github-repositories-extension), which will have the most updated information on the extension.
 
 We're excited to present the new [Remote Repositories](https://marketplace.visualstudio.com/items?itemName=github.remotehub) extension for Visual Studio Code! This is a new experience that we've been building in partnership with our friends at GitHub to enable working with source code repositories quickly and safely inside VS Code.
 


### PR DESCRIPTION
@bhavyaus pointed out it may be confusing if users find our blog post before our doc, so let's link to the doc from the blog.