### PR TITLE
Unnecessary '^'

### DIFF
--- a/docs/editor/userdefinedsnippets.md
+++ b/docs/editor/userdefinedsnippets.md
@@ -216,7 +216,7 @@ Example | Output | Explanation
 `"${TM_FILENAME/[\\.]/_/}"` | `example-123_456-TEST.js` | Replace the first `.` with `_`
 `"${TM_FILENAME/[\\.-]/_/g}"` | `example_123_456_TEST_js` | Replace each `.` or `-` with `_`
 `"${TM_FILENAME/(.*)/${1:/upcase}/}"` | `EXAMPLE-123.456-TEST.JS` | Change to all uppercase
-`"${TM_FILENAME/[^0-9^a-z]//gi}"` | `example123456TESTjs` | Remove non-alphanumeric characters
+`"${TM_FILENAME/[^0-9a-z]//gi}"` | `example123456TESTjs` | Remove non-alphanumeric characters
 
 ### Grammar
 


### PR DESCRIPTION
https://code.visualstudio.com/docs/editor/userdefinedsnippets#_transform-examples

![搜狗截图20240423171915](https://github.com/microsoft/vscode-docs/assets/81228933/d1c78687-b6c0-45c7-aaa8-68855c187a38)
The second `^` is not needed
![搜狗截图20240423173426](https://github.com/microsoft/vscode-docs/assets/81228933/5eea7e2f-8749-4dd8-8612-f5975afe3cae)

***
```jsonc
  "name": {
    "prefix": "name",
    // "body": "${TM_FILENAME/[^0-9^a-z]//gi}"
    "body": "${TM_FILENAME/[^0-9a-z]//gi}"
  }

```

![搜狗截图20240423173543](https://github.com/microsoft/vscode-docs/assets/81228933/e922a684-1030-4aa1-a4ee-b11ddadb34a5)
