### PR TITLE
Edit/formatting pass on recent updates

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -835,10 +835,7 @@ Here's a command menu item:
 
 ![menus extension point example](images/contribution-points/menus.png)
 
-Similarly, here's a command menu item added to a particular view:
-
-
-Here's an example that contributes to an arbitrary view like the terminal:
+Similarly, here's a command menu item added to a particular view. The example below contributes to an arbitrary view like the terminal:
 
 ```json
 {
@@ -1231,9 +1228,9 @@ When defined, the profile will show up in the terminal profile selector. When ac
 
 ```ts
 vscode.window.registerTerminalProfileProvider('my-ext.terminal-profile', {
-	provideTerminalProfile(token: vscode.CancellationToken): vscode.ProviderResult<vscode.TerminalOptions | vscode.ExtensionTerminalOptions> {
-		return { name: 'Profile from extension', shellPath: 'bash' };
-	}
+  provideTerminalProfile(token: vscode.CancellationToken): vscode.ProviderResult<vscode.TerminalOptions | vscode.ExtensionTerminalOptions> {
+    return { name: 'Profile from extension', shellPath: 'bash' };
+  }
 });
 ```
 

--- a/docs/datascience/azure-machine-learning.md
+++ b/docs/datascience/azure-machine-learning.md
@@ -19,7 +19,7 @@ The [Azure Machine Learning](https://marketplace.visualstudio.com/items?itemName
 
 ## Desktop or web
 
-You can use Azure Machine Learning in VS Code Desktop or [VS Code for the Web](/docs/editor/vscode-web.md). VS Code for the Web provides a free, zero-install VS Code experience running entirely in your browser at [https://vscode.dev](https://vscode.dev). Check out the [guide on launching Azure Machine Learning](https://learn.microsoft.com/azure/machine-learning/how-to-launch-vs-code-remote?view=azureml-api-2&tabs=vscode-web) to learn more.
+You can use Azure Machine Learning in VS Code Desktop or [VS Code for the Web](/docs/editor/vscode-web.md). VS Code for the Web provides a free, zero-install VS Code experience running entirely in your browser at [https://vscode.dev](https://vscode.dev). Check out the [guide on launching Azure Machine Learning](https://learn.microsoft.com/azure/machine-learning/how-to-launch-vs-code-remote?view=azureml-api-2&tabs=vscode-web) to learn more.
 
 ## Connect to remote compute instances
 

--- a/docs/datascience/notebooks-web.md
+++ b/docs/datascience/notebooks-web.md
@@ -76,7 +76,7 @@ When you're starting your remote server, be sure to:
 
 ### Limitations
 
-Since VS Code for the Web runs entirely in your web browser, there are some limitations compared to the desktop and Codespaces experiences.
+Since VS Code for the Web runs entirely in your web browser, there are some limitations compared to the desktop and Codespaces experiences.
 
 - No access the VS Code terminal (though you can run [magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html) from your notebook cells)
 - Limited debugging

--- a/docs/datascience/overview.md
+++ b/docs/datascience/overview.md
@@ -10,7 +10,7 @@ MetaDescription: Doing Data Science in Visual Studio Code.
 
 # Data Science in Visual Studio Code
 
-You can do all of your data science work within VS Code. Use Jupyter Notebooks and the [Interactive Window](/docs/python/jupyter-support-py.md) to start analyzing and visualizing your data in minutes! Power your Python coding experience with IntelliSense support and build, train, and deploy machine learning models to the cloud or the edge with Azure Machine Learning service.
+You can do all of your data science work within VS Code. Use Jupyter Notebooks and the [Interactive Window](/docs/python/jupyter-support-py.md) to start analyzing and visualizing your data in minutes! Power your Python coding experience with IntelliSense support and build, train, and deploy machine learning models to the cloud or the edge with Azure Machine Learning service.
 
 ![Preview of Jupyter Notebooks in VS Code](images/overview/jupyter-notebook-preview.png)
 

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -175,7 +175,7 @@ To do so:
 
 1. Follow the [Getting Started](/docs/remote/tunnels.md#getting-started) instructions for the Remote - Tunnels extension.
 1. [Install Docker](#installation) on your tunnel host. You do not need to install Docker locally.
-1. Follow the [steps](/docs/remote/tunnels.md#remote---tunnels-extension) for the Remote - Tunnels extension to connect to a tunnel host and open a folder there.
+1. Follow the [steps](/docs/remote/tunnels.md#remote-tunnels-extension) for the Remote - Tunnels extension to connect to a tunnel host and open a folder there.
 1. Use the **Dev Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
 
 The rest of the Dev Containers quick start applies as-is. You can learn more about the [Remote - Tunnels extension in its documentation](/docs/remote/tunnels.md). You can also see the [Develop on a remote Docker host](/remote/advancedcontainers/develop-remote-host.md) article for other options if this model does not meet your needs.

--- a/docs/editor/accessibility.md
+++ b/docs/editor/accessibility.md
@@ -100,7 +100,7 @@ One of the best approaches to selecting the best colors for a specific condition
 
 ## Dim unfocused editors and terminals
 
-Unfocused views can be dimmed to make it more clear where typed input will go, this is especially useful when working with multiple editor groups or terminals. Enable this feature by setting `"accessibility.dimUnfocused.enabled": true`, how dim it will become can be configured with `accessibility.dimUnfocused.opacity`.
+Unfocused views can be dimmed to make it clearer where typed input will go. This is especially useful when working with multiple editor groups or terminals. Enable this feature by setting `"accessibility.dimUnfocused.enabled": true`. You can control the dimness level with `accessibility.dimUnfocused.opacity`, which takes the opacity fraction from 0.2 to 1 (default 0.75).
 
 ## Keyboard navigation
 

--- a/docs/editor/vscode-web.md
+++ b/docs/editor/vscode-web.md
@@ -9,15 +9,15 @@ MetaDescription: Visual Studio Code for the Web and the vscode.dev URL
 ---
 # Visual Studio Code for the Web
 
-Visual Studio Code for the Web provides a free, zero-install Microsoft Visual Studio Code experience running entirely in your browser, allowing you to quickly and safely browse source code repositories and make lightweight code changes. To get started, go to [https://vscode.dev](https://vscode.dev) in your browser.
+Visual Studio Code for the Web provides a free, zero-install Microsoft Visual Studio Code experience running entirely in your browser, allowing you to quickly and safely browse source code repositories and make lightweight code changes. To get started, go to [https://vscode.dev](https://vscode.dev) in your browser.
 
 VS Code for the Web has many of the features of VS Code Desktop that you love, including search and syntax highlighting while browsing and editing, along with extension support to work on your codebase and make simpler edits. In addition to opening repositories, forks, and pull requests from source control providers like GitHub and Azure Repos, you can also work with code that is stored on your local machine.
 
-VS Code for the Web runs entirely in your web browser, so there are certain limitations compared to the desktop experience, which you can read more about [below](#limitations).
+VS Code for the Web runs entirely in your web browser, so there are certain limitations compared to the desktop experience, which you can read more about [below](#limitations).
 
 ## Relationship to VS Code Desktop
 
-VS Code for the Web provides a browser-based experience for navigating files and repositories and committing lightweight code changes. However, if you need access to a runtime to run, build, or debug your code, you want to use platform features such as a terminal, or you want to run extensions that aren't supported in the web, we recommend moving your work to the desktop application, [GitHub Codespaces](https://github.com/features/codespaces), or using [Remote - Tunnels](#use-your-own-compute-with-remote-tunnels) for the full capabilities of VS Code. In addition, VS Code Desktop lets you use a full set of keyboard shortcuts not limited by your browser.
+VS Code for the Web provides a browser-based experience for navigating files and repositories and committing lightweight code changes. However, if you need access to a runtime to run, build, or debug your code, you want to use platform features such as a terminal, or you want to run extensions that aren't supported in the web, we recommend moving your work to the desktop application, [GitHub Codespaces](https://github.com/features/codespaces), or using [Remote - Tunnels](#use-your-own-compute-with-remote-tunnels) for the full capabilities of VS Code. In addition, VS Code Desktop lets you use a full set of keyboard shortcuts not limited by your browser.
 
 When you're ready to switch, you'll be able to ["upgrade"](#continue-working-in-a-different-environment) to the full VS Code experience with a few clicks.
 
@@ -27,17 +27,17 @@ You can also switch between the Stable and Insiders versions of VS Code for the 
 
 By navigating to [https://vscode.dev](https://vscode.dev), you can create a new local file or project, work on an existing local project, or access source code repositories hosted elsewhere, such as on GitHub and Azure Repos (part of Azure DevOps).
 
-You can create a new local file in the web just as you would in a VS Code Desktop environment, using **File** > **New File** from the Command Palette (`kbstyle(F1)`).
+You can create a new local file in the web just as you would in a VS Code Desktop environment, using **File** > **New File** from the Command Palette (`kbstyle(F1)`).
 
 ## GitHub repos
 
-You can open a GitHub repository in VS Code for the Web directly from a URL, following the schema: `https://vscode.dev/github/<organization>/<repo>`. Using the [VS Code repository](https://github.com/microsoft/vscode) as an example, this would look like: `https://vscode.dev/github/microsoft/vscode`.
+You can open a GitHub repository in VS Code for the Web directly from a URL, following the schema: `https://vscode.dev/github/<organization>/<repo>`. Using the [VS Code repository](https://github.com/microsoft/vscode) as an example, this would look like: `https://vscode.dev/github/microsoft/vscode`.
 
 This experience is delivered at a custom `vscode.dev/github` URL, which is powered by the [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub) extension (which is part of the broader [Remote Repositories](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-repositories) extension).
 
-GitHub Repositories allows you to remotely browse and edit a repository from within the editor, without needing to pull code onto your local machine. You can learn more about the extension and how it works in our [GitHub Repositories](/docs/sourcecontrol/github.md#github-repositories-extension) guide.
+GitHub Repositories allows you to remotely browse and edit a repository from within the editor, without needing to pull code onto your local machine. You can learn more about the extension and how it works in our [GitHub Repositories](/docs/sourcecontrol/github.md#github-repositories-extension) guide.
 
->**Note**: The [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub) extension works in VS Code Desktop as well to provide fast repository browsing and editing. Once you have the extension installed, you can open a repo with the **GitHub Repositories: Open Repository...** command.
+>**Note**: The [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub) extension works in VS Code Desktop as well to provide fast repository browsing and editing. Once you have the extension installed, you can open a repo with the **GitHub Repositories: Open Repository...** command.
 
 You can also open GitHub repositories in `vscode.dev` through your browser's search bar (aka omnibox) by installing the `vscode.dev` [extension](https://chrome.google.com/webstore/detail/vs-code/kobakmhnkfaghloikphojodjebdelppk) for Chrome and Edge. Then, type `code` to activate the omnibox, followed by your repository's name. Suggestions are populated by your browser search history, so if the repo you want doesn't come up, you can also type in the fully qualified `<owner>/<repo>` name to open it, for example `microsoft/vscode`.
 
@@ -59,7 +59,7 @@ Alternatively, when you are on an Azure DevOps repository or pull request, you c
 
 ## More custom URLs
 
-Like in the desktop, you can customize VS Code for the Web through a rich ecosystem of extensions that support just about every back end, language, and service. `vscode.dev` includes URLs that provide shortcuts to common experiences.
+Like in the desktop, you can customize VS Code for the Web through a rich ecosystem of extensions that support just about every back end, language, and service. `vscode.dev` includes URLs that provide shortcuts to common experiences.
 
 We've explored a couple of URLs already (`vscode.dev/github` and `vscode.dev/azurerepos`). Here's a more complete list:
 | Service | URL Structure | Docs |
@@ -109,7 +109,7 @@ The GitHub Repositories extension makes it easy for you to clone the repository 
 
 When working on a local file in the web, your work is saved automatically if you have [Auto Save](/docs/editor/codebasics.md#save-auto-save) enabled. You can also save manually as you do when working in desktop VS Code (for example **File** > **Save**).
 
-When working on a remote repository, your work is saved in the browser's local storage until you commit it. If you open a repo or pull request using GitHub Repositories, you can push your changes in the Source Control view to persist any new work.
+When working on a remote repository, your work is saved in the browser's local storage until you commit it. If you open a repo or pull request using GitHub Repositories, you can push your changes in the Source Control view to persist any new work.
 
 You can also continue working in other environments via [Continue Working On](#continue-working-in-a-different-environment).
 
@@ -125,7 +125,7 @@ You may learn more about Remote - Tunnels in its [documentation](/docs/remote/tu
 
 ## Safe exploration
 
-VS Code for the Web runs entirely in your web browser's sandbox and offers a very limited execution environment.
+VS Code for the Web runs entirely in your web browser's sandbox and offers a very limited execution environment.
 
 When accessing code from remote repositories, the web editor doesn't "clone" the repo, but instead loads the code by invoking the services' APIs directly from your browser; this further reduces the attack surface when cloning untrusted repositories.
 

--- a/docs/getstarted/telemetry.md
+++ b/docs/getstarted/telemetry.md
@@ -83,7 +83,7 @@ The `purpose` field describes why the data is collected.
 
 * `PerformanceAndHealth` - To ensure that VS Code product and services are healthy and fast.
 * `FeatureInsight` - To understand feature usage and where to continue development investment.
-* `BusinessInsight` - To make decisions related to the business of VS Code, Microsoft and GitHub.
+* `BusinessInsight` - To make decisions related to the business of VS Code, Microsoft, and GitHub.
 
 ### Event endpoint
 

--- a/docs/getstarted/themes.md
+++ b/docs/getstarted/themes.md
@@ -223,7 +223,7 @@ You can create your own File Icon Theme from icons (preferably SVG), see the [Fi
 
 ## VS Code for the Web
 
-VS Code for the Web provides a free, zero-install VS Code experience running entirely in your browser at [https://vscode.dev](https://vscode.dev).
+VS Code for the Web provides a free, zero-install VS Code experience running entirely in your browser at [https://vscode.dev](https://vscode.dev).
 
 You can share and experience color themes through VS Code for the Web through the URL schema: `https://vscode.dev/theme/<extensionId>`.
 

--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -72,7 +72,7 @@ In the following example, the JSON file specifies that its contents follow the [
 }
 ```
 
-Note that this syntax is VS Code-specific and not part of the [JSON Schema specification](https://json-schema.org/latest/json-schema-core.html#rfc.section.7). Adding the `$schema` key changes the JSON itself, which systems consuming the JSON might not expect, for example, schema validation might fail. If this is the case, you can use one of the other mapping methods.
+Note that this syntax is VS Code-specific and not part of the [JSON Schema specification](https://json-schema.org/specification). Adding the `$schema` key changes the JSON itself, which systems consuming the JSON might not expect, for example, schema validation might fail. If this is the case, you can use one of the other mapping methods.
 
 ### Mapping in the User Settings
 
@@ -192,7 +192,7 @@ Note that `defaultSnippets` is not part of the JSON schema specification but a V
 
 ### Use rich formatting in hovers
 
-VS Code will use the standard `description` field from the [JSON Schema specification](https://json-schema.org/latest/json-schema-core.html#rfc.section.7) in order to provide information about properties on hover and during autocomplete.
+VS Code will use the standard `description` field from the [JSON Schema specification](https://json-schema.org/specification) in order to provide information about properties on hover and during autocomplete.
 
 If you want your descriptions to support formatting like links, you can opt in by using [Markdown](/docs/languages/markdown.md) in your formatting with the `markdownDescription` property.
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -627,26 +627,26 @@ In the following (`legacy` protocol-only) example all but a 'math' module is ski
 
 ## Debugging WebAssembly
 
-The JavaScript debugger can debug code compiled into WebAssembly if it includes DWARF debug information. Many toolchains support emitting this information:
+The JavaScript debugger can debug code compiled into WebAssembly if it includes [DWARF](https://dwarfstd.org) debug information. Many toolchains support emitting this information:
 
-- [C/++ with Emscripten](https://emscripten.org/): compile with the the `-g` flag to emit debug information;
-- [Zig](https://ziglang.org/): DWARF information is automatically emittted in the "Debug" build mode;
-- [Rust](https://www.rust-lang.org/): not supported at the time of writing, support is tracked in [this issue](https://github.com/rustwasm/wasm-bindgen/issues/2389)
+* [C/C++ with Emscripten](https://emscripten.org/): Compile with the the `-g` flag to emit debug information.
+* [Zig](https://ziglang.org/): DWARF information is automatically emittted in the "Debug" build mode.
+* [Rust](https://www.rust-lang.org/): Not supported at the time of writing, support is tracked in [this issue](https://github.com/rustwasm/wasm-bindgen/issues/2389).
 
-After you have your code built, you'll want to install the [DWARF debugging extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.wasm-dwarf-debugging). This is shipped as a separate extension in order to keep the VS Code core 'streamlined.' Once installed, restart any active debugging sessions, and native code should then be mapped in the debugger! You should see your source code appear in the **Loaded Sources** view, and breakpoints should work.
+After you have your code built, you'll want to install the [WebAssembly DWARF Debugging](https://marketplace.visualstudio.com/items?itemName=ms-vscode.wasm-dwarf-debugging) extension. This is shipped as a separate extension in order to keep the VS Code core 'streamlined.' Once installed, restart any active debugging sessions, and native code should then be mapped in the debugger! You should see your source code appear in the **Loaded Sources** view, and breakpoints should work.
 
-In this case, I've stopped on a breakpoint in some C++ code that creates a Mandelbrot fractal. The call stack is visible, with frames from the JavaScript code, to WebAssembly, to my mapped C++ code. You can also see the variables in my C++ code, and I've chosen to edit the memory associated with the int32 `height` variable.
+In the image below, the debugger is stopped on a breakpoint in C++ source code that creates a Mandelbrot fractal. The call stack is visible, with frames from the JavaScript code, to WebAssembly, to the mapped C++ code. You can also see the variables in the C++ code, and an edit to the memory associated with the int32 `height` variable.
 
-![](./images/nodejs-debugging/wasm-dwarf.png)
+![Debugger stopped on a breakpoint in C++ source code](images/nodejs-debugging/wasm-dwarf.png)
 
-We persue parity, but debugging WebAssembly is a little different than ordinary JavaScript:
+While close to parity, debugging WebAssembly is a little different than ordinary JavaScript:
 
-- Variables in the **Variables** view cannot be edited directly. However, you can click the **View Binary Data** action beside the variable to edit their associated memory.
-- Basic expression evaluation in the **Debug Console** and **Watch** view is provided by [lldb-eval](https://github.com/google/lldb-eval). This is different than ordinary JavaScript expressions.
-- Locations not mapped to source code will be shown in disassembled WebAssembly Text Format. For WebAssembly, the command **Disable Source Map Stepping** will cause the debugger to step only in disassembled code.
-- Breakpoints in WebAssembly code are resolved asynchronously, so breakpoints hit early on in the program's lifecycle may be missed. We're optimistic that this can be fixed in the future. If you're debugging in a browser, you can refresh the page for your breakpoint to be hit. If you're in Node.js, you can add an artificial delay, or set another breakpoint, after your WebAssembly module is loaded but before your desired breakpoint is hit.
+* Variables in the **Variables** view cannot be edited directly. However, you can select the **View Binary Data** action beside the variable to edit their associated memory.
+* Basic expression evaluation in the **Debug Console** and **Watch** views is provided by [lldb-eval](https://github.com/google/lldb-eval). This is different than ordinary JavaScript expressions.
+* Locations not mapped to source code will be shown in disassembled WebAssembly Text Format. For WebAssembly, the command **Disable Source Map Stepping** will cause the debugger to step only in disassembled code.
+* Breakpoints in WebAssembly code are resolved asynchronously, so breakpoints hit early on in a program's lifecycle may be missed. There are plans to fix this in the future. If you're debugging in a browser, you can refresh the page for your breakpoint to be hit. If you're in Node.js, you can add an artificial delay, or set another breakpoint, after your WebAssembly module is loaded but before your desired breakpoint is hit.
 
-VS Code's WebAssembly debugging is built upon the [C/++ Debugging Extension](https://github.com/ChromeDevTools/devtools-frontend/tree/main/extensions/cxx_debugging) from the Chromium authors.
+VS Code's WebAssembly debugging is built upon the [C/C++ Debugging Extension](https://github.com/ChromeDevTools/devtools-frontend/tree/main/extensions/cxx_debugging) from the Chromium authors.
 
 ## Supported Node-like runtimes
 

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -114,7 +114,7 @@ This section details all the available rules that can be customized using the `p
 | reportUntypedClassDecorator | Diagnostics for class decorators that have no type annotations. These obscure the class type, defeating many type analysis features. |
 | reportUntypedBaseClass | Diagnostics for base classes whose type cannot be determined statically. These obscure the class type, defeating many type analysis features.  |
 | reportUntypedNamedTuple | Diagnostics when “namedtuple” is used rather than “NamedTuple”. The former contains no type information, whereas the latter does. |
-| reportPrivateUsage | Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore `_` and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module. |
+| reportPrivateUsage | Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore `_` and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module. |
 | reportConstantRedefinition | Diagnostics for attempts to redefine variables whose names are all-caps with underscores and numerals. |
 | reportIncompatibleMethodOverride | Diagnostics for methods that override a method of the same name in a base class in an incompatible manner (wrong number of parameters, incompatible parameter types, or incompatible return type). |
 | reportIncompatibleVariableOverride | Diagnostics for class variable declarations that override a symbol of the same name in a base class with a type that is incompatible with the base class symbol type.  |
@@ -136,7 +136,7 @@ This section details all the available rules that can be customized using the `p
 | reportUnboundVariable | Diagnostics for unbound and possibly unbound variables.  |
 | reportInvalidStubStatement | Diagnostics for statements that should not appear within a stub file. |
 | reportUnusedCallResult | Diagnostics for call expressions whose results are not consumed and are not None. |
-| reportUnsupportedDunderAll | Diagnostics for unsupported operations performed on `__all__`. |
+| reportUnsupportedDunderAll | Diagnostics for unsupported operations performed on `__all__`. |
 | reportUnusedCoroutine | Diagnostics for call expressions that return a Coroutine and whose results are not consumed. |
 
 ## AutoComplete settings

--- a/docs/remote/tunnels.md
+++ b/docs/remote/tunnels.md
@@ -82,7 +82,7 @@ You may create and use tunnels through the `code` [CLI](/docs/editor/command-lin
 
 >**Note:** The remote machine will only be reachable through a tunnel while VS Code remains running there. Once you exit VS Code it will no longer be possible to tunnel to it until you start VS Code there again or run the `code tunnel` CLI command.
 
-## Remote - Tunnels extension
+## Remote Tunnels extension
 
 The vscode.dev instances you open through the `code` CLI or VS Code UI come with the Remote - Tunnels extension preinstalled.
 

--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -282,7 +282,7 @@ Additionally, 32-bit OEM support has been dropped with Windows 10, version 2004.
 
 ## Can I run VS Code on old macOS versions?
 
-VS Code desktop version starting with 1.83 (September 2023) is deprecating macOS Mojave (version 10.14 and older). Starting with VS Code 1.86 (January 2024) we will stop updating VS Code on macOS Mojave (version 10.14 and older). You will need to upgrade to a newer macOS version to use later versions of VS Code.
+VS Code desktop version starting with 1.83 (September 2023) is deprecating support for macOS Mojave (version 10.14 and older). Starting with VS Code 1.86 (January 2024), we will stop updating VS Code on macOS Mojave (version 10.14 and older). You will need to upgrade to a newer macOS version to use later versions of VS Code.
 
 VS Code will no longer provide product updates or security fixes on macOS Mojave (versions 10.14 and older) and VS Code version 1.85 will be the last available release for macOS Mojave (10.14 and older). You can learn more about upgrading your macOS version at [support.apple.com](https://support.apple.com/en-us/HT201260).
 

--- a/release-notes/v1_62.md
+++ b/release-notes/v1_62.md
@@ -33,7 +33,7 @@ Given the focus on shipping `vscode.dev`, not everybody on the team had cycles f
 
 [![open vscode.dev](images/1_62/vscode-dev-badge.svg)](https://vscode.dev) [![open vscode.dev](images/1_62/insiders-vscode-dev-badge.svg)](https://insiders.vscode.dev)
 
-This iteration, we released a preview of Visual Studio Code for the Web. Visual Studio Code for the Web provides a zero-install experience running entirely in your browser, allowing you to quickly and safely browse source code repositories and make lightweight code changes. To get started, go to [https://vscode.dev](https://vscode.dev) in your browser.
+This iteration, we released a preview of Visual Studio Code for the Web. Visual Studio Code for the Web provides a zero-install experience running entirely in your browser, allowing you to quickly and safely browse source code repositories and make lightweight code changes. To get started, go to [https://vscode.dev](https://vscode.dev) in your browser.
 
 VS Code for the Web has many of the features of VS Code desktop that you love, including search and syntax highlighting, along with extension support to work on your codebase. In addition to opening repositories, forks, and pull requests from source control providers like GitHub and Azure Repos, you can also work with code that is stored on your local machine.
 

--- a/release-notes/v1_70.md
+++ b/release-notes/v1_70.md
@@ -761,7 +761,7 @@ The [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-deve
 
 The Azure Developer CLI uses [extensible templates](https://github.com/topics/azd-templates) that include everything you need to get an application up and running in Azure. The templates include best practices, application code and reusable infrastructure as code assets.  More than that, they cover end-to-end scenarios that go far past "Hello World!".
 
-With the Azure Developer CLI, you can initialize, provision, and deploy an application, or better yet, use `'azd up'` to do so in one step! For a list of supported `azd` commands, see the [Developer CLI reference](https://learn.microsoft.com/azure/developer/azure-developer-cli/reference).
+With the Azure Developer CLI, you can initialize, provision, and deploy an application, or better yet, use `'azd up'` to do so in one step! For a list of supported `azd` commands, see the [Developer CLI reference](https://learn.microsoft.com/azure/developer/azure-developer-cli/reference).
 
 ## Thank you
 

--- a/remote/advancedcontainers/develop-remote-host.md
+++ b/remote/advancedcontainers/develop-remote-host.md
@@ -23,13 +23,13 @@ If you are using a Linux or macOS SSH host, you can use the [Remote - SSH](/docs
 
 The rest of the Dev Containers quick start applies as-is. You can learn more about the [Remote - SSH extension in its documentation](/docs/remote/ssh.md).
 
-### Connect using the Remote - Tunnels extension
+## Connect using the Remote - Tunnels extension
 
 If you are using a Linux machine as a tunnel host, you can use the [Remote - Tunnels](/docs/remote/tunnels.md) and Dev Containers extensions together. You do not even need to have a Docker client installed locally. This is similar to the SSH host scenario above, but uses Remote - Tunnels instead. To do so:
 
 1. Follow the [Getting Started](/docs/remote/tunnels.md#getting-started) instructions for the Remote - Tunnels extension.
 1. [Install Docker](/docs/devcontainers/containers#installation) on your tunnel host. You do not need to install Docker locally.
-1. Follow the [steps](/docs/remote/tunnels.md#remote---tunnels-extension) for the Remote - Tunnels extension to connect to a tunnel host and open a folder there.
+1. Follow the [steps](/docs/remote/tunnels.md#remote-tunnels-extension) for the Remote - Tunnels extension to connect to a tunnel host and open a folder there.
 1. Use the **Dev Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
 
 The rest of the Dev Containers quick start applies as-is. You can learn more about the [Remote - Tunnels extension in its documentation](/docs/remote/tunnels.md).


### PR DESCRIPTION
Besides general edits and formatting, also:
Fixes link to "Remote Tunnels extension" section by removing the ` - ` from the H2 and updating links.
Update JSON Schema links (noticed when reviewing https://github.com/microsoft/vscode-docs/pull/6717
Remove non-standard whitespace characters
