### PR TITLE
docs: fix typo in docs/terminal/basics.md

### DIFF
--- a/docs/terminal/basics.md
+++ b/docs/terminal/basics.md
@@ -72,7 +72,7 @@ You can open terminals in the editor area (terminal editors) with the **Terminal
 
 You can have terminal editors on either side or arranged in multiple dimensions using the editor group layout system, e.g. PowerShell and WSL terminals stacked to the right of file editors:
 
-![Terminal editors are can be layed out using the editor group layout system, for example 2 terminals could sit to the right of a text editor](images/basics/terminal-editor-grid.png)
+![Terminal editors are can be laid out using the editor group layout system, for example 2 terminals could sit to the right of a text editor](images/basics/terminal-editor-grid.png)
 
 The `terminal.integrated.defaultLocation` setting can change the default `view` or `editor` area terminal location.
 
@@ -306,7 +306,7 @@ There are also extensions available that give more options such as [Terminal Her
 
 ## Fixed dimension terminals
 
-The **Terminal: Set Fixed Dimensions** command allows changing the number of columns and rows that the terminal and it's backing psuedoterminal uses. This will add scroll bars when necessary, which may lead to an unpleasant UX and is generally not recommended, but it is a common ask on Windows in particular for reading logs or long lines when paging tools aren't available.
+The **Terminal: Set Fixed Dimensions** command allows changing the number of columns and rows that the terminal and it's backing pseudoterminal uses. This will add scroll bars when necessary, which may lead to an unpleasant UX and is generally not recommended, but it is a common ask on Windows in particular for reading logs or long lines when paging tools aren't available.
 
 You can also right-click on a terminal tab and select **Toggle Size to Content Width** (`kb(workbench.action.terminal.sizeToContentWidth)`) to resize the number of terminal columns to the largest wrapped line in the terminal.
 


### PR DESCRIPTION
This pull request corrects the typo "layed" to "laid" in the Markdown file. I kindly request the repository maintainers to review and merge it.