### PR TITLE
Update the bundle file location for esbuild scripts

### DIFF
--- a/api/working-with-extensions/bundling-extension.md
+++ b/api/working-with-extensions/bundling-extension.md
@@ -34,7 +34,7 @@ Merge these entries into the `scripts` section in `package.json`:
 ```json
 "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node", // The bundle is stored in the 'dist' folder and named extension.js (check package.json)
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "tsc -p ./"


### PR DESCRIPTION
This is to fix the discrepancy of the bundle scripts. In other sections, e.g. `Using webpack`, the doc mainly uses `dist/extension.js` as the bundle file path. However, the script for esbuild uses `out/main.js`, which may cause confusions. 

I also tried to create a new project using the latest generator. It seems that the `package.json` uses `"main": "./out/extension.js",` by default, instead of `dist/extension.js`. This may cause more issues due to discrepancies.

It would be great to use an unified bundle path in all docs.