### PR TITLE
Update Python Editing docs with more code actions 

### DIFF
--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -87,19 +87,35 @@ While editing, you can right-click different identifiers to take advantage of se
 ## Quick Fixes
 
 The add imports Quick Fix when using Pylance allows you to quickly complete import statements. First, begin by typing a package name within the editor. You will notice a Code Action is available to automatically complete the line of source code (as long as you have the module installed within the environment). Hover over the text (marked with a squiggle) and then select the Code Action light bulb when it appears. You can then select from a list of potential imports.
-![Adding an import](images/editing/quickFix.gif)
+
+![Add import code action](images/editing/quickFix.png)
 
 This Code Action also recognizes some of the popular abbreviations for the following common Python packages: `numpy` as np, `tensorflow` as tf, `pandas` as pd, `matplotlib.pyplot` as plt, `matplotlib` as mpl, `math` as m, `scipi.io` as spio, and `scipy` as sp, `panel` as pn, and `holoviews` as hv.
 
 ![Common package abbreviations](images/editing/packageAbbreviations.gif)
 
-The import suggestions list is ordered with import statements for packages (or modules) at the top. It will also include statements for more modules and/or members (classes, objects, etc.) from specified packages.
+The import suggestions list displays  the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.  In the case where the 3 high-confidence import options aren’t what you are looking for, Pylance has a **Search for additional import matches** Code Action, which displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
 
-Just like with auto imports, only top-levels symbols are suggested by default. You can customize this behavior through the `python.analysis.packageIndexDepths` setting.
+![Search for additional import matches Code Action](images/editing/search-imports-code-action.gif)
 
-## Refactoring
+Pylance also offers a **Change spelling** Code Action, which displays import suggestions for missing imports due to typos.
 
-The Python extension adds the following refactoring functionalities: **Extract Variable**, **Extract Method** and **Rename Module**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
+![Change spelling code action on missing import due to a typo](images/editing/change-spelling-code-action.gif)
+
+
+Just like with auto imports, only top-levels symbols are suggested by default. You can customize this behavior through the `python.analysis.packageIndexDepths` setting. Note that user symbol aliases (e.g. `import foo as bar`) are not supported by these Code Actions.
+
+### Implement All Inherited Abstract Classes
+
+In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod decorator`. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
+
+Pylance offers a code action to simplify the process of creating these classes. When defining a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
+
+![Implement inherited abstract classes](images/editing/implement-inherited-abstract-classes.gif)
+
+## Refactorings
+
+The Python extension adds the following refactoring functionalities via the Pylance extension: **Extract Variable**, **Extract Method**, **Rename Module** and **Move Symbol**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
 
 ### Extract Variable
 
@@ -124,6 +140,16 @@ After a Python file/module is renamed, Pylance can find all instances that may n
 To customize which references need to be updated, you can toggle the checkboxes at the line or from the file level in **Refactor Preview**. Once you've made your selections, you can select **Apply Refactoring** or **Discard Refactoring**.
 
 ![Renaming a module](images/editing/refactorRenameModule.gif)
+
+### Move Symbol
+
+The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: **Move symbol to...**, which displays a file picker so you can select the destination file for the symbol to be moved to,  and **Move symbol**, which creates a new file with the symbol name, located on the same directory as the source file where the Code Action was invoked.
+
+You can access this Code Action by hovering over the symbol you want to move, then selecting the light bulb that appears next to it. Alternatively, you can right-click on the symbol and select **Refactor...** from the context menu.
+
+
+![Move Symbol refactoring options](images/editing/move-symbol.gif)
+
 
 ### Sort Imports
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -96,7 +96,7 @@ This Code Action also recognizes some of the popular abbreviations for the follo
 
 ![Common package abbreviations](images/editing/packageAbbreviations.gif)
 
-The import suggestions list displays  the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.  In the case where the 3 high-confidence import options aren’t what you are looking for, Pylance has a **Search for additional import matches** Code Action, which displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
+The import suggestions list displays the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.  In the case where the 3 high-confidence import options aren’t what you are looking for, Pylance has a **Search for additional import matches** Code Action, which displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
 
 ![Search for additional import matches Code Action](images/editing/search-imports-code-action.gif)
 
@@ -145,9 +145,9 @@ To customize which references need to be updated, you can toggle the checkboxes 
 
 ### Move Symbol
 
-The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: **Move symbol to...**, which displays a file picker so you can select the destination file for the symbol to be moved to,  and **Move symbol**, which creates a new file with the symbol name, located on the same directory as the source file where the Code Action was invoked.
+The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: **Move symbol to...**, which displays a file picker so you can select the destination file for the symbol to be moved to,  and **Move symbol to new file**, which creates a new file with the symbol name, located on the same directory as the source file where the Code Action was invoked.
 
-You can access this Code Action by hovering over the symbol you want to move, then selecting the light bulb that appears next to it. Alternatively, you can right-click on the symbol and select **Refactor...** from the context menu.
+You can access these Code Actions by hovering over the symbol you want to move, then selecting the light bulb that appears next to the desired action. Alternatively, you can right-click on the symbol and select **Refactor...** from the context menu.
 
 
 ![Move Symbol refactoring options](images/editing/move-symbol.gif)

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -156,7 +156,7 @@ You can access these Code Actions by hovering over the symbol you want to move, 
 
 In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod` decorator. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
 
