### PR TITLE
fix: use youtube-nocookie for embeds

### DIFF
--- a/docs/getstarted/userinterface.md
+++ b/docs/getstarted/userinterface.md
@@ -11,7 +11,7 @@ MetaDescription: A quick overview of the Visual Studio Code user interface. Lear
 
 At its heart, Visual Studio Code is a code editor. Like many other code editors, VS Code adopts a common user interface and layout of an explorer on the left, showing all of the files and folders you have access to, and an editor on the right, showing the content of the files you have opened.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/nORT3-kONgA" title="Transform your VS Code user interface" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/nORT3-kONgA" title="Transform your VS Code user interface" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Basic layout
 


### PR DESCRIPTION
Use youtube-nocookie.com/embed instead of youtube.com/embed to prevent YouTube from adding cookies to our website that violate internal cookie policies.

CC @ntrogh