### PR TITLE
Update dev community slack channel

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -62,7 +62,7 @@ If you have questions for extension development, try asking on:
 
 * [VS Code Discussions](https://github.com/microsoft/vscode-discussions): GitHub community to discuss VS Code's extension platform, ask questions, help other members of the community, and get answers.
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/visual-studio-code): There are [thousands of questions](https://stackoverflow.com/questions/tagged/visual-studio-code) tagged `visual-studio-code`, and over half of them already have answers. Search for your issue, ask questions, or help your fellow developers by answering VS Code extension development questions!
-* [VS Code Dev Slack](https://aka.ms/vscode-dev-community): Public chatroom for extension developers. VS Code team members often join in the conversations.
+* [VS Code Dev Slack](https://vscode-dev-community.slack.com): Public chatroom for extension developers. VS Code team members often join in the conversations.
 
 To provide feedback on the documentation, create new issues at [Microsoft/vscode-docs](https://github.com/microsoft/vscode-docs/issues).
 If you have extension questions that you cannot find an answer for, or issues with the VS Code Extension API, please open new issues at [Microsoft/vscode](https://github.com/microsoft/vscode/issues).

--- a/blogs/2022/10/04/vscode-community-discussions.md
+++ b/blogs/2022/10/04/vscode-community-discussions.md
@@ -51,7 +51,7 @@ VS Code is what it is today because of our amazing contributors, and we want to 
 
 - [VS Code Community Discussions](https://github.com/microsoft/vscode-discussions/discussions) for extension author Q&A and announcements, officially maintained by the VS Code team
 - The [Extension Authoring](https://code.visualstudio.com/updates#_extension-authoring) section of our monthly VS Code Release Notes where extension authors can learn about newly released APIs
-- [VS Code Dev Slack](https://aka.ms/vscode-dev-community) for extension author Q&A, maintained by the community
+- [VS Code Dev Slack](https://vscode-dev-community.slack.com) for extension author Q&A, maintained by the community
 - [GitHub Issues](https://github.com/Microsoft/vscode/issues) to file an issue in our VS Code repo
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/visual-studio-code) to ask and answer questions tagged with visual-studio-code
 - [Twitter](https://twitter.com/code) for announcements and updates from members of the development team


### PR DESCRIPTION
Use direct link instead of deprecated aka.ms link
Fixes #6772