### PR TITLE
Clarify macOS support policy

### DIFF
--- a/docs/supporting/requirements.md
+++ b/docs/supporting/requirements.md
@@ -22,7 +22,7 @@ We recommend:
 VS Code is supported on the following platforms:
 
 * Windows 10 and 11 (32-bit and 64-bit)
-* macOS versions receiving security fixes from Apple, this typically includes the latest release and the 2 versions before it
+* macOS versions with Apple security update support. This is typically the latest release and the two previous versions.
 * Linux (Debian): Ubuntu Desktop 16.04, Debian 9
 * Linux (Red Hat): Red Hat Enterprise Linux 7, CentOS 7, Fedora 34
 

--- a/docs/supporting/requirements.md
+++ b/docs/supporting/requirements.md
@@ -22,7 +22,7 @@ We recommend:
 VS Code is supported on the following platforms:
 
 * Windows 10 and 11 (32-bit and 64-bit)
-* OS X High Sierra (10.13+)
+* macOS versions receiving security fixes from Apple, this typically the latest release and the 2 versions before it
 * Linux (Debian): Ubuntu Desktop 16.04, Debian 9
 * Linux (Red Hat): Red Hat Enterprise Linux 7, CentOS 7, Fedora 34
 

--- a/docs/supporting/requirements.md
+++ b/docs/supporting/requirements.md
@@ -22,7 +22,7 @@ We recommend:
 VS Code is supported on the following platforms:
 
 * Windows 10 and 11 (32-bit and 64-bit)
-* macOS versions receiving security fixes from Apple, this typically the latest release and the 2 versions before it
+* macOS versions receiving security fixes from Apple, this typically includes the latest release and the 2 versions before it
 * Linux (Debian): Ubuntu Desktop 16.04, Debian 9
 * Linux (Red Hat): Red Hat Enterprise Linux 7, CentOS 7, Fedora 34
 


### PR DESCRIPTION
We primarily want to support what Apple supports. Note that this doesn't mean we won't ship fixes for older versions of macOS, just we may not necessarily and they are typically lower priority than the supported versions.

Related microsoft/vscode#184713