### PR TITLE
Update Copilot docs with pre-release info

### DIFF
--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -102,7 +102,7 @@ The inline completions experience discussed above is available today. If you don
 Today, access to the chat experiences (in-editor and Chat view), you'll need to [join the waitlist]( https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
 
 * You must use [VS Code Insiders](https://code.visualstudio.com/insiders/).
-* Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot, and install the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the extension.
+* Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot, and install the [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the extension.
 * When prompted, authenticate with your GitHub ID.
 * To open the in-editor Chat, optionally select a block of code and press `kbstyle(Cmd+I)` on macOS or `kbstyle(Ctrl+I)` on Windows/Linux. Ask Copilot to write a Quick Sort function.
 * A "Chat" icon will appear in the Activity Bar, click on it to open the Chat view. Go ahead, ask Copilot to "write a program to calculate the airspeed velocity of an unladen swallow".

--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -102,7 +102,7 @@ The inline completions experience discussed above is available today. If you don
 Today, access to the chat experiences (in-editor and Chat view), you'll need to [join the waitlist]( https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
 
 * You must use [VS Code Insiders](https://code.visualstudio.com/insiders/).
-* Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot Nightly and install the extension.
+* Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot, and install the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the extension.
 * When prompted, authenticate with your GitHub ID.
 * To open the in-editor Chat, optionally select a block of code and press `kbstyle(Cmd+I)` on macOS or `kbstyle(Ctrl+I)` on Windows/Linux. Ask Copilot to write a Quick Sort function.
 * A "Chat" icon will appear in the Activity Bar, click on it to open the Chat view. Go ahead, ask Copilot to "write a program to calculate the airspeed velocity of an unladen swallow".

--- a/docs/editor/artificial-intelligence.md
+++ b/docs/editor/artificial-intelligence.md
@@ -23,7 +23,7 @@ You'll use the [GitHub Copilot extension](https://marketplace.visualstudio.com/i
 
 To use GitHub Copilot, you need an active GitHub Copilot subscription. In the [content below](#activate-your-free-trial), you'll learn how VS Code will help you activate your free trial directly from VS Code. You can also activate your trial starting from the [GitHub Copilot signup page](https://github.com/github-copilot/signup).
 
-> **Note:** For some of the latest features we'll explore below, you'll need to use the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension, which will provide you the latest updates in Copilot.
+> **Note:** For some of the latest features we'll explore below, you'll need to use the [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the GitHub Copilot extension, which will provide you the latest updates in Copilot.
 > ![Pre-release version of Copilot extension](images/artificial-intelligence/copilot-ext-pre-release.png)
 
 ## Sign in and sign up
@@ -54,7 +54,7 @@ There are three main ways to get assistance from Copilot:
 * **Chat view:** Ask Copilot for help with any task or question in the GitHub Copilot Chat view.
 * **Inline chat:** Talk with Copilot while writing code, inline in your files.
 
-> **Note:** To get access to the chat view and inline chat, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). You'll also need to use [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension.
+> **Note:** To get access to the chat view and inline chat, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). You'll also need to use [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the GitHub Copilot extension.
 > ![Pre-release version of Copilot extension](images/artificial-intelligence/copilot-ext-pre-release.png)
 
 ## Inline suggestions
@@ -93,7 +93,7 @@ If you don't want to accept any of the suggestions, you can continue typing, and
 
 When developing a project or learning something new, it can be a big help to get AI assistance on your questions, big or small. Copilot enables an interactive Chat experience that understands the context of your code, workspace, extensions, settings, and more.
 
-Once you've signed up and been granted access to Copilot chat through the [chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join), install the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension in VS Code. You'll be presented a new GitHub Copilot chat view in the Activity Bar:
+Once you've signed up and been granted access to Copilot chat through the [chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join), install the [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the GitHub Copilot extension in VS Code. You'll be presented a new GitHub Copilot chat view in the Activity Bar:
 
 ![Copilot view in VS Code Activity Bar](images/artificial-intelligence/copilot-view.png)
 

--- a/docs/editor/artificial-intelligence.md
+++ b/docs/editor/artificial-intelligence.md
@@ -23,7 +23,8 @@ You'll use the [GitHub Copilot extension](https://marketplace.visualstudio.com/i
 
 To use GitHub Copilot, you need an active GitHub Copilot subscription. In the [content below](#activate-your-free-trial), you'll learn how VS Code will help you activate your free trial directly from VS Code. You can also activate your trial starting from the [GitHub Copilot signup page](https://github.com/github-copilot/signup).
 
-> **Note:** For some of the latest features we'll explore below, you'll need to use the [GitHub Copilot Nightly extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly), which will provide you the latest updates in Copilot.
+> **Note:** For some of the latest features we'll explore below, you'll need to use the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension, which will provide you the latest updates in Copilot.
+> ![Pre-release version of Copilot extension](images/artificial-intelligence/copilot-ext-pre-release.png)
 
 ## Sign in and sign up
 
@@ -53,7 +54,8 @@ There are three main ways to get assistance from Copilot:
 * **Chat view:** Ask Copilot for help with any task or question in the GitHub Copilot Chat view.
 * **Inline chat:** Talk with Copilot while writing code, inline in your files.
 
-> **Note:** To get access to the chat view and inline chat, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). You'll also need to use the [GitHub Copilot Nightly extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly).
+> **Note:** To get access to the chat view and inline chat, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). You'll also need to use [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension.
+> ![Pre-release version of Copilot extension](images/artificial-intelligence/copilot-ext-pre-release.png)
 
 ## Inline suggestions
 
@@ -91,7 +93,7 @@ If you don't want to accept any of the suggestions, you can continue typing, and
 
 When developing a project or learning something new, it can be a big help to get AI assistance on your questions, big or small. Copilot enables an interactive Chat experience that understands the context of your code, workspace, extensions, settings, and more.
 
-Once you've signed up and been granted access to Copilot chat through the [chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join), install the [GitHub Copilot Nightly extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly) in VS Code. You'll be presented a new GitHub Copilot chat view in the Activity Bar:
+Once you've signed up and been granted access to Copilot chat through the [chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join), install the [pre-release version](/release-notes/v1_63.md/#pre-release-extensions) of the GitHub Copilot extension in VS Code. You'll be presented a new GitHub Copilot chat view in the Activity Bar:
 
 ![Copilot view in VS Code Activity Bar](images/artificial-intelligence/copilot-view.png)
 

--- a/docs/editor/images/artificial-intelligence/copilot-ext-pre-release.png
+++ b/docs/editor/images/artificial-intelligence/copilot-ext-pre-release.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b859c4c753600573c35ceb0f62557c6ca2a63d8e538914e9a65c2a4bb19c5169
+size 64128


### PR DESCRIPTION
Update based on https://github.com/orgs/community/discussions/59964, as Copilot Nightly has been replaced by the pre-release version of the main GitHub Copilot extension.

@gregvanl @isidorn @sandy081 let me know if you have any feedback on the updates here, especially on the image and link I added. I'm debating linking to https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions to help users understand pre-release extensions, but since the article is extension publishing focused, I linked to the release notes on pre-release extensions to start.