### PR TITLE
corrected two typos ('CodeActionProvided API' to 'CodeActionProvider API')

### DIFF
--- a/docs/editor/refactoring.md
+++ b/docs/editor/refactoring.md
@@ -79,7 +79,7 @@ The `editor.action.codeAction` command lets you configure keybindings for specif
 }
 ```
 
-Code Action kinds are specified by extensions using the enhanced `CodeActionProvided` API. Kinds are hierarchical, so `"kind": "refactor"` shows all refactoring Code Actions, whereas `"kind": "refactor.extract.function"` only shows **Extract function** refactorings.
+Code Action kinds are specified by extensions using the enhanced `CodeActionProvider` API. Kinds are hierarchical, so `"kind": "refactor"` shows all refactoring Code Actions, whereas `"kind": "refactor.extract.function"` only shows **Extract function** refactorings.
 
 Using the above keybinding, if only a single `"refactor.extract.function"` Code Action is available, it is automatically applied. If multiple **Extract function** Code Actions are available, VS Code brings up a context menu to select them:
 

--- a/release-notes/v1_20.md
+++ b/release-notes/v1_20.md
@@ -207,7 +207,7 @@ The new `editor.action.codeAction` command lets you configure keybindings for sp
 }
 ```
 
-Code Action kinds are specified by extensions using the enhanced `CodeActionProvided` API. Kinds are hierarchical, so `"kind": "refactor"` will show all refactoring Code Actions, whereas `"kind": "refactor.extract.function"` will only show Extract function refactorings.
+Code Action kinds are specified by extensions using the enhanced `CodeActionProvider` API. Kinds are hierarchical, so `"kind": "refactor"` will show all refactoring Code Actions, whereas `"kind": "refactor.extract.function"` will only show Extract function refactorings.
 
 Using the above keybinding, if only a single `"refactor.extract.function"` Code Action is available, it will be automatically applied. If multiple Extract function Code Actions are available, we bring up a context menu to select them:
 


### PR DESCRIPTION
There's no "CodeActionProvided" API