### PR TITLE
Add links to walkthrough image color mapper plugin

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -1445,6 +1445,8 @@ Walkthroughs consist of a title, description, id, and a series of steps. Additio
 
 Each step in a walkthrough has a title, description, id, and media element (either an image or Markdown content), along with an optional set of events that will cause the step to be checked (shown in the example below). Step descriptions are Markdown content, and support `**bold**`, `__underlined__`, and ``` ``code`` ``` rendering, as well as links. Similar to walkthroughs, steps can be given when conditions to hide or show them based on context keys.
 
+SVGs are recommended for images given their ability to scale and their support for VS Code's theme colors. Use the [Visual Studio Code Color Mapper](https://www.figma.com/community/plugin/1218260433851630449) Figma plugin to easily reference theme colors in the SVGs.
+
 ```json
 {
   "contributes": {

--- a/api/ux-guidelines/walkthroughs.md
+++ b/api/ux-guidelines/walkthroughs.md
@@ -14,7 +14,7 @@ Walkthroughs provide a consistent experience for onboarding users to an extensio
 **✔️ Do**
 
 - Use helpful images to add context to the current Walkthrough step.
-- Make sure images work across different color themes. Use SVGs with VS Code's [Theme Colors](/api/references/theme-color) if possible. The [Color Mapper](https://www.figma.com/community/plugin/1218260433851630449) Figma plugin enables easy theming of SVGs.
+- Make sure images work across different color themes. Use SVGs with VS Code's [Theme Colors](/api/references/theme-color) if possible. The [Visual Studio Code Color Mapper](https://www.figma.com/community/plugin/1218260433851630449) Figma plugin enables easy theming of SVGs.
 - Provide actions (for example, View all Commands) for each step. Use verbs where possible.
 
 ❌ Don't
@@ -28,4 +28,4 @@ Walkthroughs provide a consistent experience for onboarding users to an extensio
 
 - [Walkthroughs contribution point](/api/references/contribution-points#contributes.walkthroughs)
 - [SVG with Theme Color CSS variable example](https://github.com/microsoft/vscode/blob/a28eab68734e629c61590fae8c4b231c91f0eaaa/src/vs/workbench/contrib/welcomeGettingStarted/common/media/commandPalette.svg?short_path=52f2d6f#L11)
-- [Figma Color Mapper Plugin](https://www.figma.com/community/plugin/1218260433851630449)
+- [Visual Studio Code Color Mapper](https://www.figma.com/community/plugin/1218260433851630449)

--- a/api/ux-guidelines/walkthroughs.md
+++ b/api/ux-guidelines/walkthroughs.md
@@ -14,7 +14,7 @@ Walkthroughs provide a consistent experience for onboarding users to an extensio
 **✔️ Do**
 
 - Use helpful images to add context to the current Walkthrough step.
-- Make sure images work across different color themes. Use SVGs with VS Code's [Theme Colors](/api/references/theme-color) if possible.
+- Make sure images work across different color themes. Use SVGs with VS Code's [Theme Colors](/api/references/theme-color) if possible. The [Color Mapper](https://www.figma.com/community/plugin/1218260433851630449) Figma plugin enables easy theming of SVGs.
 - Provide actions (for example, View all Commands) for each step. Use verbs where possible.
 
 ❌ Don't
@@ -28,3 +28,4 @@ Walkthroughs provide a consistent experience for onboarding users to an extensio
 
 - [Walkthroughs contribution point](/api/references/contribution-points#contributes.walkthroughs)
 - [SVG with Theme Color CSS variable example](https://github.com/microsoft/vscode/blob/a28eab68734e629c61590fae8c4b231c91f0eaaa/src/vs/workbench/contrib/welcomeGettingStarted/common/media/commandPalette.svg?short_path=52f2d6f#L11)
+- [Figma Color Mapper Plugin](https://www.figma.com/community/plugin/1218260433851630449)


### PR DESCRIPTION
Adds info and links to the Visual Studio Code Color Mapper Figma plugin to:
- API reference for `walkthroughs`
- UX guidelines 