### PR TITLE
Fix missing image on quickstart tutorial

### DIFF
--- a/docs/python/python-quick-start.md
+++ b/docs/python/python-quick-start.md
@@ -43,7 +43,7 @@ When you launch VS Code for the very first time, you will need to install the Py
 
 Code Actions (also known as Quick Fixes) are provided to help fix issues when there are warnings in your code. These helpful hints are displayed in the editor left margin as a lightbulb (💡). Select the light bulb to display Code Action options. These Code Action can come from extensions such as Python, Pylance, or VS Code itself. For more information about Code Actions, see [Python Quick Fixes](/docs/python/editing.md#quick-fixes).
 
-![Gif showing Code Actions in a Python project.](images/editing/quickFix.gif)
+![Screenshot showing Code Actions in a Python project.](images/editing/quickFix.png)
 
 ## Python commands
 


### PR DESCRIPTION
We noticed a PyCon that a gif was missing from the quickstart, so this PR fixes it