### PR TITLE
docs: fix typo in docs/editor/workspace-trust.md

### DIFF
--- a/docs/editor/workspace-trust.md
+++ b/docs/editor/workspace-trust.md
@@ -43,7 +43,7 @@ To see the full list of features disabled in Restricted Mode, you can open the W
 
 ### Tasks
 
-[Tasks](/docs/editor/tasks.md) can run scripts and tool binaries, and because task definitions are defined in the workspace `.vscode` folder, they are part of the committed source code for a repo, and shared to every user of that repo. Were someone to create a malicious task, it could be unknowningly run by anyone who cloned that repository.
+[Tasks](/docs/editor/tasks.md) can run scripts and tool binaries, and because task definitions are defined in the workspace `.vscode` folder, they are part of the committed source code for a repo, and shared to every user of that repo. Were someone to create a malicious task, it could be unknowingly run by anyone who cloned that repository.
 
 If you try to run or even enumerate tasks (**Terminal** > **Run Task...**) while in Restricted Mode, VS Code will display a prompt to trust the folder and continue executing the task. Cancelling the dialog leaves VS Code in Restricted Mode.
 


### PR DESCRIPTION
This pull request corrects the typo "unknowningly" to "unknowingly" in the Markdown file. I kindly request the repository maintainers to review and merge it.