### PR TITLE
Update enter jupyter server url screenshot

### DIFF
--- a/docs/datascience/images/jupyter-kernel-management/select-enter-server-url.png
+++ b/docs/datascience/images/jupyter-kernel-management/select-enter-server-url.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5fe8767e405c808cdf6b62d76953ad2ef88a8c34c92d67cfcd4a24235818abc
-size 18308
+oid sha256:1c07f483c287c0ebf4274b29db355d4fc1aa4c887811fd2f1baa1c8801b9c9ad
+size 14630


### PR DESCRIPTION
Updated the enter Jupyter server URL screenshot in https://code.visualstudio.com/docs/datascience/jupyter-kernel-management#_existing-jupyter-server to reflect the new UI. 

Resolves #6433.

