### PR TITLE
Correct macOS Keyboard Shortcuts menu path in keybindings documentation

### DIFF
--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -16,7 +16,7 @@ Visual Studio Code lets you perform most tasks directly from the keyboard.  This
 
 ## Keyboard Shortcuts editor
 
-Visual Studio Code provides a rich and easy keyboard shortcuts editing experience using **Keyboard Shortcuts** editor. It lists all available commands with and without keybindings and you can easily change / remove / reset their keybindings using the available actions. It also has a search box on the top that helps you in finding commands or keybindings. You can open this editor by going to the menu under **File**  > **Preferences** > **Keyboard Shortcuts**. (**Code** > **Preferences** > **Keyboard Shortcuts** on macOS)
+Visual Studio Code provides a rich and easy keyboard shortcuts editing experience using **Keyboard Shortcuts** editor. It lists all available commands with and without keybindings and you can easily change / remove / reset their keybindings using the available actions. It also has a search box on the top that helps you in finding commands or keybindings. You can open this editor by going to the menu under **File**  > **Preferences** > **Keyboard Shortcuts**. (**Code** > **Settings** > **Keyboard Shortcuts** on macOS)
 
 ![Keyboard Shortcuts](images/keybinding/keyboard-shortcuts.gif)
 


### PR DESCRIPTION
`Code > Preferences > Keyboard Shortcuts` ==> `Code > Settings > Keyboard Shortcuts`