### PR TITLE
Correcting a Minor Typo in theme-color.md

### DIFF
--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -180,7 +180,7 @@ Colors for list and trees like the File Explorer. An active list/tree has keyboa
 - `listFilterWidget.background`: List/Tree Filter background color of typed text when searching inside the list/tree.
 - `listFilterWidget.outline`: List/Tree Filter Widget's outline color of typed text when searching inside the list/tree.
 - `listFilterWidget.noMatchesOutline`: List/Tree Filter Widget's outline color when no match is found of typed text when searching inside the list/tree.
-- `listFilterWidget.shadow`: Shadown color of the type filter widget in lists and tree
+- `listFilterWidget.shadow`: Shadow color of the type filter widget in lists and tree.
 - `list.filterMatchBackground`: Background color of the filtered matches in lists and trees.
 - `list.filterMatchBorder`: Border color of the filtered matches in lists and trees.
 - `list.deemphasizedForeground`: List/Tree foreground color for items that are deemphasized.


### PR DESCRIPTION
This PR addresses a minor typo in the description for `listFilterWidget.shadow`. You can find the specific location of the typo [here](https://github.com/microsoft/vscode-docs/blob/e5602c94a51f0c705684f62e70ba4b792cbf4a19/api/references/theme-color.md?plain=1#LL183C4-L183C27). I discovered this _"issue"_ while working on a new theme from scratch and wanted to ensure the documentation is flawless. Thank you for reviewing!

EDIT: May I also mention that... I wish I could submit a PR for `microsoft/vscode-website` itself. The sidebar on the right-side (nav element, with the id `docs-subnavbar`), in a desktop view, isn't scrollable. I'm not on the payroll... but surely there's a front-end engineer somewhere, sitting around, willing to do a quick fix. 😉
