### PR TITLE
Update Ruby documentation to reflect current state

### DIFF
--- a/docs/languages/images/ruby/navigation-placeholder.png
+++ b/docs/languages/images/ruby/navigation-placeholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:383c13ca3eb514543841a6e09fd2d83b887ba16ada3e2cc378448294e1053a23
+size 1838508

--- a/docs/languages/images/ruby/navigation.mp4
+++ b/docs/languages/images/ruby/navigation.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7abf44561202d2b606b3937d5e8f57bbf3b0e452e8e83b0232d8362de5a20692
+size 7109615

--- a/docs/languages/images/ruby/ruby_lsp_code_lens.png
+++ b/docs/languages/images/ruby/ruby_lsp_code_lens.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fae13a5e67ea305efc42d5944d19c6b3427ce05a9d9a3d387875af8599e18252
+size 113186

--- a/docs/languages/images/ruby/ruby_lsp_symbols.png
+++ b/docs/languages/images/ruby/ruby_lsp_symbols.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3919da6387238ef846d54a04c15304c61e38f29c5b3ba1d062142c799c41cbdf
-size 134022

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -31,7 +31,7 @@ You can find and install the Ruby LSP extension from within VS Code via the Exte
 
 ![Ruby LSP extension in the Extensions view](images/ruby/ruby_lsp_extensions_view.png)
 
