### PR TITLE
Update some links in v1_90.md

### DIFF
--- a/release-notes/v1_90.md
+++ b/release-notes/v1_90.md
@@ -245,9 +245,9 @@ This feature is currently disabled by default on this release, but please share 
 
 The `yo code` extension generators for `TypeScript` and `Web` now have an option to use `esbuild` as bundler. When you select `esbuild`, this creates a `esbuild.js` build script and adds script entries in `package.json` and build tasks in `.vscode/tasks.json`.
 
-To use `esbuild` in existing extensions, check out the [bundling extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension.md) and the [web extensions](https://code.visualstudio.com/api/extension-guides/web-extensions.md) guides.
+To use `esbuild` in existing extensions, check out the [bundling extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension) and the [web extensions](https://code.visualstudio.com/api/extension-guides/web-extensions) guides.
 
-You can find a sample project at [vscode-extension-samples/esbuild-sample](https://github.com/microsoft/vscode-extension-samples/esbuild-sample).
+You can find a sample project at [vscode-extension-samples/esbuild-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/esbuild-sample).
 
 ### Chat and Language Model API
 


### PR DESCRIPTION
All of these links are 404s, I didn't check all of them, so others may be wrong too
- updated link to bundling extensions guide
- updated link to web extensions guide
- updated link to extension esbuild sample