### PR TITLE
mask the remote Jupyter server URI

### DIFF
--- a/docs/python/images/jupyter/jupyter-running-remotely.png
+++ b/docs/python/images/jupyter/jupyter-running-remotely.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f129d353143f1395091c385f11d3f48ab9bacc4052bf1303aaace5c0980358d9
-size 149789
+oid sha256:67a04e343377d509add7aa114807a5ab8631f167721cb15fd7f7c867fb6e350c
+size 140543

--- a/docs/python/images/jupyter/jupyter-running-remotely.png
+++ b/docs/python/images/jupyter/jupyter-running-remotely.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f120cdb1906c9539ee4a87e2d4aca7dbcb20072a9ffa7f98962ea7fe1b1a0584
-size 47284
+oid sha256:f129d353143f1395091c385f11d3f48ab9bacc4052bf1303aaace5c0980358d9
+size 149789


### PR DESCRIPTION
Fixes #5806
Opted to just mask the URI since so much of the section talks about remote Jupyter servers on other computers.