### PR TITLE
Rename "AI Tools in VS Code" to "GitHub Copilot"

### DIFF
--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -13,7 +13,7 @@ March 30, 2023 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 **AI did not write this blog post, but it will make your development experiences incredible.**
 
-> **Note**: If you like to learn about the latest GitHub Copilot experience in Visual Studio Code, go to the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic, where you'll find details on the Copilot editor integration and Copilot Chat features such as inline Chat, the dedicated Chat view, and Quick Chat.
+> **Note**: If you like to learn about the latest GitHub Copilot experience in Visual Studio Code, go to the [GitHub Copilot in VS Code](https://code.visualstudio.com/docs/editor/github-copilot) topic, where you'll find details on the Copilot editor integration and Copilot Chat features such as inline Chat, the dedicated Chat view, and Quick Chat.
 
 There is a lot of buzz, excitement, and some concerns around Artificial Intelligence today. Advancements are happening almost daily, it's hard to keep up. But once you give it a try, you quickly realize what more than a million Copilot users see daily, that this technology does not disappoint, especially with Large Language Models (LLMs) like OpenAI's GPT-3.5/4.
 
@@ -109,7 +109,7 @@ To access the chat experiences (in-editor, Chat view, Quick Chat), you'll need t
 * A "Chat" icon will appear in the Activity Bar, click on it to open the Chat view. Go ahead, ask Copilot to "write a program to calculate the airspeed velocity of an unladen swallow".
 * To try out Quick Chat, you can run **Chat: Open Quick Chat** or use the `kb(workbench.action.quickchat.toggle)` keyboard shortcut.
 
-You can learn more about the GitHub Copilot and Copilot Chat extensions in the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic.
+You can learn more about the GitHub Copilot and Copilot Chat extensions in the [GitHub Copilot in VS Code](https://code.visualstudio.com/docs/editor/github-copilot) topic.
 
 ## Responsible AI
 

--- a/build/sitemap.xml
+++ b/build/sitemap.xml
@@ -226,7 +226,7 @@
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://code.visualstudio.com/docs/editor/artificial-intelligence</loc>
+        <loc>https://code.visualstudio.com/docs/editor/github-copilot</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/docs/csharp/cs-dev-kit-faq.md
+++ b/docs/csharp/cs-dev-kit-faq.md
@@ -257,4 +257,4 @@ To resolve this issue, clear out old folders from within the `obj` folder or cle
 
 ### I am not getting whole line completions
 
-Whole line completions are disabled when the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension is enabled to allow you to take advantage of the more advanced [AI completion](/docs/editor/artificial-intelligence.md) capabilities. You can verify that Copilot is enabled by checking if the Copilot logo is present in the lower right corner of VS Code.
+Whole line completions are disabled when the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension is enabled to allow you to take advantage of the more advanced [AI completion](/docs/editor/github-copilot.md) capabilities. You can verify that Copilot is enabled by checking if the Copilot logo is present in the lower right corner of VS Code.

--- a/docs/editor/github-copilot.md
+++ b/docs/editor/github-copilot.md
@@ -1,13 +1,13 @@
 ---
 Order: 7
 Area: editor
-TOCTitle: AI Tools
+TOCTitle: GitHub Copilot
 ContentId: 0aefcb70-7884-487f-953e-46c3e07f7cbe
 PageTitle: Use GitHub Copilot to enhance your coding with AI
 DateApproved: 10/4/2023
 MetaDescription: Enhance your coding with AI-powered suggestions from GitHub Copilot in Visual Studio Code.
 ---
-# AI Tools in VS Code
+# GitHub Copilot in VS Code
 
 The [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension is an AI pair programmer tool that helps you write code faster and smarter. You can use the Copilot extension in VS Code to generate code, learn from the code it generates, and even configure your editor.
 
@@ -15,7 +15,7 @@ The [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.
 
 ## Prerequisites
 
-You'll use the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension to power your AI suggestions in VS Code.
+You'll use the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension to power your artificial intelligence (AI) suggestions in VS Code.
 
 > <a class="install-extension-btn" href="vscode:extension/GitHub.copilot">Install the GitHub Copilot extension</a>
 

--- a/docs/editor/intellisense.md
+++ b/docs/editor/intellisense.md
@@ -195,7 +195,7 @@ In VS Code, you can enhance your coding with artificial intelligence (AI), such 
 
 [![GitHub Copilot extension in the VS Code Marketplace](images/intellisense/copilot-extension.png)](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Troubleshooting
 
@@ -213,7 +213,7 @@ IntelliSense is just one of VS Code's powerful features. Read on to learn more:
 * [Node.js](/docs/nodejs/nodejs-tutorial.md) - See an example of IntelliSense in action in the Node.js walkthrough.
 * [Debugging](/docs/editor/debugging.md) - Learn how to set up debugging for your application.
 * [Creating Language extensions](/api/language-extensions/programmatic-language-features.md) - Learn how to create extensions that add IntelliSense for new programming languages.
-* [Artificial Intelligence](/docs/editor/artificial-intelligence.md) - Learn how to use AI with GitHub Copilot to enhance your coding.
+* [GitHub Copilot in VS Code](/docs/editor/github-copilot.md) - Learn how to use AI with GitHub Copilot to enhance your coding.
 
 ## Common questions
 

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -206,7 +206,7 @@ To install support for Remote Development:
 
 GitHub Copilot provides suggestions for numerous languages and a wide variety of frameworks, and it works especially well for Python, JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Feedback
 

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -76,7 +76,7 @@ IntelliSense just works: hit `kb(editor.action.triggerSuggest)` at any time to g
 
 GitHub Copilot provides suggestions for numerous languages and a wide variety of frameworks, and it works especially well for Python, JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Snippets for C&#35;
 

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -161,7 +161,7 @@ One of the key advantages of VS Code is speed. When you open your Java source fi
 
 GitHub Copilot provides suggestions for numerous languages and a wide variety of frameworks, and it works especially well for Python, JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Code snippets
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -255,7 +255,7 @@ Set `"javascript.suggestionActions.enabled"` to `false` to disable suggestions.
 
 GitHub Copilot provides suggestions for numerous languages and a wide variety of frameworks, and it works especially well for Python, JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 Once you have the Copilot extension installed and enabled, you can test it our for your JavaScript projects.
 

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -33,7 +33,7 @@ Click on any linked item to get an overview of how to use VS Code in the context
 The richness of support varies across the different languages and their extensions:
 
 * Syntax highlighting and bracket matching
-* Smart completions (IntelliSense, Artificial Intelligence with [GitHub Copilot](/docs/editor/artificial-intelligence.md))
+* Smart completions (IntelliSense, Artificial Intelligence with [GitHub Copilot](/docs/editor/github-copilot.md))
 * Linting and corrections
 * Code navigation (Go to Definition, Find All References)
 * Debugging
@@ -47,7 +47,7 @@ In VS Code, you can enhance your coding with artificial intelligence (AI), such 
 
 [![GitHub Copilot extension in the VS Code Marketplace](images/overview/copilot-extension.png)](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Change the language for the selected file
 

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -63,7 +63,7 @@ IntelliSense quickly shows methods, class members, and documentation as you type
 
 GitHub Copilot provides suggestions for languages beyond Python and a wide variety of frameworks, including JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Linting
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -70,7 +70,7 @@ You can also customize the general behavior of autocomplete and IntelliSense, ev
 
 GitHub Copilot provides suggestions for numerous languages and a wide variety of frameworks, and it works especially well for Python, JavaScript, TypeScript, Ruby, Go, C# and C++.
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).
 
 ## Navigation
 

--- a/docs/sourcecontrol/github.md
+++ b/docs/sourcecontrol/github.md
@@ -253,4 +253,4 @@ In VS Code, you can enhance your coding with artificial intelligence (AI), such 
 
 [![GitHub Copilot extension in the VS Code Marketplace](images/github/copilot-extension.png)](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
 
-You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/artificial-intelligence.md).
+You can learn more about how to get started with Copilot in the [Copilot documentation](/docs/editor/github-copilot.md).

--- a/release-notes/v1_75.md
+++ b/release-notes/v1_75.md
@@ -589,7 +589,7 @@ GitHub Copilot is now generally available for businesses, with features like lic
 
 To get started, you can sign up for a free trial on the [GitHub Copilot website](https://copilot.github.com).
 
-We've also added a new [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) topic to the VS Code documentation that will help you get started with Copilot.
+We've also added a new [GitHub Copilot in VS Code](https://code.visualstudio.com/docs/editor/github-copilot) topic to the VS Code documentation that will help you get started with Copilot.
 
 ## Remote Development
 

--- a/release-notes/v1_77.md
+++ b/release-notes/v1_77.md
@@ -239,7 +239,7 @@ You can ask Copilot to look for bugs, explain tricky code, create tests, and eve
 
 ![Copilot chat example asking how to change VS Code colors](images/1_77/slash-commands-example.png)
 
-You can learn more about the VS Code team's experience and future with Copilot in the [VS Code and GitHub Copilot](https://code.visualstudio.com/blogs/2023/03/30/vscode-copilot) blog post. You can also read the [AI Tools in VS Code](https://code.visualstudio.com/docs/editor/artificial-intelligence) article for more details about using Copilot in VS Code.
+You can learn more about the VS Code team's experience and future with Copilot in the [VS Code and GitHub Copilot](https://code.visualstudio.com/blogs/2023/03/30/vscode-copilot) blog post. You can also read the [GitHub Copilot in VS Code](https://code.visualstudio.com/docs/editor/github-copilot) article for more details about using Copilot in VS Code.
 
 ## Preview features
 


### PR DESCRIPTION
The follow up will be to add a redirect from docs/editor/artificial-intelligence to /docs/editor/github-copilot to handle any existing URL bookmarks