### PR TITLE
Fix style inconsistencies in Jupyter Notebooks docs

### DIFF
--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -51,7 +51,7 @@ If you have an existing Jupyter Notebook, you can open it by right-clicking on t
 
 Once you have a notebook, you can run a code cell using the **Run** icon to the left of the cell and the output will appear directly below the code cell.
 
-To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use the keyboard shortcut `kbstyle(Shift+Enter)`.
+To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use the keyboard shortcut `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use the keyboard shortcut `kbstyle(Shift+Enter)`.
 
 ![Run Jupyter code cell](images/jupyter/native-code-cells-03.png)
 

--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -51,7 +51,7 @@ If you have an existing Jupyter Notebook, you can open it by right-clicking on t
 
 Once you have a notebook, you can run a code cell using the **Run** icon to the left of the cell and the output will appear directly below the code cell.
 
-To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use `kbstyle(Shift+Enter)`.
+To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use the keyboard shortcut `kbstyle(Shift+Enter)`.
 
 ![Run Jupyter code cell](images/jupyter/native-code-cells-03.png)
 

--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -27,7 +27,7 @@ Once the appropriate environment is activated, you can create and open a Jupyter
 
 ## Workspace Trust
 
-When getting started with Notebooks, you'll want to make sure that you are working in a trusted workspace. Harmful code can be embedded in notebooks and the [Workspace Trust](/docs/editor/workspace-trust.md) feature allows you to indicate which folders and their contents should allow or restrict automatic code execution.
+When getting started with Jupyter Notebooks, you'll want to make sure that you are working in a trusted workspace. Harmful code can be embedded in notebooks and the [Workspace Trust](/docs/editor/workspace-trust.md) feature allows you to indicate which folders and their contents should allow or restrict automatic code execution.
 
 If you attempt to open a notebook when VS Code is in an untrusted workspace running [Restricted Mode](/docs/editor/workspace-trust.md#restricted-mode), you will not be able to execute cells and rich outputs will be hidden.
 
@@ -49,9 +49,9 @@ If you have an existing Jupyter Notebook, you can open it by right-clicking on t
 
 ## Running cells
 
-Once you have a Notebook, you can run a code cell using the **Run** icon to the left of the cell and the output will appear directly below the code cell.
+Once you have a notebook, you can run a code cell using the **Run** icon to the left of the cell and the output will appear directly below the code cell.
 
-You can also use keyboard shortcuts to run code. When in command or edit mode, use `kbstyle(Ctrl+Enter)` to run the current cell or `kbstyle(Shift+Enter)` to run the current cell and advance to the next.
+To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use `kbstyle(Shift+Enter)`.
 
 ![Run Jupyter code cell](images/jupyter/native-code-cells-03.png)
 
@@ -77,7 +77,7 @@ The Notebook Editor makes it easy to create, edit, and run code cells within you
 
 ### Create a code cell
 
-By default, a blank Notebook will have an empty code cell for you to start with and an existing Notebook will place one at the bottom. Add your code to the empty code cell to get started.
+By default, a blank notebook will have an empty code cell for you to start with and an existing notebook will place one at the bottom. Add your code to the empty code cell to get started.
 
 ```python
 msg = "Hello world"
@@ -88,41 +88,37 @@ print(msg)
 
 ### Code cell modes
 
-While working with code cells, a cell can be in three states: unselected, command mode, and edit mode. The current state of a cell is indicated by a vertical bar to the left of a code cell and editor border. When no bar is visible, the cell is unselected.
+While working with code cells, a cell can be in three states: unselected, command mode, and edit mode. A vertical bar to the left of a code cell and editor border shows the current state of a cell. When no bar is visible, the cell is unselected. When a cell is selected, it can be in command mode or in edit mode.
 
 ![Unselected Jupyter code cell](images/jupyter/native-code-unselected-02.png)
 
-When a cell is selected, it can be in two different modes. It can be in command mode or in edit mode. When the cell is in command mode, it can be operated on and accept keyboard commands. When the cell is in edit mode, the cell's contents (code or Markdown) can be modified.
-
-When a cell is in command mode, a solid vertical bar will appear to the left of the cell.
+In command mode, a solid vertical bar will appear to the left of the cell. The cell can be operated on and accepts keyboard commands.
 
 ![Code cell in command mode](images/jupyter/native-code-cells-02.png)
 
- When you're in edit mode, the solid vertical bar is joined by a border around the cell editor.
+In edit mode, a solid vertical bar is joined by a border around the cell editor. The cell's contents (code or Markdown) can be modified.
 
 ![Code cell in edit mode](images/jupyter/native-code-cells-04.png)
 
