### PR TITLE
fix: non-existent hyperlinks (#7001)

### DIFF
--- a/api/references/vscode-api.md
+++ b/api/references/vscode-api.md
@@ -1963,7 +1963,7 @@ when <a href="#window.showInputBox">window.showInputBox</a> does not offer the r
 
 
 
-<a name="window.createQuickPick"></a><span class="ts" id=2818 data-target="#details-2818" data-toggle="collapse"><span class="ident">createQuickPick</span><span>&lt;</span>T extends <a class="type-ref" href="#QuickPickItem">QuickPickItem</a><span>&gt;</span><span>(</span><span>)</span><span>: </span><a class="type-ref" href="#QuickPick">QuickPick</a>&lt;<a class="type-intrinsic">T</a>&gt;</span>
+<a name="window.createQuickPick"></a><span class="ts" id=2818 data-target="#details-2818" data-toggle="collapse"><span class="ident">createQuickPick</span><span>&lt;</span>T extends <a class="type-ref" href="#QuickPickItem">QuickPickItem</a><span>&gt;</span><span>(</span><span>)</span><span>: </span><a class="type-ref" href="#QuickPick">QuickPick&lt;T&gt;</a></span>
 <div class="details collapse" id="details-2818">
 <div class="comment"><p>Creates a <a href="#QuickPick">QuickPick</a> to let the user pick an item from a list
 of items of type T.</p>


### PR DESCRIPTION
I have modified the markup to wrap the entire generic type `QuickPick<T>` in a single hyperlink

This ensures that the link correctly navigates to the appropriate section for `QuickPick<T>`, rather than trying to separately link to `QuickPick` and `T`, which don't have individual anchors in this context. This modification will indeed make the API documentation much more user-friendly.

fixed: https://github.com/microsoft/vscode-docs/issues/7001