### PR TITLE
Remove old blog posts from TOC

### DIFF
--- a/blogs/2016/05/04/extension-roundup-may.md
+++ b/blogs/2016/05/04/extension-roundup-may.md
@@ -1,5 +1,5 @@
 ---
-Order: 8
+Order:
 TOCTitle: Extensions Roundup
 PageTitle: Visual Studio Code Extensions Roundup May 2016
 MetaDescription: New, useful, and interesting extensions in Visual Studio Code for May 2016.

--- a/blogs/2016/06/27/common-language-protocol.md
+++ b/blogs/2016/06/27/common-language-protocol.md
@@ -1,5 +1,5 @@
 ---
-Order: 11
+Order:
 TOCTitle: The Language Server Protocol
 PageTitle: Common Language Server Protocol
 MetaDescription: A Common Language Server Protocol for any tool and any language.

--- a/blogs/2016/07/29/extensions-roundup-git.md
+++ b/blogs/2016/07/29/extensions-roundup-git.md
@@ -1,5 +1,5 @@
 ---
-Order: 12
+Order:
 TOCTitle: Extensions Roundup - Fun with Git
 PageTitle: Visual Studio Code Extensions Roundup - Git August 2016
 MetaDescription: Extensions to super power your Git workflow.

--- a/blogs/2016/09/08/icon-themes.md
+++ b/blogs/2016/09/08/icon-themes.md
@@ -1,5 +1,5 @@
 ---
-Order: 16
+Order:
 TOCTitle: File Icon Themes
 PageTitle: File and Folder Icons in Visual Studio Code
 MetaDescription: File and Folder Icons in Visual Studio Code

--- a/blogs/2016/09/14/js_roundup_1.md
+++ b/blogs/2016/09/14/js_roundup_1.md
@@ -1,5 +1,5 @@
 ---
-Order: 17
+Order:
 TOCTitle: JavaScript Extensions Part 1
 PageTitle: Visual Studio Code JavaScript Extensions Part 1 Sep 2016
 MetaDescription: Essential JavaScript extensions for Visual Studio Code.

--- a/blogs/2016/10/31/js_roundup_2.md
+++ b/blogs/2016/10/31/js_roundup_2.md
@@ -1,5 +1,5 @@
 ---
-Order: 18
+Order:
 TOCTitle: JavaScript Extensions Part 2
 PageTitle: Visual Studio Code JavaScript Extensions Part 2 Oct 2016
 MetaDescription: Essential JavaScript extensions for Visual Studio Code.

--- a/blogs/2016/11/15/formatters-best-practices.md
+++ b/blogs/2016/11/15/formatters-best-practices.md
@@ -1,5 +1,5 @@
 ---
-Order: 20
+Order:
 TOCTitle: Creating a Formatter Extension
 PageTitle: Creating a Formatter Extension
 MetaDescription: Best practices for creating a Visual Studio Code formatter extension.

--- a/blogs/2016/11/30/hot-exit-in-insiders.md
+++ b/blogs/2016/11/30/hot-exit-in-insiders.md
@@ -1,5 +1,5 @@
 ---
-Order: 21
+Order:
 TOCTitle: Hot Exit Comes to Insiders
 PageTitle: Hot Exit Comes to Insiders
 MetaDescription: Unsaved changes are now remembered between Visual Studio Code sessions.

--- a/blogs/2016/12/12/roundup-customize.md
+++ b/blogs/2016/12/12/roundup-customize.md
@@ -1,5 +1,5 @@
 ---
-Order: 22
+Order:
 TOCTitle: Customize VS Code Extension Roundup
 PageTitle: Customize Visual Studio Code Extension Roundup
 MetaDescription: Extensions to customize Visual Studio Code.

--- a/blogs/2017/01/15/connect-nina-e2e.md
+++ b/blogs/2017/01/15/connect-nina-e2e.md
@@ -1,5 +1,5 @@
 ---
-Order: 23
+Order:
 TOCTitle: Node.js Development with Visual Studio Code and Azure
 PageTitle: Node.js Development with Visual Studio Code and Azure
 MetaDescription: Node.js Development with Visual Studio Code and Azure

--- a/blogs/2017/02/08/syntax-highlighting-optimizations.md
+++ b/blogs/2017/02/08/syntax-highlighting-optimizations.md
@@ -1,5 +1,5 @@
 ---
-Order: 24
+Order:
 TOCTitle: Optimizations in Syntax Highlighting
 PageTitle: Optimizations in Syntax Highlighting, a Visual Studio Code Story
 MetaDescription: Optimizations in tokenization and syntax highlighting in the Visual Studio Code/Monaco editor

--- a/blogs/2017/02/12/code-lens-roundup.md
+++ b/blogs/2017/02/12/code-lens-roundup.md
@@ -1,5 +1,5 @@
 ---
