### PR TITLE
identifiers: Add Svelte

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -117,6 +117,7 @@ Shell Script (Bash) | `shellscript`
 Slim | `slim`
 SQL | `sql`
 Stylus | `stylus`
+Svelte | `svelte`
 Swift | `swift`
 TypeScript | `typescript`
 TypeScript JSX | `typescriptreact`


### PR DESCRIPTION
This identifier is used by the [Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).