-To move from edit mode to command mode, press the `kbstyle(Esc)` key. To move from command mode to edit mode, press the `kbstyle(Enter)` key. You can also use the mouse to **change the mode** by clicking the vertical bar to the left of the cell or out of the code/Markdown region in the code cell.
+To switch modes, you can use keyboard shortcuts or the mouse. On your keyboard, press the `kbstyle(Enter)` key to move to edit mode or the `kbstyle(Esc)` key to move to command mode. With your mouse, click the vertical bar to the left of the cell or out of the code/Markdown region in the code cell.
 
 ### Add additional code cells
 
-Code cells can be added to a Notebook using the main toolbar, a cell's add cell toolbar (visible with hover), and through keyboard commands.
+You can add Code cells using the main toolbar, a cell's add cell toolbar (visible with hover), and through keyboard commands.
 
 ![Add code cells](images/jupyter/native-add-cells.png)
 
- Using the plus icons in the main toolbar and a cell's hover toolbar will add a new cell directly below the currently selected cell.
+To add a new cell below the currently selected cell, use the plus icons in the main toolbar or a cell's hover toolbar.
 
-When a code cell is in command mode, the `kbstyle(A)` key can be used to add a cell above and the `kbstyle(B)` can be used to add a cell below the selected cell.
+When a code cell is in command mode, use the `kbstyle(A)` key to add a cell above and the `kbstyle(B)` key to add a cell below the selected cell.
 
 ### Select a code cell
 
-The selected code cell can be changed using the mouse, the up/down arrow keys on the keyboard, and the `kbstyle(J)` (down) and `kbstyle(K)` (up) keys. To use the keyboard, the cell must be in command mode.
+You can change a selected code cell using the mouse, the up/down arrow keys on the keyboard. When a code cell is in command mode, you can also use the `kbstyle(J)` key (down) and `kbstyle(K)` key (up).
 
 ### Select multiple code cells
 
-To select multiple cells, start with one cell in selected mode. If you want to select consecutive cells, hold down `kbstyle(Shift)` and click the last cell you want to select. If you want to select any group of cells, hold down `kbstyle(Ctrl)` and click the cells you'd like to add to your selection.
-
-Selected cells will be indicated by the filled background.
+To select multiple cells, start with one cell in selected mode. A filled background indicates selected cells. To select consecutive cells, hold down the `kbstyle(Shift)` key and click the last cell you want to select. To select any group of cells, hold down the `kbstyle(Ctrl)` key and click the cells you'd like to add to your selection.
 
 ![Multiselected cells](images/jupyter/multiselect.png)
 
@@ -132,7 +128,7 @@ Once your code is added, you can run a cell using the **Run** icon to the left o
 
 ![Run Jupyter code cell](images/jupyter/native-code-run.png)
 
-You can also use keyboard shortcuts to run a selected code cell. `kbstyle(Ctrl+Enter)` runs the currently selected cell, `kbstyle(Shift+Enter)` runs the currently selected cell and inserts a new cell immediately below (focus moves to new cell), and `kbstyle(Alt+Enter)` runs the currently selected cell and inserts a new cell immediately below (focus remains on current cell). These keyboard shortcuts can be used in both command and edit modes.
+To run a selected code cell, you can also use keyboard shortcuts in both command and edit mode. `kbstyle(Ctrl+Enter)` runs the currently selected cell. `kbstyle(Shift+Enter)` runs the currently selected cell and inserts a new cell immediately below (focus moves to new cell). `kbstyle(Alt+Enter)` runs the currently selected cell and inserts a new cell immediately below (focus remains on current cell).
 
 ### Run multiple code cells
 
@@ -142,17 +138,17 @@ Running multiple code cells can be accomplished in many ways. You can use the do
 
 ### Move a code cell
 
-Moving cells up or down within a notebook can be accomplished via dragging and dropping. For code cells, the drag and drop area is to the left of the cell editor as indicated below. For rendered Markdown cells, you may click anywhere to drag and drop cells.
+You can move cells up or down within a notebook via dragging and dropping. For code cells, the drag and drop area is to the left of the cell editor as indicated below. For rendered Markdown cells, you may click anywhere to drag and drop cells.
 
 ![Move a code cell](images/jupyter/code-move.png)
 
 To move multiple cells, you can use the same drag and drop areas in any cell included in the selection.
 
-You can also use the keyboard shortcuts `kbstyle(Alt+Arrow)` to move one or multiple selected cells.
+`kbstyle(Alt+Arrow)` also moves one or multiple selected cells.
 
 ### Delete a code cell
 
-Deleting a code cell can be accomplished by using the **Delete** icon in the code cell toolbar or through the keyboard shortcut `kbstyle(dd)` when the selected code cell is in command mode.
+To delete code, you can use the **Delete** icon in the code cell toolbar. When the selected code cell is in command mode, you can use the keyboard shortcut `kbstyle(dd)`.
 
 ![Delete a code cell](images/jupyter/native-code-delete.png)
 
@@ -172,7 +168,7 @@ Once Markdown is set, you can enter Markdown formatted content to the code cell.
 
 ![Raw Markdown displayed in code cell](images/jupyter/native-markdown-not-rendered.png)
 