-Order: 25
+Order:
 TOCTitle: Extensions using CodeLens
 PageTitle: Visual Studio Code Extensions using CodeLens
 MetaDescription: Visual Studio Code Extensions using CodeLens

--- a/blogs/2017/03/07/extension-pack-roundup.md
+++ b/blogs/2017/03/07/extension-pack-roundup.md
@@ -1,5 +1,5 @@
 ---
-Order: 26
+Order:
 TOCTitle: Extension Packs
 PageTitle: Visual Studio Code Extension Packs
 MetaDescription: Learn how to create and use Extension Packs in Visual Studio Code.

--- a/blogs/2017/04/10/sublime-text-roundup.md
+++ b/blogs/2017/04/10/sublime-text-roundup.md
@@ -1,5 +1,5 @@
 ---
-Order: 27
+Order:
 TOCTitle: Sublime Text Extension Roundup
 PageTitle: Sublime Text Extension Roundup
 MetaDescription: Learn about VS Code extensions to add features that are missing from Sublime Text.

--- a/blogs/2017/05/10/build-2017-demo.md
+++ b/blogs/2017/05/10/build-2017-demo.md
@@ -1,5 +1,5 @@
 ---
-Order: 28
+Order:
 TOCTitle: Build 2017 Demo
 PageTitle: Build 2017 Demo
 MetaDescription: Build 2017 Demo Visual Studio Code - Conquering the Cloud with an editor and a CLI

--- a/blogs/2017/06/20/great-looking-editor-roundup.md
+++ b/blogs/2017/06/20/great-looking-editor-roundup.md
@@ -1,5 +1,5 @@
 ---
-Order: 29
+Order:
 TOCTitle: Fresh Paint
 PageTitle: Fresh Paint - Give Visual Studio Code a New Look
 MetaDescription: Give VS Code a new look with these popular extensions, color themes, file icon themes and more.

--- a/blogs/2017/08/07/emmet-2.0.md
+++ b/blogs/2017/08/07/emmet-2.0.md
@@ -1,5 +1,5 @@
 ---
-Order: 30
+Order:
 TOCTitle: Emmet 2.0
 PageTitle: Emmet 2.0 in Visual Studio Code
 MetaDescription: New Emmet 2.0 brings a better Emmet experience inside VS Code.

--- a/blogs/2017/09/28/java-debug.md
+++ b/blogs/2017/09/28/java-debug.md
@@ -1,5 +1,5 @@
 ---
-Order: 31
+Order:
 TOCTitle: Java Debugging
 PageTitle: Using Visual Studio Code to Debug Java Applications
 MetaDescription: Java Development with VS Code

--- a/blogs/2017/10/03/terminal-renderer.md
+++ b/blogs/2017/10/03/terminal-renderer.md
@@ -1,5 +1,5 @@
 ---
-Order: 32
+Order:
 TOCTitle: Integrated Terminal Performance
 PageTitle: Integrated Terminal Performance Improvements
 MetaDescription: Explore the performance improvements made to Visual Studio Code's integrated terminal renderer in version 1.17

--- a/blogs/2017/10/24/theicon.md
+++ b/blogs/2017/10/24/theicon.md
@@ -1,5 +1,5 @@
 ---
-Order: 33
+Order:
 TOCTitle: The Icon Journey
 PageTitle: The Icon Journey
 MetaDescription: Summary of feedback about the new icons and next steps

--- a/blogs/2017/11/15/live-share.md
+++ b/blogs/2017/11/15/live-share.md
@@ -1,5 +1,5 @@
 ---
-Order: 34
+Order:
 TOCTitle: Introducing Live Share
 PageTitle: Introducing Visual Studio Live Share
 MetaDescription: Real-time collaborative development

--- a/blogs/2017/11/16/connect.md
+++ b/blogs/2017/11/16/connect.md
@@ -1,5 +1,5 @@
 ---
-Order: 35
+Order:
 TOCTitle: Connect 2017
 PageTitle: Visual Studio Code 2.6M Users, 12 months of momentum and more to come.
 MetaDescription: Visual Studio Code 2.6M Users, 12 months of momentum and more to come.

--- a/blogs/2017/12/20/chrome-debugging.md
+++ b/blogs/2017/12/20/chrome-debugging.md
@@ -1,5 +1,5 @@
 ---
-Order: 36
+Order:
 TOCTitle: What's New for Chrome Debugging
 PageTitle: What's New for Chrome debugging in VS Code
 MetaDescription: What's New for Chrome debugging in Visual Studio Code

--- a/blogs/2018/03/23/text-buffer-reimplementation.md
+++ b/blogs/2018/03/23/text-buffer-reimplementation.md
@@ -1,5 +1,5 @@
 ---
