### PR TITLE
Adding notes to Django and coverage docs section

### DIFF
--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -237,6 +237,7 @@ Support for running tests in parallel with pytest is available through the `pyte
 ## Run tests with coverage
 
 Test coverage is a measure of how much of your code is covered by your tests, which can help you identify areas of your code that are not being fully tested. For more information on test coverage, visit VS Code's [Test Coverage documentation](/docs/editor/testing#_test-coverage.md).
+> **Tip**: Running Python tests with coverage is currently only supported when `"python.experiments.optInto": ["pythonTestAdapter"]` is added to your User `settings.json`.
 
 To run tests with coverage enabled, select the coverage run icon in the Test Explorer or the “Run with coverage” option from any menu you normally trigger test runs from. The Python extension will run coverage using the [`pytest-cov`](https://pypi.org/project/pytest-cov/) plugin if you are using pytest, or with [`coverage.py`](https://coverage.readthedocs.io/) for unittest.
 > **Note**: Before running tests with coverage, make sure to install the correct testing coverage package for your project.
@@ -329,7 +330,7 @@ Below are all the supported commands for testing with the Python extension in VS
 ## Django unit tests
 
 The Python extension also offers support for discovering and running Django unit tests! You can get your Django tests discovered with only a few additional setup steps:
-
+> **Tip**: Django test support is currently only supported when `"python.experiments.optInto": ["pythonTestAdapter"]` is added to your User `settings.json`.
 
 1. Set `"python.testing.unittestEnabled": true,` in your `settings.json` [file](/docs/getstarted/settings.md#settingsjson).
 2. Add `MANAGE_PY_PATH` as an environment variable:

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -244,7 +244,7 @@ To run tests with coverage enabled, select the coverage run icon in the Test Exp
 
 Once the coverage run is complete, lines will be highlighted in the editor for line level coverage. Test coverage results will appear as a "Test Coverage" sub-tab in the Test Explorer, which you can also navigate to with **Testing: Focus on Test Coverage View** in Command Palette (`F1)`). On this panel you can view line coverage metrics for each file and folder in your workspace.
 
-![Gif showing running Python tests with coverage.](/docs/python/images/testing/python-coverage.gif)
+![Gif showing running Python tests with coverage.](images/testing/python-coverage.gif)
 
 For finer grain control of your coverage run when using pytest, you can edit the `python.testing.pytestArgs` setting to include your specifications. When the pytest argument `--cov` exists in `python.testing.pytestArgs`, the Python extension will make no additional edits to coverage args, to allow your customizations to take effect. If there is no `--cov` argument found, the extension will add `--cov=.` to the pytest args prior to run to enable coverage at the workspace root.
 


### PR DESCRIPTION
Previously we did not mention coverage and django test support was only supported if users are opted into the python test adapter experiment (which is currently running on 100%). Added in a tip for both of these sections to include this important information for users for the time being until this behavior is fully adopted. 

This also fixes the path for the coverage gif