### PR TITLE
Replace quickFixWidgetVisible with codeActionMenuVisible

### DIFF
--- a/api/references/when-clause-contexts.md
+++ b/api/references/when-clause-contexts.md
@@ -191,7 +191,7 @@ Context name | True when
 `referenceSearchVisible` | Peek References peek window is open.
 `inReferenceSearchEditor` | The Peek References peek window editor has focus.
 `config.editor.stablePeek` | Keep peek editors open (controlled by `editor.stablePeek` setting).
-`quickFixWidgetVisible` | Quick Fix widget is visible.
+`codeActionMenuVisible` | Code Action menu is visible.
 `parameterHintsVisible` | Parameter hints are visible (controlled by `editor.parameterHints.enabled` setting).
 `parameterHintsMultipleSignatures` | Multiple parameter hints are displayed.
 **Debugger contexts** |


### PR DESCRIPTION
`quickFixWidgetVisible` seems to have been superseded by `codeActionMenuVisible`. The former doesn't exist in the current code base, while the latter was introduced about a year ago.

References:
https://github.com/microsoft/vscode/issues/55111
https://github.com/microsoft/vscode/blob/f0d15e28789098cbb6390f793d27e71a85fa5537/src/vs/platform/actionWidget/browser/actionWidget.ts