### PR TITLE
Update description on trash implementation

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -204,7 +204,7 @@ If you see an error when deleting files from the VS Code Explorer on the Debian 
 Run these commands to solve this issue:
 
 ```bash
-sudo apt-get install gvfs-bin
+sudo apt-get install gvfs libglib2.0-bin
 ```
 
 ### Conflicts with VS Code packages from other repositories


### PR DESCRIPTION
- Properly fix https://github.com/microsoft/vscode/issues/142912
- gvfs-trash has been deprecated and it is redirected to gio trash
- See https://manpages.debian.org/bullseye/gvfs-common/gvfs-trash.1.en.html