### PR TITLE
Working without Tabs -> Simulating Buffers section

### DIFF
--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -391,11 +391,11 @@ If you're coming from buffer-centric editors such as Emacs or vi, you can emulat
 ```json
 "workbench.editor.showTabs": "single",
 "workbench.editor.revealIfOpen": true,
-"workbench.editor.revealIfOpenInActiveGroup": true,
+"workbench.editor.moveToActiveGroupIfOpen": true,
 "workbench.editor.closeEmptyGroups": false,
 ```
 
-VS Code has a model where Editors live hierarchically within Editor Groups, and to split your screen you must use Editor Groups. Using `revealIfOpen` with `revealIfOpenInActiveGroup` causes Quick Open to move already-open Editors into the active Editor Group. This allows you to emulate buffer-centric environments—no tabs, split your screen, and you can view any Editor within any Editor Group without opening a file multiple times.
+VS Code has a model where Editors live hierarchically within Editor Groups, and to split your screen you must use Editor Groups. Using `revealIfOpen` with `moveToActiveGroupIfOpen` causes Quick Open to move already-open Editors into the active Editor Group. This allows you to emulate buffer-centric environments—no tabs, split your screen, and you can view any Editor within any Editor Group without opening a file multiple times.
 
 ## Window management
 

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -52,6 +52,8 @@ When you have more than one editor open you can switch between them quickly by h
 
 >**Tip:** You can resize editors and reorder them. Drag and drop the editor title area to reposition or resize the editor.
 
+If you like to split your editor window without using tabs see [Simulating Buffers](/docs/getstarted/userinterface.md#simulating-buffers).
+
 ### Split in group
 
 You can also split the current editor without creating a new editor group with the **View: Split Editor in Group** command (`kb(workbench.action.splitEditorInGroup)`). To learn more about this editor mode and specific commands for navigating between the two sides, you can read the section in [Custom Layout](/docs/editor/custom-layout.md#split-in-group) topic.

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -387,7 +387,7 @@ Windows/Linux:
 If you're coming from buffer-centric editors such as Emacs or vi, you can emulate that workflow with:
 
 ```json
-"workbench.editor.showTabs": false, // or 'single'
+"workbench.editor.showTabs": "single",
 "workbench.editor.revealIfOpen": true,
 "workbench.editor.revealIfOpenInActiveGroup": true,
 "workbench.editor.closeEmptyGroups": false,

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -387,7 +387,7 @@ Windows/Linux:
 If you're coming from buffer-centric editors such as Emacs or vi, you can emulate that workflow with:
 
 ```json
-"workbench.editor.showTabs": none, // or 'single'
+"workbench.editor.showTabs": false, // or 'single'
 "workbench.editor.revealIfOpen": true,
 "workbench.editor.revealIfOpenInActiveGroup": true,
 "workbench.editor.closeEmptyGroups": false,

--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -382,6 +382,19 @@ Windows/Linux:
 { "key": "ctrl+w", "command": "workbench.action.closeEditorsInGroup" }
 ```
 
+### Simulating Buffers
+
+If you're coming from buffer-centric editors such as Emacs or vi, you can emulate that workflow with:
+
+```json
+"workbench.editor.showTabs": none, // or 'single'
+"workbench.editor.revealIfOpen": true,
+"workbench.editor.revealIfOpenInActiveGroup": true,
+"workbench.editor.closeEmptyGroups": false,
+```
+
+VS Code has a model where Editors live hierarchically within Editor Groups, and to split your screen you must use Editor Groups. Using `revealIfOpen` with `revealIfOpenInActiveGroup` causes Quick Open to move already-open Editors into the active Editor Group. This allows you to emulate buffer-centric environments—no tabs, split your screen, and you can view any Editor within any Editor Group without opening a file multiple times.
+
 ## Window management
 
 VS Code has some options to control how windows (instances) should be opened or restored between sessions.


### PR DESCRIPTION
⚠️ This depends on new option `moveToActiveGroupIfOpen` which is being tracked in microsoft/vscode#204942 and has PR in microsoft/vscode#205442.

Adds section to Get Started -> Working without Tabs called "Simulating Buffers" which helps users coming from buffer-centric editors such as Emacs and vi. These users are accustomed to a model where any open file ("buffer") can be easily viewed in any split, without having to re-open the file a 2nd time. These users want to split window but don't wish to care about which Editor is in which Editor Group. `revealIfOpen` + `moveToActiveGroupIfOpen` enables that functionality—if a user opens a file that's already open, instead of just surfacing the Editor within it's previous Editor Group, the Editor will be moved into the active Editor Group and then revealed. This means users can use the Quick Open to jump to files from any split without inadvertently opening it multiple times in multiple editor groups.