### PR TITLE
Update Keyboard Shortcuts path for macOS

### DIFF
--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -16,7 +16,7 @@ Visual Studio Code lets you perform most tasks directly from the keyboard.  This
 
 ## Keyboard Shortcuts editor
 
-Visual Studio Code provides a rich and easy keyboard shortcuts editing experience using **Keyboard Shortcuts** editor. It lists all available commands with and without keybindings and you can easily change / remove / reset their keybindings using the available actions. It also has a search box on the top that helps you in finding commands or keybindings. You can open this editor by going to the menu under **File**  > **Preferences** > **Keyboard Shortcuts**. (**Code** > **Preferences** > **Keyboard Shortcuts** on macOS)
+Visual Studio Code provides a rich and easy keyboard shortcuts editing experience using **Keyboard Shortcuts** editor. It lists all available commands with and without keybindings and you can easily change / remove / reset their keybindings using the available actions. It also has a search box on the top that helps you in finding commands or keybindings. You can open this editor by going to the menu under **File**  > **Preferences** > **Keyboard Shortcuts**. (**Code** > **Settings** > **Keyboard Shortcuts** on macOS)
 
 ![Keyboard Shortcuts](images/keybinding/keyboard-shortcuts.gif)
 


### PR DESCRIPTION
EDIT:
Related to #5937
I see it's marked as `don't merge`

On macOS Ventura 13.2.1 and VS Code:
```
Version: 1.76.2 (Universal)
Commit: ee2b180d582a7f601fa6ecfdad8d9fd269ab1884
Date: 2023-03-14T17:54:09.061Z
Electron: 19.1.11
Chromium: 102.0.5005.196
Node.js: 16.14.2
V8: 10.2.154.26-electron.0
OS: Darwin arm64 22.3.0
Sandboxed: No
```

the path for accessing keyboard shortcuts is not Code -> Preferences -> Keyboard Shortcuts but
Code -> Settings -> Keyboard Shortcuts