### PR TITLE
Update 1.83 settings

### DIFF
--- a/docs/getstarted/settings.md
+++ b/docs/getstarted/settings.md
@@ -370,6 +370,18 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - advanced: Uses the advanced diffing algorithm.
     "diffEditor.diffAlgorithm": "advanced",
 
+    // Controls how many lines are used as context when comparing unchanged regions.
+    "diffEditor.hideUnchangedRegions.contextLineCount": 3,
+
+    // Controls whether the diff editor shows unchanged regions.
+    "diffEditor.hideUnchangedRegions.enabled": false,
+
+    // Controls how many lines are used as a minimum for unchanged regions.
+    "diffEditor.hideUnchangedRegions.minimumLineCount": 3,
+
+    // Controls how many lines are used for unchanged regions.
+    "diffEditor.hideUnchangedRegions.revealLineCount": 20,
+
     // When enabled, the diff editor ignores changes in leading or trailing whitespace.
     "diffEditor.ignoreTrimWhitespace": true,
 
@@ -418,6 +430,13 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - never
     "editor.autoClosingBrackets": "languageDefined",
 
+    // Controls whether the editor should automatically close comments after the user adds an opening comment.
+    //  - always
+    //  - languageDefined: Use language configurations to determine when to autoclose comments.
+    //  - beforeWhitespace: Autoclose comments only when the cursor is to the left of whitespace.
+    //  - never
+    "editor.autoClosingComments": "languageDefined",
+
     // Controls whether the editor should remove adjacent closing quotes or brackets when deleting.
     //  - always
     //  - auto: Remove adjacent closing quotes or brackets only if they were automatically inserted.
@@ -458,7 +477,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls whether each bracket type has its own independent color pool.
     "editor.bracketPairColorization.independentColorPoolPerBracketType": false,
 
-    // Code Action kinds to be run on save.
+    // Run Code Actions for the editor on save.
     "editor.codeActionsOnSave": {},
 
     // Enable/disable showing group headers in the Code Action menu.
@@ -706,6 +725,9 @@ Below are the Visual Studio Code default settings and their values. You can also
 
     // Controls whether the hover is shown.
     "editor.hover.enabled": true,
+
+    // Controls the delay in milliseconds after which the hover is hidden.
+    "editor.hover.hidingDelay": 300,
 
     // Controls whether the hover should remain visible when mouse is moved over it.
     "editor.hover.sticky": true,
@@ -988,7 +1010,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Defines the maximum number of sticky lines to show.
     "editor.stickyScroll.maxLineCount": 5,
 
-    // When enabled it is possible to scroll the sticky scroll widget with the editor horizontal scrollbar.
+    // Enable scrolling of Sticky Scroll with the editor's horizontal scrollbar.
     "editor.stickyScroll.scrollWithEditor": true,
 
     // Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops.
@@ -1347,6 +1369,15 @@ Below are the Visual Studio Code default settings and their values. You can also
 
 // Workbench
 
+    // Whether to dim unfocused editors and terminals, which makes it more clear where typed input will go to. This works with the majority of editors with the notable exceptions of those that utilize iframes like notebooks and extension webview editors.
+    "accessibility.dimUnfocused.enabled": false,
+
+    // The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will only take effect when `accessibility.dimUnfocused.enabled` is enabled.
+    "accessibility.dimUnfocused.opacity": 0.75,
+
+    // Controls the height of editor tabs. Also applies to the title control bar when `workbench.editor.showTabs` is disabled.
+    "window.density.editorTabHeight": "default",
+
     // Controls the behavior of clicking an activity bar icon in the workbench.
     //  - toggle: Hide the side bar if the clicked item is already visible.
     //  - focus: Focus side bar if the clicked item is already visible.
@@ -1418,6 +1449,9 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls whether to maximize/restore the editor group when double clicking on a tab. This value is ignored when `workbench.editor.showTabs` is disabled.
     "workbench.editor.doubleClickTabToToggleEditorGroupSizes": true,
 
