### PR TITLE
docs:  endpoint clarification

### DIFF
--- a/docs/remote/vscode-server.md
+++ b/docs/remote/vscode-server.md
@@ -89,10 +89,10 @@ No, hosting it as a service is not allowed, as specified in the [VS Code Server 
 
 ### Is there a list of endpoints the VS Code Server uses?
 
-If you're working in a restricted environment, you may need to ensure the VS Code Server has access to the following endpoints:
+If you're working in a restricted environment, you may need to ensure the VS Code Server has access to the endpoints listed in the following articles:
 
-* https://code.visualstudio.com/docs/setup/network#_common-hostnames
-* https://code.visualstudio.com/docs/remote/ssh#_what-are-the-connectivity-requirements-for-the-vs-code-server-when-it-is-running-on-a-remote-machine-vm
+* [https://code.visualstudio.com/docs/setup/network#_common-hostnames](https://code.visualstudio.com/docs/setup/network#_common-hostnames)
+* [https://code.visualstudio.com/docs/remote/ssh#_what-are-the-connectivity-requirements-for-the-vs-code-server-when-it-is-running-on-a-remote-machine-vm](https://code.visualstudio.com/docs/remote/ssh#_what-are-the-connectivity-requirements-for-the-vs-code-server-when-it-is-running-on-a-remote-machine-vm)
 
 ### Are there any other extension limitations?
 


### PR DESCRIPTION
- clarify the endpoints are in the links, these are not the endpoints
- change to links, instead of text