### PR TITLE
Add section with Pylance diagnostics

### DIFF
--- a/docs/python/data-science.md
+++ b/docs/python/data-science.md
@@ -1,5 +1,5 @@
 ---
-Order: 7
+Order: 8
 Area: python
 TOCTitle: Data Science
 ContentId: 61af0524-2702-486e-a859-d1e993ddbf8f

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -1,5 +1,5 @@
 ---
-Order: 4
+Order: 5
 Area: python
 TOCTitle: Debugging
 ContentId: 3d9e6bcf-eae8-4c94-b857-89225b5c4ab5

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -72,7 +72,7 @@ For help with common Intellisense and Python editing issues, check the table bel
 | Problem | Cause | Solution |
 | --- | --- | ---|
 | The path to the Python interpreter is incorrect | The Python extension tries to find and select what it deems the best environment for the workspace. | Make sure you selected a valid interpreter path by running the **Python: Select Interpreter** command (see [Environments](/docs/python/environments.md)). |
-| Import could not be found *([importSourceResolveFailure](#pylance-diagnostics))* | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
+| Import could not be found *([reportMissingImports](#pylance-diagnostics) or reportMissingModuleSource)*    | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
 | Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
 | Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
 | You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
@@ -84,7 +84,7 @@ The list below are some of the most common diagnostics provided by Pylance and h
 
 
 ---
-##### `importResolveSourceFailure`
+##### `reportMissingModuleSource`
 This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
 
 **How to fix it**
@@ -93,7 +93,7 @@ This error occurs when Pylance is able to find type stubs for the imported packa
 - If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
 
 ---
-##### `importResolveFailure`
+##### `reportMissingImports`
 
 This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -24,7 +24,7 @@ Autocomplete and IntelliSense are provided for all files within the current work
 
 [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is the default language server for Python in VS Code, and is installed alongside the Python extension to provide IntelliSense features.
 
-Pylance is based on Microsoft’s [Pyright](https://github.com/microsoft/pyright) static type checking tool, leveraging [type stubs](https://typing.readthedocs.io/en/latest/source/stubs.html) (.pyi files) and lazy type inferencing to provide a highly-performant development experience.
+Pylance is based on Microsoft’s [Pyright](https://github.com/microsoft/pyright) static type checking tool, leveraging [type stubs](https://typing.readthedocs.io/en/latest/source/stubs.html) (`.pyi` files) and lazy type inferencing to provide a highly-performant development experience.
 
 For more on IntelliSense generally, see [IntelliSense](/docs/editor/intellisense.md).
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -22,6 +22,10 @@ IntelliSense is a general term for code editing features that relate to code com
 
 Autocomplete and IntelliSense are provided for all files within the current working folder. They're also available for Python packages that are installed in standard locations.
 
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is the default language server for Python in VS Code, and is installed alongside the Python extension to provide IntelliSense features.
+
+Pylance is based on Microsoft’s [Pyright](https://github.com/microsoft/pyright) static type checking tool, leveraging [type stubs](https://typing.readthedocs.io/en/latest/source/stubs.html) (.pyi files) and lazy type inferencing to provide a highly-performant development experience.
+
 For more on IntelliSense generally, see [IntelliSense](/docs/editor/intellisense.md).
 
 > **Tip**: Check out the [IntelliCode extension for VS Code](https://go.microsoft.com/fwlink/?linkid=2006060). IntelliCode provides a set of AI-assisted capabilities for IntelliSense in Python, such as inferring the most relevant auto-completions based on the current code context. For more information, see the [IntelliCode for VS Code FAQ](https://learn.microsoft.com/visualstudio/intellicode/intellicode-visual-studio-code).
@@ -30,9 +34,10 @@ For more on IntelliSense generally, see [IntelliSense](/docs/editor/intellisense
 
 Enabling the full set of IntelliSense features by default could end up making your development experience feel slower, so the Python extension enables a minimum set of features that allow you to be productive while still having a performant experience. However, you can customize the behavior of the analysis engine to your liking through multiple settings.
 
+
 ### Enable Auto Imports
 
-[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) offers auto import suggestions for modules in your workspace and/or packages you have installed in your environment. This enables import statements to be automatically added as you type. Auto imports are disabled by default, but you can enable them by setting `python.analysis.autoImportCompletions` to `true` in your settings.
+Pylance offers auto import suggestions for modules in your workspace and/or packages you have installed in your environment. This enables import statements to be automatically added as you type. Auto imports are disabled by default, but you can enable them by setting `python.analysis.autoImportCompletions` to `true` in your settings.
 
 By default, only top-level symbols/packages are suggested to be auto imported. For example, you may see `import matplotlib` as a suggestion, but not `import matplotlib.pyplot` by default. However, you can customize this behavior through the `python.analysis.packageIndexDepths` setting (check out the [IntelliSense settings documentation](/docs/python/settings-reference.md#pylance-language-server) to learn more). User defined symbols (those not coming from installed packages or libraries) are only automatically imported if they have already been used in files opened in the editor. Otherwise, they will only be available through the [add imports Quick Fix](/docs/python/editing.md#quick-fixes).
 
@@ -67,10 +72,47 @@ For help with common Intellisense and Python editing issues, check the table bel
 | Problem | Cause | Solution |
 | --- | --- | ---|
 | The path to the Python interpreter is incorrect | The Python extension tries to find and select what it deems the best environment for the workspace. | Make sure you selected a valid interpreter path by running the **Python: Select Interpreter** command (see [Environments](/docs/python/environments.md)). |
-| Import could not be found *(reportMissingImports)* | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
+| Import could not be found *([importSourceResolveFailure](#pylance-diagnostics))* | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
 | Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
 | Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
 | You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
+
+#### Pylance Diagnostics
+Pylance by default provides diagnostics for Python files in the Problems panel.
+
+The list below are some of the most common diagnostics provided by Pylance and how to fix them.
+
+
+---
+##### `importResolveSourceFailure`
+This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
+
+**How to fix it**
+
+- If the package is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
+- If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
+
+---
+##### `importResolveFailure`
+
+This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
+
+**How to fix it**
+- If you are importing a module, make sure it exists in your workspace or in a location that is included in the `python.autoComplete.extraPaths` setting.
+- If you are importing a package that is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
+- If you are importing a package that is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
+
+---
+##### `importCycleDetected`
+This error occurs when Pylance detects a circular dependency between two or more modules.
+
+**How to fix it**
+
+Try to reorder your import statements to break the circular dependency.
+
+---
+The severiy of Pylance's diagnostics can be customized through the `python.analysis.diagnosticSeverityOverrides` setting. Check the [settings reference](/docs/python/settings-reference.md) for more information.
+
 
 
 ## Enhance completions with AI

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -39,8 +39,6 @@ Enabling the full set of IntelliSense features by default could end up making yo
 
 Pylance offers auto import suggestions for modules in your workspace and/or packages you have installed in your environment. This enables import statements to be automatically added as you type. Auto imports are disabled by default, but you can enable them by setting `python.analysis.autoImportCompletions` to `true` in your settings.
 
-By default, only top-level symbols/packages are suggested to be auto imported. For example, you may see `import matplotlib` as a suggestion, but not `import matplotlib.pyplot` by default. However, you can customize this behavior through the `python.analysis.packageIndexDepths` setting (check out the [IntelliSense settings documentation](/docs/python/settings-reference.md#pylance-language-server) to learn more). User defined symbols (those not coming from installed packages or libraries) are only automatically imported if they have already been used in files opened in the editor. Otherwise, they will only be available through the [add imports Quick Fix](/docs/python/editing.md#quick-fixes).
-
 ### Enable IntelliSense for custom package locations
 
 To enable IntelliSense for packages that are installed in non-standard locations, add those locations to the `python.analysis.extraPaths` collection in your `settings.json` file (the default collection is empty). For example, you might have Google App Engine installed in custom locations, specified in `app.yaml` if you use Flask. In this case, you'd specify those locations as follows:
@@ -100,71 +98,6 @@ The import suggestions list is ordered with import statements for packages (or m
 
 Just like with auto imports, only top-levels symbols are suggested by default. You can customize this behavior through the `python.analysis.packageIndexDepths` setting.
 
-## Formatting
-
-Formatting makes code easier to read by human beings. It applies specific rules and conventions for line spacing, indents, spacing around operators, and so on. You can view an example on the [autopep8](https://pypi.org/project/autopep8/) page. Keep in mind, formatting doesn't affect the functionality of the code itself.
-
-[Linting](/docs/python/linting.md) helps to prevent errors by analyzing code for common syntactical, stylistic, and functional errors and unconventional programming practices. Although there is a little overlap between formatting and linting, the two capabilities are complementary.
-
-The Python extension supports source code formatting through formatter extensions, such as [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) and [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).
-
-### Setting a default formatter
-Once you install a formatter extension, you can select it as the default formatter for Python files in VS Code by following the steps below:
-1. Open a Python file in VS Code
-1. Right click on the editor
-1. Select **Format Document With...**
-1. Select **Configure Default Formater...** from the drop-down menu
-1. Select your preferred formatter extension from the list.
-
-
-Alternatively, you can set it as the default formatter for all Python files by setting `"editor.defaultFormatter"` in your User `settings.json` file, under a `[python]` scope.
-
-For example, to set Black Formatter as the default formatter, add the following setting to your User `settings.json` file:
-
-```
-  "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
-  }
-```
-
-### Formatting your code
-
-You can format your code by right-clicking on the editor and selecting **Format Document**, or by using the `kb(editor.action.formatDocument)` keyboard shortcut.
-
-You can also add the following setting to your User `settings.json` file to enable formatting on save for your code:
-
-```
-  "[python]": {
-    "editor.formatOnSave": true
-  }
-```
-
-### General formatting settings
-
-Each formatter extension may have its own settings, but the ones below are supported by both [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) and [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter):
-
-| Setting Suffix<br/> | Default value | Description |
-| --- | --- | --- |
-| args | `[]` | Arguments to be passed to the formatter. Each argument should be passed as a separate string in the array. <br> For example:<br> `black-formatter.args: ["--line-length", "100"]` |
-| importStrategy | `useBundled` | When set to `useBundled`, the extension uses the version of the tool that it ships with. When set to `fromEnvironment`, it attempts to load from your selected Python environment first, otherwise it falls back to the bundled version. |
-| path | `""` | Path to the formatter binary to be used for formatting. **Note:** Using this option may slowdown formatting. |
-| interpreter | `[]` | When set to a path to a Python executable, the extension will use that to launch the formatter server and its subprocesses. |
-| showNotifications | `off`| Controls when notifications are displayed by this extension. Supported values are `off`, `always`, `onError`, and `onWarning`. |
-
-
-### Troubleshooting formatting
-
-If formatting fails, check the following possible causes:
-
-| Problem | Solution |
-| --- | --- |
-| There are multiple formatters available for Python files | Set the default formatter by following the instructions in [the section above](#setting-a-default-formatter). |
-| Custom arguments for the formatter are incorrect. | Check that the appropriate `<formatter>.path` setting does not contain arguments, and that `<formatter>.args` contains a list of individual top-level argument elements. |
-| Format Selection fails with Black Formatter | `black` does not support formatting sections of code. To work around this limitation, you can disable format on paste and set `formatOnSave`` to format the whole file with the following settings: `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
-| The document isn't formatted.  | Check the formatter extension's Output channel to understand why the formatter has failed (run the **Output: Focus on Output** command in the Command Palette and then select the formatter extension channel).|
-
-> **Note**: If you don't find your preferred formatter listed above, you can add support via an extension. The [Python Extension Template](/api/advanced-topics/python-extension-template.md) makes it easy to integrate new Python tools into VS Code.
-
 ## Refactoring
 
 The Python extension adds the following refactoring functionalities: **Extract Variable**, **Extract Method** and **Rename Module**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
@@ -204,24 +137,25 @@ You can invoke this by installing an extension that supports sorting imports, th
 ![Sorting import statements](images/editing/sortImports.gif)
 
 
-### Troubleshooting IntelliSense
+## Troubleshooting
 
 For help with common Intellisense and Python editing issues, check the table below:
 
 | Problem | Cause | Solution |
 | --- | --- | ---|
-| Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
+| Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). <br>For example, you may see `import matplotlib` as a suggestion, but not `import matplotlib.pyplot` by default. | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
+| Pylance is not automatically adding missing imports | The auto import completion setting may be disabled. | Check the [Enable Auto Imports section](/docs/python/editing.md#customize-intellisense-behavior). |
+| Auto imports are enabled but Pylance is not automatically importing symbols defined in other files in the workspace. | User defined symbols (those not coming from installed packages or libraries) are only automatically imported if they have already been used in files opened in the editor.<br> Otherwise, they will only be available through the [add imports Quick Fix](/docs/python/editing.md#quick-fixes). |  Use the add imports Quick Fix, or make sure to open the relevant files in your workspace first.  |
 | Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
 | You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
 
-#### Pylance Diagnostics
+### Pylance Diagnostics
 Pylance by default provides diagnostics for Python files in the Problems panel.
 
 The list below are some of the most common diagnostics provided by Pylance and how to fix them.
 
-
 ---
-##### `importResolveSourceFailure`
+#### `importResolveSourceFailure`
 This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
 
 **How to fix it**
@@ -230,7 +164,7 @@ This error occurs when Pylance is able to find type stubs for the imported packa
 - If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
 
 ---
-##### `importResolveFailure`
+#### `importResolveFailure`
 
 This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
 
@@ -241,7 +175,7 @@ This error happens when Pylance is unable to find the package or module you're i
 - If you are working with an editable install and it is currently set up to use import hooks, consider switching to using `.pth` files to enhance compability and ensure smoother import behaviour. Learn more [here](https://microsoft.github.io/pyright/#/import-resolution?id=editable-installs).
 
 ---
-##### `importCycleDetected`
+#### `importCycleDetected`
 This error occurs when Pylance detects a circular dependency between two or more modules.
 
 **How to fix it**

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -65,56 +65,6 @@ For the full list of available IntelliSense controls, you can reference the Pyth
 
 You can also customize the general behavior of autocomplete and IntelliSense, even disable the features completely. You can learn more in [Customizing IntelliSense](/docs/editor/intellisense.md#customizing-intellisense).
 
-### Troubleshooting IntelliSense
-
-For help with common Intellisense and Python editing issues, check the table below:
-
-| Problem | Cause | Solution |
-| --- | --- | ---|
-| The path to the Python interpreter is incorrect | The Python extension tries to find and select what it deems the best environment for the workspace. | Make sure you selected a valid interpreter path by running the **Python: Select Interpreter** command (see [Environments](/docs/python/environments.md)). |
-| Import could not be found *([importSourceResolveFailure](#pylance-diagnostics))* | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
-| Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
-| Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
-| You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
-
-#### Pylance Diagnostics
-Pylance by default provides diagnostics for Python files in the Problems panel.
-
-The list below are some of the most common diagnostics provided by Pylance and how to fix them.
-
-
----
-##### `importResolveSourceFailure`
-This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
-
-**How to fix it**
-
-- If the package is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
-- If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
-
----
-##### `importResolveFailure`
-
-This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
-
-**How to fix it**
-- If you are importing a module, make sure it exists in your workspace or in a location that is included in the `python.autoComplete.extraPaths` setting.
-- If you are importing a package that is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
-- If you are importing a package that is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
-
----
-##### `importCycleDetected`
-This error occurs when Pylance detects a circular dependency between two or more modules.
-
-**How to fix it**
-
-Try to reorder your import statements to break the circular dependency.
-
----
-The severiy of Pylance's diagnostics can be customized through the `python.analysis.diagnosticSeverityOverrides` setting. Check the [settings reference](/docs/python/settings-reference.md) for more information.
-
-
-
 ## Enhance completions with AI
 
 [GitHub Copilot](https://copilot.github.com/) is an AI-powered code completion tool that helps you write code faster and smarter. You can use the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) in VS Code to generate code, or to learn from the code it generates.
@@ -252,6 +202,56 @@ You can invoke this by installing an extension that supports sorting imports, th
 > **Tip**: you can assign a keyboard shortcut to the `editor.action.organizeImports` command.
 
 ![Sorting import statements](images/editing/sortImports.gif)
+
+
+### Troubleshooting IntelliSense
+
+For help with common Intellisense and Python editing issues, check the table below:
+
+| Problem | Cause | Solution |
+| --- | --- | ---|
+| Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
+| Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
+| You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
+
+#### Pylance Diagnostics
+Pylance by default provides diagnostics for Python files in the Problems panel.
+
+The list below are some of the most common diagnostics provided by Pylance and how to fix them.
+
+
+---
+##### `importResolveSourceFailure`
+This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
+
+**How to fix it**
+
+- If the package is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
+- If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
+
+---
+##### `importResolveFailure`
+
+This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
+
+**How to fix it**
+- If you are importing a module, make sure it exists in your workspace or in a location that is included in the `python.autoComplete.extraPaths` setting.
+- If you are importing a package that is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
+- If you are importing a package that is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
+- If you are working with an editable install and it is currently set up to use import hooks, consider switching to using `.pth` files to enhance compability and ensure smoother import behaviour. Learn more [here](https://microsoft.github.io/pyright/#/import-resolution?id=editable-installs).
+
+---
+##### `importCycleDetected`
+This error occurs when Pylance detects a circular dependency between two or more modules.
+
+**How to fix it**
+
+Try to reorder your import statements to break the circular dependency.
+
+---
+
+The severiy of Pylance's diagnostics can be customized through the `python.analysis.diagnosticSeverityOverrides` setting. Check the [settings reference](/docs/python/settings-reference.md) for more information.
+
 
 ## Next steps
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -72,7 +72,7 @@ For help with common Intellisense and Python editing issues, check the table bel
 | Problem | Cause | Solution |
 | --- | --- | ---|
 | The path to the Python interpreter is incorrect | The Python extension tries to find and select what it deems the best environment for the workspace. | Make sure you selected a valid interpreter path by running the **Python: Select Interpreter** command (see [Environments](/docs/python/environments.md)). |
-| Import could not be found *([reportMissingImports](#pylance-diagnostics) or reportMissingModuleSource)*    | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
+| Import could not be found *([importSourceResolveFailure](#pylance-diagnostics))* | The package you are trying to import is not installed in the selected Python environment. | First, ensure the package is installed in your environment. If working in a `.py` file, type `python -m pip install {package_name}` in an activated terminal to install a package into your environment. For a Notebook, type `%pip install {package name}` in your code cell. If the package is installed, ensure you are using the correct environment/interpreter that matches the environment activated in your terminal. To select a new Python interpreter, use the **Python: Select Interpreter** command.|
 | Pylance is only offering top-level symbol options when adding imports. | By default, only top-level modules are indexed (depth =1). | Try increasing the depth to which Pylance can index your installed libraries through the `python.analysis.packageIndexDepths`. Check [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings). |
 | Pylance seems slow or is consuming too much memory when working on a large workspace. | Pylance analysis is done on all files present in a given workspace.  | If there are subfolders you know can be excluded from Pylance's analysis, you can add their paths to the `python.analysis.exclude` setting. Alternatively, you can try setting `python.analysis.indexing` to `false` to disable Pylance's indexer (**Note**: this will also impact the experience of completions and auto imports. Learn more about indexing in [code analysis settings](/docs/python/settings-reference.md#code-analysis-settings)).  |
 | You are unable to install a custom module into your Python project. | The custom module is located in a non-standard location (not installed using pip). | Add the location to the `python.autoComplete.extraPaths` setting and restart VS Code. |
@@ -84,7 +84,7 @@ The list below are some of the most common diagnostics provided by Pylance and h
 
 
 ---
-##### `reportMissingModuleSource`
+##### `importResolveSourceFailure`
 This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
 
 **How to fix it**
@@ -93,7 +93,7 @@ This error occurs when Pylance is able to find type stubs for the imported packa
 - If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
 
 ---
-##### `reportMissingImports`
+##### `importResolveFailure`
 
 This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
 

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -1,5 +1,5 @@
 ---
-Order: 5
+Order: 6
 Area: python
 TOCTitle: Environments
 ContentId: 8fe4ca8b-fc70-4216-86c7-2c11b6c14cc6

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -2,9 +2,9 @@
 Order: 4
 Area: python
 TOCTitle: Formatting
-ContentId:
+ContentId: c5039182-eee4-47ff-a2a8-dc28f4bc2cbc
 PageTitle: Formatting Python in Visual Studio Code
-DateApproved:
+DateApproved: 08/02/2023
 MetaDescription: Formatting Python in Visual Studio Code
 MetaSocialImage: images/tutorial/social.png
 ---

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -73,3 +73,11 @@ If formatting fails, check the following possible causes:
 | The document isn't formatted.  | Check the formatter extension's Output channel to understand why the formatter has failed (run the **Output: Focus on Output** command in the Command Palette and then select the formatter extension channel).|
 
 > **Note**: If you don't find your preferred formatter listed above, you can add support via an extension. The [Python Extension Template](/api/advanced-topics/python-extension-template.md) makes it easy to integrate new Python tools into VS Code.
+
+## Next steps
+
+- [Debugging](/docs/python/debugging.md) - Learn to debug Python both locally and remotely.
+- [Testing](/docs/python/testing.md) - Configure test environments and discover, run, and debug tests.
+- [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
+- [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.
+- [Python Extension Template](/api/advanced-topics/python-extension-template.md) - Create an extension to integrate your favorite linter into VS Code.

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -11,7 +11,7 @@ MetaSocialImage: images/tutorial/social.png
 
 ## Formatting Python in Visual Studio Code
 
-Formatting makes code easier to read by human beings. It applies specific rules and conventions for line spacing, indents, spacing around operators, and so on. You can view an example on the [autopep8](https://pypi.org/project/autopep8/) page. Keep in mind, formatting doesn't affect the functionality of the code itself.
+Formatting makes code easier to read by human beings. By enforcing particular rules and conventions such as line spacing, indents, and spacing around operators, the code becomes more visually organized and comprehensible. You can view an example on the [autopep8](https://pypi.org/project/autopep8/) page. Keep in mind, formatting doesn't affect the functionality of the code itself.
 
 [Linting](/docs/python/linting.md) helps to prevent errors by analyzing code for common syntactical, stylistic, and functional errors and unconventional programming practices. Although there is a little overlap between formatting and linting, the two capabilities are complementary.
 

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -56,7 +56,7 @@ Each formatter extension may have its own settings, but the ones below are suppo
 | --- | --- | --- |
 | args | `[]` | Arguments to be passed to the formatter. Each argument should be passed as a separate string in the array. <br> For example:<br> `black-formatter.args: ["--line-length", "100"]` |
 | importStrategy | `useBundled` | When set to `useBundled`, the extension uses the version of the tool that it ships with. When set to `fromEnvironment`, it attempts to load from your selected Python environment first, otherwise it falls back to the bundled version. |
-| path | `""` | Path to the formatter binary to be used for formatting. **Note:** Using this option may slowdown formatting. |
+| path | `""` | Path to the formatter binary to be used for formatting. **Note:** Using this option may slow down formatting. |
 | interpreter | `[]` | When set to a path to a Python executable, the extension will use that to launch the formatter server and its subprocesses. |
 | showNotifications | `off`| Controls when notifications are displayed by this extension. Supported values are `off`, `always`, `onError`, and `onWarning`. |
 

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -67,9 +67,9 @@ If formatting fails, check the following possible causes:
 
 | Problem | Solution |
 | --- | --- |
-| There are multiple formatters available for Python files | Set the default formatter by following the instructions in [the section above](#setting-a-default-formatter). |
+| There are multiple formatters available for Python files. | Set the default formatter by following the instructions in [the section above](#setting-a-default-formatter). |
 | Custom arguments for the formatter are incorrect. | Check that the appropriate `<formatter>.path` setting does not contain arguments, and that `<formatter>.args` contains a list of individual top-level argument elements. |
-| Format Selection fails with Black Formatter | `black` does not support formatting sections of code. To work around this limitation, you can disable format on paste and set `formatOnSave`` to format the whole file with the following settings: `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
+| The **Format Selection** command fails when using Black Formatter. | `black` does not support formatting sections of code. To work around this limitation, you can disable format on paste and set `formatOnSave`` to format the whole file with the following settings: `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
 | The document isn't formatted.  | Check the formatter extension's Output channel to understand why the formatter has failed (run the **Output: Focus on Output** command in the Command Palette and then select the formatter extension channel).|
 
 > **Note**: If you don't find your preferred formatter listed above, you can add support via an extension. The [Python Extension Template](/api/advanced-topics/python-extension-template.md) makes it easy to integrate new Python tools into VS Code.

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -1,0 +1,75 @@
+---
+Order: 4
+Area: python
+TOCTitle: Formatting
+ContentId:
+PageTitle: Formatting Python in Visual Studio Code
+DateApproved:
+MetaDescription: Formatting Python in Visual Studio Code
+MetaSocialImage: images/tutorial/social.png
+---
+
+## Formatting Python in Visual Studio Code
+
+Formatting makes code easier to read by human beings. It applies specific rules and conventions for line spacing, indents, spacing around operators, and so on. You can view an example on the [autopep8](https://pypi.org/project/autopep8/) page. Keep in mind, formatting doesn't affect the functionality of the code itself.
+
+[Linting](/docs/python/linting.md) helps to prevent errors by analyzing code for common syntactical, stylistic, and functional errors and unconventional programming practices. Although there is a little overlap between formatting and linting, the two capabilities are complementary.
+
+The Python extension supports source code formatting through formatter extensions, such as [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) and [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).
+
+### Setting a default formatter
+Once you install a formatter extension, you can select it as the default formatter for Python files in VS Code by following the steps below:
+1. Open a Python file in VS Code
+1. Right click on the editor
+1. Select **Format Document With...**
+1. Select **Configure Default Formater...** from the drop-down menu
+1. Select your preferred formatter extension from the list.
+
+
+Alternatively, you can set it as the default formatter for all Python files by setting `"editor.defaultFormatter"` in your User `settings.json` file, under a `[python]` scope.
+
+For example, to set Black Formatter as the default formatter, add the following setting to your User `settings.json` file:
+
+```
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  }
+```
+
+### Formatting your code
+
+You can format your code by right-clicking on the editor and selecting **Format Document**, or by using the `kb(editor.action.formatDocument)` keyboard shortcut.
+
+You can also add the following setting to your User `settings.json` file to enable formatting on save for your code:
+
+```
+  "[python]": {
+    "editor.formatOnSave": true
+  }
+```
+
+### General formatting settings
+
+Each formatter extension may have its own settings, but the ones below are supported by both [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) and [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter):
+
+| Setting Suffix<br/> | Default value | Description |
+| --- | --- | --- |
+| args | `[]` | Arguments to be passed to the formatter. Each argument should be passed as a separate string in the array. <br> For example:<br> `black-formatter.args: ["--line-length", "100"]` |
+| importStrategy | `useBundled` | When set to `useBundled`, the extension uses the version of the tool that it ships with. When set to `fromEnvironment`, it attempts to load from your selected Python environment first, otherwise it falls back to the bundled version. |
+| path | `""` | Path to the formatter binary to be used for formatting. **Note:** Using this option may slowdown formatting. |
+| interpreter | `[]` | When set to a path to a Python executable, the extension will use that to launch the formatter server and its subprocesses. |
+| showNotifications | `off`| Controls when notifications are displayed by this extension. Supported values are `off`, `always`, `onError`, and `onWarning`. |
+
+
+### Troubleshooting formatting
+
+If formatting fails, check the following possible causes:
+
+| Problem | Solution |
+| --- | --- |
+| There are multiple formatters available for Python files | Set the default formatter by following the instructions in [the section above](#setting-a-default-formatter). |
+| Custom arguments for the formatter are incorrect. | Check that the appropriate `<formatter>.path` setting does not contain arguments, and that `<formatter>.args` contains a list of individual top-level argument elements. |
+| Format Selection fails with Black Formatter | `black` does not support formatting sections of code. To work around this limitation, you can disable format on paste and set `formatOnSave`` to format the whole file with the following settings: `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
+| The document isn't formatted.  | Check the formatter extension's Output channel to understand why the formatter has failed (run the **Output: Focus on Output** command in the Command Palette and then select the formatter extension channel).|
+
+> **Note**: If you don't find your preferred formatter listed above, you can add support via an extension. The [Python Extension Template](/api/advanced-topics/python-extension-template.md) makes it easy to integrate new Python tools into VS Code.

--- a/docs/python/jupyter-support-py.md
+++ b/docs/python/jupyter-support-py.md
@@ -1,5 +1,5 @@
 ---
-Order: 8
+Order: 9
 Area: python
 TOCTitle: Python Interactive
 ContentId: C26E4F82-C6CD-4C52-818F-31A95F58207E

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -11,7 +11,7 @@ MetaSocialImage: images/tutorial/social.png
 
 # Linting Python in Visual Studio Code
 
-Linting highlights syntactical and stylistic problems in your Python source code, which often helps you identify and correct subtle programming errors or unconventional coding practices that can lead to errors. For example, linting detects use of an uninitialized or undefined variable, calls to undefined functions, missing parentheses, and even more subtle issues such as attempting to redefine built-in types or functions. Linting is distinct from [Formatting](/docs/python/editing.md#formatting) because linting analyzes how the code runs and detects errors whereas formatting only restructures how code **appears**.
+Linting highlights syntactical and stylistic problems in your Python source code, which often helps you identify and correct subtle programming errors or unconventional coding practices that can lead to errors. For example, linting detects use of an uninitialized or undefined variable, calls to undefined functions, missing parentheses, and even more subtle issues such as attempting to redefine built-in types or functions. Linting is distinct from [Formatting](/docs/python/formatting.md) because linting analyzes how the code runs and detects errors whereas formatting only restructures how code **appears**.
 
 > **Note**: Stylistic and syntactical code detection is enabled by the Language Server. To enable third-party linters for additional problem detection, you can enable them by using the **Python: Select Linter** command and selecting the appropriate linter.
 

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -77,8 +77,8 @@ Linters report issues with some predefined severity. This can be changed using `
 
 ## Next steps
 
+- [Formatting](/docs/python/formatting.md) - Learn about how to format your Python code.
 - [Debugging](/docs/python/debugging.md) - Learn to debug Python both locally and remotely.
 - [Testing](/docs/python/testing.md) - Configure test environments and discover, run, and debug tests.
 - [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
-- [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.
 - [Python Extension Template](/api/advanced-topics/python-extension-template.md) - Create an extension to integrate your favorite linter into VS Code.

--- a/docs/python/python-on-azure.md
+++ b/docs/python/python-on-azure.md
@@ -1,5 +1,5 @@
 ---
-Order: 12
+Order: 13
 Area: python
 TOCTitle: Deploy Python Apps
 ContentId: 12bf713e-5f20-46ac-81bb-8e05565aba3a

--- a/docs/python/python-web.md
+++ b/docs/python/python-web.md
@@ -1,5 +1,5 @@
 ---
-Order: 13
+Order: 14
 Area: python
 TOCTitle: Python in the Web
 ContentId: 366e4bbf-fa87-4813-9dfc-6c831b20a4d2

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -1,5 +1,5 @@
 ---
-Order: 14
+Order: 15
 Area: python
 TOCTitle: Settings Reference
 ContentId: d256dc5c-95e9-4c02-a82f-947bf34a3517

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -1,5 +1,5 @@
 ---
-Order: 6
+Order: 7
 Area: python
 TOCTitle: Testing
 ContentId: 9480bef3-4dfc-4671-a454-b9252567bc60

--- a/docs/python/tutorial-create-containers.md
+++ b/docs/python/tutorial-create-containers.md
@@ -1,5 +1,5 @@
 ---
-Order: 11
+Order: 12
 Area: python
 TOCTitle: Create containers
 ContentId: 4e45a3f6-b72d-4647-82a5-22f7ee593d47

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -1,5 +1,5 @@
 ---
-Order: 9
+Order: 10
 Area: python
 TOCTitle: Django Tutorial
 ContentId: 3c0948f9-85a5-4dd4-a461-59788dbfce4c

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -1,5 +1,5 @@
 ---
-Order: 10
+Order: 11
 Area: python
 TOCTitle: Flask Tutorial
 ContentId: 593d2dd6-20f0-4ad3-8ecd-067cc47ee217


### PR DESCRIPTION
cc @rchiodo @cwebster-99 

This PR:
- Moves "Formatting" out of editing.md into its own page in the docs (just like Linting)
- Changes the order of other doc pages so formatting goes right after linting
-  Moves "Troubleshooting IntelliSense" to the end of the editing.md file
- Adds a new subsection with some Pylance diagnostics and how to fix them    