### PR TITLE
🔨 Update `ProblemMatcher` interface definition

### DIFF
--- a/docs/editor/tasks-appendix.md
+++ b/docs/editor/tasks-appendix.md
@@ -282,8 +282,15 @@ interface ProblemMatcher {
      *  - ["autodetect", "path value"]: the filename is treated
      *    relative to the given path value, and if it does not
      *    exist, it is treated as absolute.
+     *  - "search": performs a deep (and, possibly, heavy) file system
+     *    search within the directories.
+     *  - ["search", {include: ["${workspaceFolder}"]}]: performs
+     *    a deep search among the directories given in the "include" array.
+     *  - ["search", {include: ["${workspaceFolder}"], exclude: []}]:
+     *    performs a deep search among the directories given in the "include"
+     *    array, excluding those named in the "exclude" array.
      */
-    fileLocation?: string | string[];
+    fileLocation?: string | string[] | ["search", {include?: string[]; exclude?: string[]}];
 
     /**
      * The name of a predefined problem pattern, the inline definition

--- a/docs/editor/tasks-appendix.md
+++ b/docs/editor/tasks-appendix.md
@@ -250,6 +250,12 @@ interface ProblemMatcher {
     owner?: string;
 
     /**
+     * A human-readable string describing the source of this problem.
+     * E.g. 'typescript' or 'super lint'.
+     */
+    source?: string;
+
+    /**
      * The severity of the VS Code problem produced by this problem matcher.
      *
      * Valid values are:


### PR DESCRIPTION
Fix microsoft/vscode#182168
This PR applies the following updates on the `ProblemMatcher` interface definition:

- Adds `source` property.
- Updates `fileLocation` property (adds `search` method)