### PR TITLE
Remove apostrophe from "it's" for possessive use

### DIFF
--- a/docs/nodejs/angular-tutorial.md
+++ b/docs/nodejs/angular-tutorial.md
@@ -10,7 +10,7 @@ MetaSocialImage: images/angular/Welcome-to-app.png
 ---
 # Using Angular in Visual Studio Code
 
-[Angular](https://angular.io/) is a popular web development platform developed and maintained by Google. Angular uses [TypeScript](/docs/languages/typescript.md) as it's main programming language. The Visual Studio Code editor supports TypeScript IntelliSense and code navigation out of the box, so you can do Angular development without installing any other extension.
+[Angular](https://angular.io/) is a popular web development platform developed and maintained by Google. Angular uses [TypeScript](/docs/languages/typescript.md) as its main programming language. The Visual Studio Code editor supports TypeScript IntelliSense and code navigation out of the box, so you can do Angular development without installing any other extension.
 
 ![Welcome to app](images/angular/Welcome-to-app.png)
 


### PR DESCRIPTION
"it's" is short for "it is", which is not right. "its" is correct here because that's the possessive word. 