### PR TITLE
Add clarity and correction to the variables section of the user snippets documentation section

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -116,7 +116,19 @@ Placeholders can have choices as values. The syntax is a comma-separated enumera
 
 ### Variables
 
-With `$name` or `${name:default}`, you can insert the value of a variable. When a variable isn't set, its **default** or the empty string is inserted. When a variable is unknown (that is, its name isn't defined) the name of the variable is inserted and it is transformed into a placeholder.
+With `$name` or `${name:default}`, you can insert the value of a variable. When a variable isn't set, its **default** or the empty string is inserted. When a variable is unknown (that is, its name isn't defined) and the variable has no default set, the name of the variable is inserted and it is transformed into a placeholder. When a variable is unknown and has a **default** set, it's **default** is inserted.
+
+Example | 'name' Value | Output | Explanation
+-----|-------|--------|------------
+`"$name"`|'text'|'text'|name's value is inserted
+&nbsp;|unset|''|an empty string is inserted
+&nbsp;|unknown|'name'|name's name is inserted as a placeholder
+`"$name:default"`|'text'|'text'|name's value is inserted
+&nbsp;|unset|''|an empty string is inserted
+&nbsp;|unknown|'default'|name's default is inserted
+`"${name:${1:placeholder}}"`|'text'|'text'|name's value is inserted
+&nbsp;|unset|'placeholder'|name's default (in this case, a placeholder) is inserted
+&nbsp;|unknown|'name'|name's default (in this case, a placeholder) is inserted
 
 The following variables can be used:
 


### PR DESCRIPTION
This PR clarifies and corrects the opening paragraph of the variables section of the [user guide section on user defined snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables).

It tries to clarify 2 details about variables, one which seems to be an incorrect explanation of functionality and the other which is quite sparse and whose improvement could be of significant help in giving readers a more useful jumping off point.

1.  The text as it currently appears indicates that unknown variables are all set to placeholders with their names as the placeholder text, however, when given a default, the default inserted in place of that default unknown placeholder. That default can be in the form of any (according to the EBNF), which makes this small difference in clarity potentially have larger consequences to readers than its size might indicate. This is a small distinction, but could lead someone to a confusing conclusion that, to my understanding, is not corrected or expanded upon anywhere else in the documentation (including the EBNF).
2. Relating to the first detail, and making it more clear what the distinction is, an example chart has been added to show a simple example of a mechanic that I think readers will often want to use, which is not clear upon first inspection. This chart also exemplifies the correction above. For formatting I followed the formatting later in the page to try to keep this as on theme as possible.


<details>
<summary>More detailed explanation with links to relevant sections of code (the end is most relevant)</summary>
The following simply details my path in double checking that a unknown variable with a default does indeed insert the default rather than a placeholder with the name of the unknown variable.

Just to double check I wasn't misunderstanding the snippet syntax or code I went through the codepath for a snippet I thought was exhibiting behaviour contrary to what the documentation was portraying in the first paragraph. This was the snippet example of ${undefinedVariableName:default} starting here:

https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/test/browser/snippetVariables.test.ts#L52

1. First in snippetParser.ts>SnippetParser>parse
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L626

3. snippetParser.ts>SnippetParser>parseFragment
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L633

4. scanner.ts>Scanner>text
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L62

5. scanner.ts>Scanner>scanner.next
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L71

   static
   `this._token = 'TokenType.Dollar'`

6. snippetParser.ts>SnippetParser>_parse
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L738

7. snippetParser.ts>SnippetParser>_parseTabstopOrVariableName
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#LL763C10-L763C37

8. snippetParser.ts>SnippetParser>_accept
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#LL703C10-L703C17

9. scanner.ts>Scanner>scanner.next
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L71

10. snippetParser.ts>SnippetParser>_backTo
   https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L712

       static
       `this._token = 'TokenType.Dollar'`

       ...

11. snippetParser.ts>SnippetParser>_parseComplexVariable
    https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/editor/contrib/snippet/browser/snippetParser.ts#LL896C10-L896C31

    `this._token = 'TokenType.CurlyOpen'`
    `this._token = 'TokenType.VariableName'`
    `this._token = 'TokenType.Colon'`
    `this._token = 'TokenType.VariableName' (the default)`
    `this._token = 'TokenType.CurlyClose'`

    `parent = [ variable, default ]`


12. snippetsFuke.ts>Snippet>resolveVariables
    https://github.com/microsoft/vscode/blob/60fe2d5970245742a89a0bdead58f0626d957f1c/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts#L62
    
    This is where the default gets set. 
    
    With no prior Typescript experience, and without setting up debug tools this took some time to figure out 😅

</details>