### PR TITLE
Formatting for recent edits

### DIFF
--- a/docs/datascience/jupyter-kernel-management.md
+++ b/docs/datascience/jupyter-kernel-management.md
@@ -4,7 +4,7 @@ Area: datascience
 TOCTitle: Manage Jupyter Kernels
 ContentId: 3b6da7e6-c449-4c62-a019-9202412aac04
 PageTitle: Manage Jupyter Kernels in Visual Studio Code
-DateApproved: 1/26/2023
+DateApproved: 8/7/2023
 MetaDescription: Descriptions of kernel selection options and tutorials on managing different types of kernels when working with Jupyter Notebooks in Visual Studio Code.
 MetaSocialImage: images/tutorial/social.png
 ---
@@ -61,19 +61,23 @@ You can create a new session from the server's kernelspec by:
 
 ## Codespaces Jupyter Server
 
-The **Connect to Codespace** category contains a special type of Jupyter server where you can use remote Jupyter servers powered by [GitHub Codespaces](https://docs.github.com/en/codespaces/overview), a cloud resource that you get [up to 60 hours free](https://github.com/features/codespaces) each month. To use the Codespaces Jupyter server:
+The **Connect to Codespace** category contains a special type of Jupyter server where you can use remote Jupyter servers powered by [GitHub Codespaces](https://docs.github.com/codespaces/overview), a cloud resource that you get [up to 60 hours free](https://github.com/features/codespaces) each month. To use the Codespaces Jupyter server:
 
 1. Install the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
-    > **Tip**: If you're on VS Code for the Web ([vscode.dev](https://vscode.dev) or [github.dev](https://github.dev)), this extension is already installed for you. Please ensure that the [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) is also installed.
-2. Go to the **Command Palette** (`kb(workbench.action.showCommands)`), select **Codespaces: Sign In** and follow the steps to sign into Codespaces.
-3. Open the kernel picker by clicking on **Select Kernel** on the upper right-hand corner of your notebook, select **Connect to codespace**.
-    > **Tip**: If you don't see the **Connect to codespace** option, go to the **Command Palette** (`kb(workbench.action.showCommands)`), select **Developer: Reload Window** to reload the window and try again.
 
-It is not required, but you can also manage all your Codespaces and Codespaces Jupyter servers on [GitHub Codespaces page](https://github.com/codespaces). To learn more, head over to the [GitHub docs](https://docs.github.com/en/codespaces/getting-started/understanding-the-codespace-lifecycle).
+    > **Note**: If you're on VS Code for the Web ([vscode.dev](https://vscode.dev) or [github.dev](https://github.dev)), this extension is already installed for you. Also ensure that the [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) is also installed.
+
+2. Go to the Command Palette (`kb(workbench.action.showCommands)`), select **Codespaces: Sign In** and follow the steps to sign into Codespaces.
+
+3. Open the kernel picker by clicking on **Select Kernel** on the upper right-hand corner of your notebook, select **Connect to Codespace**.
+
+    > **Tip**: If you don't see the **Connect to Codespace** option, go to the Command Palette (`kb(workbench.action.showCommands)`), select **Developer: Reload Window** to reload the window and try again.
+
+It is not required, but you can also manage all your Codespaces and Codespaces Jupyter servers on the [GitHub Codespaces page](https://github.com/codespaces). To learn more, you can read the [GitHub Codespaces documentation](https://docs.github.com/codespaces/getting-started/understanding-the-codespace-lifecycle).
 
 ## Adding Kernel Options
 
-If you do not have any Jupyter kernel or Python environment on your machine, VS Code can help you set up: go to the **Command Palette** (`kb(workbench.action.showCommands)`), select **Python: Create Environment**, and follow the prompts. You can also add additional ways to select kernels, by installing additional extensions like [Azure Machine Learning](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-ai).
+If you do not have any Jupyter kernel or Python environment on your machine, VS Code can help you set up: go to the Command Palette (`kb(workbench.action.showCommands)`), select **Python: Create Environment**, and follow the prompts. You can also add additional ways to select kernels, by installing additional extensions like [Azure Machine Learning](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-ai).
 
 ![More Kernel Sources](images/jupyter-kernel-management/more-kernel-sources.png)
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -4,7 +4,7 @@ Area: python
 TOCTitle: Editing Code
 ContentId: 0ccb0e35-c4b2-4001-91bf-79ff1618f601
 PageTitle: Editing Python Code in Visual Studio Code
-DateApproved: 3/6/2023
+DateApproved: 8/7/2023
 MetaDescription: Editing Python in Visual Studio Code
 MetaSocialImage: images/tutorial/social.png
 ---
@@ -153,7 +153,7 @@ Pylance by default provides diagnostics for Python files in the Problems panel.
 
 The list below are some of the most common diagnostics provided by Pylance and how to fix them.
 
-#### 'importResolveSourceFailure'
+#### importResolveSourceFailure
 
 This error occurs when Pylance is able to find type stubs for the imported package, but is unable find the package itself. This can happen when the package you are trying to import is not installed in the selected Python environment.
 
@@ -162,7 +162,7 @@ This error occurs when Pylance is able to find type stubs for the imported packa
 - If the package is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
 - If the package is not installed, you can install it by running the following command in an activated terminal: `python -m pip install {package_name}`.
 
-#### 'importResolveFailure'
+#### importResolveFailure
 
 This error happens when Pylance is unable to find the package or module you're importing, nor its type stubs.
 
@@ -173,7 +173,7 @@ This error happens when Pylance is unable to find the package or module you're i
 - If you are importing a package that is already installed in a different interpreter or kernel, [select the correct interpreter](/docs/python/environments.md#select-and-activate-an-environment).
 - If you are working with an editable install and it is currently set up to use import hooks, consider switching to using `.pth` files to enhance compatibility and ensure smoother import behavior. Learn more in the [Pyright documentation](https://microsoft.github.io/pyright/#/import-resolution?id=editable-installs).
 
-#### 'importCycleDetected'
+#### importCycleDetected
 
 This error occurs when Pylance detects a circular dependency between two or more modules.
 

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -4,11 +4,11 @@ Area: python
 TOCTitle: Formatting
 ContentId: c5039182-eee4-47ff-a2a8-dc28f4bc2cbc
 PageTitle: Formatting Python in Visual Studio Code
-DateApproved: 08/02/2023
+DateApproved: 8/7/2023
 MetaDescription: Formatting Python in Visual Studio Code
 MetaSocialImage: images/tutorial/social.png
 ---
-# Formatting Python in Visual Studio Code
+# Formatting Python in VS Code
 
 Formatting makes source code easier to read by human beings. By enforcing particular rules and conventions such as line spacing, indents, and spacing around operators, the code becomes more visually organized and comprehensible. You can view an example on the [autopep8](https://pypi.org/project/autopep8/) page. Keep in mind, formatting doesn't affect the functionality of the code itself.
 
@@ -16,7 +16,7 @@ Formatting makes source code easier to read by human beings. By enforcing partic
 
 The Python extension supports source code formatting through formatter extensions, such as [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) and [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).
 
-## Setting a default formatter
+## Set a default formatter
 
 Once you install a formatter extension, you can select it as the default formatter for Python files in VS Code by following the steps below:
 
@@ -36,7 +36,7 @@ For example, to set Black Formatter as the default formatter, add the following 
   }
 ```
 
-## Formatting your code
+## Format your code
 
 You can format your code by right-clicking on the editor and selecting **Format Document**, or by using the `kb(editor.action.formatDocument)` keyboard shortcut.
 
@@ -60,13 +60,13 @@ Each formatter extension may have its own settings, but the ones below are suppo
 | interpreter | `[]` | When set to a path to a Python executable, the extension will use that to launch the formatter server and its subprocesses. |
 | showNotifications | `off`| Controls when notifications are displayed by this extension. Supported values are `off`, `always`, `onError`, and `onWarning`. |
 
-## Troubleshooting formatting
+## Troubleshoot formatting
 
 If formatting fails, check the following possible causes:
 
 | Problem | Solution |
 | --- | --- |
-| There are multiple formatters available for Python files. | Set the default formatter by following the instructions in [the section above](#setting-a-default-formatter). |
+| There are multiple formatters available for Python files. | Set the default formatter by following the instructions in [the section above](#set-a-default-formatter). |
 | Custom arguments for the formatter are incorrect. | Check that the appropriate `<formatter>.path` setting does not contain arguments, and that `<formatter>.args` contains a list of individual top-level argument elements. |
 | The **Format Selection** command fails when using Black Formatter. | `black` does not support formatting sections of code. To work around this limitation, you can disable format on paste and set `formatOnSave` to format the whole file with the following settings: `"[python]": {"editor.formatOnPaste": false, "editor.formatOnSaveMode": "file"}`.|
 | The document isn't formatted.  | Check the formatter extension's Output channel to understand why the formatter has failed (run the **Output: Focus on Output** command in the Command Palette and then select the formatter extension channel).|


### PR DESCRIPTION
Shorten Python formatting topic H1 header to avoid a line break.
Bump DateApproved.
Remove locale from docs.github.com URLs
Avoid gerunds in H2 headers