### PR TITLE
docs: fix typo in node.js debugging page

### DIFF
--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -641,7 +641,7 @@ The JavaScript debugger can debug code compiled into WebAssembly if it includes 
 * [Zig](https://ziglang.org/): DWARF information is automatically emittted in the "Debug" build mode.
 * [Rust](https://www.rust-lang.org/): Rust emits DWARF debug information. However, wasm-pack [does not yet](https://github.com/rustwasm/wasm-pack/issues/1351) retain it during the build. So, instead of running `wasm-pack build`, users of the common wasm-bindgen/wasm-pack libraries should build manually build using two commands:
   1. `cargo install wasm-bindgen-cli` once to install the necessary command-line tool.
-  1. `cargo build --target wasm32-unknown-unkown` to build your library.
+  1. `cargo build --target wasm32-unknown-unknown` to build your library.
   1. `wasm-bindgen --keep-debug --out-dir pkg ./target/wasm32-unknown-unknown/debug/<library-name>.wasm <extra-arguments>` to generate the WebAssembly bindings, replacing `<library-name>` with the name from your Cargo.toml and configuring `<extra-arguments>` as necessary.
 
 After you have your code built, you'll want to install the [WebAssembly DWARF Debugging](https://marketplace.visualstudio.com/items?itemName=ms-vscode.wasm-dwarf-debugging) extension. This is shipped as a separate extension in order to keep the VS Code core 'streamlined.' Once installed, restart any active debugging sessions, and native code should then be mapped in the debugger! You should see your source code appear in the **Loaded Sources** view, and breakpoints should work.


### PR DESCRIPTION
Fixes typo in command