### PR TITLE
Added the command for vscode.executeFoldingRangeProvider

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -74,6 +74,12 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 * _position_ - A position in a text document
 * _(returns)_ - A promise that resolves to an array of Location or LocationLink instances.
 
+`vscode.executeFoldingRangeProvider` - Execute folding range provider.
+
+* _uri_ - Uri of a text document
+* _(returns)_ - A Promise that resolves to an array of FoldingRange instances.
+
+
 `vscode.executeImplementationProvider` - Execute all implementation providers.
 
 * _uri_ - Uri of a text document


### PR DESCRIPTION
Issue - https://github.com/microsoft/vscode-docs/issues/6258
Solution - Added the command for vscode.executeFoldingRangeProvider to the api/references/command.md web page

`vscode.executeFoldingRangeProvider` - Execute folding range provider.

* _uri_ - Uri of a text document
* _(returns)_ - A Promise that resolves to an array of FoldingRange instances.