### PR TITLE
docs: fix webview doc typo

### DIFF
--- a/api/extension-guides/webview.md
+++ b/api/extension-guides/webview.md
@@ -434,7 +434,7 @@ In addition, the **Developer: Reload Webview** command reloads all active webvie
 
 Webviews run in isolated contexts that cannot directly access local resources. This is done for security reasons. This means that in order to load images, stylesheets, and other resources from your extension, or to load any content from the user's current workspace, you must use the `Webview.asWebviewUri` function to convert a local `file:` URI into a special URI that VS Code can use to load a subset of local resources.
 
-Imagine that we want to start bundling the cat gifs into our extension rather pulling them from Giphy. To do this, we first create a URI to the file on disk and then pass these URIs through the `asWebviewUri` function:
+Imagine that we want to start bundling the cat gifs into our extension rather than pulling them from Giphy. To do this, we first create a URI to the file on disk and then pass these URIs through the `asWebviewUri` function:
 
 ```ts
 import * as vscode from 'vscode';


### PR DESCRIPTION
Adds a missing "than" to the webview documentation.