### PR TITLE
Added link to known limitations in SSH agent forwarding documentation

### DIFF
--- a/remote/advancedcontainers/sharing-git-credentials.md
+++ b/remote/advancedcontainers/sharing-git-credentials.md
@@ -70,6 +70,8 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
 fi
 ```
 
+If you encounter any issues check the Dev Container's [known limitations](/docs/devcontainers/containers.md#known-limitations).
+
 ## Sharing GPG Keys
 
 If you want to [GPG](https://www.gnupg.org/) sign your commits, you can share your local keys with your container as well. You can find out about signing using a GPG key in [GitHub's documentation](https://docs.github.com/authentication/managing-commit-signature-verification).

--- a/remote/advancedcontainers/sharing-git-credentials.md
+++ b/remote/advancedcontainers/sharing-git-credentials.md
@@ -70,7 +70,7 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
 fi
 ```
 
-If you encounter any issues check the Dev Container's [known limitations](/docs/devcontainers/containers.md#known-limitations).
+If you encounter any issues check the Dev Containers' [known limitations](/docs/devcontainers/containers.md#known-limitations).
 
 ## Sharing GPG Keys
 

--- a/remote/advancedcontainers/sharing-git-credentials.md
+++ b/remote/advancedcontainers/sharing-git-credentials.md
@@ -70,7 +70,7 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
 fi
 ```
 
-If you encounter any issues check the Dev Containers' [known limitations](/docs/devcontainers/containers.md#known-limitations).
+If you encounter any issues, you may want to check the Dev Containers extension's [known limitations](/docs/devcontainers/containers.md#known-limitations).
 
 ## Sharing GPG Keys
 


### PR DESCRIPTION
I recently encountered a problem related to the ssh agent forwarding and wasn't able to solve it until I stumbled upon this issue https://github.com/microsoft/vscode-remote-release/issues/8666 and saw that the solution was already mentioned in https://code.visualstudio.com/docs/devcontainers/containers#_known-limitations 

I feel that this section is somewhat hidden as the first documentation related to ssh agent forwarding in Dev Containers is https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials, and there was no mention of any potential issues, so I added a link to the `known limitations` sections in the `sharing-git-credentials` page.

Please let me know if this is useful.