### PR TITLE
Refresh color themes for Dark Modern

### DIFF
--- a/docs/editor/profiles.md
+++ b/docs/editor/profiles.md
@@ -176,7 +176,6 @@ This profile also sets the following settings:
 ```json
     "python.analysis.autoImportCompletions": true,
     "python.analysis.fixAll": ["source.unusedImports"],
-    "workbench.colorTheme": "Default Dark+ Experimental",
     "editor.defaultFormatter": "ms-python.black-formatter"
 ```
 
@@ -210,7 +209,6 @@ This profile also sets the following settings:
     ],
     "notebook.experimental.outputScrolling": true,
     // "notebook.outline.showCodeCells": true,
-    "workbench.colorTheme": "Default Dark+ Experimental",
     "files.exclude": {
         "**/.csv": true,
         "**/.parquet": true,
@@ -291,8 +289,7 @@ This profile comes with the following settings:
     },
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "workbench.colorTheme": "Default Dark+ Experimental"
+    }
 ```
 
 ### Angular Profile Template
@@ -337,8 +334,7 @@ This profile sets the following settings:
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "workbench.iconTheme": "material-icon-theme",
-    "workbench.colorTheme": "Default Dark+ Experimental",
+    "workbench.iconTheme": "material-icon-theme"
 ```
 
 ### Java General Profile Template
@@ -367,8 +363,7 @@ This profile sets the following settings:
     "[java]": {
         "editor.defaultFormatter": "redhat.java"
     },
-    "boot-java.rewrite.reconcile": true,
-    "workbench.colorTheme": "Default Dark+ Experimental"
+    "boot-java.rewrite.reconcile": true
 ```
 
 ## Command line

--- a/docs/getstarted/images/themes/colorthemes.png
+++ b/docs/getstarted/images/themes/colorthemes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b74110e21b4e11242eb8fff1faf51fa327abc06fff6d628c1ee597f4c9048cf
-size 16134
+oid sha256:c6ca7846bca9e5b692ff92dbe00022f5af47f7161cec6e77c33eb1cc00ffa408
+size 103284

--- a/docs/getstarted/images/themes/preferred-color-themes.png
+++ b/docs/getstarted/images/themes/preferred-color-themes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8671e3af0a86a26cd3b37d08ac130f2625d6aed3ff6c9a9486c7bbbf3c936c
+size 63921

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -26,7 +26,7 @@ The active color theme is stored in your user [settings](/docs/getstarted/settin
 
 ```json
   // Specifies the color theme used in the workbench.
-  "workbench.colorTheme": "Default Dark+"
+  "workbench.colorTheme": "Solarized Dark"
 ```
 
 > **Tip:** By default, the theme is stored in your user settings and applies globally to all workspaces. You can also configure a workspace specific theme. To do so, set a theme in the Workspace [settings](/docs/getstarted/settings.md#workspace-settings).
@@ -45,12 +45,14 @@ You can search for themes in the Extensions view (`kb(workbench.view.extensions)
 
 Windows and macOS support light and dark color schemes. There is a setting, `window.autoDetectColorScheme`, that instructs VS Code to listen to changes to the OS's color scheme and switch to a matching theme accordingly.
 
-To customize the themes that are used when a color scheme changes, you can set the preferred light, dark, and high contrast themes with the settings:
+To customize the themes that are used when a color scheme changes, you can set the preferred light, dark, and high contrast themes in the Settings editor:
 
-* `workbench.preferredLightColorTheme` - defaults to "Default Light+"
-* `workbench.preferredDarkColorTheme` - defaults to "Default Dark+"
-* `workbench.preferredHighContrastColorTheme` - defaults to "Default High Contrast"
-* `workbench.preferredHighContrastLightColorTheme` - defaults to "Default High Contrast Light"
+* **Workbench: Preferred Dark Color Theme** - defaults to "Dark Modern"
+* **Workbench: Preferred Light Color Theme** - defaults to "Light Modern"
+* **Workbench: Preferred High Contrast Color Theme** - defaults to "Dark High Contrast"
+* **Workbench: Preferred High Contrast Light Color Theme** - defaults to "Light High Contrast"
+
+![Settings editor filtered on the preferred color themes settings](images/themes/preferred-color-themes.png)
 
 ## Customizing a Color Theme
 


### PR DESCRIPTION
Refresh image and use Solarized Dark as the example
Also remove obsolete references to Dark+ Experimental in Profiles example