### PR TITLE
Properly use ed25519 throughout SSH keys guide

### DIFF
--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -34,7 +34,7 @@ To set up SSH key based authentication for your remote host. First we'll create 
 If you do not have a key, run the following command in a **local** terminal / PowerShell to generate an SSH key pair:
 
 ```bash
-ssh-keygen -t rsa -b 4096
+ssh-keygen -t ed25519 -b 4096
 ```
 
 > **Tip:** Don't have `ssh-keygen`? Install [a supported SSH client](#installing-a-supported-ssh-client).


### PR DESCRIPTION
The Quick start section has commands to set up key based authentication where most of the commands used a ed25519 key, but the ssh-keygen command uses rsa. Someone following the commands exactly will encounter a problem when trying to copy the id_ed25519 key when it does not exist (but id_rsa will).