### PR TITLE
Add callout that Sovereign Cloud accounts don't work

### DIFF
--- a/docs/editor/settings-sync.md
+++ b/docs/editor/settings-sync.md
@@ -138,6 +138,8 @@ No, the [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan
 
 VS Code Settings Sync supports signing in with either a Microsoft account (for example Outlook or Azure accounts) or a GitHub account. Sign in with GitHub Enterprise accounts is not supported. Other authentication providers may be supported in the future and you can review the proposed Authentication Provider API in [issue #88309](https://github.com/microsoft/vscode/issues/88309).
 
+> NOTE: VS Code Settings Sync does not support using your [Microsoft Sovereign Cloud](https://www.microsoft.com/en-us/industry/sovereignty/cloud) account at this time. If this is something you would like, please let us know what kind of Microsoft Sovereign Cloud you would like to use [in this GitHub issue](https://github.com/microsoft/vscode/issues/196509).
+
 ### Can I use a different backend or service for Settings Sync?
 
 Settings Sync uses a dedicated service to store settings and coordinate updates. A service provider API may be exposed in the future to allow for custom Settings Sync backends.


### PR DESCRIPTION
These don't work, and require a lot of work to work... so let's call it out.