### PR TITLE
Update RPM installation command for code.rpm

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -132,7 +132,7 @@ nix-env -i vscode
 The [VS Code .rpm package (64-bit)](https://go.microsoft.com/fwlink/?LinkID=760867) can also be manually downloaded and installed, however, auto-updating won't work unless the repository above is installed. Once downloaded it can be installed using your package manager, for example with `dnf`:
 
 ```bash
-sudo dnf install <file>.rpm
+sudo dnf install ./code-<arch>.rpm
 ```
 
 Note that other binaries are also available on the [VS Code download page](/Download).


### PR DESCRIPTION
This pull request updates the documentation to include a manual installation command for the VS Code `.rpm` package using `dnf`:


`sudo dnf install ./code-<arch>.rpm`

- **Purpose:** Simplifies the process for users who prefer to manually download and install the `.rpm` package without adding the Microsoft repository.
- **Benefit:** Allows users to install locally downloaded packages while ensuring dependencies are handled by `dnf`. It also provides clear instructions for using the local path (`./`) for easy navigation.