-Pylance offers a code action to simplify the process of creating these classes. When you define a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
+Pylance offers a Code Action to simplify the process of creating these classes. When you define a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
 
 ![Implement inherited abstract classes](images/editing/implement-inherited-abstract-classes.gif)
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -112,7 +112,7 @@ Pylance displays the **Change spelling** Quick Fix on unresolved variables or mi
 
 > **Note**: For user symbols, these Quick Fixes will suggest the imports only from the files where they are defined. Import suggestions from files where the user symbols are external/imported aren't supported.
 >
-> Also note that for symbols coming from installed packages (typically located under the `site-packages` folder of your Python environment), only those defined in the package's `__init__.py` file are suggested by these Quick Fixes. You can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting, but please note it may impact Pylance's performance.
+> Also note that for symbols coming from installed packages (typically located under the `site-packages` folder of your Python environment), only those defined in the package's root folder, such as in its `__init__.py` file, are suggested by these Quick Fixes. You can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting, but please note it may impact Pylance's performance.
 
 ## Refactorings
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -86,9 +86,9 @@ While editing, you can right-click different identifiers to take advantage of se
 
 ## Quick Fixes
 
-### Add Missing Imports
+### Add import
 
-The add imports Quick Fix when using Pylance allows you to quickly complete import statements. First, begin by typing a package name within the editor. You will notice a Code Action is available to automatically complete the line of source code (as long as you have the module installed within the environment). Hover over the text (marked with a squiggle) and then select the Code Action light bulb when it appears. You can then select from a list of potential imports.
+The add import Quick Fix when using Pylance allows you to quickly complete import statements. First, begin by typing a package name within the editor. You will notice a Code Action is available to automatically complete the line of source code (as long as you have the module installed within the environment). Hover over the text (marked with a squiggle) and then select the Code Action light bulb when it appears. You can then select from a list of potential imports.
 
 ![Add import code action](images/editing/quickFix.png)
 
@@ -96,28 +96,25 @@ This Code Action also recognizes some of the popular abbreviations for the follo
 
 ![Common package abbreviations](images/editing/packageAbbreviations.gif)
 
-The import suggestions list displays the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.  In the case where the 3 high-confidence import options aren’t what you are looking for, Pylance has a **Search for additional import matches** Code Action, which displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
+The import suggestions list displays the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.
+
+### Search for additional import matches
+The add import Quick Fix only shows 3 high-confidence import options by default. In the case where they aren't what you are looking for, Pylance has a **Search for additional import matches** Quick Fix for missing import errors, which also displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
 
 ![Search for additional import matches Code Action](images/editing/search-imports-code-action.gif)
 
-Pylance also offers a **Change spelling** Code Action, which displays import suggestions for missing imports due to typos.
+
+### Change spelling
+The **Change spelling** Quick Fix is displayed by Pylance on unresolved variable or missing imports diagnostics when they are likely caused by typos. This Code Action suggests the correct spelling of the symbol based on the closest matches found in the workspace.
 
 ![Change spelling code action on missing import due to a typo](images/editing/change-spelling-code-action.gif)
 
 
