### PR TITLE
Add link to AI Tools in VS Code topic

### DIFF
--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -13,6 +13,8 @@ March 30, 2023 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 **AI did not write this blog post, but it will make your development experiences incredible.**
 
+> **Note**: If you like to learn about the latest GitHub Copilot experience in Visual Studio Code, go to the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic, where you'll find details on the Copilot editor integration and Copilot Chat features such as inline Chat, the dedicated Chat view, and Quick Chat.
+
 There is a lot of buzz, excitement, and some concerns around Artificial Intelligence today. Advancements are happening almost daily, it's hard to keep up. But once you give it a try, you quickly realize what more than a million Copilot users see daily, that this technology does not disappoint, especially with Large Language Models (LLMs) like OpenAI's GPT-3.5/4.
 
 In this post, we want to give a little background on AI in VS Code, show you some exciting new experiences powered by GitHub Copilot, and give a peek into where and how we see things going forward.
@@ -90,7 +92,7 @@ So, if you think of yourself as the Pilot of VS Code and GitHub Copilot as…wel
 
 ## Getting started today
 
-To see Copilot in action and get more tips on how to get the most out of Copilot, [check out this awesome video](https://youtu.be/gDJzr9DBKTI).
+To see Copilot in action and get more tips on how to get the most out of Copilot, [check out this awesome introductory video](https://youtu.be/gDJzr9DBKTI) or dive into the full [VS Code Copilot Series](https://www.youtube.com/playlist?list=PLj6YeMhvp2S5_hvBl2SE-7YCHYlLQ0bPt) on Youtube.
 
 The inline completions experience discussed above is available today. If you don't have Copilot through your organization, you can sign up [here](https://github.com/features/copilot) and start a free trial. From there:
 
@@ -99,14 +101,15 @@ The inline completions experience discussed above is available today. If you don
 * When prompted, authenticate with your GitHub ID.
 * Open a code file and let the magic happen!
 
-Today, access to the chat experiences (in-editor and Chat view), you'll need to [join the waitlist](https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
+Today, to access the chat experiences (in-editor, Chat view, Quick Chat), you'll need to [join the waitlist](https://github.com/github-copilot/chat_waitlist_signup/join) for access to the technical preview as we ramp up the service. Once admitted:
 
-* Open the Extensions view (`kb(workbench.view.extensions)`), search for GitHub Copilot, and install the [pre-release version](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions) of the extension.
+* Open the Extensions view (`kb(workbench.view.extensions)`), search for the GitHub Copilot Chat extension.
 * When prompted, authenticate with your GitHub ID.
-* To open the in-editor Chat, optionally select a block of code and press `kbstyle(Cmd+I)` on macOS or `kbstyle(Ctrl+I)` on Windows/Linux. Ask Copilot to write a Quick Sort function.
+* To open the in-editor Chat, optionally select a block of code and press `kb(inlineChat.start)`. Ask Copilot to write a Quick Sort function.
 * A "Chat" icon will appear in the Activity Bar, click on it to open the Chat view. Go ahead, ask Copilot to "write a program to calculate the airspeed velocity of an unladen swallow".
+* To try out Quick Chat, you can run **Chat: Open Quick Chat** or use the `kb(chat.action.askQuickQuestion)` keyboard shortcut.
 
-You can learn more about the GitHub Copilot extension in the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic.
+You can learn more about the GitHub Copilot and Copilot Chat extensions in the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic.
 
 ## Responsible AI
 


### PR DESCRIPTION
Also update the "Getting started today" section for the Copilot Chat extension