### PR TITLE
Update warning icon to match check mark and red X

### DIFF
--- a/docs/csharp/debugging.md
+++ b/docs/csharp/debugging.md
@@ -215,7 +215,7 @@ The runtime added support for applying changes while debugging on Linux/macOS on
 | Console | ✅ | Linux/macOS Only |
 | Test Projects | ✅ | Linux/macOS Only |
 | Class Library Projects | ✅ | Linux/macOS Only |
-| ASP.NET Core | ⚠* _Currently only supports changes on `.cs` files_ | Linux/macOS Only |
+| ASP.NET Core | ⚠️* _Currently only supports changes on `.cs` files_ | Linux/macOS Only |
 | MAUI | ❌* _Available soon_ | -- |
 | Unity | ❌ | -- |
 


### PR DESCRIPTION
Currently: 

![image](https://github.com/microsoft/vscode-docs/assets/12818376/e9ad16fb-a9da-4713-b14c-c97921f984c3)

update to:

![image](https://github.com/microsoft/vscode-docs/assets/12818376/ec6ca9fb-7eda-4442-9d77-8b6c3e2c2caf)
