### PR TITLE
Add variable `${/}` new in v1.86

### DIFF
--- a/docs/editor/variables-reference.md
+++ b/docs/editor/variables-reference.md
@@ -33,6 +33,7 @@ The following predefined variables are supported:
 - **${execPath}** - the path to the running VS Code executable
 - **${defaultBuildTask}** - the name of the default build task
 - **${pathSeparator}** - the character used by the operating system to separate components in file paths
+- **${/}** - shorthand for **${pathSeparator}**
 
 ### Predefined variables examples
 


### PR DESCRIPTION
`${/}` variable was implemented in microsoft/vscode#200750 and added to release note of v1.86 in 938983cf7379, but missing from the list of predefined variables.

See also https://code.visualstudio.com/updates/v1_86#_shorthand-for-path-separator-variable.