### PR TITLE
Use npx to invoke Yeoman

### DIFF
--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -9,10 +9,10 @@ MetaDescription: Create your first Visual Studio Code extension (plug-in) with a
 
 # Your First Extension
 
-In this topic, we'll teach you the fundamental concepts for building extensions. Make sure you have [Node.js](https://nodejs.org) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) with:
+In this topic, we'll teach you the fundamental concepts for building extensions. Make sure you have [Node.js](https://nodejs.org) and [Git](https://git-scm.com/) installed, then run [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) with:
 
 ```bash
-npm install -g yo generator-code
+npx --package yo --package generator-code -- yo code
 ```
 
 The generator scaffolds a TypeScript or JavaScript project ready for development. Run the generator and fill out a few fields for a TypeScript project:

--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -9,17 +9,25 @@ MetaDescription: Create your first Visual Studio Code extension (plug-in) with a
 
 # Your First Extension
 
-In this topic, we'll teach you the fundamental concepts for building extensions. Make sure you have [Node.js](https://nodejs.org) and [Git](https://git-scm.com/) installed, then run [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) with:
+In this topic, we'll teach you the fundamental concepts for building extensions. Make sure you have [Node.js](https://nodejs.org) and [Git](https://git-scm.com/) installed, then use [Yeoman](https://yeoman.io/) and [VS Code Extension Generator](https://www.npmjs.com/package/generator-code) to scaffold a TypeScript or JavaScript project ready for development.
+
+- If you do not want to install Yeoman for later use run
+
+  ```bash
+  npx --package yo --package generator-code -- yo code
+  ```
+
+- If you instead want to install it globally to ease running it repeatedly run
+
+  ```bash
+  npm install --global yo generator-code
+
+  yo code
+  ```
+
+With either choice fill out a few fields for a TypeScript project:
 
 ```bash
-npx --package yo --package generator-code -- yo code
-```
-
-The generator scaffolds a TypeScript or JavaScript project ready for development. Run the generator and fill out a few fields for a TypeScript project:
-
-```bash
-yo code
-
 # ? What type of extension do you want to create? New Extension (TypeScript)
 # ? What's the name of your extension? HelloWorld
 ### Press <Enter> to choose default for all options below ###


### PR DESCRIPTION
Nowadays it is usually bad advice to install package globally and also not needed to just invoke a command once. So, it is better to use `npx` to invoke Yeoman here.