### PR TITLE
docs: update `glob` usage in testing extension

### DIFF
--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -173,7 +173,7 @@ When running the extension integration test, `--extensionTestsPath` points to th
 ```ts
 import * as path from 'path';
 import * as Mocha from 'mocha';
-import * as glob from 'glob';
+import { glob } from 'glob';
 
 export function run(): Promise<void> {
   // Create the mocha test
@@ -185,11 +185,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname, '..');
 
   return new Promise((c, e) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-      if (err) {
-        return e(err);
-      }
-
+    glob('**/**.test.js', { cwd: testsRoot }).then((files) => {
       // Add files to the test suite
       files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
 
@@ -205,6 +201,8 @@ export function run(): Promise<void> {
       } catch (err) {
         e(err);
       }
+    }).catch((err) => {
+      return e(err);
     });
   });
 }


### PR DESCRIPTION
The `glob` library used in the testing example docs has been updated to use `promise` instead of `callback` starting from version `v9.0.0`. This PR will update the documentation for these changes.

https://github.com/isaacs/node-glob/blob/v9/changelog.md#90



Thanks :)