### PR TITLE
Fix example code in testing-extension.md

### DIFF
--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -96,7 +96,7 @@ import * as vscode from 'vscode';
 // import * as myExtension from '../extension';
 
 suite('Extension Test Suite', () => {
-  after(() => {
+  suiteTeardown(() => {
     vscode.window.showInformationMessage('All tests done!');
   });
 


### PR DESCRIPTION
When I ran the example file in `Testing Extensions` docs, it failed with `ReferenceError: after is not defined`. The test file looks like written in [TDD interface](https://mochajs.org/#tdd) of mocha. I think we need to use `suiteTeardown` hook instead of `after` hook (which is only available in BDD interface).