### PR TITLE
chore: disable asyncSdl to fix build

### DIFF
--- a/.pipelines/onebranch.official.yml
+++ b/.pipelines/onebranch.official.yml
@@ -41,8 +41,7 @@ extends:
 
     globalSdl:
       asyncSdl:
-        enabled: true
-        tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        enabled: false
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
       policheck:


### PR DESCRIPTION
I have confirmed that using an absolute path did not fix the build issue.