-Just like with auto imports, only top-levels symbols are suggested by default. You can customize this behavior through the `python.analysis.packageIndexDepths` setting. Note that user symbol aliases (e.g. `import foo as bar`) are not supported by these Code Actions.
-
-### Implement All Inherited Abstract Classes
-
-In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod` decorator. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
-
-Pylance offers a code action to simplify the process of creating these classes. When defining a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
-
-![Implement inherited abstract classes](images/editing/implement-inherited-abstract-classes.gif)
+> **Note**: Symbol aliases defined in user code (e.g.  `bar` on `import foo as bar`) are not supported by these Quick Fixes for performance reasons. Just like with auto imports, only top-level symbols are suggested by default, but you can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting.
 
 ## Refactorings
 
-The Python extension adds the following refactoring functionalities via the Pylance extension: **Extract Variable**, **Extract Method**, **Rename Module** and **Move Symbol**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
+The Python extension adds the following refactoring functionalities via the Pylance extension: **Extract Variable**, **Extract Method**, **Rename Module**, **Move Symbol** and **Implement All Inherited Abstract Classes**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
 
 ### Extract Variable
 
@@ -151,6 +148,14 @@ You can access these Code Actions by hovering over the symbol you want to move, 
 
 
 ![Move Symbol refactoring options](images/editing/move-symbol.gif)
+
+### Implement All Inherited Abstract Classes
+
+In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod` decorator. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
+
+Pylance offers a code action to simplify the process of creating these classes. When defining a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
+
+![Implement inherited abstract classes](images/editing/implement-inherited-abstract-classes.gif)
 
 
 ### Sort Imports

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -86,6 +86,8 @@ While editing, you can right-click different identifiers to take advantage of se
 
 ## Quick Fixes
 
+### Add Missing Imports
+
 The add imports Quick Fix when using Pylance allows you to quickly complete import statements. First, begin by typing a package name within the editor. You will notice a Code Action is available to automatically complete the line of source code (as long as you have the module installed within the environment). Hover over the text (marked with a squiggle) and then select the Code Action light bulb when it appears. You can then select from a list of potential imports.
 
 ![Add import code action](images/editing/quickFix.png)

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -109,7 +109,7 @@ Just like with auto imports, only top-levels symbols are suggested by default. Y
 
 ### Implement All Inherited Abstract Classes
 
-In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod decorator`. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
+In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod` decorator. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
 
 Pylance offers a code action to simplify the process of creating these classes. When defining a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -88,7 +88,7 @@ While editing, you can right-click different identifiers to take advantage of se
 
 ### Add import
 
-The add import Quick Fix when using Pylance allows you to quickly complete import statements. First, begin by typing a package name within the editor. You will notice a Code Action is available to automatically complete the line of source code (as long as you have the module installed within the environment). Hover over the text (marked with a squiggle) and then select the Code Action light bulb when it appears. You can then select from a list of potential imports.
+When using Pylance, the add import Quick Fix enables you to quickly complete import statements for modules that are installed in your environment. As you start typing a package name in the editor, a Code Action is available to automatically complete the line of source code. Hover over the text (marked with a squiggle) and select the Code Action light bulb. You can then select from the list of potential imports.
 
 ![Add import code action](images/editing/quickFix.png)
 
@@ -99,22 +99,22 @@ This Code Action also recognizes some of the popular abbreviations for the follo
 The import suggestions list displays the top 3 high-confidence import options, prioritized based on: most recently used imports, symbols from the same module, symbols from the standard library, symbols from user modules, symbols from third-party packages, and finally sorting by module and symbol name.
 
 ### Search for additional import matches
-The add import Quick Fix only shows 3 high-confidence import options by default. In the case where they aren't what you are looking for, Pylance has a **Search for additional import matches** Quick Fix for missing import errors, which also displays a quick pick menu that allows you to search for import options that prefix-match the missing import symbol.
+By default, the add import Quick Fix only shows 3 high-confidence import options. If they don't list what you are looking for, you can use the Pylance **Search for additional import matches** Quick Fix for missing import errors. This Quick Fix displays a quick pick menu that enables you to search for import options that prefix-match the missing import symbol.
 
 ![Search for additional import matches Code Action](images/editing/search-imports-code-action.gif)
 
 
 ### Change spelling
-The **Change spelling** Quick Fix is displayed by Pylance on unresolved variable or missing imports diagnostics when they are likely caused by typos. This Code Action suggests the correct spelling of the symbol based on the closest matches found in the workspace.
+Pylance displays the **Change spelling** Quick Fix on unresolved variables or missing imports diagnostics when they are likely caused by typos. This Code Action suggests the correct spelling of the symbol, based on the closest matches found in the workspace.
 
 ![Change spelling code action on missing import due to a typo](images/editing/change-spelling-code-action.gif)
 
 
