### PR TITLE
Fine-tune GitHub's language detection for the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.md diff=markdown
+
+# Fine-tune GitHub's language detection
+docs/** -linguist-documentation
+*.md linguist-detectable


### PR DESCRIPTION
Since the whole repo is dedicated to documentation, documentation is the "source code" of this repo. In order to capture this in language stats (and potentially attract more contributors):
1. Consider `docs/` folder "source", not documentation.
2. Count all Markdown files as "source".

The "language of the repo" is expected to change from CSS to Markdown.

|Before| After|
|---|---|
|![image](https://github.com/microsoft/vscode-docs/assets/25753618/5742e31a-df4a-4ffd-b3f2-e03e30f52a14)|![image](https://github.com/microsoft/vscode-docs/assets/25753618/65001b7f-9e4a-44e5-b525-1516300f62e8)|
|![image](https://github.com/microsoft/vscode-docs/assets/25753618/c6bbf251-66fe-4fba-89a2-9a2444715254)|![image](https://github.com/microsoft/vscode-docs/assets/25753618/b7f63efa-1d4b-4fb5-9aa8-3a6f3bc95ea2)|
