### PR TITLE
Add themes used in 1.80 release notes

### DIFF
--- a/docs/editor/artificial-intelligence.md
+++ b/docs/editor/artificial-intelligence.md
@@ -215,6 +215,6 @@ You can ask Copilot questions that emerge as you write and iterate on code, such
 
 Congratulations, you've now used artificial intelligence to enhance your coding!
 
-You can read more about Copilot and how to use it in VS Code in the [GitHub Copilot documentation](https://docs.github.com/copilot/getting-started-with-github-copilot/getting-started-with-github-copilot-in-visual-studio-code).
+You can read more about Copilot and how to use it in VS Code in the [GitHub Copilot documentation](https://docs.github.com/copilot/getting-started-with-github-copilot?tool=vscode).
 
 Or check out the [VS Code Copilot Series](https://www.youtube.com/playlist?list=PLj6YeMhvp2S5_hvBl2SE-7YCHYlLQ0bPt) on Youtube, where you can find more introductory content as well as programming-specific videos for using Copilot with [Python](https://www.youtube.com/watch?v=DSHfHT5qnGc), [C#](https://www.youtube.com/watch?v=VsUQlSyQn1E), [Java](https://www.youtube.com/watch?v=zhCB95cE0HY), [PowerShell](https://www.youtube.com/watch?v=EwtRzAFiXEM), and more.

--- a/release-notes/v1_80.md
+++ b/release-notes/v1_80.md
@@ -274,6 +274,8 @@ The toolbar continues to work with all three label strategies: `always`, `never`
 
 <video src="images/1_80/nb_toolbar_hide.mp4" autoplay loop controls muted title="Notebook toolbar hide actions"></video>
 
+_Theme: [Monokai Pro (Filter Ristretto)](https://marketplace.visualstudio.com/items?itemName=monokai.theme-monokai-pro-vscode) (preview on [vscode.dev](https://vscode.dev/theme/monokai.theme-monokai-pro-vscode/Monokai%20Pro%20(Filter%20Ristretto)))_
+
 ### Interactive Window backup and restore
 
 The Python Interactive Window is now fully integrated with the [hot exit](https://code.visualstudio.com/docs/editor/codebasics#_hot-exit) feature and restores the editor state between VS Code reloads. The `interactiveWindow.restore` setting no longer has any effect and was removed.
@@ -281,6 +283,8 @@ The Python Interactive Window is now fully integrated with the [hot exit](https:
 If hot exit is disabled, there is a prompt when closing VS Code giving you the option to save the editor state as a `.ipynb` file.
 
 <video src="images/1_80/interactive-window-restore.mp4" autoplay loop controls muted title="Restoring Interactive Window editor"></video>
+
+_Theme: [Bearded Theme feat. Gold D Raynh](https://marketplace.visualstudio.com/items?itemName=BeardedBear.beardedtheme) (preview on [vscode.dev](https://vscode.dev/theme/BeardedBear.beardedtheme/Bearded%20Theme%20feat.%20Gold%20D%20Raynh))
 
 ## Languages
 


### PR DESCRIPTION
Also changed docs.github.com Copilot link to go to VS Code documentation tab