### PR TITLE
Update chat docs to use #cpp instead of #cpp_context

### DIFF
--- a/api/extension-guides/chat.md
+++ b/api/extension-guides/chat.md
@@ -238,7 +238,7 @@ cat.followupProvider = {
 
 ## Variables
 
-Chat extensions can also contribute chat *variables*, which provide context about the extension's domain. For example, a C++ extension might contribute a variable `#cpp_context` that would get resolved based on the state of the language service - what C++ version is being used and what C++ programming approach is preferred.
+Chat extensions can also contribute chat *variables*, which provide context about the extension's domain. For example, a C++ extension might contribute a variable `#cpp` that would get resolved based on the state of the language service - what C++ version is being used and what C++ programming approach is preferred.
 
 Users can refer to a chat variable in a prompt by using the `#` symbol. A variable is resolved by either the chat extension that contributed that variable, or by VS Code when it's a built-in variable (for example, `#file` or `#selection`). VS Code offers the list of registered variables upon typing the `#` symbol in the chat input.
 


### PR DESCRIPTION
After discussion with the C++ team, we're planning to use a `#cpp` name instead of the more verbose `#cpp_context` name. The VS Code docs don't necessarily need to match, but it would be nice if they did.

cc @isidorn @lukka @esweet431 @lutzroeder 