### PR TITLE
Add mention of Copilot for SEO

### DIFF
--- a/docs/editor/artificial-intelligence.md
+++ b/docs/editor/artificial-intelligence.md
@@ -3,7 +3,7 @@ Order: 7
 Area: editor
 TOCTitle: AI Tools
 ContentId: 0aefcb70-7884-487f-953e-46c3e07f7cbe
-PageTitle: Enhance your coding with artificial intelligence
+PageTitle: Use GitHub Copilot to enhance your coding with AI
 DateApproved: 6/8/2023
 MetaDescription: Enhance your coding with AI-powered suggestions from GitHub Copilot in Visual Studio Code.
 ---


### PR DESCRIPTION
Mention GitHub Copilot in the page title to improve SEO to direct to this article rather than the blog post