-To render Markdown cells, you can select the check mark in the cell toolbar, or use the `kbstyle(Ctrl+Enter)` and `kbstyle(Shift+Enter)` keyboard shortcuts.
+To render Markdown cells, you can select the check mark in the cell toolbar, or use the keyboard shortcuts `kbstyle(Ctrl+Enter)` and `kbstyle(Shift+Enter)`.
 
 ![How to render Markdown](images/jupyter/native-markdown-htr.png)
 
@@ -218,7 +214,7 @@ Within a Python Notebook, it's possible to view, inspect, sort, and filter the v
 
 ### Data Viewer
 
-For additional information about your variables, you can also double-click on a row or use the **Show variable in data viewer** button next to the variable for a more detailed view of a variable in the Data Viewer.
+For additional information about your variables, you can also double-click a row or use the **Show variable in data viewer** button next to the variable for a more detailed view of a variable in the Data Viewer.
 
 ![Data Viewer](images/jupyter/data-viewer.png)
 
@@ -280,7 +276,7 @@ If you want to use the full set of debugging features supported in VS Code, such
 
 ### Search through notebook
 
-You can search kbstyle(Ctrl/Cmd + F) through an entire notebook or you can search parts of your notebook by filtering your search options. When searching through your notebook, click on the Filter option (funnel icon) to search across:
+You can search `kbstyle(Ctrl/Cmd + F)` through an entire notebook or you can search parts of your notebook by filtering your search options. When searching through your notebook, click the Filter option (funnel icon) to search across:
 - Markdown cell input (**Markdown Source**)
 - Markdown cell output (**Rendered Markdown**)
 - Code cell input (**Code Cell Source**)

--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -276,7 +276,7 @@ If you want to use the full set of debugging features supported in VS Code, such
 
 ### Search through notebook
 
-You can search `kbstyle(Ctrl/Cmd + F)` through an entire notebook or you can search parts of your notebook by filtering your search options. When searching through your notebook, click the Filter option (funnel icon) to search across:
+You can search through a notebook (or parts of it by filtering the search options) by using the keyboard shortcut `kbstyle(Ctrl/Cmd + F)`. Click the Filter option (funnel icon) to search across:
 - Markdown cell input (**Markdown Source**)
 - Markdown cell output (**Rendered Markdown**)
 - Code cell input (**Code Cell Source**)

--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -51,7 +51,7 @@ If you have an existing Jupyter Notebook, you can open it by right-clicking on t
 
 Once you have a notebook, you can run a code cell using the **Run** icon to the left of the cell and the output will appear directly below the code cell.
 
-To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use the keyboard shortcut `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use the keyboard shortcut `kbstyle(Shift+Enter)`.
+To run code, you can also use keyboard shortcuts in both command and edit mode. To run the current cell, use `kbstyle(Ctrl+Enter)`. To run the current cell and advance to the next, use `kbstyle(Shift+Enter)`.
 
 ![Run Jupyter code cell](images/jupyter/native-code-cells-03.png)
 
@@ -100,7 +100,7 @@ In edit mode, a solid vertical bar is joined by a border around the cell editor.
 
 ![Code cell in edit mode](images/jupyter/native-code-cells-04.png)
 
-To switch modes, you can use keyboard shortcuts or the mouse. On your keyboard, press the `kbstyle(Enter)` key to move to edit mode or the `kbstyle(Esc)` key to move to command mode. With your mouse, click the vertical bar to the left of the cell or out of the code/Markdown region in the code cell.
+To switch modes, you can use your keyboard or mouse. On your keyboard, press the `kbstyle(Enter)` key to move to edit mode or the `kbstyle(Esc)` key to move to command mode. With your mouse, click the vertical bar to the left of the cell or out of the code/Markdown region in the code cell.
 
 ### Add additional code cells
 
@@ -144,7 +144,7 @@ You can move cells up or down within a notebook via dragging and dropping. For c
 
 To move multiple cells, you can use the same drag and drop areas in any cell included in the selection.
 
-`kbstyle(Alt+Arrow)` also moves one or multiple selected cells.
+The keyboard shortcut `kbstyle(Alt+Arrow)` also moves one or multiple selected cells.
 
 ### Delete a code cell
 


### PR DESCRIPTION
While watching VS Code Day 2023 on Youtube, I heard about the option to use notebooks in VSCode. Exciting! 

Thanks for the great presentation, @minsa110 🚀 ✨ 

I went to the docs to learn more (as I could not remember) and found some inconsistencies. I hope you like my changes.

Focus: 
- click vs click on (this is what I started with, as usual, just two places :)
- capitalization (Jupyter Notebook(s) vs notebook(s))
- active vs passive voice
- shortcut code formatting using the kbstyle tag
- usage of the term "keyboard shortcut" / "the xyz key"

