### PR TITLE
Update project name section

### DIFF
--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -9,9 +9,11 @@ DateApproved: 06/05/2024
 ---
 # Set Docker Compose project name
 
-Visual Studio Code will respect the value of the [COMPOSE_PROJECT_NAME](https://docs.docker.com/compose/reference/envvars/#compose_project_name)  environment variable if set for the VS Code process or in a `.env` file in the root of the project.
+Visual Studio Code will respect the value you configure for the Docker Compose [project name](https://docs.docker.com/compose/project-name/).
 
-For example, after shutting down all VS Code windows, you can start VS Code from the command line as follows:
+For example, when the `COMPOSE_PROJECT_NAME` environment variable is set for the VS Code process or in a `.env` file in the same folder as the `docker-compose.yml`:
+
+After shutting down all VS Code windows, you can start VS Code from the command line as follows:
 
 ```bash
 # from bash
@@ -24,8 +26,10 @@ $env:COMPOSE_PROJECT_NAME=foo
 code .
 ```
 
-Or add the following to a `.env` file in the root of the project (**not** in the `.devcontainer` folder):
+Or add the following to a `.env` file in the same folder as the `docker-compose.yml`:
 
 ```
 COMPOSE_PROJECT_NAME=foo
 ```
+
+When no project name is configured and the `docker-compose.yml` is in the `.devcontainer` folder the Docker Compose default of using the `docker-compose.yml` folder's basename is overridden with `${project-folder-basename}_devcontainer` to avoid name collisions with other projects.

--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -11,7 +11,9 @@ DateApproved: 06/05/2024
 
 Visual Studio Code will respect the value you configure for the Docker Compose [project name](https://docs.docker.com/compose/project-name/).
 
-You can set the `COMPOSE_PROJECT_NAME` environment variable for the VS Code process, or specify it in a `.env` file in the same folder as the `docker-compose.yml`.
+The top-level property `name` in the `docker-compose.yml` can be used to set the project name.
+
+Alternatively, you can set the `COMPOSE_PROJECT_NAME` environment variable for the VS Code process, or specify it in a `.env` file in the same folder as the `docker-compose.yml`.
 
 > **Note**: make sure to close all open VS Code windows first.
 

--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -11,7 +11,9 @@ DateApproved: 06/05/2024
 
 Visual Studio Code will respect the value you configure for the Docker Compose [project name](https://docs.docker.com/compose/project-name/).
 
-For example, when the `COMPOSE_PROJECT_NAME` environment variable is set for the VS Code process or in a `.env` file in the same folder as the `docker-compose.yml`:
+You can set the `COMPOSE_PROJECT_NAME` environment variable for the VS Code process, or specify it in a `.env` file in the same folder as the `docker-compose.yml`.
+
+> **Note**: make sure to close all open VS Code windows first.
 
 After shutting down all VS Code windows, you can start VS Code from the command line as follows:
 

--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -34,4 +34,4 @@ Alternatively, add the following entry to a `.env` file in the same folder as th
 COMPOSE_PROJECT_NAME=foo
 ```
 
-When no project name is configured and the `docker-compose.yml` is in the `.devcontainer` folder the Docker Compose default of using the `docker-compose.yml` folder's basename is overridden with `${project-folder-basename}_devcontainer` to avoid name collisions with other projects.
+When no project name is configured and the `docker-compose.yml` is in the `.devcontainer` folder, the Docker Compose default of using the `docker-compose.yml` folder's basename is overridden with `${project-folder-basename}_devcontainer` to avoid name collisions with other projects.

--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -28,7 +28,7 @@ $env:COMPOSE_PROJECT_NAME=foo
 code .
 ```
 
-Or add the following to a `.env` file in the same folder as the `docker-compose.yml`:
+Alternatively, add the following entry to a `.env` file in the same folder as the `docker-compose.yml`:
 
 ```
 COMPOSE_PROJECT_NAME=foo

--- a/remote/advancedcontainers/set-docker-compose-project-name.md
+++ b/remote/advancedcontainers/set-docker-compose-project-name.md
@@ -15,7 +15,7 @@ You can set the `COMPOSE_PROJECT_NAME` environment variable for the VS Code proc
 
 > **Note**: make sure to close all open VS Code windows first.
 
-After shutting down all VS Code windows, you can start VS Code from the command line as follows:
+To start VS Code from the command line:
 
 ```bash
 # from bash


### PR DESCRIPTION
Pointing to the more general section on docker.com since we now also support the `name` property in the `docker-compose.yml`.

Mentioning our override to avoid name collisions at the end.