### PR TITLE
Update WSL installed extensions screenshots

### DIFF
--- a/docs/remote/images/wsl/wsl-installed-remote-indicator.png
+++ b/docs/remote/images/wsl/wsl-installed-remote-indicator.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad0f39a1a18555d2577e0659271432dd24018be06555317986deb8dcb0e4d84f
-size 5929
+oid sha256:67ab39891692adf19103c4efad5c566f6f6ce49eebadd8ae62bf471bc512f60a
+size 22586

--- a/docs/remote/images/wsl/wsl-local-installed-extensions.png
+++ b/docs/remote/images/wsl/wsl-local-installed-extensions.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:266ed20c9eba4a41149ab6b4a92d016a539434d1633736e77eb48a044bb1b502
-size 8021
+oid sha256:f934b7ce3574178c596c94d7a3cb3062350f06e46e3052cd1bfd71c73e08941c
+size 34328


### PR DESCRIPTION
This PR fixes #6972 by renewing two screenshots that show the extensions pane in WSL. One of the two screenshots showed an extension that's deprecated (Debugger for Chrome).