### PR TITLE
Freshness Pass Cpp Editing Page

### DIFF
--- a/docs/cpp/configure-intellisense-crosscompilation.md
+++ b/docs/cpp/configure-intellisense-crosscompilation.md
@@ -1,5 +1,5 @@
 ---
-Order: 14
+Order: 15
 Area: cpp
 TOCTitle: Configure IntelliSense for cross-compiling
 ContentId: 381b7ce1-5766-49b0-ad26-f9eedae70e63

--- a/docs/cpp/configure-intellisense.md
+++ b/docs/cpp/configure-intellisense.md
@@ -1,5 +1,5 @@
 ---
-Order: 13
+Order: 14
 Area: cpp
 TOCTitle: Configure IntelliSense
 ContentId: bf494c65-12b4-4506-ab6c-1fad76d7ccf1

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -71,11 +71,11 @@ For example, on the Windows platform, use:
 
 #### vc_format
 
-By default, if an `.editorconfig` file with relevant settings is identified near the code being formatted, the Visual C++ formatting engine is used instead of clang-format. Otherwise, navigate to the `C_Cpp.formatting` [setting](/docs/getstarted/settings.md) and set it to `vc_format` to use the Visual C++ formatting engine always.
+By default, if an `.editorconfig` file with relevant settings is identified near the code being formatted, the Visual C++ formatting engine is used instead of clang-format. Otherwise, navigate to the `C_Cpp.formatting` [setting](/docs/getstarted/settings.md) and set it to `vc_format` to use the Visual C++ formatting engine.
 
 ### Enhanced semantic colorization
 
-When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, etc., see [Enhanced colorization](/docs/cpp/colorization-cpp.md). For more information on configuring IntelliSense, see [IntelliSense configuration](/docs/cpp/configure-intellisense.md).
+When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, and more, see [Enhanced colorization](/docs/cpp/colorization-cpp.md). For more information on configuring IntelliSense, see [IntelliSense configuration](/docs/cpp/configure-intellisense.md).
 
 ### Quick Info
 
@@ -85,23 +85,23 @@ You can hover over a symbol to see an inline view of its definition:
 
 ### Doxygen comments
 
-Doxygen is a tool that generates documentation from source code. When you annotate code with comments, Doxygen will then generate documentation for these functions. For doxygen comments, type `/**` and press `Enter` to generate a doxygen comment block. Supported doxygen tags include: `@brief`,`@tparam`, `@param`, `@return`, `@exception`, `@deprecated`, `@note`, `@attention`, and `@pre`.
+Doxygen is a tool that generates documentation from source code. When you annotate code with comments, Doxygen then generates documentation for these functions. For doxygen comments, type `/**` and press `Enter` to generate a doxygen comment block. Supported doxygen tags include: `@brief`,`@tparam`, `@param`, `@return`, `@exception`, `@deprecated`, `@note`, `@attention`, and `@pre`.
 
 ### Markdown comments
 
-The C++ Extension by default supports showing a subset of markdown in your editor. This subset supports all markdown comments except the symbols "_" and "*". Toggle the new **Markdown in Comments** setting to enable all markdown, keep this subset of markdown, or disable markdown support.
+By default, the C++ extension supports showing a subset of markdown in your editor. This subset supports all markdown comments except the symbols `_` and `*`. Toggle the new **Markdown in Comments** setting to either enable all markdown, keep this subset of markdown, or disable markdown support.
 
-## Navigating source code
+## Navigate source code
 
-The source code navigation features provided are powerful tools for understanding for your codebase. These let you quickly search for symbols in your code, navigate to their definitions, and find references to them.
+The source code navigation features can help improve your understanding of your codebase. These let you quickly search for symbols in your code, navigate to their definitions, or find references to them.
 
-Navigation is powered by a set of tags stored in a local database of symbol information. Whenever a folder containing C++ source code files is opened, the  C/C++ extension creates a database of the symbols defined in those files. This database is updated whenever a file is saved, and shared between all workspaces that use the same source code.
+Navigation is powered by a set of tags stored in a local database of symbol information. Whenever a folder containing C++ source code files is opened, the  C/C++ extension creates a database of the symbols defined in those files. This database is updated whenever a file is changed. If a document is closed without saving, the database is updated to the last saved state.
 
 ### Search for symbols
 
 You can search for symbols in the current file or workspace to navigate your code more quickly.
 
-To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches appears; which is filtered as you type. Choose from the list of matches to navigate to its location.
+To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches appears, which is filtered as you type. Choose from the list of matches to navigate to that symbol's location.
 
 ![Searching the current file](images/cpp/filesearch.png)
 
@@ -109,13 +109,13 @@ To search for a symbol in the current workspace, press `kb(workbench.action.show
 
 ![Searching in your workspace](images/cpp/workspacesearch.png)
 
-You can also search for symbols by accessing these commands through the **Command Palette**(`kb(workbench.action.showCommands)`). Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the '@' and '#' commands.
+You can also search for symbols by accessing these commands through the **Command Palette**(`kb(workbench.action.showCommands)`). Use **Quick Open** (`kb(workbench.action.quickOpen)`), then enter the `@` command to search the current file, or the `#` command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the `@` and `#` commands.
 
 ### Call hierarchy
 
-A Call Hierarchy view shows all calls to or from a function. It lets you understand the complex calling relationships between the functions in your source code.
+The Call Hierarchy view shows all calls to or from a function. It lets you understand the complex calling relationships between the functions in your source code.
 
-To view the call hierarchy, select a function, right-click to display the context menu, and choose **Show Call Hierarchy**. You can also use the keyboard shortcut (`Shift+Alt+H` on windows), or invoke the **Command Palette** (`kb(workbench.action.showCommands)`) and run the command **Calls: Show Call Hierarchy**. This populates the call tree in the side bar with all of the functions called by your selected function.
+To view the call hierarchy, select a function, right-click to display the context menu, and choose **Show Call Hierarchy**. You can also use the keyboard shortcut (`Shift+Alt+H` on Windows), or invoke the **Command Palette** (`kb(workbench.action.showCommands)`) and run the command **Calls: Show Call Hierarchy**. This populates the call tree in the side bar with all of the functions called by your selected function.
 
 ![Selecting call hierarchy and showing calls in sidebar](images/cpp/call-hierarchy.gif)
 
@@ -125,23 +125,23 @@ Toggle the phone icon in the side bar menu to switch to incoming calls. Incoming
 
 ### Peek
 
-The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code.
+The Peek feature displays a few lines of code inside a **peek window**, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code.
 
-To open a *peek window*, navigate to the context menu by right-clicking and selecting **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
+To open a **peek window**, navigate to the context menu by right-clicking, then select **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
 
 ![Peek definition](images/cpp/peekdefn.png)
 
-With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just select result or double-click in the source code displayed on the left-hand side of the peek window.
+With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, select the result or double-click in the source code displayed on the left-hand side of the peek window.
 
 ### Go to definition
 
-Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code. Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`, or right-click and choose **Go to Definition** from the context menu. When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
+Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code. Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`, or right-click and choose **Go to Definition** from the context menu. When there's only one definition of the symbol, you are navigated directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
 
-If no definitions can be found for the symbol you selected, the C/C++ Extension will automatically search for a declaration of the symbol.
+If no definitions can be found for the symbol you selected, the C/C++ extension automatically searches for a declaration of the symbol.
 
 ### Go to declaration
 
-Use the **Go to Declaration** feature to navigate to the location a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations. Select a symbol in your source code, right-click, and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
+Use the **Go to Declaration** feature to navigate to the location where a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations. Select a symbol in your source code, right-click, and choose **Go to Declaration** from the context menu. This navigates you to the location of the symbol's declaration.
 
 ### Go to references
 
@@ -155,13 +155,13 @@ Use the **Go to Type Definition** feature to jump to where a type is defined in 
 
 Read on to find out about:
 
-* [Debugging](/docs/cpp/cpp-debug.md) - find out how to use the debugger with your project
-* [Configure IntelliSense](/docs/cpp/configure-intellisense.md) - configure IntelliSense for your project
+* [Debugging C++ Code](/docs/cpp/cpp-debug.md)
+* [Configure IntelliSense](/docs/cpp/configure-intellisense.md)
 * [Configure VS Code for MSVC](/docs/cpp/config-msvc.md)
 * [Configure VS Code for Mingw-w64 and GCC](/docs/cpp/config-mingw.md)
 * [Configure VS Code for macOS](/docs/cpp/config-clang-mac.md)
