### PR TITLE
Clarify snippet escaping rules

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -220,7 +220,7 @@ Example | Output | Explanation
 
 ### Grammar
 
-Below is the EBNF ([extended Backus-Naur form](https://en.wikipedia.org/wiki/Extended_Backus-Naur_form)) for snippets. With `\` (backslash), you can escape `$`, `}`, and `\`. Within choice elements, the backslash also escapes comma and pipe characters.
+Below is the EBNF ([extended Backus-Naur form](https://en.wikipedia.org/wiki/Extended_Backus-Naur_form)) for snippets. With `\` (backslash), you can escape `$`, `}`, and `\`. Within choice elements, the backslash also escapes comma and pipe characters. Only the characters required to be escaped can be escaped, so `$` should not be escaped within these constructs and neither `$` or `}` should be escaped inside choice constructs.
 
 ```
 any         ::= tabstop | placeholder | choice | variable | text


### PR DESCRIPTION
The current text reads like you can escape $ and } where not strictly necessary, but according to VS Code's behaviour and https://github.com/microsoft/vscode/issues/201059 this is not the case - you may only escape the characters that are required to be escaped, otherwise you'll see backslashes in the output.

LSP PR: https://github.com/microsoft/language-server-protocol/pull/1868