### PR TITLE
tasks.md: add `source` property to `problemMatcher`

### DIFF
--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -674,6 +674,7 @@ Here is a finished `tasks.json` file with the code above (comments removed) wrap
             "problemMatcher": {
                 "owner": "cpp",
                 "fileLocation": ["relative", "${workspaceFolder}"],
+                "source": "gcc",
                 "pattern": {
                     "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
                     "file": 1,

--- a/docs/editor/tasks.md
+++ b/docs/editor/tasks.md
@@ -639,6 +639,8 @@ A matcher that captures the above warning (and errors) looks like this:
     "owner": "cpp",
     // The file name for reported problems is relative to the opened folder.
     "fileLocation": ["relative", "${workspaceFolder}"],
+    // The name that will be shown as the source of the problem.
+    "source": "gcc",
     // The actual pattern to match problems in the output.
     "pattern": {
         // The regular expression. Example to match: helloWorld.c:5:3: warning: implicit declaration of function ‘printf’ [-Wimplicit-function-declaration]


### PR DESCRIPTION
Currently, the `source` property is only mentioned under [Modifying an existing problem matcher](https://code.visualstudio.com/docs/editor/tasks#_modifying-an-existing-problem-matcher), but with no details, and it applies to more than just existing matchers.

It would be great to add it as part of the example as demonstrated in this PR, though it's incomplete: This also requires updating the screenshot below.

---

Related feature request I just opened on the VSCode repo: [QoL improvement: Show task `label` as source of problem if `problemMatcher` doesn't specify a `source`](https://github.com/microsoft/vscode/issues/225072)