-* [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
-* [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.
-* [Tasks](/docs/editor/tasks.md) - use tasks to build your project and more
+* [Basic Editing in VS Code](/docs/editor/codebasics.md)
+* [Code Navigation in VS Code](/docs/editor/editingevolved.md)
+* [Tasks in VS Code](/docs/editor/tasks.md)
 
 If you have any other questions or run into any issues, please file an issue on [GitHub](https://github.com/microsoft/vscode-cpptools/issues). You might be asked to provide logging information from the extension to help diagnose the issue. See [C/C++ extension logging](/docs/cpp/enable-logging-cpp.md) for help on providing extension logs.

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -1,23 +1,23 @@
 ---
 Order: 9
 Area: cpp
-TOCTitle: Editing
+TOCTitle: Editing and Navigating Code
 ContentId: 61D63E54-67E2-4743-B5CB-C6E7F582982A
-PageTitle: Edit and navigate C++ code in Visual Studio Code
-DateApproved: 7/25/2019
+PageTitle: Edit and navigate C++ code
+DateApproved: 1/2/2023
 MetaDescription: How to edit and navigate C++ source files in Visual Studio Code.
 ---
-# Edit C++ in Visual Studio Code
+# Editing and Navigating C++ in Visual Studio Code
 
-This topic provides a quick overview of general C/C++ editor features, as well as some that are specific to C/C++. For more information about editing in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
+This topic provides a quick overview of general C/C++ editor features, as well as some that are specific to C/C++. For more information about editing and navigating in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
 
-The C/C++ extension supports [Remote Development](/docs/remote/remote-overview.md).
+## Editing Set Up
 
-## Editing features
+To provide the best editing experience, the C++ extension needs to know where it can find each header file referenced in your code. By default, the extension searches the current source directory, its sub-directories, and some platform-specific locations. If a referenced header file can't be found, a red squiggle is displayed underneath the #include directive.
 
-The C/C++ extension for VS Code has many features that help you write code, understand it, and navigate around in your source files. To provide the best experience, the extension needs to know where it can find each header file referenced in your code. By default, the extension searches the current source directory, its sub-directories, and some platform-specific locations. If a referenced header file can't be found, VS Code displays a green squiggle underneath each #include directive that references it.
+To specify additional include directories, select an #include that has not been referenced. Next, select the lightbulb that appear and choose `Edit "includePath" setting`. This opens the C/C++ Extension's Configurations interface. Under the Include Path section you can specify the paths for any additional include directories.
 
-To specify additional include directories to be searched, place your cursor over any #include directive that displays a green squiggle, then click the lightbulb action when it appears. This opens the file `c_cpp_properties.json` for editing; here you can specify additional include directories for each platform configuration individually by adding more directories to the 'browse.path' property.
+![Process of adding a new header to the include path](images\intellisense\AddingIncludePathToConfig.gif)
 
 ## List members
 
@@ -34,9 +34,9 @@ You can format an entire file with **Format Document** (`kb(editor.action.format
 * `editor.formatOnSave` - to format when you save your file.
 * `editor.formatOnType` - to format as you type (triggered on the `kbstyle(;)` character).
 
-By default, the clang-format style is set to "file" which means it looks for a `.clang-format` file inside your workspace. If the `.clang-format` file is found, formatting is applied according to the settings specified in the file. If no `.clang-format` file is found in your workspace, formatting is applied based on a default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md) instead. Currently, the default formatting style is "Visual Studio" which is an approximation of the default code formatter in Visual Studio.
+By default, the clang-format style is set to "file". This means, if a `.clang-format` file is found in your workspace, the settings specified in the file will be used as a formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
 
-The Visual Studio clang-format style is not yet an official clang-format style but it implies the following clang-format settings:
+Currently, the default formatting style is "Visual Studio" which is an approximation of the default code formatter in Visual Studio. It implies the following settings:
 
 ```json
 UseTab: (VS Code current setting)
@@ -49,7 +49,7 @@ ColumnLimit: 0
 
 To use a different version of clang-format than the one that ships with the extension, change the `C_Cpp.clang_format_path` [setting](/docs/getstarted/settings.md) to the path where the clang-format binary is installed.
 
-For example, on the Windows platform:
+For example, on the Windows platform, use:
 
 ```json
   "C_Cpp.clang_format_path": "C:\\Program Files (x86)\\LLVM\\bin\\clang-format.exe"
@@ -77,13 +77,23 @@ Currently, the C/C++ extension doesn't parse code in a way that helps it disting
 
 With the peek window open, you browse the list of competing definitions to find the one you're interested in. If you want to navigate to the location of one of the definitions just double-click the definition you're interested in, or by double-clicking anywhere in the source code displayed on the left-hand side of the peek window.
 
-## Navigate source code
+### Peek Declaration
 
-The source code navigation features provided by the C/C++ extension are powerful tools for understanding and getting around in your codebase. These features are powered by tags stored in a local database of symbol information. With the C/C++ extension installed, this database is generated whenever a folder containing C++ source code files is loaded into VS Code. The database icon appears next to the active configuration name ("Win32" in the image below) while the tag-parser is generating this information.
+The **Peek Definition** feature displays a few lines of code near the definition inside a *peek window*, so that you don't have to navigate away from your current location.
 
-![The platform indicator during tag parsing](images/cpp/parsing.png)
+To peek at a symbol's definition, place your cursor on the symbol anywhere it's used in your source code and then press `kb(editor.action.peekDefinition)`. Alternatively, you can choose **Peek Definition** from the context menu (right-click, then choose **Peek Definition**).
 
-The icon disappears when all the symbols have been tagged.
+![Peek definition](images/cpp/peekdefn.png)
+
+Currently, the C/C++ extension doesn't parse code in a way that helps it distinguish between competing definitions based on how the symbol is used. These competing definitions arise when the symbol defines different things in different contexts, such as occurs with overloaded functions, classes and their constructors, and other situations. When this happens, each of the competing definitions is listed in the right-hand side of the peek window with the source code of the current selection displayed on the left.
+
+With the peek window open, you browse the list of competing definitions to find the one you're interested in. If you want to navigate to the location of one of the definitions just double-click the definition you're interested in, or by double-clicking anywhere in the source code displayed on the left-hand side of the peek window.
+
+## Navigating source code
+
+The source code navigation features provided are powerful tools for understanding for your codebase. These let you quickly search for symbols in your code, navigate to their definitions, and find references to them.
+
+Navigation is powered by a set of tags stored in a local database of symbol information. Whenever a folder containing C++ source code files is opened, the  C/C++ extension creates a database of the symbols defined in those files. This database is updated whenever a file is saved, and shared between all workspaces that use the same source code.
 
 ### Search for symbols
 
@@ -93,17 +103,19 @@ To search for a symbol in the current file, press `kb(workbench.action.gotoSymbo
 
 ![Searching the current file](images/cpp/filesearch.png)
 
-To search for a symbol in the current workspace, press `kb(workbench.action.showAllSymbols)`, then enter the name of the symbol. A list of potential matches will appear as before. If you choose a match that was found in a file that's not already open, the file will be opened before navigating to the match's location.
+To search for a symbol in the current workspace, press `kb(workbench.action.showAllSymbols)`, then enter the name of the symbol. A list of potential matches will appear. If you choose a match that was found in a file that's not already open, the file will be opened before navigating to the match's location.
 
 ![Searching in your workspace](images/cpp/workspacesearch.png)
 
-You can also search for symbols by accessing these commands through the **Command Palette**. Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are just shortcuts for the '@' and '#' commands, so everything works the same.
+You can also search for symbols by accessing these commands through the **Command Palette**. Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the '@' and '#' commands.
 
 ### Go to Definition
 
-You can also quickly navigate to where a symbol is defined by using the **Go to Definition** feature.
+Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code.
 
-To go to a symbol's definition, place your cursor on the symbol anywhere it is used in your source code and then press `kb(editor.action.revealDefinition)`. Or, choose **Go to Definition** from the context menu (right-click, then choose **Go to Definition**). When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section and you have to choose the definition that you want to go to.
+Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`. Or, choose **Go to Definition** from the context menu (right-click, then choose **Go to Definition**). When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
+
+If no definitions can be found for the symbol you selected, the C/C++ Extension will automatically search for a declaration of the symbol.
 
 ## Next steps
 
@@ -113,7 +125,6 @@ Read on to find out about:
 * [Configure VS Code for MSVC](/docs/cpp/config-msvc.md)
 * [Configure VS Code for Mingw-w64 and GCC](/docs/cpp/config-mingw.md)
 * [Configure VS Code for macOS](/docs/cpp/config-clang-mac.md)
-* [Configure IntelliSense for cross-compiling](/docs/cpp/configure-intellisense-crosscompilation.md)
 * [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
 * [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.
 * [Tasks](/docs/editor/tasks.md) - use tasks to build your project and more

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -65,20 +65,6 @@ You can hover over a symbol to see an inline view of its definition:
 
 ![Quick info](images/mingw/quickinfo.png)
 
-### Peek
-
-The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code.
-
-To open a *peek window*, navigate to the context menu by right-clicking and selecting **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
-
-* Peek Declaration: Navigates to or displays the declaration of a symbol in the *peek window*.
-* Peek References: Displays a list of references to a symbol in the *peek window*. I can also be invoked by pressing `kb(editor.action.goToReferences)`.
-* Peek Type Definition: Displays the type definition of a symbol in the *peek window*.
-* Peek Definition: Displays the definition of a symbol in the *peek window*. It can also be invoked by pressing `kb(editor.action.peekDefinition)`.
-![Peek definition](images/cpp/peekdefn.png)
-
-With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just select result or double-click in the source code displayed on the left-hand side of the peek window.
-
 ## Navigating source code
 
 The source code navigation features provided are powerful tools for understanding for your codebase. These let you quickly search for symbols in your code, navigate to their definitions, and find references to them.
@@ -97,7 +83,7 @@ To search for a symbol in the current workspace, press `kb(workbench.action.show
 
 ![Searching in your workspace](images/cpp/workspacesearch.png)
 
-You can also search for symbols by accessing these commands through the **Command Palette**. Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the '@' and '#' commands.
+You can also search for symbols by accessing these commands through the **Command Palette**(`kb(workbench.action.showCommands)`). Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the '@' and '#' commands.
 
 ### Call hierarchy
 
@@ -111,25 +97,33 @@ Toggle the phone icon in the side bar menu to switch to incoming calls. Incoming
 
 ![Nested Calls for Call Hierarchy](images/cpp/nested-calls-call-hierarchy.png)
 
+### Peek
+
+The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code.
+
+To open a *peek window*, navigate to the context menu by right-clicking and selecting **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
+
+![Peek definition](images/cpp/peekdefn.png)
+
+With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just select result or double-click in the source code displayed on the left-hand side of the peek window.
+
 ### Go to definition
 
-Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code.
-
-Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`. Or, choose **Go to Definition** from the context menu (right-click, then choose **Go to Definition**). When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
+Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code. Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`, or right-click and choose **Go to Definition** from the context menu. When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
 
 If no definitions can be found for the symbol you selected, the C/C++ Extension will automatically search for a declaration of the symbol.
 
 ### Go to declaration
 
-Use the **Go to Declaration** feature to quickly navigate to where a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations.
-
-Select a symbol in your source code, right-click and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
+Use the **Go to Declaration** feature to navigate to the location a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations. Select a symbol in your source code, right-click and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
 
 ### Go to references
 
-Use the **Go to References** feature to understand how often and where a symbol is referenced in your source code.
+Use the **Go to References** feature to understand how often and where a symbol is referenced in your source code. Select a symbol in your source code and press `kb(editor.action.goToReferences)` or right-click and choose **Go to References** from the context menu. If any references are found, they are displayed in a peek window.
 
-Select a symbol in your source code and then press `kb(editor.action.goToReferences)` or right-click and choose **Go to References** from the context menu. If any references are found, they are displayed in a peek window.
+### Go to type definition
+
+Use the **Go to Type Definition** feature to jump to where a type is defined in your source code. Select a type in your source code and press `kb(editor.action.goToTypeDefinition)` or right-click and choose **Go to Type Definition** from the context menu.
 
 ## Next steps
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -57,7 +57,7 @@ For example, on the Windows platform, use:
 
 ### Enhanced semantic colorization
 
-When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, etc., see [Enhanced colorization](/docs/cpp/colorization-cpp.md).
+When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, etc., see [Enhanced colorization](/docs/cpp/colorization-cpp.md). For more information on configuring IntelliSense, see [IntelliSense configuration](/docs/cpp/configure-intellisense.md).
 
 ### Quick Info
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -79,10 +79,6 @@ To open a *peek window*, navigate to the context menu by right-clicking and sele
 
 With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just double-click result or anywhere in the source code displayed on the left-hand side of the peek window.
 
-<!-- WIP -->
-
-For definitions, the C/C++ extension currently doesn't parse code in a way that helps it distinguish between competing definitions based on how the symbol is used. These competing definitions arise when the symbol defines different things in different contexts, such as occurs with overloaded functions, classes and their constructors, and other situations. When this happens, each of the competing definitions is listed in the right-hand side of the peek window with the source code of the current selection displayed on the left.
-
 ## Navigating source code
 
 The source code navigation features provided are powerful tools for understanding for your codebase. These let you quickly search for symbols in your code, navigate to their definitions, and find references to them.

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -44,7 +44,7 @@ You can format an entire file with **Format Document** (`kb(editor.action.format
 * `editor.formatOnSave` - to format when you save your file.
 * `editor.formatOnType` - to format as you type (triggered on the `kbstyle(;)` character).
 
-To learn more about formatting, see [Formatting](/docs/editor/codebasics#_formatting).
+To learn more about formatting, see [Formatting](/docs/editor/codebasics.md#formatting).
 
 ### Clang-format
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -67,17 +67,17 @@ You can hover over a symbol to see an inline view of its definition:
 
 ### Peek
 
-The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code
+The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code.
 
 To open a *peek window*, navigate to the context menu by right-clicking and selecting **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
 
-- Peek Definition - Displays the definition of a symbol in the *peek window*. It can also be invoked by pressing `kb(editor.action.peekDefinition)`.
+* Peek Declaration: Navigates to or displays the declaration of a symbol in the *peek window*.
+* Peek References: Displays a list of references to a symbol in the *peek window*. I can also be invoked by pressing `kb(editor.action.goToReferences)`.
+* Peek Type Definition: Displays the type definition of a symbol in the *peek window*.
+* Peek Definition: Displays the definition of a symbol in the *peek window*. It can also be invoked by pressing `kb(editor.action.peekDefinition)`.
 ![Peek definition](images/cpp/peekdefn.png)
-- Peek Declaration - Navigates to or displays the declaration of a symbol in the *peek window*.
-- Peek References - Displays a list of references to a symbol in the *peek window*.
-- Peek Type Definition - Displays the type definition of a symbol in the *peek window*.
 
-With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just double-click result or anywhere in the source code displayed on the left-hand side of the peek window.
+With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just select result or double-click in the source code displayed on the left-hand side of the peek window.
 
 ## Navigating source code
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -4,7 +4,7 @@ Area: cpp
 TOCTitle: Editing and Navigating
 ContentId: 61D63E54-67E2-4743-B5CB-C6E7F582982A
 PageTitle: Edit and navigate
-DateApproved: 1/2/2024
+DateApproved: 1/16/2024
 MetaDescription: How to edit and navigate C++ source files in Visual Studio Code.
 ---
 # Editing and Navigating
@@ -19,7 +19,7 @@ To specify additional include directories, select an #include that has no refere
 
 ![Process of adding a new header to the include path](images\intellisense\AddingIncludePathToConfig.gif)
 
-## List members
+### List members
 
 When you type a member access symbol (`.` or `->`) the editor displays a list of members. As you type more letters, the list is filtered in real time:
 
@@ -27,16 +27,18 @@ When you type a member access symbol (`.` or `->`) the editor displays a list of
 
 ### Code formatting
 
-The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html), which is included with the extension.
+The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [vc_format](). Both of these formatting options are included in the extension, with clang-format being the default.
 
 You can format an entire file with **Format Document** (`kb(editor.action.formatDocument)`) or just the current selection with **Format Selection** (`kb(editor.action.formatSelection)`) in right-click context menu. You can also configure autoformatting with the following [settings](/docs/getstarted/settings.md):
 
 * `editor.formatOnSave` - to format when you save your file.
 * `editor.formatOnType` - to format as you type (triggered on the `kbstyle(;)` character).
 
-By default, the clang-format style is set to "file". This means, if a `.clang-format` file is found in your workspace, the settings specified in the file are used as the formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
+### Clang-format
 
-Currently, the default formatting style is "Visual Studio", an approximation of the default code formatter in Visual Studio. It implies the following settings:
+By default, the clang-format style is set to `file`. This means, if a `.clang-format` file is found in your workspace, the settings specified in the file are used as the formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
+
+Currently, the default formatting style is `Visual Studio`, an approximation of the default code formatter in Visual Studio. It implies the following settings:
 
 ```json
 UseTab: (VS Code current setting)
@@ -55,6 +57,10 @@ For example, on the Windows platform, use:
   "C_Cpp.clang_format_path": "C:\\Program Files (x86)\\LLVM\\bin\\clang-format.exe"
 ```
 
+#### vc_format
+
+By default, if an `.editorconfig` file with relevant settings is identified near the code being formatted, the Visual C++ formatting engine is used instead of clang-format. Otherwise, navigate to the `C_Cpp.formatting` [setting](/docs/getstarted/settings.md) and set it to `vc_format` to use the Visual C++ formatting engine always.
+
 ### Enhanced semantic colorization
 
 When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, etc., see [Enhanced colorization](/docs/cpp/colorization-cpp.md). For more information on configuring IntelliSense, see [IntelliSense configuration](/docs/cpp/configure-intellisense.md).
@@ -64,6 +70,14 @@ When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports se
 You can hover over a symbol to see an inline view of its definition:
 
 ![Quick info](images/mingw/quickinfo.png)
+
+### Doxygen comments
+
+Doxygen is a tool that generates documentation from source code. When you annotate code with comments, Doxygen will then generate documentation for these functions. For doxygen comments, type `/**` and press `Enter` to generate a doxygen comment block. Supported doxygen tags include: `@brief`,`@tparam`, `@param`, `@return`, `@exception`, `@deprecated`, `@note`, `@attention`, and `@pre`.
+
+### Markdown comments
+
+The C++ Extension by default supports showing a subset of markdown in your editor. This subset supports all markdown comments except the symbols "_" and "*". Toggle the new **Markdown in Comments** setting to enable all markdown, keep this subset of markdown, or disable markdown support.
 
 ## Navigating source code
 
@@ -75,7 +89,7 @@ Navigation is powered by a set of tags stored in a local database of symbol info
 
 You can search for symbols in the current file or workspace to navigate your code more quickly.
 
-To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches will appear; which is filtered as you type. Choose from the list of matches to navigate to its location.
+To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches appears; which is filtered as you type. Choose from the list of matches to navigate to its location.
 
 ![Searching the current file](images/cpp/filesearch.png)
 
@@ -89,7 +103,7 @@ You can also search for symbols by accessing these commands through the **Comman
 
 A Call Hierarchy view shows all calls to or from a function. It lets you understand the complex calling relationships between the functions in your source code.
 
-To view the call hierarchy, select a function, right-click to display the context menu and choose **Show Call Hierarchy**. You can also use the keyboard shortcut (`Shift+Alt+H` on windows), or invoke the **Command Palette** (`kb(workbench.action.showCommands)`) and run the command **Calls: Show Call Hierarchy**. This populates the call tree in the side bar with all of the functions called by your selected function.
+To view the call hierarchy, select a function, right-click to display the context menu, and choose **Show Call Hierarchy**. You can also use the keyboard shortcut (`Shift+Alt+H` on windows), or invoke the **Command Palette** (`kb(workbench.action.showCommands)`) and run the command **Calls: Show Call Hierarchy**. This populates the call tree in the side bar with all of the functions called by your selected function.
 
 ![Selecting call hierarchy and showing calls in sidebar](images/cpp/call-hierarchy.gif)
 
@@ -115,7 +129,7 @@ If no definitions can be found for the symbol you selected, the C/C++ Extension 
 
 ### Go to declaration
 
-Use the **Go to Declaration** feature to navigate to the location a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations. Select a symbol in your source code, right-click and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
+Use the **Go to Declaration** feature to navigate to the location a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations. Select a symbol in your source code, right-click, and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
 
 ### Go to references
 
@@ -129,13 +143,13 @@ Use the **Go to Type Definition** feature to jump to where a type is defined in 
 
 Read on to find out about:
 
-* [Configure VS Code for Windows Subsystem for Linux](/docs/cpp/config-wsl.md)
+* [Debugging](/docs/cpp/cpp-debug.md) - find out how to use the debugger with your project
+* [Configure IntelliSense](/docs/cpp/configure-intellisense.md) - configure IntelliSense for your project
 * [Configure VS Code for MSVC](/docs/cpp/config-msvc.md)
 * [Configure VS Code for Mingw-w64 and GCC](/docs/cpp/config-mingw.md)
 * [Configure VS Code for macOS](/docs/cpp/config-clang-mac.md)
 * [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
 * [Code Navigation](/docs/editor/editingevolved.md) - Move quickly through your source code.
 * [Tasks](/docs/editor/tasks.md) - use tasks to build your project and more
-* [Debugging](/docs/editor/debugging.md) - find out how to use the debugger with your project
 
-If you have any other questions or run into any issues, please file an issue on [GitHub](https://github.com/microsoft/vscode-cpptools/issues). You may be asked to provide logging information from the extension to help diagnose the issue. See [C/C++ extension logging](/docs/cpp/enable-logging-cpp.md) for help on providing extension logs.
+If you have any other questions or run into any issues, please file an issue on [GitHub](https://github.com/microsoft/vscode-cpptools/issues). You might be asked to provide logging information from the extension to help diagnose the issue. See [C/C++ extension logging](/docs/cpp/enable-logging-cpp.md) for help on providing extension logs.

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -99,7 +99,19 @@ To search for a symbol in the current workspace, press `kb(workbench.action.show
 
 You can also search for symbols by accessing these commands through the **Command Palette**. Use **Quick Open** (`kb(workbench.action.quickOpen)`) then enter the '@' command to search the current file, or the '#' command to search the current workspace. `kb(workbench.action.gotoSymbol)` and `kb(workbench.action.showAllSymbols)` are shortcuts for the '@' and '#' commands.
 
-### Go to Definition
+### Call hierarchy
+
+A Call Hierarchy view shows all calls to or from a function. It lets you understand the complex calling relationships between the functions in your source code.
+
+To view the call hierarchy, select a function, right-click to display the context menu and choose **Show Call Hierarchy**. You can also use the keyboard shortcut (`Shift+Alt+H` on windows), or invoke the **Command Palette** (`kb(workbench.action.showCommands)`) and run the command **Calls: Show Call Hierarchy**. This populates the call tree in the side bar with all of the functions called by your selected function.
+
+![Selecting call hierarchy and showing calls in sidebar](images/cpp/call-hierarchy.gif)
+
+Toggle the phone icon in the side bar menu to switch to incoming calls. Incoming calls show whenever your function is referenced by another function. You can also explore nested calls by selecting a function already shown in the call tree and right-clicking on that function to view the available commands.
+
+![Nested Calls for Call Hierarchy](images/cpp/nested-calls-call-hierarchy.png)
+
+### Go to definition
 
 Use the **Go to Definition** feature to quickly navigate to where a symbol is defined in your source code.
 
@@ -107,13 +119,13 @@ Select a symbol in your source code and then press `kb(editor.action.revealDefin
 
 If no definitions can be found for the symbol you selected, the C/C++ Extension will automatically search for a declaration of the symbol.
 
-### Go to Declaration
+### Go to declaration
 
 Use the **Go to Declaration** feature to quickly navigate to where a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations.
 
 Select a symbol in your source code, right-click and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
 
-### Go to References
+### Go to references
 
 Use the **Go to References** feature to understand how often and where a symbol is referenced in your source code.
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -3,17 +3,27 @@ Order: 9
 Area: cpp
 TOCTitle: Editing and Navigating
 ContentId: 61D63E54-67E2-4743-B5CB-C6E7F582982A
-PageTitle: Edit and navigate
+PageTitle: Features for editing and navigating C++ code in VS Code such as
 DateApproved: 1/16/2024
 MetaDescription: How to edit and navigate C++ source files in Visual Studio Code.
 ---
-# Editing and Navigating
+# Editing and Navigating C++ Code
 
-This article provides an overview of code editing and navigating features specific to the C/C++ Extension. For more information about general editing and navigating in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
+This article provides an overview of code editing and navigating features specific to the C/C++ extension. For more information about general editing and navigating in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
 
-## Editing Set Up
+## Editing C++ code
 
-To provide the best editing experience, the C++ extension needs to know where it can find each header file referenced in your code. By default, the extension searches the current source directory, its subdirectories, and some platform-specific locations. If a referenced header file can't be found, a red squiggle is displayed underneath the #include directive.
+The source code editing features provided by the C/C++ extension are powerful tools for editing, formatting, and understanding your codebase.
+
+## Identifying header files
+
+To provide the best editing experience, the C++ extension needs to know where to find each header file that is referenced in your code. By default, the extension searches the current source directory, its subdirectories, and some platform-specific locations. If a referenced header file can't be found, a red squiggle is displayed underneath the `#include` directive.
+
+To specify additional include directories,
+
+1. Select an `#include` path that has no reference.
+1. Select the light bulb that appears and choose **Edit "includePath" setting**, which opens the C/C++ extension's Settings editor.
+1. Under the **Include Path** section, you can specify the paths for any additional include directories.
 
 To specify additional include directories, select an #include that has no reference. Next, select the light bulb that appears and choose `Edit "includePath" setting`, which opens the C/C++ Extension's Configurations interface. Under the Include Path section, you can specify the paths for any additional include directories.
 
@@ -21,22 +31,24 @@ To specify additional include directories, select an #include that has no refere
 
 ### List members
 
-When you type a member access symbol (`.` or `->`) the editor displays a list of members. As you type more letters, the list is filtered in real time:
+When you type a member access symbol (`.` or `->`), the editor displays a list of members. As you type more letters, the list is filtered in real time:
 
 ![List members](images/cpp/list-members-cpp.png)
 
 ### Code formatting
 
-The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and [vc_format](). Both of these formatting options are included in the extension, with clang-format being the default.
+The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and vc_format. Both of these formatting options are included in the extension, with clang-format being the default.
 
-You can format an entire file with **Format Document** (`kb(editor.action.formatDocument)`) or just the current selection with **Format Selection** (`kb(editor.action.formatSelection)`) in right-click context menu. You can also configure autoformatting with the following [settings](/docs/getstarted/settings.md):
+You can format an entire file with **Format Document** (`kb(editor.action.formatDocument)`) or just the current selection with **Format Selection** (`kb(editor.action.formatSelection)`) in right-click context menu. You can also trigger formatting based on user gestures such as typing, saving, and pasting with the following [settings](/docs/getstarted/settings.md):
 
 * `editor.formatOnSave` - to format when you save your file.
 * `editor.formatOnType` - to format as you type (triggered on the `kbstyle(;)` character).
 
+To learn more about formatting, see [Formatting](/docs/editor/codebasics#_formatting).
+
 ### Clang-format
 
-By default, the clang-format style is set to `file`. This means, if a `.clang-format` file is found in your workspace, the settings specified in the file are used as the formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
+By default, the clang-format style is set to `file`. This means that if a `.clang-format` file is found in your workspace, the settings specified in the file are used as the formatting reference. Otherwise formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
 
 Currently, the default formatting style is `Visual Studio`, an approximation of the default code formatter in Visual Studio. It implies the following settings:
 

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -1,42 +1,42 @@
 ---
 Order: 9
 Area: cpp
-TOCTitle: Editing and Navigating Code
+TOCTitle: Editing and Navigating
 ContentId: 61D63E54-67E2-4743-B5CB-C6E7F582982A
-PageTitle: Edit and navigate C++ code
-DateApproved: 1/2/2023
+PageTitle: Edit and navigate
+DateApproved: 1/2/2024
 MetaDescription: How to edit and navigate C++ source files in Visual Studio Code.
 ---
-# Editing and Navigating C++ in Visual Studio Code
+# Editing and Navigating
 
-This topic provides a quick overview of general C/C++ editor features, as well as some that are specific to C/C++. For more information about editing and navigating in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
+This article provides an overview of code editing and navigating features specific to the C/C++ Extension. For more information about general editing and navigating in Visual Studio Code, see [Basic Editing](/docs/editor/codebasics.md) and [Code Navigation](/docs/editor/editingevolved.md).
 
 ## Editing Set Up
 
-To provide the best editing experience, the C++ extension needs to know where it can find each header file referenced in your code. By default, the extension searches the current source directory, its sub-directories, and some platform-specific locations. If a referenced header file can't be found, a red squiggle is displayed underneath the #include directive.
+To provide the best editing experience, the C++ extension needs to know where it can find each header file referenced in your code. By default, the extension searches the current source directory, its subdirectories, and some platform-specific locations. If a referenced header file can't be found, a red squiggle is displayed underneath the #include directive.
 
-To specify additional include directories, select an #include that has not been referenced. Next, select the lightbulb that appear and choose `Edit "includePath" setting`. This opens the C/C++ Extension's Configurations interface. Under the Include Path section you can specify the paths for any additional include directories.
+To specify additional include directories, select an #include that has no reference. Next, select the light bulb that appears and choose `Edit "includePath" setting`, which opens the C/C++ Extension's Configurations interface. Under the Include Path section, you can specify the paths for any additional include directories.
 
 ![Process of adding a new header to the include path](images\intellisense\AddingIncludePathToConfig.gif)
 
 ## List members
 
-When you type a member access symbol (`.` or `->`) the editor will display a list of members. As you type additional letters, the list is filtered in real time:
+When you type a member access symbol (`.` or `->`) the editor displays a list of members. As you type more letters, the list is filtered in real time:
 
 ![List members](images/cpp/list-members-cpp.png)
 
 ### Code formatting
 
-The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) which is included with the extension.
+The C/C++ extension for Visual Studio Code supports source code formatting using [clang-format](https://clang.llvm.org/docs/ClangFormat.html), which is included with the extension.
 
-You can format an entire file with **Format Document** (`kb(editor.action.formatDocument)`) or just the current selection with **Format Selection** (`kb(editor.action.formatSelection)`) in right-click context menu. You can also configure auto-formatting with the following [settings](/docs/getstarted/settings.md):
+You can format an entire file with **Format Document** (`kb(editor.action.formatDocument)`) or just the current selection with **Format Selection** (`kb(editor.action.formatSelection)`) in right-click context menu. You can also configure autoformatting with the following [settings](/docs/getstarted/settings.md):
 
 * `editor.formatOnSave` - to format when you save your file.
 * `editor.formatOnType` - to format as you type (triggered on the `kbstyle(;)` character).
 
-By default, the clang-format style is set to "file". This means, if a `.clang-format` file is found in your workspace, the settings specified in the file will be used as a formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
+By default, the clang-format style is set to "file". This means, if a `.clang-format` file is found in your workspace, the settings specified in the file are used as the formatting reference. Otherwise, formatting is based on the default style specified in the `C_Cpp.clang_format_fallbackStyle` [setting](/docs/getstarted/settings.md).
 
-Currently, the default formatting style is "Visual Studio" which is an approximation of the default code formatter in Visual Studio. It implies the following settings:
+Currently, the default formatting style is "Visual Studio", an approximation of the default code formatter in Visual Studio. It implies the following settings:
 
 ```json
 UseTab: (VS Code current setting)
@@ -57,7 +57,7 @@ For example, on the Windows platform, use:
 
 ### Enhanced semantic colorization
 
-When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. See [Enhanced colorization](/docs/cpp/colorization-cpp.md) for more details about setting colors for classes, functions, variables and so on.
+When IntelliSense is enabled, the Visual Studio Code C/C++ extension supports semantic colorization. For more information about setting colors for classes, functions, variables, etc., see [Enhanced colorization](/docs/cpp/colorization-cpp.md).
 
 ### Quick Info
 
@@ -65,29 +65,23 @@ You can hover over a symbol to see an inline view of its definition:
 
 ![Quick info](images/mingw/quickinfo.png)
 
-### Peek Definition
+### Peek
 
-The **Peek Definition** feature displays a few lines of code near the definition inside a *peek window*, so that you don't have to navigate away from your current location.
+The *Peek* feature displays a few lines of code inside a *peek window*, so that you don't have to navigate away from your current location. It's useful for quickly understanding the context of a symbol without having to navigate away from your current code
 
-To peek at a symbol's definition, place your cursor on the symbol anywhere it's used in your source code and then press `kb(editor.action.peekDefinition)`. Alternatively, you can choose **Peek Definition** from the context menu (right-click, then choose **Peek Definition**).
+To open a *peek window*, navigate to the context menu by right-clicking and selecting **Peek**. There, you can choose to peek at a symbol's definition, declaration, type definition, or references.
 
+- Peek Definition - Displays the definition of a symbol in the *peek window*. It can also be invoked by pressing `kb(editor.action.peekDefinition)`.
 ![Peek definition](images/cpp/peekdefn.png)
+- Peek Declaration - Navigates to or displays the declaration of a symbol in the *peek window*.
+- Peek References - Displays a list of references to a symbol in the *peek window*.
+- Peek Type Definition - Displays the type definition of a symbol in the *peek window*.
 
-Currently, the C/C++ extension doesn't parse code in a way that helps it distinguish between competing definitions based on how the symbol is used. These competing definitions arise when the symbol defines different things in different contexts, such as occurs with overloaded functions, classes and their constructors, and other situations. When this happens, each of the competing definitions is listed in the right-hand side of the peek window with the source code of the current selection displayed on the left.
+With the peek window open, you browse the list of results shown to find the one you're interested in. If you want to navigate to the location of one of these results, just double-click result or anywhere in the source code displayed on the left-hand side of the peek window.
 
-With the peek window open, you browse the list of competing definitions to find the one you're interested in. If you want to navigate to the location of one of the definitions just double-click the definition you're interested in, or by double-clicking anywhere in the source code displayed on the left-hand side of the peek window.
+<!-- WIP -->
 
-### Peek Declaration
-
-The **Peek Definition** feature displays a few lines of code near the definition inside a *peek window*, so that you don't have to navigate away from your current location.
-
-To peek at a symbol's definition, place your cursor on the symbol anywhere it's used in your source code and then press `kb(editor.action.peekDefinition)`. Alternatively, you can choose **Peek Definition** from the context menu (right-click, then choose **Peek Definition**).
-
-![Peek definition](images/cpp/peekdefn.png)
-
-Currently, the C/C++ extension doesn't parse code in a way that helps it distinguish between competing definitions based on how the symbol is used. These competing definitions arise when the symbol defines different things in different contexts, such as occurs with overloaded functions, classes and their constructors, and other situations. When this happens, each of the competing definitions is listed in the right-hand side of the peek window with the source code of the current selection displayed on the left.
-
-With the peek window open, you browse the list of competing definitions to find the one you're interested in. If you want to navigate to the location of one of the definitions just double-click the definition you're interested in, or by double-clicking anywhere in the source code displayed on the left-hand side of the peek window.
+For definitions, the C/C++ extension currently doesn't parse code in a way that helps it distinguish between competing definitions based on how the symbol is used. These competing definitions arise when the symbol defines different things in different contexts, such as occurs with overloaded functions, classes and their constructors, and other situations. When this happens, each of the competing definitions is listed in the right-hand side of the peek window with the source code of the current selection displayed on the left.
 
 ## Navigating source code
 
@@ -99,11 +93,11 @@ Navigation is powered by a set of tags stored in a local database of symbol info
 
 You can search for symbols in the current file or workspace to navigate your code more quickly.
 
-To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches will appear; it is filtered as you type. Choose from the list of matches to navigate to its location.
+To search for a symbol in the current file, press `kb(workbench.action.gotoSymbol)`, then enter the name of the symbol you're looking for. A list of potential matches will appear; which is filtered as you type. Choose from the list of matches to navigate to its location.
 
 ![Searching the current file](images/cpp/filesearch.png)
 
-To search for a symbol in the current workspace, press `kb(workbench.action.showAllSymbols)`, then enter the name of the symbol. A list of potential matches will appear. If you choose a match that was found in a file that's not already open, the file will be opened before navigating to the match's location.
+To search for a symbol in the current workspace, press `kb(workbench.action.showAllSymbols)`, then enter the name of the symbol. A list of potential matches will appear. If the match you choose is located in a file that's not already open, the file will be opened before navigating to the match's location.
 
 ![Searching in your workspace](images/cpp/workspacesearch.png)
 
@@ -116,6 +110,18 @@ Use the **Go to Definition** feature to quickly navigate to where a symbol is de
 Select a symbol in your source code and then press `kb(editor.action.revealDefinition)`. Or, choose **Go to Definition** from the context menu (right-click, then choose **Go to Definition**). When there's only one definition of the symbol, you'll navigate directly to its location, otherwise the competing definitions are displayed in a peek window as described in the previous section.
 
 If no definitions can be found for the symbol you selected, the C/C++ Extension will automatically search for a declaration of the symbol.
+
+### Go to Declaration
+
+Use the **Go to Declaration** feature to quickly navigate to where a symbol is declared in your source code. This feature functions the same as **Go to Definition**, but for declarations.
+
+Select a symbol in your source code, right-click and choose **Go to Declaration** from the context menu. This will navigate you to the location of the symbol's declaration.
+
+### Go to References
+
+Use the **Go to References** feature to understand how often and where a symbol is referenced in your source code.
+
+Select a symbol in your source code and then press `kb(editor.action.goToReferences)` or right-click and choose **Go to References** from the context menu. If any references are found, they are displayed in a peek window.
 
 ## Next steps
 

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -53,7 +53,7 @@ You can then name the new function that was created. The new function that conta
 
 ## Quick Fixes/Code Actions
 
-The C/C++ Extension provides C/C++ specific suggestions for how to fix and improve your C++ code based on your code context. View these suggestions either by hovering over a symbol and selecting the `QuickFix` link, or by selecting a code action(lightbulb) as it appears next to your code. For example, if a section of code can be extracted to a method, selecting the lightbulb icon will have the extract to method option available. Other than the features mentioned above, the C/C++ extension provides quick fixes/code actions in the following situations:
+The C/C++ extension provides C/C++ specific suggestions for how to fix and improve your C++ code based on your code context. View these suggestions either by hovering over a symbol and selecting the **QuickFix** link, or by selecting a code action (light bulb) as it appears next to your code. For example, if a section of code can be extracted to a method, selecting the light bulb icon shows Extract to method. Other than the features mentioned above, the C/C++ extension provides quick fixes/code actions in the following situations:
 
 ### Add missing header files
 

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -4,7 +4,7 @@ Area: cpp
 TOCTitle: Refactoring
 ContentId: 5b5da770-b59f-4eca-94a3-78e824d16b52
 PageTitle: Refactoring C++ code
-DateApproved: 1/3/2024
+DateApproved: 1/16/2024
 MetaDescription: How to refactor C++ source files in Visual Studio Code.
 ---
 # Refactoring C++ code

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -15,30 +15,49 @@ The C/C++ Extension in Visual Studio Code has multiple refactoring features to h
 
 Simplify the process of creating a function's declaration or definition by letting the C/C++ extension generate these items for you. This functionality applies to member functions, namespaces as classes, and templates.
 
+![Create a definition and a declaration across two files](images/refactoring/create-declaration-and-definition-different-files.gif)
+
 To create a function declaration or definition, either:
 
-* Click on your class function definition, then the Code Action (lightbulb icon) on the left. This will open a dropdown where you can select **Create a Declaration**. For creating a definition, it is the same process, just click on the function declaration, then select the Code Action for **Create a Definition**.
-* Right click a function’s declaration or definition and select the **Create Definition/Declaration** from the context menu. Based on your code, the definition or the declaration will be created.
-* Select the function, then use the **Command Palette** (`kb(workbench.action.showCommands)`) and type in the command **Create Declaration/Definition**.  Based on your code, the definition or the declaration will be created.
+* Select your class function definition, then the Code Action (light bulb icon) which opens a dropdown where you can select **Create a Declaration**. For creating a definition, it is the same process, choose the function declaration, then select the Code Action for **Create a Definition**.
+* Right-click a function’s declaration or definition and select the **Create Definition/Declaration** from the context menu. Based on your code, a definition or a declaration will be created.
+* Select the function, then use the **Command Palette** (`kb(workbench.action.showCommands)`) and type in the command **Create Declaration/Definition**. Based on your code, a definition or a declaration will be created.
 
-The location of where the definitions and declarations will be created is based on the patterns you have already established in your code. For example, if you previously had added definitions and declarations in the same file, the extension will also add any new ones to that same file. Function order will be maintained automatically.
+The location of where the definitions and declarations are created is based on the previous patterns you established in your code. For example, if you previously added definitions and declarations in the same file, the extension will also add any new ones to that same file. Function order is maintained automatically.
 
-If you have defined declarations or definitions in a different file from your source file, the extension will follow your convention. In the common case of having a header and a source file with matching names, the other file will be identified, even if the header file has not been included in the source file. In this case, once the declaration or definition has been added, your header file will be automatically referenced in your source file for you.
+![Create a definition and a declaration in the same file](images/refactoring/create-declaration-and-definition-same-file.gif)
+
+If you defined declarations or definitions in a different file from your source file, the extension follows your convention. For example, for a header and a source file with matching names, both are identified, even if the header file has not been included in the source file. In this case, once the declaration or definition is added, your header file is automatically referenced in your source file for you.
 
 If you do not have any precedent of where you create definitions or declarations, we will create a header or source file with a matching name to your current file for you.
 
-For templates, if a function template is declared in a header file, the definition of that function template will be created in the same header file. This also applies for non-template member functions of class templates.
+For templates, if a function template is declared in a header file, the definition of that function template will be created in the same header file. This also applies for nontemplate member functions of class templates.
 
 ## Extract to method
 
 The Extract Method refactoring feature allows you to extract a block of code into a separate method to help improve code readability, reduce duplication, and make the code more modular.
 
-To extract a method, select the C++ code you would like to extract. A code action (lightbulb) will appear with the option **Extract to Function**. Otherwise, right click on the code and select **Refactor > Extract** or use the keyboard command `Ctrl + Shift + R, Ctrl + E` to get more information. You can then name the new function that has been created. The new function containing your highlighted code will be placed above the current function.
+To extract a method, select the C++ code you would like to extract. A code action (light bulb) will appear with the option **Extract to Function**. Otherwise, right-click on the code and select **Refactor > Extract** or use the keyboard command (`Ctrl + Shift + R, Ctrl + E` on windows) to get more information. You can then name the new function that has been created. The new function containing your highlighted code will be placed above the current function.
+
+![Extract Method and create declaration](images/refactoring/extract-method.gif)
 
 ## Quick Fixes/Light bulbs
 
-Quick Fixes, shown as light bulbs in your code, are suggestions for how to fix and improve your code. The C/C++ extension provides C/C++ specific quick fixes in the following scenarios:
+Quick Fixes, shown as light bulbs in your code, are suggestions for how to fix and improve your code. The C/C++ extension provides C/C++ specific quick fixes in many scenarios, including:
 
 ### Add missing header files
 
-If there is an unknown symbol in your C++ code and the C/C++ Extension identifies the correct header file in your workspace, you will now have a quick fix available. Select the quick fix and the necessary header file include will be added to the top of your current C++ file.
+If there is an unknown symbol in your C++ code and the C/C++ Extension identifies the correct header file in your workspace, there is now a quick fix available. Select the quick fix and the necessary header file include will be added to the top of your current C++ file.
+
+![Add Missing Include in code using a code action](images/refactoring/quick-fix-add-missing-includes.gif)
+
+## Next steps
+
+Read on to find out about:
+
+* [C++ Code Navigation](/docs/cpp/cpp-ide.md)
+* [Basic Editing](/docs/editor/codebasics.md) - Learn about the powerful VS Code editor.
+* [Tasks](/docs/editor/tasks.md) - use tasks to build your project and more
+* [Debugging](/docs/editor/debugging.md) - find out how to use the debugger with your project
+
+If you have any other questions or run into any issues, please file an issue on [GitHub](https://github.com/microsoft/vscode-cpptools/issues). You might be asked to provide logging information from the extension to help diagnose the issue. See [C/C++ extension logging](/docs/cpp/enable-logging-cpp.md) for help on providing extension logs.

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -1,0 +1,44 @@
+---
+Order: 11
+Area: cpp
+TOCTitle: Refactoring
+ContentId: 5b5da770-b59f-4eca-94a3-78e824d16b52
+PageTitle: Refactoring C++ code
+DateApproved: 1/3/2024
+MetaDescription: How to refactor C++ source files in Visual Studio Code.
+---
+# Refactoring C++ code
+
+The C/C++ Extension in Visual Studio Code has multiple refactoring features to help you improve your code's structure, readability, and maintainability without altering its runtime behavior. These include features such as Extract Method and Create Declaration and Definitions.
+
+## Create declarations or definitions
+
+Simplify the process of creating a function's declaration or definition by letting the C/C++ extension generate these items for you. This functionality applies to member functions, namespaces as classes, and templates.
+
+To create a function declaration or definition, either:
+
+* Click on your class function definition, then the Code Action (lightbulb icon) on the left. This will open a dropdown where you can select **Create a Declaration**. For creating a definition, it is the same process, just click on the function declaration, then select the Code Action for **Create a Definition**.
+* Right click a function’s declaration or definition and select the **Create Definition/Declaration** from the context menu. Based on your code, the definition or the declaration will be created.
+* Select the function, then use the **Command Palette** (`kb(workbench.action.showCommands)`) and type in the command **Create Declaration/Definition**.  Based on your code, the definition or the declaration will be created.
+
+The location of where the definitions and declarations will be created is based on the patterns you have already established in your code. For example, if you previously had added definitions and declarations in the same file, the extension will also add any new ones to that same file. Function order will be maintained automatically.
+
+If you have defined declarations or definitions in a different file from your source file, the extension will follow your convention. In the common case of having a header and a source file with matching names, the other file will be identified, even if the header file has not been included in the source file. In this case, once the declaration or definition has been added, your header file will be automatically referenced in your source file for you.
+
+If you do not have any precedent of where you create definitions or declarations, we will create a header or source file with a matching name to your current file for you.
+
+For templates, if a function template is declared in a header file, the definition of that function template will be created in the same header file. This also applies for non-template member functions of class templates.
+
+## Extract to method
+
+The Extract Method refactoring feature allows you to extract a block of code into a separate method to help improve code readability, reduce duplication, and make the code more modular.
+
+To extract a method, select the C++ code you would like to extract. A code action (lightbulb) will appear with the option **Extract to Function**. Otherwise, right click on the code and select **Refactor > Extract** or use the keyboard command `Ctrl + Shift + R, Ctrl + E` to get more information. You can then name the new function that has been created. The new function containing your highlighted code will be placed above the current function.
+
+## Quick Fixes/Light bulbs
+
+Quick Fixes, shown as light bulbs in your code, are suggestions for how to fix and improve your code. The C/C++ extension provides C/C++ specific quick fixes in the following scenarios:
+
+### Add missing header files
+
+If there is an unknown symbol in your C++ code and the C/C++ Extension identifies the correct header file in your workspace, you will now have a quick fix available. Select the quick fix and the necessary header file include will be added to the top of your current C++ file.

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -9,7 +9,7 @@ MetaDescription: How to refactor C++ source files in Visual Studio Code.
 ---
 # Refactoring C++ code
 
-The C/C++ Extension in Visual Studio Code has multiple refactoring features to help you improve your code's structure, readability, and maintainability without altering its runtime behavior. These include features such as Extract Method and Create Declaration and Definitions.
+The C/C++ extension in Visual Studio Code has multiple refactoring features to help you improve your code's structure, readability, and maintainability without altering its runtime behavior. These include features such as Extract Method and Create Declaration and Definitions.
 
 ## Create declarations or definitions
 
@@ -19,41 +19,41 @@ Simplify the process of creating a function's declaration or definition by letti
 
 To create a function declaration or definition, either:
 
-* Select your class function definition, then the Code Action (light bulb icon) which opens a dropdown where you can select **Create a Declaration**. For creating a definition, it is the same process, choose the function declaration, then select the Code Action for **Create a Definition**.
-* Right-click a function’s declaration or definition and select the **Create Definition/Declaration** from the context menu. Based on your code, a definition or a declaration will be created.
-* Select the function, then use the **Command Palette** (`kb(workbench.action.showCommands)`) and type in the command **Create Declaration/Definition**. Based on your code, a definition or a declaration will be created.
+* Select your class function definition, select the Code Action (light bulb icon), and then select **Create a Declaration**. Similarly, to create a definition, select the function declaration, select the Code Action, and then select **Create a Definition**.
+* Right-click a function’s declaration or definition and select the **Create Definition/Declaration** from the context menu. Based on your code, a definition or a declaration is created.
+* Select the function, then use the **Command Palette** (`kb(workbench.action.showCommands)`) and type in the command **Create Declaration/Definition**. Based on your code, a definition or a declaration is created.
 
-The location of where the definitions and declarations are created is based on the previous patterns you established in your code. For example, if you previously added definitions and declarations in the same file, the extension will also add any new ones to that same file. Function order is maintained automatically.
+The location where definitions and declarations are created is based on the previous patterns you established in your code. For example, if you previously added definitions and declarations in the same file, the extension also adds new ones to that same file. The function order is maintained automatically.
 
 ![Create a definition and a declaration in the same file](images/refactoring/create-declaration-and-definition-same-file.gif)
 
 If you defined declarations or definitions in a different file from your source file, the extension follows your convention. For example, for a header and a source file with matching names, both are identified, even if the header file has not been included in the source file. In this case, once the declaration or definition is added, your header file is automatically referenced in your source file for you.
 
-If you do not have any precedent of where you create definitions or declarations, we will create a header or source file with a matching name to your current file for you.
+Otherwise, the extension creates a new header or source file for you that matches the name of your current file. This new file contains the new declaration or definition that has been generated. The new file is then automatically referenced in your current file.
 
-For templates, if a function template is declared in a header file, the definition of that function template will be created in the same header file. This also applies for nontemplate member functions of class templates.
+For templates, if a function template is declared in a header file, the definition of that function template is created in the same header file. This also applies for nontemplate member functions of class templates.
 
 ### Copy declarations or definitions
 
-If you want to choose the location that your declaration or definition is added in code, you can use the code action **Copy Declaration/Definition**. This adds the declaration or definition to your clipboard rather than directly to your code.
+If you want to choose the location where your declaration or definition is added in code, you can use the code action **Copy Declaration/Definition**. This adds the declaration or definition to the clipboard instead of adding it directly to your code.
 
 To invoke the code action, select a function that has a Quick Fix available, then select the Code Action (light bulb) and choose **Copy definition of ‘YourFunctionName’** or **Copy declaration of ‘YourFunctionName’**.
 
 ![Copy a declaration or definition](images/refactoring/copy-declaration-definition.gif)
 
-If the declaration/definition is not formatted when you paste, turn on auto formatting using **Settings** (`kb(workbench.action.openSettings)`) > **Format On Paste**. Enabling this will automatically format all items you paste in the editor.
-
 ## Extract to method
 
-The Extract Method refactoring feature allows you to extract a block of code into a separate method to help improve code readability, reduce duplication, and make the code more modular.
+The Extract Method refactoring feature enables you to extract a block of code into a separate method to help improve code readability, reduce duplication, and make the code more modular.
 
-To extract a method, select the C++ code you would like to extract. A code action (light bulb) will appear with the option **Extract to Function**. Otherwise, right-click on the code and select **Refactor > Extract** or use the keyboard command (`Ctrl + Shift + R, Ctrl + E` on windows) to get more information. You can then name the new function that has been created. The new function containing your highlighted code will be placed above the current function.
+To extract a method, select the C++ code you want to extract, select the code action (light bulb), and then select **Extract to Function**. Alternately, right-click on the code and select **Refactor > Extract** or use the keyboard command (`Ctrl + Shift + R, Ctrl + E` on windows) to get more information.
+
+You can then name the new function that was created. The new function that contains your selected code is placed above the current function.
 
 ![Extract Method and create declaration](images/refactoring/extract-method.gif)
 
 ## Quick Fixes/Code Actions
 
-The C/C++ Extension provides C/C++ specific suggestions for how to fix and improve your C++ code. These can be accessed through a code action (lightbulb icon) as you code or through the Quick Fixes link when you hover over an item. These are available for many scenarios discussed previously, such as extract to method, copy declaration/definition, or create declaration/definition. Otherwise, a code actions can help:
+The C/C++ Extension provides C/C++ specific suggestions for how to fix and improve your C++ code based on your code context. View these suggestions either by hovering over a symbol and selecting the `QuickFix` link, or by selecting a code action(lightbulb) as it appears next to your code. For example, if a section of code can be extracted to a method, selecting the lightbulb icon will have the extract to method option available. Other than the features mentioned above, the C/C++ extension provides quick fixes/code actions in the following situations:
 
 ### Add missing header files
 

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -33,6 +33,16 @@ If you do not have any precedent of where you create definitions or declarations
 
 For templates, if a function template is declared in a header file, the definition of that function template will be created in the same header file. This also applies for nontemplate member functions of class templates.
 
+### Copy declarations or definitions
+
+If you want to choose the location that your declaration or definition is added in code, you can use the code action **Copy Declaration/Definition**. This adds the declaration or definition to your clipboard rather than directly to your code.
+
+To invoke the code action, select a function that has a Quick Fix available, then select the Code Action (light bulb) and choose **Copy definition of ‘YourFunctionName’** or **Copy declaration of ‘YourFunctionName’**.
+
+![Copy a declaration or definition](images/refactoring/copy-declaration-definition.gif)
+
+If the declaration/definition is not formatted when you paste, turn on auto formatting using **Settings** (`kb(workbench.action.openSettings)`) > **Format On Paste**. Enabling this will automatically format all items you paste in the editor.
+
 ## Extract to method
 
 The Extract Method refactoring feature allows you to extract a block of code into a separate method to help improve code readability, reduce duplication, and make the code more modular.
@@ -41,9 +51,9 @@ To extract a method, select the C++ code you would like to extract. A code actio
 
 ![Extract Method and create declaration](images/refactoring/extract-method.gif)
 
-## Quick Fixes/Light bulbs
+## Quick Fixes/Code Actions
 
-Quick Fixes, shown as light bulbs in your code, are suggestions for how to fix and improve your code. The C/C++ extension provides C/C++ specific quick fixes in many scenarios, including:
+The C/C++ Extension provides C/C++ specific suggestions for how to fix and improve your C++ code. These can be accessed through a code action (lightbulb icon) as you code or through the Quick Fixes link when you hover over an item. These are available for many scenarios discussed previously, such as extract to method, copy declaration/definition, or create declaration/definition. Otherwise, a code actions can help:
 
 ### Add missing header files
 

--- a/docs/cpp/customize-default-settings-cpp.md
+++ b/docs/cpp/customize-default-settings-cpp.md
@@ -1,5 +1,5 @@
 ---
-Order: 12
+Order: 13
 Area: cpp
 TOCTitle: Settings
 ContentId: 4E34F6AF-BFC6-4BBB-8464-2E50C85AE826

--- a/docs/cpp/images/cpp/call-hierarchy.gif
+++ b/docs/cpp/images/cpp/call-hierarchy.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c86ed22b11ed5667006bd4b462de637216b4b415326ea514f059e6a51e418572
+size 2713769

--- a/docs/cpp/images/cpp/filesearch.png
+++ b/docs/cpp/images/cpp/filesearch.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae130fef3c0615b2acbfb0bcdae915bf20eda1468937b950fe1fe5100abd8a76
-size 17408
+oid sha256:b37146ece86f2143759d6927617898101f80e89a69d87f30cb63f801456ddc95
+size 66728

--- a/docs/cpp/images/cpp/nested-calls-call-hierarchy.png
+++ b/docs/cpp/images/cpp/nested-calls-call-hierarchy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd7cb5f042d4449b1231584a1fc4748e7f03ac88cfda9feac2d68a041c575f16
+size 60880

--- a/docs/cpp/images/cpp/parsing.png
+++ b/docs/cpp/images/cpp/parsing.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01be558a71d2f41e9bd2a9aa532478b4f21759534c6c34fbd2a1a932afac073e
-size 1537

--- a/docs/cpp/images/cpp/workspacesearch.png
+++ b/docs/cpp/images/cpp/workspacesearch.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eaae5dc38a4e8b0dcea5d133725602aaac47a692ff95a44d4720de503803beda
-size 16963
+oid sha256:88eae4e2ab849f786de159e2a1b20f3060daf8d32510032fa003702ace504ed5
+size 34729

--- a/docs/cpp/images/intellisense/AddingIncludePathToConfig.gif
+++ b/docs/cpp/images/intellisense/AddingIncludePathToConfig.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e15e20681bbf9d166dff0af1f220087a40f01d4487792c7809c16aa6213d82a
+size 6905756

--- a/docs/cpp/images/refactoring/copy-declaration-definition.gif
+++ b/docs/cpp/images/refactoring/copy-declaration-definition.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3a16fb5995b17b109da3e6e6b65931ab7e21d51b38abf18d99cae7b8f50de68
+size 1243577

--- a/docs/cpp/images/refactoring/create-declaration-and-definition-different-files.gif
+++ b/docs/cpp/images/refactoring/create-declaration-and-definition-different-files.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f691118c19128f3c365cc65fd5bac36d7b646432d82b958fd85ea3f7eb29b073
+size 713980

--- a/docs/cpp/images/refactoring/create-declaration-and-definition-same-file.gif
+++ b/docs/cpp/images/refactoring/create-declaration-and-definition-same-file.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1b3f7dedb89154111a44b252c2d0b1efb8b9914637dddf2b22ce37d56ff8d19
+size 157213

--- a/docs/cpp/images/refactoring/extract-method.gif
+++ b/docs/cpp/images/refactoring/extract-method.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0fc93327fc6266423bed9afe6640bbd8f8ea8e2aea3ae41267ba77942a0f601
+size 928929

--- a/docs/cpp/images/refactoring/quick-fix-add-missing-includes.gif
+++ b/docs/cpp/images/refactoring/quick-fix-add-missing-includes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80e0680961c61013450b6ee9027b9b9f614ea05258421868ba57bd30fc84fd2d
+size 416761

--- a/docs/cpp/launch-json-reference.md
+++ b/docs/cpp/launch-json-reference.md
@@ -1,5 +1,5 @@
 ---
-Order: 11
+Order: 12
 Area: cpp
 TOCTitle: Configure debugging
 ContentId: 8cb0c932-d5f2-41e7-b297-5fd100ce4e0c


### PR DESCRIPTION
Updating the editing page to include more features that we support, reformatting, and doing an overall freshness pass. Also adding a lot of features of the extension which are split with a new refactoring page. 

Features add: 
- Go to Declaration 
- Go to References 
- Go to Type Definition 
- Call Hierarchy 
- Extract Method 
- Code Action: Add missing includes 
- Create Declaration/Definition