### PR TITLE
Add clarification for portable command line options behaviour oddity

### DIFF
--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -102,7 +102,7 @@ There are several CLI options that help with reproducing errors and advanced set
 
 Argument|Description
 ------------------|-----------
-`--extensions-dir <dir>` | Set the root path for extensions. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder\*).
+`--extensions-dir <dir>` | Set the root path for extensions. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder in the VS Code installation).
 `--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder\*).
 `-s, --status` | Print process usage and diagnostics information.
 `-p, --performance` | Start with the **Developer: Startup Performance** command enabled.

--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -29,7 +29,7 @@ You can launch VS Code from the command line to quickly open a file, folder, or 
 
 **Note:** Users on macOS must first run a command (**Shell Command: Install 'code' command in PATH**) to add VS Code executable to the `PATH` environment variable. Read the [macOS setup guide](/docs/setup/mac.md) for help.
 
-Windows and Linux installations should add the VS Code binaries location to your system path. If this isn't the case, you can manually add the location to the `Path` environment variable (`$PATH` on Linux). For example, on Windows, VS Code is installed under `AppData\Local\Programs\Microsoft VS Code\bin`. To review platform-specific setup instructions, see [Setup](/docs/setup/setup-overview.md).
+Windows and Linux installations should add the VS Code binaries location to your system path. If this isn't the case, you can manually add the location to the `Path` environment variable (`$PATH` on Linux). For example, on Windows, the default VS Code binaries location is `AppData\Local\Programs\Microsoft VS Code\bin`. To review platform-specific setup instructions, see [Setup](/docs/setup/setup-overview.md).
 
 > **Insiders:** If you are using the VS Code [Insiders](/insiders) preview, you launch your Insiders build with `code-insiders`.
 
@@ -102,8 +102,8 @@ There are several CLI options that help with reproducing errors and advanced set
 
 Argument|Description
 ------------------|-----------
-`--extensions-dir <dir>` | Set the root path for extensions. Has no effect in [Portable Mode](/docs/editor/portable.md).
-`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. Has no effect in [Portable Mode](/docs/editor/portable.md).
+`--extensions-dir <dir>` | Set the root path for extensions. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder\*).
+`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder\*).
 `-s, --status` | Print process usage and diagnostics information.
 `-p, --performance` | Start with the **Developer: Startup Performance** command enabled.
 `--disable-gpu` | Disable GPU hardware acceleration.

--- a/docs/editor/command-line.md
+++ b/docs/editor/command-line.md
@@ -103,7 +103,7 @@ There are several CLI options that help with reproducing errors and advanced set
 Argument|Description
 ------------------|-----------
 `--extensions-dir <dir>` | Set the root path for extensions. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder in the VS Code installation).
-`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder\*).
+`--user-data-dir <dir>` | Specifies the directory that user data is kept in, useful when running as root. (Overridden in [Portable Mode](/docs/editor/portable.md) by the presence of the data folder in the VS Code installation).
 `-s, --status` | Print process usage and diagnostics information.
 `-p, --performance` | Start with the **Developer: Startup Performance** command enabled.
 `--disable-gpu` | Disable GPU hardware acceleration.

--- a/docs/editor/portable.md
+++ b/docs/editor/portable.md
@@ -23,12 +23,15 @@ Portable mode is supported on the ZIP download for Windows, and the TAR.GZ downl
 
 After unzipping the VS Code download, create a `data` folder within VS Code's folder:
 
-```
-|- VSCode-win32-x64-1.25.0-insider
+<pre>
+<code>|- VSCode-win32-x64-1.25.0-insider
 |   |- Code.exe (or code executable)
-|   |- data
-|   |- ...
-```
+|   |- data (this will override the <a href="/docs/editor/command-line.md#advanced-cli-options">--user-data-dir &lt;dir&gt; and --extensions-dir &lt;dir&gt;</a> command line options *)
+|   |- bin
+|   |  |- code (relevant executable for command line options)
+|   |  |- ...
+|   |- ...</code>
+</pre>
 
 From then on, that folder will be used to contain all VS Code data, including session state, preferences, extensions, etc.
 


### PR DESCRIPTION
The documentation for command line options stated that 2 options `--user-data-dir <dir>` and `--extensions-dir <dir>` did not work in Portable Mode, though this was not entirely accurate as the features were neither deprecates nor nonfunctional but did have special conditions for usage (they need no data folder to be present).

Related to this, some documentation made it unclear that `Microsoft VS Code/bin/code` was the recommended executable from which to launch vscode for command line arguments to function.

[Relevant issue with more detail](https://github.com/microsoft/vscode/issues/181876)
