### PR TITLE
Clarify where the `scm/sourceControl` menu appears

### DIFF
--- a/api/extension-guides/scm-provider.md
+++ b/api/extension-guides/scm-provider.md
@@ -133,7 +133,7 @@ When creating them, `SourceControl` and `SourceControlResourceGroup` instances r
 }
 ```
 
-The `scm/sourceControl` menu is located contextually near SourceControl instances:
+The `scm/sourceControl` menu is the context menu on each SourceControl instance in the Source Control Repositories view (previously named Source Control Providers):
 
 ![source control menu](images/scm-provider/sourcecontrol-menu.png)
 


### PR DESCRIPTION
The screenshot immediately after this change would benefit from an update. It shows an outdated view title; SOURCE CONTROL PROVIDERS is now SOURCE CONTROL REPOSITORIES (noted in the updated text) as well as old Activity Bar icons, no blue Commit button and capitalized CHANGES header. Nor does it even show an open `scm/sourceControl` context menu on one of the four repositories in that view.