### PR TITLE
April plan to Insiders release notes placeholder

### DIFF
--- a/release-notes/v1_78.md
+++ b/release-notes/v1_78.md
@@ -9,12 +9,11 @@ DownloadVersion: 1.78.0
 ---
 # April 2023 (version 1.78)
 
-<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
-
 Welcome to the Insiders build. These are the preliminary notes for the April 1.78 release of Visual Studio Code. As we get closer to the release date, you'll find details below about new features and important fixes.
 
 Until the April milestone release notes are available, you can still track our progress:
 
+* **[April iteration plan](https://github.com/microsoft/vscode/issues/178951)** - Review what's planned for the milestone.
 * **[Commit log](https://github.com/Microsoft/vscode/commits/main)** - GitHub commits to the vscode open-source repository.
 * **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22April+2023%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
 


### PR DESCRIPTION
Also remove the download links since 1.78 Stable isn't available yet