-We'll discuss many of Ruby LSP features in this topic but you can also refer to the extension's documentation at [https://github.com/Shopify/vscode-ruby-lsp](https://github.com/Shopify/vscode-ruby-lsp).
+We'll discuss many of Ruby LSP features in this topic but you can also refer to the extension's documentation at [https://github.com/Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp).
 
 ### Check your installation
 
@@ -44,20 +44,28 @@ The extension generates a `.ruby-lsp` folder automatically with a custom bundle 
 By default, the extension tries to automatically detect the Ruby version manager you're using and use the right versions and paths accordingly. If you want to customize that behavior, set the following configuration in your user [settings](/docs/getstarted/settings.md):
 
 ```json
-"rubyLsp.rubyVersionManager": "rbenv"
+{
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "rbenv"
+  }
+}
 ```
 
-The extension will automatically try to update the `ruby-lsp` language server gem once per day; if you want to force that to happen, use the Command Palette (`kb(workbench.action.showCommands)`) to execute **Ruby LSP: Update language server gem**.
+The extension will automatically try to update the `ruby-lsp` language server gem periodically; if you want to force that to happen, use the Command Palette (`kb(workbench.action.showCommands)`) to execute **Ruby LSP: Update language server gem**.
 
-If you have any problems, see [troubleshooting](https://github.com/Shopify/vscode-ruby-lsp#troubleshooting) for next steps.
+If you have any problems, see [troubleshooting](https://github.com/Shopify/ruby-lsp/blob/main/TROUBLESHOOTING.md) for next steps.
 
 ## Main features
 
-### Symbol detection
+### Navigation and IntelliSense
 
-Ruby LSP parses source code and provides symbol detection and navigation for the Outline pane, file breadcrumbs, and symbol searches (accessible with `kb(workbench.action.gotoSymbol)` by default).
+The Ruby LSP provides several navigation and IntelliSense related features, such as go to definition, hover, workspace
+symbol, document symbol, completion and signature help.
 
-![Ruby document symbols](images/ruby/ruby_lsp_symbols.png)
+<video src="images/ruby/navigation.mp4" placeholder="images/ruby/navigation-placeholder.png" autoplay loop controls
+    muted title="Demo of navigation and intellisense features">
+    Sorry, your browser doesn't support HTML 5 video.
+</video>
 
 To learn more about moving quickly through your source code with VS Code, check out [Code Navigation](/docs/editor/editingevolved.md).
 
@@ -74,10 +82,6 @@ While inlay hints can be helpful for understanding your code, you can also disab
     "inlayHint": false,
 }
 ```
-
-### Code snippets
-
-As you type in a Ruby file, Ruby LSP might suggest expanding snippets used for common Ruby operations such as creating a new method, class, block, or test boilerplate. To see the full list, check out the snippets file in the Ruby LSP [GitHub repository](https://github.com/Shopify/vscode-ruby-lsp/blob/main/snippets.json).
 
 ### Semantic syntax highlighting
 
@@ -134,17 +138,26 @@ In addition to Quick Fixes, the Ruby LSP also provides refactor options through 
 
 ![Refactor extract to variable](images/ruby/ruby_lsp_refactor.png)
 
-## Debugging support with rdbg
+## Debugging
 
-For debug support inside of VS Code, the Ruby LSP requires the VS Code RDBG extension to connect to debug (Ruby's official debugger).
+The Ruby LSP extension supports debugging using the debug gem (Ruby's official debugger). Alternatively, developers can
+also install the [VS Code RDBG](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension
+to get debugging functionality.
 
-### Install debugging support
+The following documentation is for the Ruby LSP's debugger client. Please refer to [RDBG's README](https://github.com/ruby/vscode-rdbg)
+for instructions on how to configure it.
 
-Install the [VS Code RDBG](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension.
+### Debugging tests
 
-### Set up debugging configuration
+The Ruby LSP adds CodeLens buttons on top of unit tests that enable you to run examples in the Test Explorer, run them
+in a new terminal or launch the debugger. For these uses, no configuration is required.
 
-To use the debugger, you will need to create [debugging configurations](/docs/editor/debugging.md#launch-configurations) in a `launch.json` file. The configuration lets you pass arguments to your program, run pre-launch tasks, set environment variables, and much more.
+![Test running code lenses](images/ruby/ruby_lsp_code_lens.png)
+
+### Debugging through launch tasks
+
+To use the debugger through launch tasks, you will need to create [debugging configurations](/docs/editor/debugging.md#launch-configurations)
+in a `launch.json` file. The configuration lets you configure the program to be executed.
 
 To create a `launch.json` for a Ruby program:
 
@@ -158,32 +171,26 @@ Example:
 {
     "version": "0.2.0",
     "configurations": [
-        // Run all tests in a file using Minitest
+        // Launch the debugger for any given program. In this case, it will run the current file using Ruby
         {
-            "type": "rdbg",
-            "name": "Minitest - current file",
+            "type": "ruby_lsp",
+            "name": "Debug",
             "request": "launch",
-            "script": "-Itest ${file}",
-            "askParameters": false
+            "program": "ruby ${file}",
         },
-        // If your test runner supports line numbers, such as in Rails,
-        // you can add a task like this one to run only the test under the cursor
+        // Launch the debugger for the current test file
         {
-            "name": "Minitest - current line",
-            "type": "rdbg",
+            "type": "ruby_lsp",
             "request": "launch",
-            "command": "${workspaceRoot}/bin/rails",
-            "script": "test",
-            "args": [
-                "${file}:${lineNumber}"
-            ],
-            "askParameters": false,
+            "name": "Debug test file",
+            "program": "ruby -Itest ${relativeFile}"
         },
-        // Attach the debugger to an active process (for example, Rails server)
+        // Attach the debugger client to an existing Ruby process that has already been launched with the debugger
+        // server
         {
-            "type": "rdbg",
-            "name": "Attach with rdbg",
-            "request": "attach"
+            "type": "ruby_lsp",
+            "request": "attach",
+            "name": "Attach to existing server",
         }
     ]
 }
@@ -201,11 +208,11 @@ After adding the launch configurations, we can debug Ruby programs by adding bre
 
 ## Next steps
 
-This has been a brief overview showing the Ruby LSP extension features within VS Code. For more information, see the details provided in the Ruby LSP [README](https://github.com/Shopify/vscode-ruby-lsp), including how to tune specific [VS Code editor](https://github.com/Shopify/vscode-ruby-lsp#configuration) configurations.
+This has been a brief overview showing the Ruby LSP extension features within VS Code. For more information, see the details provided in the Ruby LSP [README](https://github.com/Shopify/ruby-lsp), including how to tune specific [VS Code editor](https://github.com/Shopify/ruby-lsp/blob/main/vscode/README.md) configurations.
 
-To stay up to date on the latest features/bug fixes for the Ruby LSP extension, see the Releases page for the [language server gem](https://github.com/Shopify/ruby-lsp/releases) and for the [Ruby LSP extension](https://github.com/Shopify/vscode-ruby-lsp/releases).
+To stay up to date on the latest features/bug fixes for the Ruby LSP extension, see the Releases page for the [monorepo](https://github.com/Shopify/ruby-lsp/releases), which includes both the server and VS Code extension implementations.
 
-If you have any issues or feature requests, feel free to log them in the Ruby LSP extension [GitHub repo](https://github.com/Shopify/vscode-ruby-lsp/issues).
+If you have any issues or feature requests, feel free to log them in the Ruby LSP's [GitHub repo](https://github.com/Shopify/ruby-lsp/issues).
 
 If you'd like to learn more about VS Code, try these topics:
 


### PR DESCRIPTION
The Ruby LSP project has evolved significantly since we added the first iteration of the documentation. This PR updates the docs to reflect the current state of features.

The summary of the changes are:

1. Included a section on navigation and intellisense, which we've been putting a lot of effort into. I added a video to showcase all features at a glance. Please let me know if the size/format is okay. I based it on the videos I found for the JavaScript docs
2. Updated the format of the version manager configuration, which we changed
3. Removed the code snippets section. It honestly doesn't add much value and we're planning on moving all of that to the server eventually so that completion is more accurate
4. Updated the debugging section to mention that the Ruby LSP now has a built-in debugger client. The client supports both launch configurations and usage through code lenses
5. Finally, we originally had two repositories for the VS Code extension and server (`Shopify/vscode-ruby-lsp` and `Shopify/ruby-lsp`). The separation was causing a lot of confusion, so we merged everything into a monorepo in `Shopify/ruby-lsp`. I updated all references to the old repo