### PR TITLE
Add languages guide for Ruby

### DIFF
--- a/docs/languages/images/ruby/ruby_lsp_breakpoint.png
+++ b/docs/languages/images/ruby/ruby_lsp_breakpoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cba973a20470ad00a020146f99717e89007165ae4664eb131a92a3767fab1765
+size 27615

--- a/docs/languages/images/ruby/ruby_lsp_debugging_session.png
+++ b/docs/languages/images/ruby/ruby_lsp_debugging_session.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9a9375bb9742b1e925875a36ef6d4e643c41bde79b8a2fd02af2554ff84a6a4
+size 308881

--- a/docs/languages/images/ruby/ruby_lsp_extension.png
+++ b/docs/languages/images/ruby/ruby_lsp_extension.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41748745cb34cc1194d411f8d629ac610af77ac9a274c322579fd29b1d8e1824
+size 67624

--- a/docs/languages/images/ruby/ruby_lsp_extensions_view.png
+++ b/docs/languages/images/ruby/ruby_lsp_extensions_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3266791c0c0b4f7486cedbca2d50bd58178ac1653747085621ccec0cefde10eb
+size 50495

--- a/docs/languages/images/ruby/ruby_lsp_inlay_hints.png
+++ b/docs/languages/images/ruby/ruby_lsp_inlay_hints.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9112bd7b516ccf28cbbf559da6a96d430b7803c97e33a89f61233b20b803b9d
+size 27143

--- a/docs/languages/images/ruby/ruby_lsp_linting.png
+++ b/docs/languages/images/ruby/ruby_lsp_linting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63b2f292eb89bc39972486d3fd819d64720c06b3c52366c79f7258c1910a1d31
+size 57009

--- a/docs/languages/images/ruby/ruby_lsp_quickfix.png
+++ b/docs/languages/images/ruby/ruby_lsp_quickfix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea8e2fb460147a9cf3ea2e372046cbcd293c35a7d930d76af7beef93d6f513a0
+size 24311

--- a/docs/languages/images/ruby/ruby_lsp_refactor.png
+++ b/docs/languages/images/ruby/ruby_lsp_refactor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca1f8fc40b26b13710819bb280cc5351f2a91e93238eaca4fac96dfa01b0f9b1
+size 26151

--- a/docs/languages/images/ruby/ruby_lsp_semantic_highlighting.png
+++ b/docs/languages/images/ruby/ruby_lsp_semantic_highlighting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edede3039f794094f065b7acb822f8426306f008c53b902d3720ef6759eee62d
+size 48644

--- a/docs/languages/images/ruby/ruby_lsp_status_center.png
+++ b/docs/languages/images/ruby/ruby_lsp_status_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac8da79b23a8675415c381561e0648a02882132b9ff5acde6c561e8238469302
+size 57468

