### PR TITLE
Add missing activation events

### DIFF
--- a/api/references/activation-events.md
+++ b/api/references/activation-events.md
@@ -15,14 +15,26 @@ MetaDescription: To support lazy activation of Visual Studio Code extensions (pl
 - [`onCommand`](/api/references/activation-events#onCommand)
 - [`onDebug`](/api/references/activation-events#onDebug)
   - [`onDebugInitialConfigurations`](/api/references/activation-events#onDebugInitialConfigurations)
+  - [`onDebugDynamicConfigurations`](/api/references/activation-events#onDebugDynamicConfigurations)
   - [`onDebugResolve`](/api/references/activation-events#onDebugResolve)
+  - [`onDebugAdapterProtocolTracker`](/api/references/activation-events#onDebugAdapterProtocolTracker)
 - [`workspaceContains`](/api/references/activation-events#workspaceContains)
 - [`onFileSystem`](/api/references/activation-events#onFileSystem)
+- [`onEditSession`](/api/references/activation-events#onEditSession)
+- [`onSearch`](/api/references/activation-events#onSearch)
 - [`onView`](/api/references/activation-events#onView)
 - [`onUri`](/api/references/activation-events#onUri)
+- [`onOpenExternalUri`](/api/references/activation-events#onOpenExternalUri)
 - [`onWebviewPanel`](/api/references/activation-events#onWebviewPanel)
 - [`onCustomEditor`](/api/references/activation-events#onCustomEditor)
+- [`onNotebook`](/api/references/activation-events#onNotebook)
+- [`onRenderer`](/api/references/activation-events#onRenderer)
 - [`onAuthenticationRequest`](/api/references/activation-events#onAuthenticationRequest)
+- [`onTaskType`](/api/references/activation-events#onTaskType)
+- [`onTerminalProfile`](/api/references/activation-events#onTerminalProfile)
+- [`onTerminalQuickFixRequest`](/api/references/activation-events#onTerminalQuickFixRequest)
+- [`onWalkthrough`](/api/references/activation-events#onWalkthrough)
+- [`onIssueReporterOpened`](/api/references/activation-events#onIssueReporterOpened)
 - [`onStartupFinished`](/api/references/activation-events#onStartupFinished)
 - [`*`](/api/references/activation-events#Start-up)
 
@@ -33,11 +45,9 @@ We also provide a reference of all fields in the [`package.json` extension manif
 This activation event is emitted and interested extensions will be activated whenever a file that resolves to a certain language gets opened.
 
 ```json
-...
 "activationEvents": [
     "onLanguage:python"
 ]
-...
 ```
 
 The `onLanguage` event takes a [language identifier](/docs/languages/identifiers) value.
@@ -50,7 +60,6 @@ Multiple languages can be declared with separate `onLanguage` entries in the `ac
     "onLanguage:markdown",
     "onLanguage:typescript"
 ]
-...
 ```
 
 > **Note**: Beginning with VS Code 1.74.0, languages contributed by your extension do not require a corresponding `onLanguage` activation event declaration for your extension to be activated.
@@ -70,11 +79,9 @@ Additionally, if your extension needs to be activated before any language is use
 This activation event is emitted and interested extensions will be activated whenever a command is being invoked:
 
 ```json
-...
 "activationEvents": [
     "onCommand:extension.sayHello"
 ]
-...
 ```
 
 > **Note**: Beginning with VS Code 1.74.0, commands contributed by your extension do not require a corresponding `onCommand` activation event declaration for your extension to be activated.
@@ -84,18 +91,22 @@ This activation event is emitted and interested extensions will be activated whe
 This activation event is emitted and interested extensions will be activated before a debug session is started:
 
 ```json
-...
 "activationEvents": [
     "onDebug"
 ]
-...
 ```
 
-These are two more fine-grained `onDebug` activation events:
+These are four more fine-grained `onDebug` activation events:
 
 ### onDebugInitialConfigurations
 
-`onDebugInitialConfigurations` is fired just before the `provideDebugConfigurations` method of the `DebugConfigurationProvider` is called.
+This activation event is emitted just before the `provideDebugConfigurations` method of the `DebugConfigurationProvider` is called to provide initial debug configurations, such as whenever a `launch.json` needs to be created.
+
+### onDebugDynamicConfigurations
+
+This activation event is emitted just before the `provideDebugConfigurations` method of the `DebugConfigurationProvider` is called to provide dynamic debug configurations when the user asks for them, such as through the UI via the "Select and Start Debugging" command.
+
+The presence of this activation event is used as a signal that the extension contributes dynamic debug configurations.
 
 ### onDebugResolve
 
@@ -103,29 +114,37 @@ These are two more fine-grained `onDebug` activation events:
 
 **Rule of thumb:** If activation of a debug extension is lightweight, use `onDebug`. If it is heavyweight, use `onDebugInitialConfigurations` and/or `onDebugResolve` depending on whether the `DebugConfigurationProvider` implements the corresponding methods `provideDebugConfigurations` and/or `resolveDebugConfiguration`. See [Using a DebugConfigurationProvider](/api/extension-guides/debugger-extension#using-a-debugconfigurationprovider) for more details on these methods.
 
+### onDebugAdapterProtocolTracker
+
+`onDebugAdapterProtocolTracker:type` is emitted whenever a debug session with the specific type is about to be launched and a debug protocol tracker might be needed.
+
 ## workspaceContains
 
-This activation event is emitted and interested extensions will be activated whenever a folder is opened and the folder contains at least one file that matches a [glob pattern](/docs/editor/glob-patterns).
+`workspaceContains:path` is emitted and interested extensions will be activated whenever a folder is opened and the folder contains at least one file that matches a [glob pattern](/docs/editor/glob-patterns).
 
 ```json
-...
 "activationEvents": [
     "workspaceContains:**/.editorconfig"
 ]
-...
 ```
 
 ## onFileSystem
 
-This activation event is emitted and interested extensions will be activated whenever a file or folder from a specific _scheme_ is read. This is usually the `file`-scheme, but with custom file system providers more schemes come into place, e.g `ftp` or `ssh`.
+`onFileSystem:scheme` is emitted and interested extensions will be activated whenever a file or folder from a specific _scheme_ is read. This is usually the `file`-scheme, but with custom file system providers more schemes come into place, e.g `ftp` or `ssh`.
 
 ```json
-...
 "activationEvents": [
     "onFileSystem:sftp"
 ]
-...
 ```
+
+## onEditSession
+
+`onEditSession:scheme` is emitted when an edit session is accessed with the given scheme.
+
+## onSearch
+
+`onSearch:scheme` is emitted when a search is started in the folder with the given scheme.
 
 ## onView
 
@@ -134,26 +153,21 @@ This activation event is emitted and interested extensions will be activated whe
 The activation event below will fire whenever a view with the `nodeDependencies` id is visible:
 
 ```json
-...
 "activationEvents": [
     "onView:nodeDependencies"
 ]
-...
 ```
 
 > **Note**: Beginning with VS Code 1.74.0, views contributed by your extension do not require a corresponding `onView` activation event declaration for your extension to be activated.
-
 
 ## onUri
 
 This activation event is emitted and interested extensions will be activated whenever a system-wide Uri for that extension is opened. The Uri scheme is fixed to either `vscode` or `vscode-insiders`. The Uri authority must be the extension's identifier. The rest of the Uri is arbitrary.
 
 ```json
-...
 "activationEvents": [
     "onUri"
 ]
-...
 ```
 
 If the `vscode.git` extension defines `onUri` as an activation event, it will be activated in any of the following Uris are open:
@@ -161,6 +175,10 @@ If the `vscode.git` extension defines `onUri` as an activation event, it will be
 - `vscode://vscode.git/init`
 - `vscode://vscode.git/clone?url=https%3A%2F%2Fgithub.com%2FMicrosoft%2Fvscode-vsce.git`
 - `vscode-insiders://vscode.git/init` (for VS Code Insiders)
+
+## onOpenExternalUri
+
+This activation event is emitted when an external uri (such as a http or https link) is being opened.
 
 ## onWebviewPanel
 
@@ -192,6 +210,14 @@ will cause the extension to be activated when VS Code needs to restore a custom 
 
 > **Note**: Beginning with VS Code 1.74.0, custom editors contributed by your extension do not require a corresponding `onCustomEditor` activation event declaration for your extension to be activated.
 
+## onNotebook
+
+`onNotebook:type` is emitted when the specified notebook document type is opened.
+
+## onRenderer
+
+`onRenderer:id` is emitted when a notebook output renderer is used.
+
 ## onAuthenticationRequest
 
 This activation event is emitted and interested extensions will be activated whenever an extension requests an authentication session (via the `authentication.getSession()` API) with the matching `providerId`.
@@ -208,16 +234,34 @@ will cause the extension to be activated when VS Code needs retrieve an `Authent
 
 > **Note**: Beginning with VS Code 1.74.0, authentication providers contributed by your extension do not require a corresponding `onAuthenticationRequest` activation event declaration for your extension to be activated.
 
+## onTaskType
+
+`onTaskType:type` is emitted when tasks of a certain type need to be listed or resolved.
+
+## onTerminalProfile
+
+`onTerminalProfile:id` is emitted when a specific terminal profile is launched.
+
+## onTerminalQuickFixRequest
+
+`onTerminalQuickFixRequest:id` is emitted when a command matches the selector with this ID.
+
+## onWalkthrough
+
+`onWalkthrough:id` is emitted when a specified walkthrough is opened.
+
+## onIssueReporterOpened
+
+This activation event is emitted when the issue reporter is opened (e.g. **Help: Report Issue**).
+
 ## onStartupFinished
 
 This activation event is emitted and interested extensions will be activated **some time after** VS Code starts up. This is similar to the `*` activation event, but it will not slow down VS Code startup. Currently, this event is emitted after all the `*` activated extensions have finished activating.
 
 ```json
-...
 "activationEvents": [
     "onStartupFinished"
 ]
-...
 ```
 
 ## Start up
@@ -227,11 +271,9 @@ The `*` activation event is emitted and interested extensions will be activated 
 > **Note:** To ensure a great user experience, please use this activation event in your extension only when no other activation events combination works in your use-case.
 
 ```json
-...
 "activationEvents": [
     "*"
 ]
-...
 ```
 
 > **Note:** An extension can listen to multiple activation events, and that is preferable to listening to `"*"`.


### PR DESCRIPTION
Complete the list of activation events by adding missing entries and a brief description of each.

Closes #5745 by completing the list.
Closes #6600 by documenting `onDebugInitialConfigurations` and `onDebugDynamicConfigurations` with the difference between them.