### PR TITLE
Fix broken docs by rehosting images lost in migration away from intellicode-docs-pr

### DIFF
--- a/docs/editor/images/intellisense/intellicode-usage-examples-v2.gif
+++ b/docs/editor/images/intellisense/intellicode-usage-examples-v2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:951f4b8e0fb064b5946a74438e5b8f5e28e3cb1ff10fde1afceae2e896791e5d
+size 49555500

--- a/docs/python/images/editing/intellicodeCompletions.gif
+++ b/docs/python/images/editing/intellicodeCompletions.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4532a9727402d27c29546b9e4da463df45903c8ea900eb231eeff055da22db33
+size 103966

--- a/docs/python/images/editing/intellicodeCompletionsIntellisenseDriven.gif
+++ b/docs/python/images/editing/intellicodeCompletionsIntellisenseDriven.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7bfffe69ca2dddb24ca39b71ddba1fa50d66913223a6484e958e555c706dcdb
+size 143586


### PR DESCRIPTION
Marketplace and docs pages are broken at the moment due to image files lost in repository migration.
This PR restores three images relating to IntelliCode Completions for Python and API Usage Examples.