### PR TITLE
Update config-linux.md

### DIFF
--- a/docs/cpp/config-linux.md
+++ b/docs/cpp/config-linux.md
@@ -190,7 +190,7 @@ with this:
 
 ### Modifying tasks.json
 
-You can modify your `tasks.json` to build multiple C++ files by using an argument like `"${workspaceFolder}/*.cpp"` instead of `${file}`.This will build all `.cpp` files in your current folder. You can also modify the output filename by replacing `"${fileDirname}/${fileBasenameNoExtension}"` with a hard-coded filename (for example 'helloworld.out').
+You can modify your `tasks.json` to build multiple C++ files by using an argument like `${workspaceFolder}/*.cpp` instead of `${file}`.This will build all `.cpp` files in your current folder. You can also modify the output filename by replacing `"${fileDirname}/${fileBasenameNoExtension}"` with a hard-coded filename (for example 'helloworld.out').
 
 ## Debug helloworld.cpp
 


### PR DESCRIPTION
Documentation incorrectly states to replace ${file} with "${workspaceFolder/*.cpp" which would lead to two quotes surrounding the arg.

I have removed the incorrect characters.