+    // Controls if the empty editor text hint should be visible in the editor.
+    "workbench.editor.empty.hint": "text",
+
     // Controls whether opened editors show as preview editors. Preview editors do not stay open, are reused until explicitly set to be kept open (via double-click or editing), and show file names in italics.
     "workbench.editor.enablePreview": true,
 
@@ -1485,6 +1519,9 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - shrink: A pinned tab shrinks to a compact fixed size showing parts of the editor name.
     "workbench.editor.pinnedTabSizing": "normal",
 
+    // When enabled, displays pinned tabs in a separate row above all other tabs.
+    "workbench.editor.pinnedTabsOnSeparateRow": false,
+
     // When enabled, a language detection model that takes into account editor history will be given higher precedence.
     "workbench.editor.preferHistoryBasedLanguageDetection": true,
 
@@ -1546,9 +1583,6 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - default: The default size.
     //  - large: Increases the size, so it can be grabbed more easily with the mouse.
     "workbench.editor.titleScrollbarSizing": "default",
-
-    // Controls if the untitled text hint should be visible in the editor.
-    "workbench.editor.untitled.hint": "text",
 
     // Controls the format of the label for an untitled editor.
     //  - content: The name of the untitled file is derived from the contents of its first line unless it has an associated file path. It will fallback to the name in case the line is empty or contains no word characters.
@@ -1625,7 +1659,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls whether lists and trees have smooth scrolling.
     "workbench.list.smoothScrolling": false,
 
-    // Controls how type navigation works in lists and trees in the workbench. When set to 'trigger', type navigation begins once the 'list.triggerTypeNavigation' command is run.
+    // Controls how type navigation works in lists and trees in the workbench. When set to `trigger`, type navigation begins once the `list.triggerTypeNavigation` command is run.
     "workbench.list.typeNavigationMode": "automatic",
 
     // Controls whether local file history is enabled. When enabled, the file contents of an editor that is saved will be stored to a backup location to be able to restore or review the contents later. Changing this setting has no effect on existing local file history entries.
@@ -1743,12 +1777,6 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls the visibility of view header actions. View header actions may either be always visible, or only visible when that view is focused or hovered over.
     "workbench.view.alwaysShowHeaderActions": false,
 
-    // Whether to dim unfocused editors and terminals, making the focused view more obvious.
-    "workbench.view.dimUnfocused.enabled": false,
-
-    // The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will only take effect when `workbench.view.dimUnfocused.enabled` is enabled.
-    "workbench.view.dimUnfocused.opacity": 0.75,
-
     // When enabled, an extension's walkthrough will open upon install of the extension.
     "workbench.welcomePage.walkthroughs.openOnInstall": true,
 
@@ -1840,10 +1868,10 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - none: Never reopen a window. Unless a folder or workspace is opened (e.g. from the command line), an empty window will appear.
     "window.restoreWindows": "all",
 
-    // Controls the window title based on the active editor.
+    // Controls the window title based on the current context such as the opened workspace or active editor.
     "window.title": "${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}",
 
-    // Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.
+    // Adjust the appearance of the window title bar to be native by the OS or custom.
     "window.titleBarStyle": "custom",
 
     // Separator used by `window.title`.
@@ -1898,7 +1926,7 @@ Below are the Visual Studio Code default settings and their values. You can also
         "**/Thumbs.db": true
     },
 
-    // Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.
+    // Hot Exit controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.
     //  - off: Disable hot exit. A prompt will show when attempting to close a window with editors that have unsaved changes.
     //  - onExit: Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`
     //  - onExitAndWindowClose: Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu), and also for any window with a folder opened regardless of whether it's the last window. All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`
@@ -1913,7 +1941,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Configure paths or glob patterns to exclude from being marked as read-only if they match as a result of the `files.readonlyInclude` setting.
     "files.readonlyExclude": {},
 
-    // Marks files as readonly when their file permissions indicate as such. This can be overridden via `files.readonlyInclude` and `files.readonlyExclude` settings.
+    // Marks files as read-only when their file permissions indicate as such. This can be overridden via `files.readonlyInclude` and `files.readonlyExclude` settings.
     "files.readonlyFromPermissions": false,
 
     // Configure paths or glob patterns to mark as read-only.
