### PR TITLE
Add Documentation for .NET SDK Container Build (with Git LFS)

### DIFF
--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -34,7 +34,6 @@ Example `launch.json` configuration for debugging a Node.js application:
 ```json
 {
     "configurations": [
-    
         {
             "name": "Docker Node.js Launch",
             "type": "docker",
@@ -76,9 +75,16 @@ Example `launch.json` configuration for debugging a Python application:
 
 ## .NET
 
-More information about debugging .NET applications within Docker containers can be found in [Debug .NET within Docker containers](/docs/containers/debug-netcore.md).
+We offer two ways of building & debugging your project within Docker containers:
 
-Example `launch.json` configuration for debugging a .NET application:
+- **[With .NET SDK](/docs/containers/debug-netcore.md#net-sdk-container-build-debug-without-dockerfile)**: This option offers a simplified container debugging experience without the need for a `Dockerfile`. If you are familiar with `MSBuild` or want a straightforward approach, this is the recommended choice.
+  > Note: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.
+
+- **[With a Dockerfile](/docs/containers/debug-netcore.md#debug-with-dockerfile)**: If you prefer working / customizing your project with a `Dockerfile`, choose this option.
+
+For more details about these two options, refer to [Debug .NET within Docker containers](/docs/containers/debug-netcore.md).
+
+Example `launch.json` configuration for debugging a .NET application using `Dockerfile`:
 
 ```json
 {

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -75,7 +75,7 @@ Example `launch.json` configuration for debugging a Python application:
 
 ## .NET
 
-We offer two ways of building & debugging your project within Docker containers:
+You can choose between two ways of building and debugging your project within Docker containers:
 
 - **With .NET SDK**: This option offers a simplified container debugging experience without the need for a `Dockerfile`. If you are familiar with `MSBuild` or want a straightforward approach, this is the recommended choice.
   >**Note**: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -77,10 +77,10 @@ Example `launch.json` configuration for debugging a Python application:
 
 We offer two ways of building & debugging your project within Docker containers:
 
-- **[With .NET SDK](/docs/containers/debug-netcore.md#net-sdk-container-build-debug-without-dockerfile)**: This option offers a simplified container debugging experience without the need for a `Dockerfile`. If you are familiar with `MSBuild` or want a straightforward approach, this is the recommended choice.
->**Note**: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.
+- **With .NET SDK**: This option offers a simplified container debugging experience without the need for a `Dockerfile`. If you are familiar with `MSBuild` or want a straightforward approach, this is the recommended choice.
+  >**Note**: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.
 
-- **[With a Dockerfile](/docs/containers/debug-netcore.md#debug-with-dockerfile)**: If you prefer customizing your project with a `Dockerfile`, choose this option.
+- **With a Dockerfile**: If you prefer customizing your project with a `Dockerfile`, choose this option.
 
 For more details about these two options, refer to [Debug .NET within Docker containers](/docs/containers/debug-netcore.md).
 

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -78,9 +78,9 @@ Example `launch.json` configuration for debugging a Python application:
 We offer two ways of building & debugging your project within Docker containers:
 
 - **[With .NET SDK](/docs/containers/debug-netcore.md#net-sdk-container-build-debug-without-dockerfile)**: This option offers a simplified container debugging experience without the need for a `Dockerfile`. If you are familiar with `MSBuild` or want a straightforward approach, this is the recommended choice.
-  > Note: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.
+>**Note**: This option is only available for .NET SDK 7 and above and uses the `dotnet publish` command to build the image.
 
-- **[With a Dockerfile](/docs/containers/debug-netcore.md#debug-with-dockerfile)**: If you prefer working / customizing your project with a `Dockerfile`, choose this option.
+- **[With a Dockerfile](/docs/containers/debug-netcore.md#debug-with-dockerfile)**: If you prefer customizing your project with a `Dockerfile`, choose this option.
 
 For more details about these two options, refer to [Debug .NET within Docker containers](/docs/containers/debug-netcore.md).
 

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -79,7 +79,7 @@ To enable SSL (using the HTTPS protocol), you will need to make a few changes to
 
 For additional customization options, see the documentation on [Tasks](/docs/containers/reference.md) and [Debug containerized apps](/docs/containers/debug-common.md).
 
-## Saving Project File Preference for [.NET SDK Container Build](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container)
+## Saving Project File Preference for .NET SDK Container Build
 
 If you have a workspace folder with multiple .NET project files and you want to exclusively debug one specific project (without being prompted to choose from a list of project files every time you `kb(workbench.action.debug.start)`), you can save your launch profile by following these steps:
 

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -9,7 +9,7 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 
 ## Prerequisites
 
-1. Install the [.NET SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET debugger.
+1. Install the [.NET SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET debugger. If you install .NET SDK 7 or later, you have the option of debugging without a Dockerfile.
 
 1. Install the Visual Studio Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp), which includes support for attaching to the .NET debugger with VS Code.
 
@@ -19,8 +19,28 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 
 ## Walkthrough
 
-1. If needed, create a .NET project with `dotnet new`.
-1. Open the project folder in VS Code.
+- If needed, create a .NET project with `dotnet new`.
+- Open the project folder in VS Code.
+- Optionally, set a breakpoint.
+
+## .NET SDK vs. Dockerfile Build
+
+For those seeking a streamlined container debugging experience without the need for a Dockerfile or who are well-acquainted with MSBuild, the .NET SDK option is the ideal choice. On the other hand, if you feel more at ease working with Dockerfiles, opt for Dockerfile.
+
+### .NET SDK Container Build (Debug without `Dockerfile`)
+
+1. Press `kb(workbench.action.debug.start)` or choose **Start Debugging** from the **Run** menu. (Make sure you don't have any existing launch profiles in `launch.json`)
+1. You're going to be prompted with a list of debuggers, choose Select **Docker: Debug in Container**
+1. You will be prompted with options to either build with a `Dockerfile` (**Use a Dockerfile**) or build using the .NET SDK (**Use .NET SDK**)
+1. Select **Use .NET SDK**
+1. If you have multiple project files in your workspace, choose the project file associated with the project you want to debug
+1. Your .NET app will run in a Docker container, and the web app will open in your browser.
+
+> Note: **Supported .NET SDK Versions:** This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
+
+
+### Debug with `Dockerfile`
+
 1. Wait until a notification appears asking if you want to add required assets for debugging. Select **Yes**:
 
    ![csharpPrompt](images/debug/csharp-prompt.png)
@@ -28,7 +48,6 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 1. Open the Command Palette (`kb(workbench.action.showCommands)`) and enter **Docker: Add Docker Files to Workspace...**. If you have already dockerized your app, you can instead do **Docker: Initialize for Docker debugging**. Follow the prompts.
 1. Switch to the **Run and Debug** view (`kb(workbench.view.debug)`).
 1. Select the **Docker .NET Core Launch** launch configuration.
-1. Optionally, set a breakpoint.
 1. Start debugging! (`kb(workbench.action.debug.start)`)
 
 ## Running and debugging with SSL support
@@ -60,3 +79,16 @@ To enable SSL (using the HTTPS protocol), you will need to make a few changes to
    ```
 
 For additional customization options, see the documentation on [Tasks](/docs/containers/reference.md) and [Debug containerized apps](/docs/containers/debug-common.md).
+
+## Saving Project File Preference for [.NET SDK Container Build](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container)
+
+If you have a workspace folder with multiple .NET project files and you want to exclusively debug one specific project (without being prompted to choose from a list of project files every time you `kb(workbench.action.debug.start)`), you can save your launch profile by following these steps:
+
+1. Follow the steps in [.NET SDK Container Build](#net-sdk-container-build-debug-without-dockerfile) and keep the debug session live
+1. Click on the `gear` icon in your debugger view.
+
+   ![dockerSharedFolders](images/debug/debugger-scaffolding.png)
+
+1. Select **Docker: Debug in Container**
+1. Choose the project file associated with the project you want to debug
+1. Your project preference is saved & you no longer need to choose a project file on `kb(workbench.action.debug.start)`

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -35,7 +35,7 @@ For those seeking a streamlined container debugging experience without the need 
 1. If you have multiple project files in your workspace, choose the project file associated with the project you want to debug.
 1. Your .NET app will run in a Docker container, and the web app will open in your browser.
 
-> Note: **Supported .NET SDK Versions:** This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
+>**Note**: **Supported .NET SDK Versions:** This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
 
 
 ### Debug with `Dockerfile`

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -9,7 +9,7 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 
 ## Prerequisites
 
-1. Install the [.NET SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET debugger. If you install .NET SDK 7 or later, you have the option of debugging without a Dockerfile.
+1. Install the [.NET SDK](https://www.microsoft.com/net/download), which includes support for attaching to the .NET debugger. With .NET SDK 7 or later, you have the option of debugging without a Dockerfile.
 
 1. Install the Visual Studio Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp), which includes support for attaching to the .NET debugger with VS Code.
 
@@ -30,10 +30,9 @@ For those seeking a streamlined container debugging experience without the need 
 ### .NET SDK Container Build (Debug without `Dockerfile`)
 
 1. Press `kb(workbench.action.debug.start)` or choose **Start Debugging** from the **Run** menu. (Make sure you don't have any existing launch profiles in `launch.json`)
-1. You're going to be prompted with a list of debuggers, choose Select **Docker: Debug in Container**
-1. You will be prompted with options to either build with a `Dockerfile` (**Use a Dockerfile**) or build using the .NET SDK (**Use .NET SDK**)
-1. Select **Use .NET SDK**
-1. If you have multiple project files in your workspace, choose the project file associated with the project you want to debug
+1. You're prompted with a list of debuggers. Choose **Docker: Debug in Container**
+1. When prompted with options to either build with a `Dockerfile` (**Use a Dockerfile**) or build using the .NET SDK (**Use .NET SDK**), select **Use .NET SDK**.
+1. If you have multiple project files in your workspace, choose the project file associated with the project you want to debug.
 1. Your .NET app will run in a Docker container, and the web app will open in your browser.
 
 > Note: **Supported .NET SDK Versions:** This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
@@ -84,11 +83,12 @@ For additional customization options, see the documentation on [Tasks](/docs/con
 
 If you have a workspace folder with multiple .NET project files and you want to exclusively debug one specific project (without being prompted to choose from a list of project files every time you `kb(workbench.action.debug.start)`), you can save your launch profile by following these steps:
 
-1. Follow the steps in [.NET SDK Container Build](#net-sdk-container-build-debug-without-dockerfile) and keep the debug session live
+1. Follow the steps in [.NET SDK Container Build](#net-sdk-container-build-debug-without-dockerfile) and keep the debug session live.
 1. Click on the `gear` icon in your debugger view.
 
    ![dockerSharedFolders](images/debug/debugger-scaffolding.png)
 
 1. Select **Docker: Debug in Container**
 1. Choose the project file associated with the project you want to debug
-1. Your project preference is saved & you no longer need to choose a project file on `kb(workbench.action.debug.start)`
+
+Your project preference is saved, and you no longer need to choose a project file on `kb(workbench.action.debug.start)`

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -25,17 +25,17 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 
 ## .NET SDK vs. Dockerfile Build
 
-For those seeking a streamlined container debugging experience without the need for a Dockerfile or who are well-acquainted with MSBuild, the .NET SDK option is the ideal choice. On the other hand, if you feel more at ease working with Dockerfiles, opt for Dockerfile.
+There are two ways to build and debug your app inside a container: using a Dockerfile or, for .NET 7 and above, without a Dockerfile.
 
 ### .NET SDK Container Build (Debug without `Dockerfile`)
 
-1. Press `kb(workbench.action.debug.start)` or choose **Start Debugging** from the **Run** menu. (Make sure you don't have any existing launch profiles in `launch.json`)
+1. Press `kb(workbench.action.debug.start)` or choose **Start Debugging** from the **Run** menu. (If you have any existing launch profiles in `launch.json`, you can comment them out with `kb(editor.action.commentLine)`)
 1. You're prompted with a list of debuggers. Choose **Docker: Debug in Container**
 1. When prompted with options to either build with a `Dockerfile` (**Use a Dockerfile**) or build using the .NET SDK (**Use .NET SDK**), select **Use .NET SDK**.
 1. If you have multiple project files in your workspace, choose the project file associated with the project you want to debug.
 1. Your .NET app will run in a Docker container, and the web app will open in your browser.
 
->**Note**: **Supported .NET SDK Versions:** This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
+>**Note**: Supported .NET SDK Versions: This feature is available for .NET SDK version 7.0.300 and above by default. For versions between 7.0.100 and 7.0.300, enable it with `dotnet add package Microsoft.NET.Build.Containers`. You can read more about .NET SDK Container build on [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container).
 
 
 ### Debug with `Dockerfile`

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -25,7 +25,7 @@ MetaDescription: Debug a .NET app running in a Docker container, using Visual St
 
 ## .NET SDK vs. Dockerfile Build
 
-There are two ways to build and debug your app inside a container: using a Dockerfile or, for .NET 7 and above, without a Dockerfile.
+There are two ways to build and debug your app inside a container: using a Dockerfile or, for .NET 7 and later, without a Dockerfile.
 
 ### .NET SDK Container Build (Debug without `Dockerfile`)
 

--- a/docs/containers/images/debug/debugger-scaffolding.png
+++ b/docs/containers/images/debug/debugger-scaffolding.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02b5dcee76d06634e321c3ed128eca374eaffd19b00541c7641364d1a49f340
+size 31379


### PR DESCRIPTION
I made a new PR per @gregvanl's request to use Git LFS since I will be committing an image. 

It's identical to https://github.com/microsoft/vscode-docs/pull/6521 but uses LFS to keep the repo size small. 

TODO: address all comments