### PR TITLE
docs: fix typo in docs/languages/markdown.md

### DIFF
--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -25,7 +25,7 @@ The Outline view is a great way to review your document's header structure and o
 
 ### Snippets for Markdown
 
-VS Code includes some useful snippets that can speed up writing Markdown. This includes snippets for code blocks, images, and more. Press `kb(editor.action.triggerSuggest)` (Trigger Suggest) while editing to see a list of suggested Markdown snippets. You can also use the dedicated snippet picker by selcting **Insert Snippet** in the Command Palette.
+VS Code includes some useful snippets that can speed up writing Markdown. This includes snippets for code blocks, images, and more. Press `kb(editor.action.triggerSuggest)` (Trigger Suggest) while editing to see a list of suggested Markdown snippets. You can also use the dedicated snippet picker by selecting **Insert Snippet** in the Command Palette.
 
 >**Tip:** You can add in your own User Defined Snippets for Markdown. Take a look at [User Defined Snippets](/docs/editor/userdefinedsnippets.md) to find out how.
 


### PR DESCRIPTION
This pull request corrects the typo "selcting" to "selecting" in the Markdown file. I kindly request the repository maintainers to review and merge it.