### PR TITLE
virtual-documents.md: fix typo

### DIFF
--- a/api/extension-guides/virtual-documents.md
+++ b/api/extension-guides/virtual-documents.md
@@ -65,7 +65,7 @@ const myProvider = new class implements vscode.TextDocumentContentProvider {
 };
 ```
 
-The event emitter has a `fire` method which is can be used to notify VS Code when a change has happened in a document. The document which has changed is identified by its uri given as argument to the `fire` method. The provider will then be called again to provide the updated content, assuming the document is still open.
+The event emitter has a `fire` method which can be used to notify VS Code when a change has happened in a document. The document which has changed is identified by its uri given as argument to the `fire` method. The provider will then be called again to provide the updated content, assuming the document is still open.
 
 That's all what's needed to make VS Code listen for changes of virtual document. To see a more complex example making use of this feature, look at: [https://github.com/microsoft/vscode-extension-samples/blob/main/contentprovider-sample/README.md](https://github.com/microsoft/vscode-extension-samples/blob/main/contentprovider-sample/README.md).
 


### PR DESCRIPTION
"which is can" -> "which can"