### PR TITLE
docs: release v1.90: change raw link to hyperlink with descriptive text

### DIFF
--- a/release-notes/v1_90.md
+++ b/release-notes/v1_90.md
@@ -295,7 +295,7 @@ for await (const part of response.text) {
 }
 ```
 
-This is the gist of the language model API. Head over to https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample for a more complete example. Stay tuned for more samples, documentation, and further extensions of the API.
+This is the gist of the language model API. Refer to the [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample) for a more complete example. Stay tuned for more samples, documentation, and further extensions of the API.
 
 The Java extension for VS Code is already using the Language Model API to provide Copilot-based rewrite capabilities for your Java code. Learn more about these updates in the [Java in Visual Studio Code May 2024](https://devblogs.microsoft.com/java/java-on-visual-studio-code-update-may-2024/) blog post.
 

--- a/release-notes/v1_90.md
+++ b/release-notes/v1_90.md
@@ -301,7 +301,7 @@ The Java extension for VS Code is already using the Language Model API to provid
 
 ##### `@vscode/prompt-tsx` library
 
-To aid with developing GitHub Copilot extensions for VS Code, we've developed and published a TSX-based library for declaring complex prompts and converting them to chat messages, subject to your LLM's context window limits. In developing this, we took inspiration from Anysphere's [`priompt`](https://github.com/anysphere/priompt) library. If you're an extension author who is planning to use the chat and language model APIs, consider trying out the latest alpha release of this library: https://www.npmjs.com/package/@vscode/prompt-tsx
+To aid with developing GitHub Copilot extensions for VS Code, we've developed and published a TSX-based library for declaring complex prompts and converting them to chat messages, subject to your LLM's context window limits. In developing this, we took inspiration from Anysphere's [`priompt`](https://github.com/anysphere/priompt) library. If you're an extension author who is planning to use the chat and language model APIs, consider trying out the latest alpha release of this library: [@vscode/prompt-tsx](https://www.npmjs.com/package/@vscode/prompt-tsx).
 
 ### Extending GitHub Copilot through GitHub Apps
 


### PR DESCRIPTION
Was a bit surprised by the raw un-clickable link.

![image](https://github.com/microsoft/vscode-docs/assets/5954994/eba259d3-d32c-4a29-9697-522365d8b55c)

I reworded it a little and added a hyperlink.