### PR TITLE
Add to Yum/DNF the same comment about code-insiders than the other methods

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -60,14 +60,14 @@ Then update the package cache and install the package using `dnf` (Fedora 22 and
 
 ```bash
 dnf check-update
-sudo dnf install code
+sudo dnf install code # or code-insiders
 ```
 
 Or on older versions using `yum`:
 
 ```bash
 yum check-update
-sudo yum install code
+sudo yum install code # or code-insiders
 ```
 
 Due to the manual signing process and the system we use to publish, the yum repo may lag behind and not get the latest version of VS Code immediately.


### PR DESCRIPTION
Checked locally that `code-insiders` is present in the repository.

As such, just adding it to the documentation so that the next to read it know it is there :smile: Like it is available for other methods to install.