### PR TITLE
Adding UCRT support for MinGW

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -38,7 +38,7 @@ Get the latest version of MinGW-w64 via [MSYS2](https://www.msys2.org/), which p
 1. In this terminal, install the MinGW-w64 toolchain by running the following command:
 
     ```MSYS2
-    pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
     ```
 
 1. Accept the default number of packages in the `toolchain` group by pressing `kbstyle(Enter)`.
@@ -51,7 +51,7 @@ Get the latest version of MinGW-w64 via [MSYS2](https://www.msys2.org/), which p
    1. In the Windows search bar, type **Settings** to open your Windows Settings.
    1. Search for **Edit environment variables for your account**.
    1. In your **User variables**, select the `Path` variable and then select **Edit**.
-   1. Select **New** and add the MinGW-w64 destination folder you recorded during the installation process to the list. If you used the default settings above, then this will be the path: `C:\msys64\mingw64\bin`.
+   1. Select **New** and add the MinGW-w64 destination folder you recorded during the installation process to the list. If you used the default settings above, then this will be the path: `C:\msys64\ucrt64\bin`.
    1. Select **OK** to save the updated PATH. You will need to reopen any console windows for the new PATH location to be available.
 
 ### Check your MinGW installation
@@ -176,7 +176,7 @@ Your new `tasks.json` file should look similar to the JSON below:
         {
             "type": "cppbuild",
             "label": "C/C++: g++.exe build active file",
-            "command": "C:\\msys64\\mingw64\\bin\\g++.exe",
+            "command": "C:\\msys64\\ucrt64\\bin\\g++.exe",
             "args": [
                 "-fdiagnostics-color=always",
                 "-g",
@@ -335,7 +335,7 @@ VS Code creates a `launch.json` file in the `.vscode` folder`, which looks somet
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:\\msys64\\mingw64\\bin\\gdb.exe",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -424,6 +424,16 @@ If you have Visual Studio or WSL installed, you may need to change `compilerPath
 ### MSYS2 is installed, but g++ and gdb are still not found
 
 You must follow the steps on the [MSYS2 website](https://www.msys2.org/) and use the MSYS CLI to install MinGW-w64, which contains those tools. You will also need to install the full MinGW-w64 toolchain (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`) to get the `gdb` debugger.
+
+### As a Windows user, running the pacman command gives me an error
+
+UCRT on Windows machines is only included in Windows 10 or later. If you are using another version of Windows, run the following command that does not use UCRT:
+
+```MSYS2
+pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+```
+
+When adding the the MinGW-w64 destination folder to your list of environment variables, the default path will then be: `C:\msys64\mingw64\bin`.
 
 ### MinGW 32-bit
 

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -38,7 +38,7 @@ Get the latest version of MinGW-w64 via [MSYS2](https://www.msys2.org/), which p
 1. In this terminal, install the MinGW-w64 toolchain by running the following command:
 
     ```MSYS2
-   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+   pacman -S mingw-w64-ucrt-x86_64-toolchain
     ```
 
 1. Accept the default number of packages in the `toolchain` group by pressing `kbstyle(Enter)`.
@@ -423,7 +423,7 @@ If you have Visual Studio or WSL installed, you may need to change `compilerPath
 
 ### MSYS2 is installed, but g++ and gdb are still not found
 
-You must follow the steps on the [MSYS2 website](https://www.msys2.org/) and use the MSYS CLI to install MinGW-w64, which contains those tools. You will also need to install the full MinGW-w64 toolchain (`pacman -S --needed base-devel mingw-w64-x86_64-toolchain`) to get the `gdb` debugger.
+You must follow the steps on the [MSYS2 website](https://www.msys2.org/) to use the MSYS CLI to install the full MinGW-w64 toolchain(`pacman -S mingw-w64-ucrt-x86_64-toolchain`), as well as all required prerequisites. The toolchain includes g++ and gdb.
 
 ### As a Windows user, running the pacman command gives me an error
 

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -83,7 +83,7 @@ To understand the process, let's install Mingw-w64 via [MSYS2](https://www.msys2
 1. In this terminal, install the MinGW-w64 toolchain by running the following command:
 
     ```MSYS2
-    pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+    pacman -S mingw-w64-ucrt-x86_64-toolchain
     ```
 
 1. Accept the default number of packages in the `toolchain` group by pressing `kbstyle(Enter)`.
@@ -96,7 +96,7 @@ To understand the process, let's install Mingw-w64 via [MSYS2](https://www.msys2
    1. In the Windows search bar, type **Settings** to open your Windows Settings.
    1. Search for **Edit environment variables for your account**.
    1. In your **User variables**, select the `Path` variable and then select **Edit**.
-   1. Select **New** and add the MinGW-w64 destination folder you recorded during the installation process to the list. If you selected the default installation steps, the path is: `C:\msys64\mingw64\bin`.
+   1. Select **New** and add the MinGW-w64 destination folder you recorded during the installation process to the list. If you selected the default installation steps, the path is: `C:\msys64\ucrt64\bin`.
    1. Select **OK** to save the updated PATH. For the new `PATH` to be available, reopen your console windows.
 1. Check that your MinGW-w64 tools are correctly installed and available, open a **new** Command Prompt and type:
 


### PR DESCRIPTION
With UCRT being added in our extension (among other MSYS versions) as noted in our [changelog](https://github.com/microsoft/vscode-cpptools/releases/tag/v1.17.2) we now need to update our docs to support UCRT as the default minGW installation version.