### PR TITLE
Removed yarn parameter in deploying from GitHub

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -87,7 +87,7 @@ You can enable the build to run continuously when pushing to a branch and even o
 
 ```json
 "scripts": {
-  "deploy": "vsce publish --yarn"
+  "deploy": "vsce publish"
 }
 ```
 


### PR DESCRIPTION
## Summary
Specifying `--yarn` will prevent people using npm from `building` or `deploying` the package.

## Examples
- [Example of a this breaking an Action](https://github.com/dangreene0/tf2-vscript-snippets/actions/runs/6871551981)
- [Example of workflow without yarn parameter](https://github.com/dangreene0/tf2-vscript-snippets/actions/runs/6871636061/job/18688806034)

## Solutions
- Remove the `--yarn` instruction since it should detect what is necessary. (In this PR)
- Specify to use `--yarn` when they install with yarn.
- Separate `--yarn` and `--no-yarn` sections.