### PR TITLE
Revert "fix: upstream broke our build again (#7031)"

### DIFF
--- a/.pipelines/onebranch.official.yml
+++ b/.pipelines/onebranch.official.yml
@@ -16,7 +16,7 @@ resources:
     - repository: templates
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
-      ref: 4cfb37c3dc0a2f68b44cdab6070338ba94df8fef
+      ref: refs/heads/main
 
   pipelines:
     - pipeline: vscode-website-prod


### PR DESCRIPTION
This reverts commit a0f1c2d8adbb4034411252704657db28b7206e8a.

It turns out we're not allowed to use an older upstream template.