### PR TITLE
feat: create separate assets archive for vnext

### DIFF
--- a/.pipelines/templates/jobs/build.yml
+++ b/.pipelines/templates/jobs/build.yml
@@ -83,3 +83,13 @@ jobs:
       archiveType: 'zip'
       includeRootFolder: false
       archiveFile: $(Build.ArtifactStagingDirectory)/out/website.zip
+    displayName: Archive complete website
+
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: $(Pipeline.Workspace)/vscode-website/dist/client/assets
+      archiveType: 'zip'
+      includeRootFolder: false
+      archiveFile: $(Build.ArtifactStagingDirectory)/out/website-assets.zip
+    displayName: Archive website assets
+    condition: ${{ eq(parameters.jobDisplayName, 'vscode-site-vnext') }}


### PR DESCRIPTION
Creates a new archive for just the client assets so that we could eventually deploy the assets in their own separate process.

Verification build https://dev.azure.com/monacotools/Monaco/_build/results?buildId=293204&view=results