### PR TITLE
identifiers: Add OCaml

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -99,6 +99,7 @@ Makefile | `makefile`
 Markdown | `markdown`
 Objective-C | `objective-c`
 Objective-C++ | `objective-cpp`
+OCaml | `ocaml`
 Pascal | `pascal`
 Perl | `perl` and `perl6`
 PHP | `php`


### PR DESCRIPTION
This identifier is used by the [OCaml extension](https://github.com/ocamllabs/vscode-ocaml-platform).