### PR TITLE
Case-sensitive JSON correction

### DIFF
--- a/docs/cpp/colorization-cpp.md
+++ b/docs/cpp/colorization-cpp.md
@@ -12,7 +12,7 @@ MetaDescription: How to customize semantic colorization of C++ code in Visual St
 The Visual Studio Code C/C++ extension now supports semantic colorization, when IntelliSense is enabled.  Use of enhanced colorization is controlled by the C_Cpp.enhancedColorization setting.  This setting is enabled by default.
 
 ```json
-"C_Cpp.enhancedColorization": "Enabled"
+"C_Cpp.enhancedColorization": "enabled"
 ```
 
 ## Themes


### PR DESCRIPTION
Although enhanced colorization is enabled by default for C/C++, the JSON as currently displayed in the docs raises an IntelliSense warning for an invalid value due to incorrect capitalization. This groundbreaking commit changes "E" to "e" and restores balance to the VS Code Docs.

(I fully admit this is not the most substantial PR, but, as it fixes an invalid code snippet, I hope the correction is at least marginally helpful :joy_cat:)