### PR TITLE
Update Accessible View command ID

### DIFF
--- a/docs/editor/accessibility.md
+++ b/docs/editor/accessibility.md
@@ -188,7 +188,7 @@ Use `editor.tabFocusMode` to control whether the terminal receives the `kbstyle(
 
 The terminal has a feature called [shell integration](/docs/terminal/shell-integration.md) that enables many additional features that are not found in other terminals. When using a screen reader, the [Run Recent Command](/docs/terminal/shell-integration.md#run-recent-command) and [Go to Recent Directory](/docs/terminal/shell-integration.md#go-to-recent-directory) features are particularly useful.
 
-Another shell integration powered command, **Terminal: Navigate Accessible Buffer** (`kb(workbench.action.terminal.navigateAccessibleBuffer)`), lets you navigate between terminal commands similar to **Go to Symbol in Editor...** navigation in the editor.
+Another shell integration powered command, **Go to Symbol in Accessible View** (`kb(editor.action.accessibleViewGoToSymbol)`), lets you navigate between terminal commands similar to **Go to Symbol in Editor...** navigation in the editor.
 
 ### Minimum contrast ratio
 

--- a/release-notes/v1_77.md
+++ b/release-notes/v1_77.md
@@ -40,7 +40,7 @@ Welcome to the March 2023 release of Visual Studio Code. There are many updates 
 
 The terminal accessible buffer, which provides screen reader users access to the terminal contents via **Terminal: Focus Accessible Buffer** (`kb(workbench.action.terminal.focusAccessibleBuffer)`), now dynamically updates and remains active until `kbstyle(Escape)` or `kbstyle(Tab)` are used to end the session.
 
-When the accessible buffer is focused in a terminal with shell integration, **Terminal: Navigate Accessible Buffer** (`kb(workbench.action.terminal.navigateAccessibleBuffer)`) enables navigation between terminal commands similar to how editors can be navigated with **Go to Symbol in Editor...**.
+When the accessible buffer is focused in a terminal with shell integration, **Go to Symbol in Accessible View** (`kb(editor.action.accessibleViewGoToSymbol)`) enables navigation between terminal commands similar to how editors can be navigated with **Go to Symbol in Editor...**.
 
 ### Hover control navigation
 

--- a/release-notes/v1_78.md
+++ b/release-notes/v1_78.md
@@ -52,7 +52,7 @@ Previously, users of accessibility mode experienced different behavior when work
 
 * Jump between commands using `kb(workbench.action.terminal.accessibleBufferGoToNextCommand)` and `kb(workbench.action.terminal.accessibleBufferGoToPreviousCommand)`.
 * Use **Set Selection Anchor**, **Select from Anchor to Cursor**, and page navigation via `kb(cursorPageUpSelect)` and `kb(cursorPageDownSelect)`.
-* Preview the position when using **Terminal: Navigate Accessible Buffer** (`kb(workbench.action.terminal.navigateAccessibleBuffer)`) before accepting a command to go to a new location.
+* Preview the position when using **Go to Symbol in Accessible View** (`kb(editor.action.accessibleViewGoToSymbol)`) before accepting a command to go to a new location.
 * Engage with the output while dynamic updates occur.
 
 #### Terminal Accessibility Help menu


### PR DESCRIPTION
workbench.action.terminal.navigateAccessibleBuffer is replaced by "Go to Symbol in Accessible View" editor.action.accessibleViewGoToSymbol