### PR TITLE
Fix recommended dotfiles install command

### DIFF
--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -569,7 +569,7 @@ Or in `settings.json`:
 {
     "dotfiles.repository": "your-github-id/your-dotfiles-repo",
     "dotfiles.targetPath": "~/dotfiles",
-    "dotfiles.installCommand": "~/dotfiles/install.sh"
+    "dotfiles.installCommand": "install.sh"
 }
 ```
 

--- a/docs/devcontainers/images/containers/dotfiles.png
+++ b/docs/devcontainers/images/containers/dotfiles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56e835299042569d58c5bb717364119550da45528ab46e863adf67c926ddebc6
-size 116065
+oid sha256:4ad93e28884a59b66b7ce52594df0ad79a6def09e33e7751408d663ba9bb5c1b
+size 107538

--- a/docs/devcontainers/images/containers/dotfiles.png
+++ b/docs/devcontainers/images/containers/dotfiles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c7e66edf41dac8685227bfde2d58af4668d4d9253c01c1362cbb25fd8a1e515
-size 24256
+oid sha256:56e835299042569d58c5bb717364119550da45528ab46e863adf67c926ddebc6
+size 116065


### PR DESCRIPTION
I was trying to get my dotfiles to work inside a dev container by following the recommended `settings.json` configuration in the published docs, which suggest using tildes to expand the install command path:

```json
{
  "dotfiles.repository": "dslatkin/dotfiles",
  "dotfiles.targetPath": "~/tmp-dotfiles",
  "dotfiles.installCommand": "~/tmp-dotfiles/install.sh"
}
```

I noticed that I wasn't able to get my dotfiles to install and discovered the following output in my container creation logs:

```
[4536 ms] Setting current directory to ~/tmp-dotfiles
Could not locate ~/tmp-dotfiles/install.sh...
```

The following change _did_ work to install my dotfiles, however:

```diff
  {
    "dotfiles.repository": "dslatkin/dotfiles",
    "dotfiles.targetPath": "~/tmp-dotfiles",
-   "dotfiles.installCommand": "~/tmp-dotfiles/install.sh"
+   "dotfiles.installCommand": "install.sh"
  }
```

I believe the `installCommand` setting doesn't work as suggested because the [code checking for the install file](https://github.com/devcontainers/cli/blob/5a5a9b209d673a4b9e5389f6d64ac124cce3ec62/src/spec-common/dotfiles.ts#L50-L71) would be attempting to expand a tilde symbol enclosed in double quotes, which doesn't work. I think this change was introduced in a [somewhat recent merge](https://github.com/devcontainers/cli/pull/541) that makes the install process a bit more diligent about checking for the existence of the file before executing it.

cc @joshspicer @chrmarti.

Thank you!