### PR TITLE
Follow up edits

### DIFF
--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -99,13 +99,14 @@ The inline completions experience discussed above is available today. If you don
 * When prompted, authenticate with your GitHub ID.
 * Open a code file and let the magic happen!
 
-Today, access to the chat experiences (in-editor and Chat view), you'll need to [join the waitlist]( https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
+Today, access to the chat experiences (in-editor and Chat view), you'll need to [join the waitlist](https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
 
-* You must use [VS Code Insiders](https://code.visualstudio.com/insiders/).
 * Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot, and install the [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the extension.
 * When prompted, authenticate with your GitHub ID.
 * To open the in-editor Chat, optionally select a block of code and press `kbstyle(Cmd+I)` on macOS or `kbstyle(Ctrl+I)` on Windows/Linux. Ask Copilot to write a Quick Sort function.
 * A "Chat" icon will appear in the Activity Bar, click on it to open the Chat view. Go ahead, ask Copilot to "write a program to calculate the airspeed velocity of an unladen swallow".
+
+You can learn more about the GitHub Copilot extension in the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic.
 
 ## Responsible AI
 

--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -19,7 +19,7 @@ Alternatively, you can also download a [Zip archive](/docs/?dv=winzip), extract 
 
 >**Tip:** Setup will add Visual Studio Code to your `%PATH%`, so from the console you can type 'code .' to open VS Code on that folder. You will need to restart your console after the installation for the change to the `%PATH%` environmental variable to take effect.
 
-## User vs. System setup
+## User setup versus system setup
 
 VS Code provides both Windows **user** and **system** level setups.
 

--- a/release-notes/v1_77.md
+++ b/release-notes/v1_77.md
@@ -229,7 +229,7 @@ Review the [changelog for the 0.62.0](https://github.com/microsoft/vscode-pull-r
 
 ![GitHub Copilot extension](images/1_77/copilot-extension.png)
 
-We are excited to announce the preview of deeper Copilot integration into VS Code. By using the [GitHub Copilot Nightly](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly) extension and [VS Code Insiders](https://code.visualstudio.com/insiders) build, you'll be able to try out new features such as:
+We are excited to announce the preview of deeper Copilot integration into VS Code. By using the **Pre-Release** version of the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension, you'll be able to try out new features such as:
 
 * **Inline suggestions:** Copilot suggestions appear inline as you work in your code.
 * **Chat view:** Ask Copilot for help with any task or question in the GitHub Copilot Chat view.

--- a/release-notes/v1_78.md
+++ b/release-notes/v1_78.md
@@ -342,7 +342,7 @@ Review the [changelog for the 0.64.0](https://github.com/microsoft/vscode-pull-r
 
 ### GitHub Copilot
 
->**Note**: To get access to the new chat-based GitHub Copilot features, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). These features are only available in VS Code [Insiders](https://code.visualstudio.com/insiders) with the [GitHub Copilot Nightly](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly) extension.
+>**Note**: To get access to the new chat-based GitHub Copilot features, you'll need to sign up for the [GitHub Copilot chat waitlist](https://github.com/github-copilot/chat_waitlist_signup/join). These features are only available in the **Pre-Release** version of the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension.
 
 #### Chat editors
 

--- a/release-notes/v1_79.md
+++ b/release-notes/v1_79.md
@@ -357,7 +357,7 @@ You can learn about new extension features and bug fixes in the [Remote Developm
 
 #### Use Copilot Chat in Stable VS Code
 
-Previously, you had to use VS Code Insiders to use Copilot Chat. As of VS Code 1.79, you can use Copilot Chat in stable VS Code as well. You will still have to install the [GitHub Copilot Nightly](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-nightly) extension.
+Previously, you had to use VS Code Insiders to use Copilot Chat. As of VS Code 1.79, you can use Copilot Chat in stable VS Code as well. You will still have to install the **Pre-Release** version of the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension.
 
 #### Editor chat
 


### PR DESCRIPTION
Update release notes for latest GitHub Copilot extension installation (works in VS Code stable, use pre-release version instead of deprecated GitHub Copilot Nightly extension)
Add link to AI Tools in VS Code article from Chris' hugely popular blog post
Revert H2 change in https://github.com/microsoft/vscode-docs/pull/6452 to avoid breaking any external bookmarks.