### PR TITLE
Add toggle fold

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -359,6 +359,8 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
   * 'selectionLines': Array of the start lines (0-based) of the editor selections to apply the fold action to. If not set, the active selection(s) will be used.
   If no levels or direction is set, folds the region at the locations or if already collapsed, the first uncollapsed parent instead.
 
+`editor.toggleFold` - Folds or unfolds the content in the editor depending on its current state
+
 `editor.actions.findWithArgs` - Open a new In-Editor Find Widget with specific options.
 
 * searchString - String to prefill the find input

--- a/docs/customization/keyboard-shortcuts.md
+++ b/docs/customization/keyboard-shortcuts.md
@@ -33,6 +33,7 @@ Key|Command
 `kb(scrollPagedown)`|Scroll page down
 `kb(editor.fold)`|Fold (collapse) region
 `kb(editor.unfold)`|Unfold (uncollapse) region
+`kb(editor.toggleFold)`|Toggle Fold region
 `kb(editor.foldRecursively)`|Fold (collapse) all subregions
 `kb(editor.unfoldRecursively)`|Unfold (uncollapse) all subregions
 `kb(editor.foldAll)`|Fold (collapse) all regions

--- a/docs/getstarted/keybindings.md
+++ b/docs/getstarted/keybindings.md
@@ -429,6 +429,7 @@ Scroll Page Down|`kb(scrollPageDown)`|`scrollPageDown`
 Scroll Page Up|`kb(scrollPageUp)`|`scrollPageUp`
 Fold (collapse) region|`kb(editor.fold)`|`editor.fold`
 Unfold (uncollapse) region|`kb(editor.unfold)`|`editor.unfold`
+Toggle Fold region|`kb(editor.toggleFold)`|`editor.toggleFold`
 Fold (collapse) all subregions|`kb(editor.foldRecursively)`|`editor.foldRecursively`
 Unfold (uncollapse) all subregions|`kb(editor.unfoldRecursively)`|`editor.unfoldRecursively`
 Fold (collapse) all regions|`kb(editor.foldAll)`|`editor.foldAll`

--- a/docs/getstarted/tips-and-tricks.md
+++ b/docs/getstarted/tips-and-tricks.md
@@ -644,7 +644,7 @@ Whole document format: `kb(editor.action.formatDocument)`
 
 ### Code folding
 
-Keyboard Shortcut: `kb(editor.fold)` and `kb(editor.unfold)`
+Keyboard Shortcut: `kb(editor.fold)`, `kb(editor.unfold)` and `kb(editor.toggleFold)`
 
 ![code folding](images/tips-and-tricks/code_folding.gif)
 


### PR DESCRIPTION
The `editor.toggleFold` command is not documented anywhere, this PR adds it alongside the editor.fold and editor.unfold