@@ -1958,6 +1986,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Options for customizing the keyboard overlay in screencast mode.
     "screencastMode.keyboardOptions": {
         "showKeys": true,
+        "showKeybindings": true,
         "showCommands": true,
         "showCommandGroups": false,
         "showSingleEditorCursorMoves": true
@@ -2267,6 +2296,27 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service.
     "update.showReleaseNotes": true,
 
+// Comments
+
+    // Controls whether the comment thread should collapse when the thread is resolved.
+    "comments.collapseOnResolve": true,
+
+    // Controls whether the comments widget scrolls or expands.
+    "comments.maxHeight": true,
+
+    // Controls when the comments view should open.
+    //  - never: The comments view will never be opened.
+    //  - file: The comments view will open when a file with comments is active.
+    //  - firstFile: If the comments view has not been opened yet during this session it will open the first time during a session that a file with comments is active.
+    //  - firstFileUnresolved: If the comments view has not been opened yet during this session and the comment is not resolved, it will open the first time during a session that a file with comments is active.
+    "comments.openView": "firstFile",
+
+    // Determines if relative time will be used in comment timestamps (ex. '1 day ago').
+    "comments.useRelativeTime": true,
+
+    // Controls the visibility of the comments bar and comment threads in editors that have commenting ranges and comments. Comments are still accessible via the Comments view and will cause commenting to be toggled on in the same way running the command "Comments: Toggle Editor Commenting" toggles comments.
+    "comments.visible": true,
+
 // Debug
 
     // Allow setting breakpoints in any file.
@@ -2362,7 +2412,10 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Before starting a new debug session in an integrated or external terminal, clear the terminal.
     "debug.terminal.clearBeforeReusing": false,
 
-    // Controls the location of the debug toolbar. Either `floating` in all views, `docked` in the debug view, or `hidden`.
+    // Controls the location of the debug toolbar.
+    //  - floating: Show debug toolbar in all views.
+    //  - docked: Show debug toolbar only in debug views.
+    //  - hidden: Do not show debug toolbar.
     "debug.toolBarLocation": "floating",
 
     // Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces.
@@ -2430,7 +2483,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - preserve-aligned: Preserve wrapping of attributes but align.
     "html.format.wrapAttributes": "auto",
 
-    // Indent wrapped attributes to after N characters. Use `null` to use the default indent size. Ignored if `html.format.wrapAttributes` is set to 'aligned'.
+    // Indent wrapped attributes to after N characters. Use `null` to use the default indent size. Ignored if `html.format.wrapAttributes` is set to `aligned`.
     "html.format.wrapAttributesIndentSize": null,
 
     // Maximum amount of characters per line (0 = disable).
@@ -2470,9 +2523,6 @@ Below are the Visual Studio Code default settings and their values. You can also
 
     // Associate schemas to JSON files in the current project.
     "json.schemas": [],
-
-    // Enable/disable default sorting on save
-    "json.sortOnSave.enable": false,
 
     // Traces the communication between VS Code and the JSON language server.
     "json.trace.server": "off",
@@ -3025,6 +3075,9 @@ Below are the Visual Studio Code default settings and their values. You can also
     // The maximum amount of memory (in MB) to allocate to the TypeScript server process.
     "typescript.tsserver.maxTsServerMemory": 3072,
 
+    // Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.
+    "typescript.tsserver.nodePath": "",
+
     // Additional paths to discover TypeScript Language Service plugins.
     "typescript.tsserver.pluginPaths": [],
 
@@ -3051,6 +3104,9 @@ Below are the Visual Studio Code default settings and their values. You can also
 
     // Enable/disable TypeScript validation.
     "typescript.validate.enable": true,
+
+    // Exclude symbols that come from library files in Go to Symbol in Workspace results.
+    "typescript.workspaceSymbols.excludeLibrarySymbols": true,
 
     // Controls which files are searched by Go to Symbol in Workspace.
     //  - allOpenProjects: Search all open JavaScript or TypeScript projects for symbols.
@@ -3094,9 +3150,10 @@ Below are the Visual Studio Code default settings and their values. You can also
     "testing.gutterEnabled": true,
 
     // Controls when the testing view should open.
-    //  - neverOpen: Never automatically open the testing view
-    //  - openOnTestStart: Open the testing view when tests start
-    //  - openOnTestFailure: Open the testing view on any test failure
+    //  - neverOpen: Never automatically open the testing views
+    //  - openOnTestStart: Open the test results view when tests start
+    //  - openOnTestFailure: Open the test result view on any test failure
+    //  - openExplorerOnTestStart: Open the test explorer when tests start
     "testing.openTesting": "openOnTestStart",
 
     // Control whether save all dirty editors before running a test.
@@ -3468,6 +3525,9 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Whether the cell toolbar should appear on hover or click.
     "notebook.cellToolbarVisibility": "click",
 
+    // Run a series of Code Actions for a notebook on save.
+    "notebook.codeActionsOnSave": {},
+
     // Control whether the notebook editor should be rendered in a compact form. For example, when turned on, it will decrease the left margin width.
     "notebook.compactView": true,
 
@@ -3521,6 +3581,9 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Control whether the actions on the notebook toolbar should render label or not.
     "notebook.globalToolbarShowLabel": "always",
 
+    // When enabled the Go to Symbol Quick Pick will display full code symbols from the notebook, as well as Markdown headers.
+    "notebook.gotoSymbols.showAllSymbols": false,
+
     // Control where the insert cell actions should appear.
     //  - betweenCells: A toolbar that appears on hover between cells.
     //  - notebookToolbar: The toolbar at the top of the notebook editor.
@@ -3553,13 +3616,19 @@ Below are the Visual Studio Code default settings and their values. You can also
     "notebook.output.lineHeight": 0,
 
     // Initially render notebook outputs in a scrollable region when longer than the limit.
-    "notebook.output.scrolling": true,
+    "notebook.output.scrolling": false,
 
     // Controls how many lines of text are displayed in a text output.
     "notebook.output.textLineLimit": 30,
 
     // Controls whether the lines in output should wrap.
     "notebook.output.wordWrap": false,
+
+    // How far to scroll when revealing the next cell upon running notebook.cell.executeAndSelectBelow.
+    //  - fullCell: Scroll to fully reveal the next cell.
+    //  - firstLine: Scroll to reveal the first line of the next cell.
+    //  - none: Do not scroll.
+    "notebook.scrolling.revealNextCellOnExecute": "fullCell",
 
     // Whether the cell status bar should be shown.
     //  - hidden: The cell Status bar is always hidden.
@@ -3596,7 +3665,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     "terminal.external.osxExec": "Terminal.app",
 
     // Customizes which terminal to run on Windows.
-    "terminal.external.windowsExec": "C:\\Windows\\System32\\cmd.exe",
+    "terminal.external.windowsExec": "C:\\WINDOWS\\System32\\cmd.exe",
 
     // When opening a repository from the Source Control Repositories view in a terminal, determines what kind of terminal will be launched
     //  - integrated: Use VS Code's integrated terminal.
@@ -3697,7 +3766,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - notRemote: Enable only when not in a remote workspace.
     "terminal.integrated.enableFileLinks": "on",
 
-    // Enables image support in the terminal. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences.
+    // Enables image support in the terminal.
     "terminal.integrated.enableImages": false,
 
     // Show a warning dialog when pasting multiple lines into the terminal. The dialog does not show when:
@@ -3728,6 +3797,12 @@ Below are the Visual Studio Code default settings and their values. You can also
 
     // Scrolling speed multiplier when pressing `Alt`.
     "terminal.integrated.fastScrollSensitivity": 5,
+
+    // Controls whether the terminal, accessible buffer, or neither will be focused after `Terminal: Run Selected Text In Active Terminal` has been run.
+    //  - terminal: Always focus the terminal.
+    //  - accessible-buffer: Always focus the accessible buffer.
+    //  - none: Do nothing.
+    "terminal.integrated.focusAfterRun": "none",
 
     // Controls the font family of the terminal. Defaults to `editor.fontFamily`'s value.
     "terminal.integrated.fontFamily": "",
@@ -3907,7 +3982,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     //  - right: Show the terminal tabs view to the right of the terminal
     "terminal.integrated.tabs.location": "right",
 
-    // Separator used by `terminal.integrated.tabs.title` and `terminal.integrated.tabs.title`.
+    // Separator used by `terminal.integrated.tabs.title` and `terminal.integrated.tabs.description`.
     "terminal.integrated.tabs.separator": " - ",
 
     // Controls whether terminal split and kill buttons are displays next to the new terminal button.
@@ -4532,22 +4607,25 @@ Below are the Visual Studio Code default settings and their values. You can also
 
 // Accessibility
 
+    // Provide information about actions that can be taken in the comment widget or in a file which contains comments.
+    "accessibility.verbosity.comments": true,
+
     // Provide information about how to navigate changes in the diff editor when it is focused
     "accessibility.verbosity.diffEditor": true,
 
-    // Provide information about relevant actions in an untitled text editor.
-    "accessibility.verbosity.editor.untitledHint": true,
+    // Provide information about relevant actions in an empty text editor.
+    "accessibility.verbosity.emptyEditorHint": true,
 
     // Provide information about how to open the hover in an accessible view.
     "accessibility.verbosity.hover": true,
 
-    // Provide information about how to access the inline editor chat accessibility help menu and alert with hints that describe how to use the feature when the input is focused
+    // Provide information about how to access the inline editor chat accessibility help menu and alert with hints that describe how to use the feature when the input is focused.
     "accessibility.verbosity.inlineChat": true,
 
-    // Provide information about how to access the inline completions hover and accessible view
+    // Provide information about how to access the inline completions hover and accessible view.
     "accessibility.verbosity.inlineCompletions": true,
 
-    // Provide information about how to change a keybinding in the keybindings editor when a row is focused
+    // Provide information about how to change a keybinding in the keybindings editor when a row is focused.
     "accessibility.verbosity.keybindingsEditor": true,
 
     // Provide information about how to focus the cell container or inner editor when a notebook cell is focused.
@@ -4556,10 +4634,10 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Provide information about how to open the notification in an accessible view.
     "accessibility.verbosity.notification": true,
 
-    // Provide information about how to access the chat help menu when the chat input is focused
+    // Provide information about how to access the chat help menu when the chat input is focused.
     "accessibility.verbosity.panelChat": true,
 
-    // Provide information about how to access the terminal accessibility help menu when the terminal is focused
+    // Provide information about how to access the terminal accessibility help menu when the terminal is focused.
     "accessibility.verbosity.terminal": true,
 
 // Merge Editor
@@ -4776,7 +4854,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls the commit message length threshold for showing a warning.
     "git.inputValidationLength": 72,
 
-    // Controls the commit message subject length threshold for showing a warning. Unset it to inherit the value of `config.inputValidationLength`.
+    // Controls the commit message subject length threshold for showing a warning. Unset it to inherit the value of `git.inputValidationLength`.
     "git.inputValidationSubjectLength": 50,
 
     // Open the merge editor for files that are currently under conflict.
@@ -4870,7 +4948,7 @@ Below are the Visual Studio Code default settings and their values. You can also
     // Controls whether to show a notification when a push is successful.
     "git.showPushSuccessNotification": false,
 
-    // Controls the threshold of the similarity index (amount of additions/deletions compared to the file's size) for changes in a pair of added/deleted files to be considered a rename.
+    // Controls the threshold of the similarity index (the amount of additions/deletions compared to the file's size) for changes in a pair of added/deleted files to be considered a rename.
     "git.similarityThreshold": 50,
 
     // Control which changes are automatically staged by Smart Commit.


### PR DESCRIPTION
This would normally be done during end game week in vscode-docs vnext but catching up from vacation.
Adding new 1.83 settings
Shortening some descriptions to keep /docs/getstarted/settings.md from getting too long and unreadable.
Typos and a little formatting (ending periods to description sentences)