### PR TITLE
Azure Account -> Azure Resources and GitLab support removal, GitHub addition

### DIFF
--- a/docs/containers/images/registries/github.png
+++ b/docs/containers/images/registries/github.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a564c23da454dffa723d909244b1cc63ffd5a55d1c5386fb06595c828a07b307
+size 10569

--- a/docs/containers/images/registries/github.png
+++ b/docs/containers/images/registries/github.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a564c23da454dffa723d909244b1cc63ffd5a55d1c5386fb06595c828a07b307
-size 10569
+oid sha256:8292094c9741331f1cc6dd9e35fbec441e478e3efcb31d10068990ccdfde59ac
+size 11214

--- a/docs/containers/images/registries/gitlab.png
+++ b/docs/containers/images/registries/gitlab.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa9d40a26c1b1824ddd0b6bd0d34633d4f4f6406819fb7dc64c3fab9b4d79790
-size 2173

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -39,7 +39,7 @@ The extension can scaffold Docker files for most popular development languages (
 
 ## Docker Explorer
 
-The Docker extension contributes a Docker Explorer view to VS Code. The Docker Explorer lets you examine and manage Docker assets: containers, images, volumes, networks, and container registries. If the Azure Account extension is installed, you can browse your Azure Container Registries as well.
+The Docker extension contributes a Docker Explorer view to VS Code. The Docker Explorer lets you examine and manage Docker assets: containers, images, volumes, networks, and container registries. If you are signed in to your Microsoft account and it has access to Azure subscriptions, you can browse your Azure Container Registries as well.
 
 The right-click menu provides access to commonly used commands for each type of asset.
 
@@ -77,7 +77,7 @@ Once your `Compose Up` command completes, navigate to the Docker Explorer to vie
 
 ## Using image registries
 
-You can display the content and push, pull, or delete images from [Azure Container Registry](https://learn.microsoft.com/azure/container-registry), [Docker Hub](https://hub.docker.com/), [GitLab](https://gitlab.com/), and more:
+You can display the content and push, pull, or delete images from [Azure Container Registry](https://learn.microsoft.com/azure/container-registry), [Docker Hub](https://hub.docker.com/), and more:
 
 ![Azure Container Registry content](images/overview/container-registry.png)
 

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -77,7 +77,7 @@ Once your `Compose Up` command completes, navigate to the Docker Explorer to vie
 
 ## Using image registries
 
-You can display the content and push, pull, or delete images from [Azure Container Registry](https://learn.microsoft.com/azure/container-registry), [Docker Hub](https://hub.docker.com/), and more:
+You can display the content and push, pull, or delete images from [Azure Container Registry](https://learn.microsoft.com/azure/container-registry), [Docker Hub](https://hub.docker.com/), [GitHub](https://github.com/), and more:
 
 ![Azure Container Registry content](images/overview/container-registry.png)
 

--- a/docs/containers/quickstart-container-registries.md
+++ b/docs/containers/quickstart-container-registries.md
@@ -15,14 +15,13 @@ Users can connect to Docker registries from the following sources:
 
 - [Azure Container Registry](https://learn.microsoft.com/azure/container-registry)
 - [Docker Hub](https://hub.docker.com/)
-- [GitLab](https://gitlab.com/) container registry
 - Any generic private registry that supports the [Docker V2 api](https://docs.docker.com/registry/spec/api/)
 
 ## Push an image to a container registry
 
 Before you can deploy a Docker image, the image must be uploaded to a container registry. The image can be uploaded to [Docker Hub](https://hub.docker.com/), [Azure Container Registry (ACR)](https://learn.microsoft.com/azure/container-registry/container-registry-get-started-portal) or another registry. You can follow the same steps to push the image regardless of whether you're pushing to Docker Hub, Azure Container Registries, or any other registry. If you don't already have an Azure Container Registry, you can create one during the **Push** step.
 
-1. Open the Docker Explorer, select **Connect Registry...** icon under the **Registries** group, and follow the prompt. Choose the provider (for example, Azure or Docker Hub) and provide the credential to connect to the registry. If prompted, install the [Azure Account](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) extension.
+1. Open the Docker Explorer, select **Connect Registry...** icon under the **Registries** group, and follow the prompt. Choose the provider (for example, Azure or Docker Hub) and provide the credential to connect to the registry. If prompted, install the [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups) extension.
 
     ![Connect to Registry](images/registries/connect-registry-2.png)
 
@@ -65,7 +64,7 @@ For each tagged image in a repository, here are the actions that can be performe
 
 ## Azure Container Registry
 
-This option requires the [Azure Account](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) extension to be able to connect to your Azure account and display all of the different subscriptions and registries.
+This option requires the [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups) extension to be able to connect to your Azure account and display all of the different subscriptions and registries.
 Once authenticated, the node **Azure** will display the subscriptions along with registries each have:
 
 ![Azure Container Registry](images/registries/azure-registries.png)
@@ -98,21 +97,6 @@ For each tagged image in a repository, here are the actions that can be performe
 - **Deploy Image to Azure Container Apps**: deploys the image to Azure Container Apps, see [Deploy images to Azure](/docs/containers/app-service.md) page
 - **Untag Image**: untags the image
 - **Delete Image**: deletes the image permanently
-
-## GitLab
-
-This connects to Docker registries in your [GitLab](https://gitlab.com/) account. Once you select this option, you are asked to type in your GitLab account credentials.
-
-![GitLab](images/registries/gitlab.png)
-
-For each repository in the GitLab registry, here are the actions that can be performed:
-
-- **Pull Repository**: copies all of the images in a given repository locally
-- **Refresh**: refreshes the repository to reflect changes
-
-For each tagged image in a repository, here are the actions that can be performed:
-
-- **Pull Image**: copies the latest version of the image locally
 
 ## Next steps
 

--- a/docs/containers/quickstart-container-registries.md
+++ b/docs/containers/quickstart-container-registries.md
@@ -15,6 +15,7 @@ Users can connect to Docker registries from the following sources:
 
 - [Azure Container Registry](https://learn.microsoft.com/azure/container-registry)
 - [Docker Hub](https://hub.docker.com/)
+- [GitHub](https://github.com) container registry
 - Any generic private registry that supports the [Docker V2 api](https://docs.docker.com/registry/spec/api/)
 
 ## Push an image to a container registry
@@ -60,6 +61,9 @@ For each repository in the Docker Hub registry, here are the actions that can be
 For each tagged image in a repository, here are the actions that can be performed:
 
 - **Pull image**: copies the latest version of the image locally
+- **Copy Full Tag**: copies the full tag to the clipboard
+- **Deploy Image to Azure App Service**: deploys the image to Azure App Service, see [Deploy images to Azure](/docs/containers/app-service.md) page
+- **Deploy Image to Azure Container Apps**: deploys the image to Azure Container Apps, see [Deploy images to Azure](/docs/containers/app-service.md) page
 - **Open in browser**: opens the browser and navigates to the given image on Docker Hub
 
 ## Azure Container Registry
@@ -93,10 +97,31 @@ For each tagged image in a repository, here are the actions that can be performe
 - **Pull Image**: copies the latest version of the image locally
 - **Copy Full Tag**: copies the full tag to the clipboard
 - **Copy Image Digest**: copies the image digest, which is a SHA256 hash identifier that Docker uses, to the clipboard. See [Docker Docs](https://docs.docker.com/engine/reference/commandline/images/#list-image-digests) for more info on image digests
+- **Inspect Image Manifest**: inspects the image's registry manifest. This is not the same as inspecting the image when it is pulled locally.
 - **Deploy Image to Azure App Service**: deploys the image to Azure App Service, see [Deploy images to Azure](/docs/containers/app-service.md) page
 - **Deploy Image to Azure Container Apps**: deploys the image to Azure Container Apps, see [Deploy images to Azure](/docs/containers/app-service.md) page
 - **Untag Image**: untags the image
 - **Delete Image**: deletes the image permanently
+
+## GitHub
+
+This connects to Docker registries in your [GitHub](https://github.com/) account. Once you select this option, you are asked to type in your GitHub account credentials.
+
+![GitHub](images/registries/github.png)
+
+For each repository in the GitHub registry, here are the actions that can be performed:
+
+- **Pull Repository**: copies all of the images in a given repository locally
+- **Refresh**: refreshes the repository to reflect changes
+
+For each tagged image in a repository, here are the actions that can be performed:
+
+- **Pull Image**: copies the latest version of the image locally
+- **Copy Full Tag**: copies the full tag to the clipboard
+- **Copy Image Digest**: copies the image digest, which is a SHA256 hash identifier that Docker uses, to the clipboard. See [Docker Docs](https://docs.docker.com/engine/reference/commandline/images/#list-image-digests) for more info on image digests
+- **Inspect Image Manifest**: inspects the image's registry manifest. This is not the same as inspecting the image when it is pulled locally.
+- **Deploy Image to Azure App Service**: deploys the image to Azure App Service, see [Deploy images to Azure](/docs/containers/app-service.md) page
+- **Deploy Image to Azure Container Apps**: deploys the image to Azure Container Apps, see [Deploy images to Azure](/docs/containers/app-service.md) page
 
 ## Next steps
 

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -158,7 +158,7 @@ The Docker Explorer provides an interactive experience to examine and manage Doc
 
 You can use the command **Azure Container Registry: Build Image in Azure** to build an image that you can then deploy to Azure App Service or Azure Container Apps.
 
-1. Install the [Azure account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account). Open the **Command Palette** (`kb(workbench.action.showCommands)`) and search for the command **Azure: Sign In**. If you don't have an Azure account, you can sign up for a [free trial](https://azure.microsoft.com/free/?utm_source=campaign&utm_campaign=vscode-azure-account&mktingSource=vscode-azure-account).
+1. Install the [Azure Resources extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups). Open the **Command Palette** (`kb(workbench.action.showCommands)`) and search for the command **Azure: Sign In**. If you don't have an Azure account, you can sign up for a [free trial](https://azure.microsoft.com/free/?utm_source=campaign&utm_campaign=vscode-azure-account&mktingSource=vscode-azure-account).
 
 1. There are two ways to invoke the build in Azure command. You can right-click on the Dockerfile, and choose **Build Image in Azure**. You can also use the **Command Palette** (`kb(workbench.action.showCommands)`) and search for the command **Azure Container Registry: Build Image in Azure**.
 

--- a/docs/java/java-webapp.md
+++ b/docs/java/java-webapp.md
@@ -119,7 +119,7 @@ Once the extension is installed, you can take the following steps to create a ne
 
 ### Build and deploy to a Web App
 
-The deploy process leverages the [Azure Account](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account) extension (installed along with the Azure App Service extension as a dependency) and you need to sign in with your Azure subscription. If you do not have an Azure subscription, [sign up today](https://azure.microsoft.com//free/?b=16.48) for a free 30 day account and get $200 in Azure Credits to try out any combination of Azure services.
+The deploy process leverages the [Azure Resources](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureresourcegroups) extension (installed along with the Azure App Service extension as a dependency) and you need to sign in with your Azure subscription. If you do not have an Azure subscription, [sign up today](https://azure.microsoft.com//free/?b=16.48) for a free 30 day account and get $200 in Azure Credits to try out any combination of Azure services.
 
 Once you have signed in, you can open the command prompt or terminal window and build the project using Maven commands. This will generate a new `war` or `jar` artifact in the `target` directory.
 


### PR DESCRIPTION
A couple of things in this PR.

- Azure Account is being slowly deprecated and replaced with the built-in Microsoft authentication provider. I could use some help with the verbiage here. The Azure Resources extension is required to sign in to some tenants (e.g., those with extra MFA after the primary sign-in) and is recommended (though not strictly required) if a sovereign cloud is being used.
- GitLab container registry support has been removed from the Docker extension (see https://github.com/microsoft/vscode-docker/issues/4132)
- GitHub container registry support has been added to the Docker extension (see https://github.com/microsoft/vscode-docker/issues/869)

Closes https://github.com/microsoft/vscode-docker/issues/4147