### PR TITLE
docs: fix typos

### DIFF
--- a/docs/datascience/notebooks-web.md
+++ b/docs/datascience/notebooks-web.md
@@ -71,7 +71,7 @@ To enter your remote Jupyter server URL with older versions of VS Code and Jupyt
 
 When you're starting your remote server, be sure to:
 
-1. Alow all origins (for example `--NotebookApp.allow_origin='*'`) to allow your servers to be accessed externally.
+1. Allow all origins (for example `--NotebookApp.allow_origin='*'`) to allow your servers to be accessed externally.
 2. Set the notebook to listen on all IPs (`--NotebookApp.ip='0.0.0.0'`).
 
 ### Limitations

--- a/docs/editor/editingevolved.md
+++ b/docs/editor/editingevolved.md
@@ -163,7 +163,7 @@ Warnings and Errors can provide Code Actions (also known as Quick Fixes) to help
 
 ## Inlay Hints
 
-Some languages provide inlay hints: that is additional information about source code that is rendered inline. This is usually used to show infered types. The sample below shows inlay hints that display the inferred types of JavaScript variables and function return types.
+Some languages provide inlay hints: that is additional information about source code that is rendered inline. This is usually used to show inferred types. The sample below shows inlay hints that display the inferred types of JavaScript variables and function return types.
 
 ![Inlay hints for inferred types in TypeScript](images/editingevolved/inlay-hints.png)
 

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -323,7 +323,7 @@ As you're typing the parameters for your test function, Pylance will offer you a
 
 When hovering over a fixture reference or a parameterized argument reference, Pylance will show the inferred type annotation, either based on the return values of the fixture, or based on the inferred types of the arguments passed to the parameterization decorator.
 
-![Pylance type inference based on the types of arguments passed to the paramaterization decorator.](images/testing/pytest-inferred-parametrized-argument.png)
+![Pylance type inference based on the types of arguments passed to the parameterization decorator.](images/testing/pytest-inferred-parametrized-argument.png)
 
 Pylance also offers [code actions](/docs/editor/refactoring.md#code-actions--quick-fixes-and-refactorings) to add type annotations to test functions that have fixture parameters.  Inlay hints for inferred fixture parameter types can also be enabled by setting `python.analysis.inlayHints.pytestParameters` to `true` in your User settings.
 

--- a/docs/terminal/advanced.md
+++ b/docs/terminal/advanced.md
@@ -60,7 +60,7 @@ On macOS, `kbstyle(Cmd+K)` is a common keybindings in terminals to clear the scr
 }
 ```
 
-Additionally, this keyboard shortcut will be overridden automatically if any extensions contribute `kbstyle(Cmd+K)` keybindings due to how keybinding priority works. To reenable the `kbstyle(Cmd+K)` clear keybinding in this case, you can redefine it in user keybindings, which have a higher priority than extension keybindings:
+Additionally, this keyboard shortcut will be overridden automatically if any extensions contribute `kbstyle(Cmd+K)` keybindings due to how keybinding priority works. To re-enable the `kbstyle(Cmd+K)` clear keybinding in this case, you can redefine it in user keybindings, which have a higher priority than extension keybindings:
 
 ```json
 {


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `docs/datascience/notebooks-web.md`
1 typo in `docs/editor/editingevolved.md`
1 typo in `docs/python/testing.md`
1 typo in `docs/terminal/advanced.md`


Best!