### PR TITLE
Add 1.79 release notes placeholder for Insiders

### DIFF
--- a/release-notes/v1_78.md
+++ b/release-notes/v1_78.md
@@ -9,6 +9,8 @@ DownloadVersion: 1.78.0
 ---
 # April 2023 (version 1.78)
 
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
 Welcome to the April 2023 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
 
 * **[Accessibility improvements](#accessibility)** - Better screen reader support, new audio cues.

--- a/release-notes/v1_79.md
+++ b/release-notes/v1_79.md
@@ -1,0 +1,24 @@
+---
+Order:
+TOCTitle: May 2023
+PageTitle: Visual Studio Code May 2023
+MetaDescription: Learn what is new in the Visual Studio Code May 2023 Release (1.79)
+MetaSocialImage: 1_79/release-highlights.png
+Date: 2023-5-31
+DownloadVersion: 1.79.0
+---
+# May 2023 (version 1.79)
+
+Welcome to the Insiders build. These are the preliminary notes for the May 1.79 release of Visual Studio Code. As we get closer to the release date, you'll find details below about new features and important fixes.
+
+Until the May milestone release notes are available, you can still track our progress:
+
+* **[Commit log](https://github.com/Microsoft/vscode/commits/main)** - GitHub commits to the vscode open-source repository.
+* **[Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22May+2023%22+is%3Aclosed)** - Resolved bugs and implemented feature requests in the milestone.
+
+We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>


### PR DESCRIPTION
Also add download links to 1.78 release notes, which was dropped accidentally