### PR TITLE
fix incorrect extension entry point

### DIFF
--- a/api/extension-guides/webview.md
+++ b/api/extension-guides/webview.md
@@ -62,7 +62,7 @@ Here's the `package.json` for the first version of the **Cat Coding** extension.
     "vscode": "^1.74.0"
   },
   "activationEvents": [],
-  "main": "./out/src/extension",
+  "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
I followed the docs -- https://code.visualstudio.com/api/extension-guides/webview#webviews-api-basics

And I got this error.
![image](https://github.com/microsoft/vscode-docs/assets/18543527/43c3a74c-70bc-4c66-9273-6ad6a518a2c2)

The extension entry point is incorrect.