-> **Note**: Symbol aliases defined in user code (e.g.  `bar` on `import foo as bar`) are not supported by these Quick Fixes for performance reasons. Just like with auto imports, only top-level symbols are suggested by default, but you can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting.
+> **Note**: Symbol aliases defined in user code (for example,  the `bar` alias in `import foo as bar`) are not supported by these Quick Fixes for performance reasons. Just like with auto imports, only top-level symbols are suggested by default, but you can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting.
 
 ## Refactorings
 
-The Python extension adds the following refactoring functionalities via the Pylance extension: **Extract Variable**, **Extract Method**, **Rename Module**, **Move Symbol** and **Implement All Inherited Abstract Classes**. It also supports extensions that implement additional refactoring features such as **Sort Imports**.
+The Python extension adds the following refactoring functionalities via the Pylance extension: **Extract Variable**, **Extract Method**, **Rename Module**, **Move Symbol** and **Implement All Inherited Abstract Classes**. It also supports extensions that implement additional refactoring features, such as **Sort Imports**.
 
 ### Extract Variable
 
@@ -142,7 +142,10 @@ To customize which references need to be updated, you can toggle the checkboxes 
 
 ### Move Symbol
 
-The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: **Move symbol to...**, which displays a file picker so you can select the destination file for the symbol to be moved to,  and **Move symbol to new file**, which creates a new file with the symbol name, located on the same directory as the source file where the Code Action was invoked.
+The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: 
+
+* **Move symbol to...**: displays a file picker to select the destination file for the symbol to be moved to.
+* **Move symbol to new file**: creates a new file with the symbol name, located in the same directory as the source file where the Code Action was invoked.
 
 You can access these Code Actions by hovering over the symbol you want to move, then selecting the light bulb that appears next to the desired action. Alternatively, you can right-click on the symbol and select **Refactor...** from the context menu.
 
@@ -153,7 +156,7 @@ You can access these Code Actions by hovering over the symbol you want to move, 
 
 In Python, abstract classes serve as "blueprints" for other classes and help build modular, reusable code by promoting clear structure and requirements for subclasses to adhere to. To define an abstract class in Python, you can create a class that inherits from the `ABC` class in the `abc` module, and annotate its methods with the `@abstractmethod` decorator. Then, you can create new classes that inherit from this abstract class, and define an implementation for the base methods.
 
-Pylance offers a code action to simplify the process of creating these classes. When defining a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
+Pylance offers a code action to simplify the process of creating these classes. When you define a new class that inherits from an abstract one, you can now use the **Implement all inherited abstract classes** Code Action to automatically implement all abstract methods and properties from the parent class:
 
 ![Implement inherited abstract classes](images/editing/implement-inherited-abstract-classes.gif)
 

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -110,7 +110,9 @@ Pylance displays the **Change spelling** Quick Fix on unresolved variables or mi
 ![Change spelling code action on missing import due to a typo](images/editing/change-spelling-code-action.gif)
 
 
-> **Note**: Symbol aliases defined in user code (for example,  the `bar` alias in `import foo as bar`) are not supported by these Quick Fixes for performance reasons. Just like with auto imports, only top-level symbols are suggested by default, but you can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting.
+> **Note**: For user symbols, these Quick Fixes will suggest the imports only from the files where they are defined. Import suggestions from files where the user symbols are external/imported aren't supported.
+>
+> Also note that for symbols coming from installed packages (typically located under the `site-packages` folder of your Python environment), only those defined in the package's `__init__.py` file are suggested by these Quick Fixes. You can customize this behavior for specific packages through the `python.analysis.packageIndexDepths` setting, but please note it may impact Pylance's performance.
 
 ## Refactorings
 
@@ -142,7 +144,7 @@ To customize which references need to be updated, you can toggle the checkboxes 
 
 ### Move Symbol
 
-The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files: 
+The Pylance extension offers two Code Actions to simplify the process of moving symbols to different files:
 
 * **Move symbol to...**: displays a file picker to select the destination file for the symbol to be moved to.
 * **Move symbol to new file**: creates a new file with the symbol name, located in the same directory as the source file where the Code Action was invoked.

--- a/docs/python/images/editing/change-spelling-code-action.gif
+++ b/docs/python/images/editing/change-spelling-code-action.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:570d6d91235a4ad72eee56fb0e3777aba2e14c26079c8cc2dfa515a2108e0288
+size 476264

