### PR TITLE
ready: update Unity development configuration docs to clarify Mono install channel

### DIFF
--- a/docs/other/unity.md
+++ b/docs/other/unity.md
@@ -23,7 +23,9 @@ From [Using .NET in Visual Studio Code](/docs/languages/dotnet.md):
 
 1. [Windows only] Logout or restart Windows to allow changes to `%PATH%` to take effect.
 
-1. [macOS only] To avoid seeing "Some projects have trouble loading. Please review the output for more details", make sure to install the latest stable [Mono](https://www.mono-project.com/download/) release.
+1. [macOS only] To avoid seeing "Some projects have trouble loading. Please review the output for more details", make sure to install the latest **Stable** [Mono](https://www.mono-project.com/download/) release.
+
+    **Note**: Ensure you download the latest Mono release on the **Stable** channel. Releases on the **Visual Studio** channel will not work to configure Visual Studio Code for Unity.
 
    **Note**: This version of Mono, which is installed into your system, will not interfere with the version of MonoDevelop that is installed by Unity.
 


### PR DESCRIPTION
What this PR addresses:
- on OSX, `Mono` must be installed in order to configure vscode for Unity development
- Mono's download page UI highlights the Visual Studio release channel (greys out the Stable channel button)
- The Stable release channel is what must be installed to configure vscode for Unity dev

Currently, the docs mention "stable" but to me it wasn't clear that it referred to the release channel:

<img width="768" alt="image" src="https://github.com/microsoft/vscode-docs/assets/36137079/edb24d20-c6cc-4d11-bf10-731ddc217419">
