### PR TITLE
Enable a few more markdown language features for repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,11 @@
     "markdown.validate.ignoredLinks": [
         "/Download",
         "/insiders"
-    ]
+    ],
+    "markdown.copyFiles.destination": {
+        "/release-notes/**/*": "/release-notes/images/${documentBaseName}/"
+    },
+    "editor.codeActionsOnSave": {
+        "source.organizeLinkDefinitions": true
+    }
 }


### PR DESCRIPTION
- Added `markdown.copyFiles.destination` so VS Code creates files dropped into release notes in expected path (requires VS Code 1.79)

- Turned on `organizeLinkDefinitions` on save. This removes unused link definitions and sorts the remaining definitions 