--- a/docs/python/images/editing/implement-inherited-abstract-classes.gif
+++ b/docs/python/images/editing/implement-inherited-abstract-classes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea00c55aff9234cf66445f892f4a6b4f341f898b4e287d73e6f8200c83db4aad
+size 254192

--- a/docs/python/images/editing/move-symbol.gif
+++ b/docs/python/images/editing/move-symbol.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30a45352ee6bc8891eca0addb18755d4091b9e2f9d3466d3d39fefb2bff87439
+size 2733421

--- a/docs/python/images/editing/move-symbol.png
+++ b/docs/python/images/editing/move-symbol.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1867dd88b12a6c096320ada4b0e63daef6ec0bfebd88ac7a4ab554f03a0498df
+size 52528

--- a/docs/python/images/editing/quickFix.gif
+++ b/docs/python/images/editing/quickFix.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f77d911c081d6fd55d1e875e45b4d79c4108c62c6d927a47f932682817a9c227
-size 70487

--- a/docs/python/images/editing/quickFix.png
+++ b/docs/python/images/editing/quickFix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fdff3b41e99de90092a12b7fd7b9299b9af32ebc40451b85103860c311ad942
+size 53907

--- a/docs/python/images/editing/quickFix.png
+++ b/docs/python/images/editing/quickFix.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fdff3b41e99de90092a12b7fd7b9299b9af32ebc40451b85103860c311ad942
-size 53907
+oid sha256:ac2339cc59316bd85feb6a32a81cadcd952193be09e32e90ed93d322862fea71
+size 35645

--- a/docs/python/images/editing/search-imports-code-action.gif
+++ b/docs/python/images/editing/search-imports-code-action.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ddb5955429a3c52dabab9e0fa2a7a20bfed4806b984dbd1002f8f270ad0a0b8
+size 1614839

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -75,7 +75,7 @@ The language server settings apply when `python.languageServer` is `Pylance` or 
 | diagnosticSeverityOverrides | {} | Allows a user to override the severity levels for individual diagnostics. <br> For each rule, the available severity levels are `error` (red squiggle), `warning` (yellow squiggle), `information` (blue squiggle), and `none` (rule disabled). <br> For information about the keys to use for the diagnostic severity rules, see the **Diagnostic severity rules** section below. |
 | fixAll | `[]` | A list of code actions to run when running the **Fix All** command or the `source.fixAll` code action. <br> Accepted values in this list: <ul><li> `source.unusedImports`: removes all unused imports in the open file</li> <li> `source.convertImportFormat`: converts the imports according to the `python.analysis.importFormat` setting </li> |
 | logLevel | `Error` | Specifies the level of logging to be performed by the language server.<br> The possible levels of logging, in increasing level of information provided, are `Error`, `Warning`, `Information`, and `Trace`.|
-| autoIndent | true | Whether Pylance should automatically indent code on type. <br> Accepted values are `true` or `false`. |
+| autoIndent | true | Whether to automatically adjust indentation based on language semantics when typing Python code. <br> Accepted values are `true` or `false`. |
 
 **Diagnostic severity rules**
 

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -75,6 +75,7 @@ The language server settings apply when `python.languageServer` is `Pylance` or 
 | diagnosticSeverityOverrides | {} | Allows a user to override the severity levels for individual diagnostics. <br> For each rule, the available severity levels are `error` (red squiggle), `warning` (yellow squiggle), `information` (blue squiggle), and `none` (rule disabled). <br> For information about the keys to use for the diagnostic severity rules, see the **Diagnostic severity rules** section below. |
 | fixAll | `[]` | A list of code actions to run when running the **Fix All** command or the `source.fixAll` code action. <br> Accepted values in this list: <ul><li> `source.unusedImports`: removes all unused imports in the open file</li> <li> `source.convertImportFormat`: converts the imports according to the `python.analysis.importFormat` setting </li> |
 | logLevel | `Error` | Specifies the level of logging to be performed by the language server.<br> The possible levels of logging, in increasing level of information provided, are `Error`, `Warning`, `Information`, and `Trace`.|
+| autoIndent | true | Whether Pylance should automatically indent code on type. <br> Accepted values are `true` or `false`. |
 
 **Diagnostic severity rules**
 


### PR DESCRIPTION
In this PR:
- Adding latest Pylance's code actions for add missing imports & implement abstract classes
- Adding a note that add import code actions don't support user symbol aliases
- Adding new Pylance setting to disable/enable auto indent   