### PR TITLE
Remove publishing instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,4 @@ The history of this repo before we adopted LFS can be found at [microsoft/vscode
 
 ## Publishing
 
-Steps for how to publish documentation changes can be found [here](https://github.com/microsoft/vscode-website#publishing-a-documentation-change) in the (private) repository of the VS Code website.
-
 Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on https://code.visualstudio.com but the intent is that they will usually be live within 24 hours.


### PR DESCRIPTION
Remove the link to the publishing instructions on our private vscode-website repo.

Resolves https://github.com/microsoft/vscode-docs/issues/7660