### PR TITLE
DOC: Debug notebooks uses settings, not launch.json configurations.

### DIFF
--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -280,6 +280,8 @@ If you want to use the full set of debugging features supported in VS Code, such
 2. Then select the **Debug Cell** button in the menu next to the **Run** button. This will run the cell in a debug session, and will pause on your breakpoints in any code that runs, even if it is in a different cell or a `.py` file.
 3. You can use the Debug view, Debug Console, and all the buttons in the Debug Toolbar as you normally would in VS Code.
 
+Note that debugging cells in a jupyter notebook does not use any of the debug configurations in launch.json.  It can be customized instead via settings such as `jupyter.debugJustMyCode`.
+
 ![Debug cell button](images/jupyter/debug-cell.png)
 
 ### Search through notebook


### PR DESCRIPTION
A few people have been asking about which  launch.json configuration notebook debugging picks up. [e.g.](https://github.com/microsoft/vscode-jupyter/discussions/13394).

Across debugging, enough people ask about justMyCode that it is mentioned now in a tooltip when you skip a frame.  But there's nothing in the notebook docs about how to set it, which is different from the standard launch.json.   I assume since [debugging tests](https://code.visualstudio.com/docs/python/testing#_debug-tests) included this tidbit, at least something minimal would be desirable here too.