### PR TITLE
Update high-contrast theme image

### DIFF
--- a/docs/editor/images/accessibility/high-contrast.png
+++ b/docs/editor/images/accessibility/high-contrast.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:150d1275cf0d82c138d8f9bde7a743443f674c4518d7c8eedb44d2a4c6cfdf29
-size 35814
+oid sha256:1f61c5bd97790ef6a5ed76d039e41312f03e230c6e733f07b0381cfa83f495b1
+size 70709


### PR DESCRIPTION
Fix #6883 following given recomendations.
(Continued from #6886)

vscode version: 1.84.2

 
![high-contrast](https://github.com/microsoft/vscode-docs/assets/105132863/e132b761-21eb-4b47-8fa0-b14472d8fe81)
