### PR TITLE
Preciser description about OpenSSH incompatibility limitation

### DIFF
--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -563,7 +563,7 @@ From this point forward, the dotfiles repository will be used whenever a contain
 * If you clone a Git repository using SSH and your SSH key has a passphrase, VS Code's pull and sync features may hang when running remotely. Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
 * Local proxy settings are not reused inside the container, which can prevent extensions from working unless the appropriate proxy information is configured (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information).
 * You cannot use Dev Containers from a Remote - SSH connection to a Windows machine.
-* There is an incompatibility between OpenSSH versions on Windows when the ssh-agent runs with version <= 8.8 and the SSH client (on any platform) runs version >= 8.9. The workaround is to upgrade OpenSSH on Windows to 8.9 or later, either using winget or an installer from [Win32-OpenSSH/releases](https://github.com/PowerShell/Win32-OpenSSH/releases).
+* There is an incompatibility between OpenSSH versions on Windows when the ssh-agent runs with version <= 8.8 and the SSH client (on any platform) runs version >= 8.9. I.e., though `ssh-add -l` will correctly show your ssh-agent's keys inside the container, any `git` operation interacting with the remote will fail (`Permission denied (publickey).`). The recommended workaround is to upgrade OpenSSH on Windows to 8.9 or later, either using winget or an installer from [Win32-OpenSSH/releases](https://github.com/PowerShell/Win32-OpenSSH/releases).
 
 See [here for a list of active issues](https://aka.ms/vscode-remote/containers/issues) related to Containers.
 


### PR DESCRIPTION
I've been struggling with the OpenSSH and devcontainers version mismatch issue for quite some time, as it is very hard to sort out. Ultimately https://github.com/microsoft/vscode-remote-release/issues/8666 helped me.

In order to reduce the time for many others looking for this I suggest updating the description of the limitation so that searching for the most obvious things (`ssh-add -l`, the git error message and 'devcontainer') has a higher chance finding the documentation (instead of helpful yet not applicable StackOverflow threads). Also I don't think this is (will be) very uncommon, given that a vanilla Windows11 (22H2) ships with a too old OpenSSH version.