### PR TITLE
Explain onView activation event is not emit by built in views

### DIFF
--- a/api/references/activation-events.md
+++ b/api/references/activation-events.md
@@ -129,7 +129,7 @@ This activation event is emitted and interested extensions will be activated whe
 
 ## onView
 
-This activation event is emitted and interested extensions will be activated whenever a view of the specified id is expanded in the VS Code sidebar (Extensions or Source Control are examples of built-in views).
+This activation event is emitted and interested extensions will be activated whenever a view of the specified id is expanded in the VS Code sidebar. Built-in views do not emit an activation event.
 
 The activation event below will fire whenever a view with the `nodeDependencies` id is visible:
 


### PR DESCRIPTION
onView is only emitted by custom views, per microsoft/vscode#176805. It is additionally confusing that the documentation gives a couple of examples that cannot be applied because they are built-in views.