### PR TITLE
Add clarification for debugger extension per OS

### DIFF
--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -231,8 +231,8 @@ The rust-analyzer extension supports debugging Rust from within VS Code.
 
 To start debugging, you will first need to install one of two language extension with debugging support:
 
-* [Microsoft C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) (ms-vscode.cpptools)
-* [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) (vadimcn.vscode-lldb)
+* [Microsoft C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) (ms-vscode.cpptools) – *on Windows*
+* [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) (vadimcn.vscode-lldb) – *on macOS/Linux*
 
 If you forget to install one of these extensions, rust-analyzer will provide a notification with links to the VS Code Marketplace when you try to start a debug session.
 


### PR DESCRIPTION
While following the tutorial on macOS, I installed the first listed extension and had to look up why the debugger wasn’t working (giving the "MIDebuggerPath" error). A small addition like that could probably help other noobs in compiled languages like me :)