### PR TITLE
fix: backslash to escape special char in markdown table

### DIFF
--- a/docs/editor/emmet.md
+++ b/docs/editor/emmet.md
@@ -176,7 +176,7 @@ Topic | Old Emmet | Emmet 2.0
 Snippets vs Abbreviations | Supports both in 2 separate properties called `snippets` and `abbreviations` | The 2 have been combined into a single property called snippets. See default [HTML snippets](https://github.com/emmetio/snippets/blob/master/html.json) and [CSS snippets](https://github.com/emmetio/snippets/blob/master/css.json)
 CSS snippet names | Can contain `:` | Do not use `:` when defining snippet names. It is used to separate property name and value when Emmet tries to fuzzy match the given abbreviation to one of the snippets.
 CSS snippet values | Can end with `;` | Do not add `;` at end of snippet value. Emmet will add the trailing `;` based on the file type (css/less/scss vs sass/stylus) or the emmet preference set for `css.propertyEnd`, `sass.propertyEnd`, `stylus.propertyEnd`
-Cursor location | `${cursor}` or `|` can be used | Use only textmate syntax like `${1}` for tab stops and cursor locations
+Cursor location | `${cursor}` or `\|` can be used | Use only textmate syntax like `${1}` for tab stops and cursor locations
 
 ### HTML Emmet snippets
 


### PR DESCRIPTION
I think a backslash is missing on this page.

Before:
![image](https://github.com/microsoft/vscode-docs/assets/7253929/547023c3-4540-4bd8-9e00-86b2ea296a29)

After:
![image](https://github.com/microsoft/vscode-docs/assets/7253929/de79a198-f584-418c-9a28-8730e013dfc7)
