### PR TITLE
Add locked editor groups

### DIFF
--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -281,7 +281,7 @@ You can Drag and Drop editor groups on the workbench, move individual Tabs betwe
 
 ### Locked editor groups
 
-By default, files will always open in the active editor group. Locked editor groups help to avoid this. The `workbench.editor.autoLockGroups` setting allows you to select editors that should lock a group automatically when they open. This only applies when the editor is the first to open in an otherwise empty or new group.
+By default, files will always open in the active editor group. Locked editor groups help to avoid this. The `workbench.editor.autoLockGroups` setting allows you to select editor types that should lock a group automatically when they open. This only applies when the editor is the first to open in an otherwise empty or new group.
 
 ```json
 "workbench.editor.autoLockGroups": {
@@ -305,7 +305,7 @@ Locked groups behave differently than unlocked groups:
 - New editors will not open in a locked group unless explicitly moved there.
 - If an editor skips a locked group, the new editor will either open in the most recently used unlocked group or create a new group to the side of the locked one.
 
-If you have more than one editor group opened, you can lock it from the "..." overflow menu or using the **View: Toggle Editor Group Lock** or **View: Lock Editor Lock** commands.
+If you have more than one editor group opened, you can lock it manually from the "..." overflow menu or using the **View: Toggle Editor Group Lock** or **View: Lock Editor Lock** commands.
 
 <!-- Required?  Lock group option in overflow menu https://code.visualstudio.com/assets/updates/1_60/locked-editor-group.png -->
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -290,7 +290,7 @@ By default, files will always open in the active editor group. Locked editor gro
 }
 ```
 
-Terminals are configured by default to cause a new group to lock automatically. A lock icon in the action toolbar (top right) indicates a locked group. The locked state of an editor group is persisted and restored across restarts. You can lock empty groups for a more stable editor layout.
+Terminals are configured by default to cause a new group to lock automatically. A lock icon in the action toolbar (top right) indicates a locked group. The locked state of an editor group is persisted and restored across restarts.
 
 <!-- Required? Locked editor https://code.visualstudio.com/assets/updates/1_61/editor-readonly-deleted.png -->
 
@@ -305,7 +305,9 @@ Locked groups behave differently than unlocked groups:
 - New editors will not open in a locked group unless explicitly moved there.
 - If an editor skips a locked group, the new editor will either open in the most recently used unlocked group or create a new group to the side of the locked one.
 
-If you have more than one editor group opened, you can lock it manually from the "..." overflow menu or using the **View: Toggle Editor Group Lock** or **View: Lock Editor Lock** commands.
+If you have more than one editor group opened, you can lock it manually from the "..." overflow menu or using the **View: Toggle Editor Group Lock** or **View: Lock Editor Lock** commands. 
+
+You can also lock empty groups for a more stable editor layout. With setting `workbench.editor.closeEmptyGroups` you can control whether an empty group is closed when the last tab in a group is closed. When disabled, empty groups will remain part of the grid.  
 
 <!-- Required?  Lock group option in overflow menu https://code.visualstudio.com/assets/updates/1_60/locked-editor-group.png -->
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -279,6 +279,36 @@ You can Drag and Drop editor groups on the workbench, move individual Tabs betwe
 
 >**Note:** VS Code uses editor groups whether or not you have enabled Tabs.  Without Tabs, editor groups are a stack of your open items with the most recently selected item visible in the editor pane.
 
+### Locked editor groups
+
+By default, files will always open in the active editor group. Locked editor groups help to avoid this. The `workbench.editor.autoLockGroups` setting allows you to select editors that should lock a group automatically when they open. This only applies when the editor is the first to open in an otherwise empty or new group.
+
+```json
+"workbench.editor.autoLockGroups": {
+  "default": false,
+  "terminalEditor": true
+}
+´´´
+
+Terminals are configured by default to cause a new group to lock automatically. A lock icon in the action toolbar (top right) indicates a locked group. The locked state of an editor group is persisted and restored across restarts. You can lock empty groups for a more stable editor layout.
+
+<!-- Required? Locked editor https://code.visualstudio.com/assets/updates/1_61/editor-readonly-deleted.png -->
+
+You can control the behavior of locked editor groups with these settings:
+
+`workbench.action.lockEditorGroup`
+`workbench.action.unlockEditorGroup`
+`workbench.action.toggleEditorGroupLock`
+
+Locked groups behave differently than unlocked groups:
+
+- New editors will not open in a locked group unless explicitly moved there.
+- If an editor skips a locked group, the new editor will either open in the most recently used unlocked group or create a new group to the side of the locked one.
+
+If you have more than one editor group opened, you can lock it from the "..." overflow menu or using the **View: Toggle Editor Group Lock** or **View: Lock Editor Lock** commands.
+
+<!-- Required?  Lock group option in overflow menu https://code.visualstudio.com/assets/updates/1_60/locked-editor-group.png -->
+
 ## Grid editor layout
 
 By default, editor groups are laid out in vertical columns (for example when you split an editor to open it to the side). You can easily arrange editor groups in any layout you like, both vertically and horizontally:

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -288,7 +288,6 @@ By default, files will always open in the active editor group. Locked editor gro
   "default": false,
   "terminalEditor": true
 }
-´´´
 
 Terminals are configured by default to cause a new group to lock automatically. A lock icon in the action toolbar (top right) indicates a locked group. The locked state of an editor group is persisted and restored across restarts. You can lock empty groups for a more stable editor layout.
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -288,6 +288,7 @@ By default, files will always open in the active editor group. Locked editor gro
   "default": false,
   "terminalEditor": true
 }
+```
 
 Terminals are configured by default to cause a new group to lock automatically. A lock icon in the action toolbar (top right) indicates a locked group. The locked state of an editor group is persisted and restored across restarts. You can lock empty groups for a more stable editor layout.
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -294,11 +294,11 @@ Terminals are configured by default to cause a new group to lock automatically. 
 
 <!-- Required? Locked editor https://code.visualstudio.com/assets/updates/1_61/editor-readonly-deleted.png -->
 
-You can control the behavior of locked editor groups with these settings:
+You can control the lock state of editor groups with these commands:
 
-`workbench.action.lockEditorGroup`
-`workbench.action.unlockEditorGroup`
-`workbench.action.toggleEditorGroupLock`
+- `workbench.action.lockEditorGroup` - locks a group
+- `workbench.action.unlockEditorGroup` - unlocks a group
+- `workbench.action.toggleEditorGroupLock` - toggles the current lock state of the group
 
 Locked groups behave differently than unlocked groups:
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docs/issues/6312

I spent some time figuring out how the locked editor groups feature is working after reading the release notes docs linked in the referenced issue.

This PR adds some information to the docs. I hope this help as the basis for the final update.

FYI @gjsjohnmurray