### PR TITLE
Add Chat view image for marketplace

### DIFF
--- a/docs/copilot/images/copilot-chat/copilot-view.png
+++ b/docs/copilot/images/copilot-chat/copilot-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed5c5917829f5e430e61e5de74e90e1f985e7b9a3f3fa3a8c48e0d23ae4e69d3
+size 145195


### PR DESCRIPTION
Add missing image for the Copilot Chat view that is referenced from the Copilot extension README.