### PR TITLE
chore: pass absolute path to asyncSdl

### DIFF
--- a/.pipelines/onebranch.official.yml
+++ b/.pipelines/onebranch.official.yml
@@ -40,6 +40,8 @@ extends:
       retryCount: 3
 
     globalSdl:
+      asyncSdl:
+        enabled: false
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
       policheck:

--- a/.pipelines/onebranch.official.yml
+++ b/.pipelines/onebranch.official.yml
@@ -41,7 +41,8 @@ extends:
 
     globalSdl:
       asyncSdl:
-        enabled: false
+        enabled: true
+        tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
       policheck:


### PR DESCRIPTION
There's a new stage that shows up in the CI builds and it's always broken because it can't find tsaoptions.json.

This PR attempts to fix the issue by passing in an absolute path.