### PR TITLE
Update Github Actions snippet regarding extension CI

### DIFF
--- a/api/working-with-extensions/continuous-integration.md
+++ b/api/working-with-extensions/continuous-integration.md
@@ -143,11 +143,11 @@ jobs:
     runs-on: $\{{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 18.x
     - run: npm install
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'


### PR DESCRIPTION
Just updates the actions (checkout, setup-node) from v3 to v4, as well as Node from 16 to 18.

18.x is the default on github action runners, but it could also be updated to 20.x if anything for longevity. Node 18 goes EOL in April 2025.