### PR TITLE
Fix typo and streamline language in documentation

### DIFF
--- a/docs/terminal/shell-integration.md
+++ b/docs/terminal/shell-integration.md
@@ -78,7 +78,7 @@ Add the following to your `~/.bashrc` file. Run `code ~/.bashrc` in Git Bash to 
 
 #### Portability versus performance
 
-The recommended approach above to install shell integration relies on executing our CLI to find the path to the shell integration script. This is great as it works cross-platform and also with all install types, provided `code` in on the `$PATH`. This currently launches Node.js in order to fetch the path, which can add a small delay to shell startup. To reduce this, you can inline the script above by resolving the path ahead of time and adding it directly into your init script.
+The above shell integration installation is cross-platform and compatible with any installation type if `code` is in the `$PATH`. However, this recommended approach starts Node.js to fetch the script path, leading to a slight delay in shell startup. To mitigate this delay, inline the script above by resolving the path ahead of time and adding it directly into your init script.
 
 ```sh
 # Output the executable's path first:


### PR DESCRIPTION
Fixes a typo:
> ... `code` **in** on the `$PATH` ...

Additionally, revises paragraph for conciseness