### PR TITLE
Fix manual .NET installation for Windows example

### DIFF
--- a/docs/csharp/cs-dev-kit-faq.md
+++ b/docs/csharp/cs-dev-kit-faq.md
@@ -90,7 +90,7 @@ If .NET installation is failing or you want to reuse an existing installation of
 ```json
 {
     "dotnetAcquisitionExtension.existingDotnetPath": [
-        { "extensionId": "msazuretools.azurerm-vscode-tools", "path": "C\\Program Files\\dotnet\\dotnet.exe" }
+        { "extensionId": "msazuretools.azurerm-vscode-tools", "path": "C:\\Program Files\\dotnet\\dotnet.exe" }
     ]
 }
 ```


### PR DESCRIPTION
The colon was missing from the path meaning when copy/pasted the snippet would not work