--- a/docs/languages/images/ruby/ruby_lsp_symbols.png
+++ b/docs/languages/images/ruby/ruby_lsp_symbols.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3919da6387238ef846d54a04c15304c61e38f29c5b3ba1d062142c799c41cbdf
+size 134022

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -1,0 +1,252 @@
+---
+Order: 20
+Area: languages
+TOCTitle: Ruby
+ContentId: ???
+PageTitle: Ruby with Visual Studio Code
+DateApproved: ???
+MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Ruby.
+---
+# Ruby in Visual Studio Code
+
+[Ruby](https://www.ruby-lang.org) is a dynamic, open-source programming language known for its simplicity and
+productivity. With an expressive and elegant syntax, part of the Ruby philosophy is to make developers happy. It is
+often used for web development with a range of different frameworks, and for scripting, allowing for fast iterations
+when building prototypes.
+
+This topic goes into detail about setting up and using Ruby within Visual Studio Code, with the
+[Ruby LSP](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp) extension.
+
+![Ruby extension banner](images/ruby/ruby_lsp_extension.png)
+
+## Installation
+
+### 1. Install Ruby through a version manager
+
+While Ruby is installed by default on some operating systems (such as macOS and some distributions of Linux), we
+recommend using a version manager such as [rbenv](https://github.com/rbenv/rbenv) to be able to access newer versions of
+Ruby on Windows, macOS, and Linux. Follow the [installation guidance](https://github.com/rbenv/rbenv#installation) for
+your platform.
+
+>**Note**: As with installing any new toolset on your machine, you'll want to make sure to restart your terminal/Command
+Prompt and VS Code instances to use the updated toolset location in your platform's PATH variable.
+
+### 2. Install the Ruby LSP extension in VS Code
+
+You can find and install the Ruby LSP extension from within VS Code via the Extensions view
+(`kb(workbench.view.extensions)`) and searching for 'Ruby LSP'.
+
+![Ruby LSP extension in the Extensions view](images/ruby/ruby_lsp_extensions_view.png)
+
+We'll discuss many of Ruby LSP features in this topic but you can also refer to the extension's documentation at
+[https://github.com/Shopify/vscode-ruby-lsp](https://github.com/Shopify/vscode-ruby-lsp).
+
+### Check your installation
+
+After installing, check the language status item to see the status of the Ruby LSP server. If the version manager has
+been configured, it should display the right Ruby version for your project. The server status should display starting or
+running, but not error.
+
+![Ruby LSP language status center](images/ruby/ruby_lsp_status_center.png)
+
+The extension will generate a `.ruby-lsp` folder automatically with a custom bundle that includes the language server
+gem `ruby-lsp`. No configuration should be required.
+
+By default, the extension will try to automatically detect the Ruby version manager you're using and use the right
+versions and paths accordingly. If you want to customize that behavior, set the following configuration:
+
+```json
+"rubyLsp.rubyVersionManager": "rbenv"
+```
+
+The extension will automatically try to update the `ruby-lsp` language server gem once per day; if you want to force
+that to happen, use the Command Palette (`kb(workbench.action.showCommands)`) to execute `Ruby LSP: Update language
+server gem`.
+
+If you have any problems, see [troubleshooting](https://github.com/Shopify/vscode-ruby-lsp#troubleshooting) for next
+steps.
+
+## Main features
+
+### Symbol detection
+
+Ruby LSP parses code and provides symbol detection and navigation for the Outline pane, file breadcrumbs and symbol
+searches (accessible with CMD + SHIFT + O by default).
+
+![Ruby document symbols](images/ruby/ruby_lsp_symbols.png)
+
+To learn more about moving quickly through your source code with VS Code, check out [Code Navigation](/docs/editor/editingevolved.md).
+
+### Inlay hints
+
+Ruby LSP is able to display useful information about inferred or implicit values in your code. In the example below, you
+can see `StandardError` being shown as the implicit exception class being rescued in an empty `rescue` call.
+
+![Ruby program with inlay hints displayed](images/ruby/ruby_lsp_inlay_hints.png)
+
+While inlay hints can be helpful for understanding your code, you can also disable the feature via the
+**Editor > Inlay Hints: Enabled** setting (`editor.inlayHints.enabled`) or use the following to disable this feature
+only for Ruby LSP:
+
+```json
+"rubyLsp.enabledFeatures": {
+    "inlayHint": false,
+}
+```
+
+### Code snippets
+
+As you type in a Ruby file, Ruby LSP might suggest expanding snippets used for common Ruby operations such as creating a
+new method, class, block, or test boilerplate. To see the full list, check out the snippets file in the Ruby LSP
+[GitHub repository](https://github.com/Shopify/vscode-ruby-lsp/blob/main/snippets.json).
+
+### Semantic syntax highlighting
+
+Ruby LSP is able to use [semantic syntax highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview)
+and styling due to its rich understanding of a project source code. For example, it can highlight
+- method invocations consistently, without confusing it with local variables
+- local arguments (such as method, block or lambda arguments) consistently inside the scope in which they exist
+
+![Ruby LSP semantic highlighting](images/ruby/ruby_lsp_semantic_highlighting.png)
+
+>**Note**: This screenshot is using the Spinel theme included in the
+[Ruby extension pack](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-extensions-pack). Themes must use
+the information surfaced by the Ruby LSP in order to provide rich highlighting for Ruby files.
+
+To use this feature, the editor must have semantic highlighting enabled.
+
+```json
+"editor.semanticHighlighting.enabled": true,
+```
+
+### Linting and formatting
+
+By default, Ruby LSP provides linting and formatting through an integration with
+[RuboCop](https://github.com/rubocop/rubocop). You can format your Ruby file using `kb(editor.action.formatDocument)` or
+by running the **Format Document** command from the Command Palette (`kb(workbench.action.showCommands)`) or the context
+menu in the editor.
+
+If your project does not use RuboCop, the Ruby LSP will format files using
+[SyntaxTree](https://ruby-syntax-tree.github.io/syntax_tree).
+
+![Linting a Ruby file](images/ruby/ruby_lsp_linting.png)
+
+You also have the option to run the formatter on each save (**Editor: Format On Save**) to keep your Ruby code properly
+formatted automatically while you are working. To do that, you must enable format on save.
+
+```json
+"editor.formatOnSave": true
+```
+
+The Ruby LSP also provides some convenience completions using format on type. For example, it will auto-continue comment
+lines and auto-close `end` tokens, pipes, or string interpolation curly braces. To use format on type, make sure it's
+enabled in the editor with:
+
+```json
+"editor.formatOnType": true
+```
+
+### Quick Fixes
+
+When the linter finds errors and warnings in your source code, Ruby LSP can often provide suggested Quick Fixes (also
+called Code Actions), which are available via a light bulb hover in the editor. You can quickly open available Quick
+Fixes via the `kb(editor.action.quickFix)`.
+
+![Quick Fixes for linting violations](images/ruby/ruby_lsp_quickfix.png)
+
+### Refactoring
+
+In addition to Quick Fixes, the Ruby LSP also provides refactor options through code actions. For example, it can
+extract a Ruby expression into a local variable with a single click.
+
+![Refactor extract to variable](images/ruby/ruby_lsp_refactor.png)
+
+## Debugging support with `rdbg`
+
+For debug support inside of VS Code, the Ruby LSP requires the VS Code RDBG extension to connect to debug (Ruby's
+official debugger).
+
+### Install debugging support
+
+Install the [VS Code RDBG](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension.
+
+### Set up debugging configuration
+
+To use the debugger you will need to create [debugging configurations](/docs/editor/debugging.md#launch-configurations)
+in a `launch.json` file. The configuration lets you pass arguments to your program, run pre-launch tasks, set
+environment variables, and much more.
+
+To create a `launch.json` for a Ruby program:
+
+1. In the Debug view (`kb(workbench.view.debug)`), select the **create a launch.json file** link.
+2. This will display a dropdown, which several default launch configuration types. You can pick the first option, but
+we'll add more configurations
+3. We can now edit the created `.vscode/launch.json` file to add more ways to launch your Ruby program for debugging
+
+Example:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        // Run all tests in a file using Minitest
+        {
+            "type": "rdbg",
+            "name": "Minitest - current file",
+            "request": "launch",
+            "script": "-Itest ${file}",
+            "askParameters": false
+        },
+        // If your test runner supports line numbers, such as in Rails, you can add a task like this one to run only the
+        // test under the cursor
+        {
+            "name": "Minitest - current line",
+            "type": "rdbg",
+            "request": "launch",
+            "command": "${workspaceRoot}/bin/rails",
+            "script": "test",
+            "args": [
+                "${file}:${lineNumber}"
+            ],
+            "askParameters": false,
+        },
+        // Attach the debugger to an active process (e.g. Rails server)
+        {
+            "type": "rdbg",
+            "name": "Attach with rdbg",
+            "request": "attach"
+        }
+    ]
+}
+```
+
+After adding the launch configurations, we can debug Ruby programs by adding breakpoints and executing our launch tasks.
+
+1. Open a Ruby file and click the left gutter in the editor to set a break point. It should display as a red dot.
+
+![Red breakpoint dot in the left gutter of the editor](images/ruby/ruby_lsp_breakpoint.png)
+
+2. Start debugging by selecting the desired task under `Run and Debug` and clicking the start debugging button (Default
+hokey: F5).
+
+![Debug session stopped at breakpoint](images/ruby/ruby_lsp_debugging_session.png)
+
+## Next steps
+
+This has been a brief overview showing the Ruby LSP extension features within VS Code. For more information, see the
+details provided in the Ruby LSP [README](https://github.com/Shopify/vscode-ruby-lsp), including how to tune specific
+[VS Code editor](https://github.com/Shopify/vscode-ruby-lsp#configuration) configurations.
+
+To stay up to date on the latest features/bug fixes for the Ruby LSP extension, see the Releases page for the
+[language server gem](https://github.com/Shopify/ruby-lsp/releases) and for the
+[VS Code extension](https://github.com/Shopify/vscode-ruby-lsp/releases).
+
+If you have any issues or feature requests, feel free to log them in the Ruby LSP extension
+[GitHub repo](https://github.com/Shopify/vscode-ruby-lsp/issues).
+
+If you'd like to learn more about VS Code, try these topics:
+
+* [Basic Editing](/docs/editor/codebasics.md) - A quick introduction to the basics of the VS Code editor.
+* [Install an Extension](/docs/editor/extension-marketplace.md) - Learn about other extensions are available in the
+[Marketplace](https://marketplace.visualstudio.com/vscode).
+* [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.


### PR DESCRIPTION
Add a guide for the Ruby language in VS Code. The entry explains how to set up and use the Ruby LSP and is very similar to the Rust docs.

cc @isidorn