### PR TITLE
Onboard onto MCR

### DIFF
--- a/.pipelines/onebranch.buddy.yml
+++ b/.pipelines/onebranch.buddy.yml
@@ -25,7 +25,7 @@ resources:
       trigger: true
 
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  WindowsContainerImage: 'mcr.microsoft.com/windows/nanoserver:ltsc2019'
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates

--- a/.pipelines/onebranch.official.yml
+++ b/.pipelines/onebranch.official.yml
@@ -25,7 +25,7 @@ resources:
       trigger: true
 
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  WindowsContainerImage: 'mcr.microsoft.com/windows/nanoserver:ltsc2019'
   Codeql.enabled: true
   Codeql.SourceRoot: $(Pipeline.Workspace)/vscode-website
   Codeql.TSAEnabled: true


### PR DESCRIPTION
The vscode-docs pipelines are failing on a new Initialize Container step.
This PR switches the images to MCR ones.