-Order: 37
+Order:
 TOCTitle: Text Buffer Reimplementation
 PageTitle: Text Buffer Reimplementation, a Visual Studio Code Story
 MetaDescription: Text Buffer Reimplementation in the Visual Studio Code/Monaco editor

--- a/blogs/2018/04/25/bing-settings-search.md
+++ b/blogs/2018/04/25/bing-settings-search.md
@@ -1,5 +1,5 @@
 ---
-Order: 38
+Order:
 TOCTitle: Settings Search
 PageTitle: Bing-powered settings search in VS Code
 MetaDescription: Improving settings search in VS Code with Bing

--- a/blogs/2018/05/07/live-share-public-preview.md
+++ b/blogs/2018/05/07/live-share-public-preview.md
@@ -1,5 +1,5 @@
 ---
-Order: 39
+Order:
 TOCTitle: Live Share Preview
 PageTitle: Announcing the Visual Studio Live Share Public Preview
 MetaDescription: Real-time collaborative development

--- a/blogs/2018/07/12/introducing-logpoints-and-auto-attach.md
+++ b/blogs/2018/07/12/introducing-logpoints-and-auto-attach.md
@@ -1,5 +1,5 @@
 ---
-Order: 40
+Order:
 TOCTitle: Logpoints and auto-attach
 PageTitle: Introducing Logpoints and auto-attach
 MetaDescription: Introducing Logpoints and auto-attach to make debugging easier and simpler to use in Visual Studio Code

--- a/blogs/2018/08/07/debug-adapter-protocol-website.md
+++ b/blogs/2018/08/07/debug-adapter-protocol-website.md
@@ -1,5 +1,5 @@
 ---
-Order: 41
+Order:
 TOCTitle: New home for Debug Adapter Protocol
 PageTitle: A new home for the Debug Adapter Protocol
 MetaDescription: A new home for the Debug Adapter Protocol

--- a/blogs/2018/09/10/introducing-github-pullrequests.md
+++ b/blogs/2018/09/10/introducing-github-pullrequests.md
@@ -1,5 +1,5 @@
 ---
-Order: 42
+Order:
 TOCTitle: GitHub Pull Requests
 PageTitle: Introducing GitHub Pull Requests for Visual Studio Code
 MetaDescription: Introducing GitHub Pull Requests for Visual Studio Code

--- a/blogs/2018/09/12/engineering-with-azure-pipelines.md
+++ b/blogs/2018/09/12/engineering-with-azure-pipelines.md
@@ -1,5 +1,5 @@
 ---
-Order: 43
+Order:
 TOCTitle: Using Azure Pipelines
 PageTitle: Visual Studio Code using Azure Pipelines
 MetaDescription: Visual Studio Code using Azure Pipelines

--- a/blogs/2018/11/26/event-stream.md
+++ b/blogs/2018/11/26/event-stream.md
@@ -1,5 +1,5 @@
 ---
-Order: 44
+Order:
 TOCTitle: Event-Stream Package Security Update
 PageTitle: Event-Stream Package Security Update
 MetaDescription: Event-Stream Package Security Update

--- a/blogs/2018/12/04/rich-navigation.md
+++ b/blogs/2018/12/04/rich-navigation.md
@@ -1,5 +1,5 @@
 ---
-Order: 45
+Order:
 TOCTitle: Rich Code Navigation
 PageTitle: Rich Code Navigation
 MetaDescription: First look at a rich code navigation experience in Visual Studio

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -219,7 +219,7 @@ After editing your settings, type `kb(workbench.action.files.save)` to save your
 
 ### Zen Mode
 
-Zen Mode lets you focus on your code by hiding all UI except the editor (no Activity Bar, Status Bar, Side Bar and Panel), going to full screen and centering the editor layout. Zen mode can be toggled using **View** menu, **Command Palette** or by the shortcut `kb(workbench.action.toggleZenMode)`. Double `kbstyle(Esc)` exits Zen Mode. The transition to full screen can be disabled via `zenMode.fullScreen`.
+Zen Mode lets you focus on your code by hiding all UI except the editor (no Activity Bar, Status Bar, Side Bar and Panel), going to full screen and centering the editor layout. Zen mode can be toggled using **View** > **Appearance** menu, **Command Palette** or by the shortcut `kb(workbench.action.toggleZenMode)`. Double `kbstyle(Esc)` exits Zen Mode. The transition to full screen can be disabled via `zenMode.fullScreen`.
 
 Zen Mode can be further tuned by the following settings:
 


### PR DESCRIPTION
Remove blog posts from before 2019 from the Blogs TOC. The topics are still live on code.visualstudio.com and can be navigated to via links or direct URL. The goal is to keep the TOC length reasonable.
Removing the Order value removes a topic from the TOC

Also small fix as Zen Mode check mark is now under View > Appearance