### PR TITLE
Polish in-product release notes markdown styles

### DIFF
--- a/release-notes/css/inproduct_releasenotes.css
+++ b/release-notes/css/inproduct_releasenotes.css
@@ -4,33 +4,8 @@ html {
 }
 body {
     padding-bottom: 100px;
-}
-
-h1,h2,h3 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-}
-
-h1 {
-    font-size: 4rem;
-    margin-bottom:1.5rem;
-}
-
-h2 {
-    font-size: 3rem;
-    margin-top: 3rem;
-}
-
-
-h3 {
-    font-size: 2.2rem;
-}
-
-h4 {
-    font-size: 1.5rem;
-	 font-weight: 600;
-    margin-top: 3rem;
-    margin-bottom: 1rem;
+	margin: 0 auto;
+	max-width: 980px;
 }
 
 #scroll-to-top {

--- a/remote-release-notes/css/inproduct_releasenotes.css
+++ b/remote-release-notes/css/inproduct_releasenotes.css
@@ -4,33 +4,8 @@ html {
 }
 body {
     padding-bottom: 100px;
-}
-
-h1,h2,h3 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-}
-
-h1 {
-    font-size: 4rem;
-    margin-bottom:1.5rem;
-}
-
-h2 {
-    font-size: 3rem;
-    margin-top: 3rem;
-}
-
-
-h3 {
-    font-size: 2.2rem;
-}
-
-h4 {
-    font-size: 1.5rem;
-	font-weight: 600;
-    margin-top: 3rem;
-    margin-bottom: 1rem;
+    margin: 0 auto;
+    max-width: 980px;
 }
 
 #scroll-to-top {


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/pull/185801

This removes the overrides on font styles to ensure our markdown looks the same in different areas of the product. It also improves readability by setting a max width on the content and centering it, similar to gh.com.

cc @mjbvz 