### PR TITLE
Add more information about KDE 6

### DIFF
--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -181,15 +181,6 @@ If the error you're seeing is "Cannot create an item in a locked collection", ch
 
 It's possible that your wallet (aka keyring) is closed. If you open [KWalletManager](https://apps.kde.org/kwalletmanager5), you can see if the default `kdewallet` is closed and if it is, make sure you open it.
 
-On KDE Neon Unstable, `kwallet5` and `kwallet6` currently conflict with each other. It is recommended to remove kwallet5 and reinstall kwallet6 to fix any potential issues:
-
-```
-apt remove libkf5wallet-bin
-apt install --reinstall kf6-kwallet
-```
-
-After a reboot, you will now be running KWallet6 properly.
-
 #### Other Linux desktop environments
 
 First off, if your desktop environment wasn't detected, you can [open an issue on VS Code](https://github.com/microsoft/vscode/issues/new/choose) with the verbose logs from above. This is important for us to support additional desktop configurations.

--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -177,7 +177,18 @@ If the error you're seeing is "Cannot create an item in a locked collection", ch
 
 #### KDE
 
+> KDE 6 is not yet fully supported by Visual Studio Code. An upcoming release will add support for KWallet6.
+
 It's possible that your wallet (aka keyring) is closed. If you open [KWalletManager](https://apps.kde.org/kwalletmanager5), you can see if the default `kdewallet` is closed and if it is, make sure you open it.
+
+On KDE Neon Unstable, `kwallet5` and `kwallet6` currently conflict with each other. It is recommended to remove kwallet5 and reinstall kwallet6 to fix any potential issues:
+
+```
+apt remove libkf5wallet-bin
+apt install --reinstall kf6-kwallet
+```
+
+After a reboot, you will now be running KWallet6 properly.
 
 #### Other Linux desktop environments
 

--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -177,7 +177,7 @@ If the error you're seeing is "Cannot create an item in a locked collection", ch
 
 #### KDE
 
-> KDE 6 is not yet fully supported by Visual Studio Code. An upcoming release will add support for KWallet6.
+> KDE 6 is not yet fully supported by Visual Studio Code. As a workaround: The latest kwallet6 is also accessible as kwallet5, so you can force it to use kwallet5 by setting the password store to `kwallet5` as explained below in [Configure the keyring to use with VS Code](#_other-linux-desktop-environments).
 
 It's possible that your wallet (aka keyring) is closed. If you open [KWalletManager](https://apps.kde.org/kwalletmanager5), you can see if the default `kdewallet` is closed and if it is, make sure you open it.
 


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode/pull/187402, this makes the necessary docs change.

This can be merged before that PR is merged, it informs users about the compatibility issue with KDE 6, which that PR will fix.

The neon-specific instructions will only apply after the PR is merged, but I thought it would make sense to already add them so users can take these steps in advance.