### PR TITLE
Add eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"extends": [
+		"plugin:security/recommended"
+	]
+}


### PR DESCRIPTION
I'm adding this file for the SDL CI to pick up. Let me know if I need to modify a pipeline in order for the Guardian ESLint task to pick up this file. 

Edit: If the website repo already sets up the doc repo inside of it, then it seems that the website repo's eslintrc is already used. Therefore, we might not need this change. Locally, the ESLint extension is confused between this eslintrc and the parent eslintrc. This PR is also missing a few other dependencies such as the Microsoft SDL plugin.