### PR TITLE
Dev Containers supports all host OSes

### DIFF
--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -169,7 +169,7 @@ The rest of the Dev Containers quick start applies as-is. You can learn more abo
 
 ### Open a folder on a remote Tunnel host in a container
 
-If you are using a Linux machine as a tunnel host, you can use the [Remote - Tunnels](/docs/remote/tunnels.md) and Dev Containers extensions together. You do not even need to have a Docker client installed locally. This is similar to the SSH host scenario above, but uses Remote - Tunnels instead.
+You can use the [Remote - Tunnels](/docs/remote/tunnels.md) and Dev Containers extensions together to open a folder on your remote host inside of a container. You do not even need to have a Docker client installed locally. This is similar to the SSH host scenario above, but uses Remote - Tunnels instead.
 
 To do so:
 

--- a/docs/remote/tunnels.md
+++ b/docs/remote/tunnels.md
@@ -98,7 +98,7 @@ Like the other Remote Development extensions, the name of your remote machine wi
 
 ### Open a folder on a Remote Tunnels host in a container
 
-If you are using a Linux machine as a tunnel host, you can use the Remote - Tunnels and [Dev Containers](/docs/devcontainers/containers.md) extensions together to open a folder on your remote host inside of a container. You do not even need to have a Docker client installed locally.
+You can use the Remote - Tunnels and [Dev Containers](/docs/devcontainers/containers.md) extensions together to open a folder on your remote host inside of a container. You do not even need to have a Docker client installed locally.
 
 To do so:
 

--- a/remote/advancedcontainers/develop-remote-host.md
+++ b/remote/advancedcontainers/develop-remote-host.md
@@ -25,7 +25,7 @@ The rest of the Dev Containers quick start applies as-is. You can learn more abo
 
 ## Connect using the Remote - Tunnels extension
 
-If you are using a Linux machine as a tunnel host, you can use the [Remote - Tunnels](/docs/remote/tunnels.md) and Dev Containers extensions together. You do not even need to have a Docker client installed locally. This is similar to the SSH host scenario above, but uses Remote - Tunnels instead. To do so:
+You can use the [Remote - Tunnels](/docs/remote/tunnels.md) and Dev Containers extensions together to open a folder on your remote host inside of a container. You do not even need to have a Docker client installed locally. This is similar to the SSH host scenario above, but uses Remote - Tunnels instead. To do so:
 
 1. Follow the [Getting Started](/docs/remote/tunnels.md#getting-started) instructions for the Remote - Tunnels extension.
 1. [Install Docker](/docs/devcontainers/containers#installation) on your tunnel host. You do not need to install Docker locally.


### PR DESCRIPTION
Missed these when updating the documention recently.