### PR TITLE
fix: add `not` to testing API introduction

### DIFF
--- a/api/extension-guides/testing.md
+++ b/api/extension-guides/testing.md
@@ -9,7 +9,7 @@ MetaDescription: Testing APIs in VS Code allow users to discover and run unit te
 
 # Testing API
 
-The Testing API allows Visual Studio Code extensions to discover tests in the workspace and publish results. Users can execute tests in the Test Explorer view, from decorations, and inside commands. With these new APIs, Visual Studio Code supports richer displays of outputs and diffs than was previously possible.
+The Testing API allows Visual Studio Code extensions to discover tests in the workspace and publish results. Users can execute tests in the Test Explorer view, from decorations, and inside commands. With these new APIs, Visual Studio Code supports richer displays of outputs and diffs than was previously not possible.
 
 >**Note**: The Testing API is available in VS Code version 1.59 and higher.
 


### PR DESCRIPTION
It seems that `not` should be added given the structure of the sentence.