### PR TITLE
Added the support.md file documentation

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -297,6 +297,7 @@ Here are some tips for making your extension look great on the Marketplace:
 
 - Add a `LICENSE` file to the root of your extension with the information about the extension's license.
 - Add a `CHANGELOG.md` file to the root of your extension with the information about the history of the changes for your extension.
+- Add a `SUPPORT.md` file to the root of your extension with the information about how to get support for your extension.
 - Set the banner background color on the Marketplace page by specifying the corresponding hex value via the `galleryBanner.color` property in `package.json`.
 - Set an icon by specifying a relative path to a 128x128px PNG file included in your extension via the `icon` property in `package.json`.
 


### PR DESCRIPTION
I noticed when you can add a `SUPPORT.md` to your extension, it will show a `support` link under the resources.

<img width="1070" alt="Xnapper-2024-02-28-15 03 01" src="https://github.com/microsoft/vscode-docs/assets/2900833/93899dd5-cedb-45c7-8ce7-16eae8184ce6">

I have added the documentation for this in the **Marketplace integration** section