### PR TITLE
Update linux ssh-agent snippet to include "ssh-add"

### DIFF
--- a/remote/advancedcontainers/sharing-git-credentials.md
+++ b/remote/advancedcontainers/sharing-git-credentials.md
@@ -32,7 +32,7 @@ There are some cases when you may be cloning your repository using SSH keys inst
 You can add your local SSH keys to the agent if it is running by using the `ssh-add` command. For example, run this from a terminal or PowerShell:
 
 ```bash
-ssh-add $HOME/.ssh/github_rsa
+ssh-add $HOME/.ssh/<your ssh key>
 ```
 
 On Windows and Linux, you may get an error because the agent is not running (macOS typically has it running by default). Follow these steps to resolve the problem:
@@ -67,9 +67,12 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
         ssh-agent -s &> $HOME/.ssh/ssh-agent
    fi
    eval `cat $HOME/.ssh/ssh-agent` > /dev/null
-   ssh-add 2> /dev/null
+   ssh-add $HOME/.ssh/<your ssh key> 2> /dev/null
 fi
 ```
+On the last line, replace `<your ssh key>` with your specific ssh key.
+
+For example `ssh-add $HOME/.ssh/id_ed25519 2> /dev/null`
 
 If you encounter any issues, you may want to check the Dev Containers extension's [known limitations](/docs/devcontainers/containers.md#known-limitations).
 

--- a/remote/advancedcontainers/sharing-git-credentials.md
+++ b/remote/advancedcontainers/sharing-git-credentials.md
@@ -66,7 +66,8 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
         # Launch a new instance of the agent
         ssh-agent -s &> $HOME/.ssh/ssh-agent
    fi
-   eval `cat $HOME/.ssh/ssh-agent`
+   eval `cat $HOME/.ssh/ssh-agent` > /dev/null
+   ssh-add 2> /dev/null
 fi
 ```
 


### PR DESCRIPTION
as ssh-add does not persist in linux, the ssh-add command must be executed every time and should therefore be added to the snippet (see [this stackoverflow](https://stackoverflow.com/a/74704066) answer which led me to finding this).

Furthermore I found it annoying that `eval "cat $HOME/.ssh/ssh-agent"` echoes the PID of the ssh-agent and therefore polutes your terminal, therefore I suggest muting it's output.