### PR TITLE
Add section on moving the Chat view

### DIFF
--- a/docs/editor/github-copilot.md
+++ b/docs/editor/github-copilot.md
@@ -244,6 +244,22 @@ If Copilot Chat detects that a code block contains a command, you can run it dir
 
 ![Copilot Chat code block to list files with Run in Terminal option visible](images/artificial-intelligence/run-in-terminal.png)
 
+### Chat view locations
+
+By default, the Chat view is displayed in the [Primary side bar](/docs/getstarted/userinterface.md#basic-layout) but like other views in VS Code, you can [drag and drop](/docs/editor/custom-layout.md#drag-and-drop-views-and-panels) it anywhere. For example, you could drag and drop the Chat view into the Panel region:
+
+![Chat view in the Panel region](images/artificial-intelligence/chat-in-panel.png)
+
+You can also open the Chat view in the editor region for a larger display area. From the Chat view title bar **More Actions** (`...`) menu, select **Open Session in Editor**.
+
+![Copilot Chat view title bar More Actions with Open Session in Editor selected](images/artificial-intelligence/open-session-in-editor.png)
+
+Just like any open editor, you can move editor-hosted Chat views into separate [Editor Groups](/docs/getstarted/userinterface.md#editor-groups) and use display customizations such as [Grid layout](/docs/editor/custom-layout.md#grid-layout) to have multiple chat sessions open in the editor region.
+
+To move the Chat view back to the side bar, use the **Open Session in Side Bar** command in the editor title bar when the Chat view is the active editor.
+
+![Chat view in editor with Open Session in Side bar displayed](images/artificial-intelligence/open-session-in-sidebar.png)
+
 ## Inline chat
 
 An additional key functionality of Copilot is answering questions inline as you're coding. This allows you to harness the power of AI while staying in your existing editor workflow.

--- a/docs/editor/images/artificial-intelligence/chat-in-panel.png
+++ b/docs/editor/images/artificial-intelligence/chat-in-panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c7b2c4a2b686234646ac097c5164b1927198eaace8af56d6aaf377ed3a18e2d
+size 68220

--- a/docs/editor/images/artificial-intelligence/open-session-in-editor.png
+++ b/docs/editor/images/artificial-intelligence/open-session-in-editor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26e07c551250e4119ccc68347294fe3a75c6266fc7e9280a798132eb797324c
+size 14406

--- a/docs/editor/images/artificial-intelligence/open-session-in-sidebar.png
+++ b/docs/editor/images/artificial-intelligence/open-session-in-sidebar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:700db01352c456ca57b34a1b5712b6cb0124aabb1000fa6fe7122cf1e838ef20
+size 91502


### PR DESCRIPTION
There is an earlier example of moving the Chat view to the Secondary Side Bar earlier so show example moving to the Panel region
