### PR TITLE
Fix highlight lang names

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -37,7 +37,7 @@ Get the latest version of MinGW-w64 via [MSYS2](https://www.msys2.org/), which p
 
 1. In this terminal, install the MinGW-w64 toolchain by running the following command:
 
-    ```MSYS2
+    ```sh
    pacman -S mingw-w64-ucrt-x86_64-toolchain
     ```
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -356,7 +356,7 @@ This allows you to have a separate **more complex** `devcontainer.json` you use 
 
 Note that you can also opt to manually add metadata to an image label instead. These properties will be picked up even if you didn't use the Dev Container CLI to build (and can be updated by the CLI even if you do). For example, consider this Dockerfile snippet:
 
-```Dockerfile
+```docker
 LABEL devcontainer.metadata='[{ \
   "capAdd": [ "SYS_PTRACE" ], \
   "remoteUser": "devcontainer", \

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -82,7 +82,7 @@ To understand the process, let's install Mingw-w64 via [MSYS2](https://www.msys2
 
 1. In this terminal, install the MinGW-w64 toolchain by running the following command:
 
-    ```MSYS2
+    ```sh
     pacman -S mingw-w64-ucrt-x86_64-toolchain
     ```
 


### PR DESCRIPTION
Fixes the syntax names used for highlighting so that shiki can highlight the blocks properly.