### PR TITLE
extension: Better explain how to start debugging

### DIFF
--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -34,7 +34,7 @@ yo code
 
 ```
 
-Then, inside the editor, press `kb(workbench.action.debug.start)`. This will compile and run the extension in a new **Extension Development Host** window.
+Inside the editor, open `src/extension.ts` and press `kb(workbench.action.debug.start)`. This will compile and run the extension in a new **Extension Development Host** window.
 
 Run the **Hello World** command from the Command Palette (`kb(workbench.action.showCommands)`) in the new window:
 


### PR DESCRIPTION
Walking through a test plan I had to create an extension. I couldn't figure out why I wasn't able to run the extension, turns out `extension.ts` needs to be open.