### PR TITLE
Document the fourth param to vscode.diff

### DIFF
--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -268,7 +268,7 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 * _left_ - Left-hand side resource of the diff editor
 * _right_ - Right-hand side resource of the diff editor
 * _title_ - Human readable title for the diff editor
-* _options_ - (optional) Editor options. See vscode.TextDocumentShowOptions
+* _options_ - (optional) Either the column in which to open, or editor options (see vscode.TextDocumentShowOptions)
 
 `vscode.prepareTypeHierarchy` - Prepare type hierarchy at a position inside a document
 

--- a/api/references/commands.md
+++ b/api/references/commands.md
@@ -268,6 +268,7 @@ let success = await commands.executeCommand('vscode.openFolder', uri);
 * _left_ - Left-hand side resource of the diff editor
 * _right_ - Right-hand side resource of the diff editor
 * _title_ - Human readable title for the diff editor
+* _options_ - (optional) Editor options. See vscode.TextDocumentShowOptions
 
 `vscode.prepareTypeHierarchy` - Prepare type hierarchy at a position inside a document
 


### PR DESCRIPTION
This being missing from the docs cost me an hour or two! I only found it when I searched for other code using the API and found that about half of callers passed this fourth option.

While it's called columnOrOptions, I've only been able to get it to work with a vscode.TextDocumentShowOptions.