### PR TITLE
doesn't provide built-in language support in the core editor

### DIFF
--- a/api/language-extensions/overview.md
+++ b/api/language-extensions/overview.md
@@ -9,7 +9,7 @@ MetaDescription: Learn how to write a Language Extension (plug-in) to add suppor
 
 # Language Extensions Overview
 
-Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code not only provides built-in language support, such as bat, clojure etc., but also offers a set of APIs that enable rich language features. For example, it has a bundled [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension that allows VS Code to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
+Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code without extensions doesn't provide built-in language support but offers a set of APIs that enable rich language features. For example, it has a bundled [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension that allows VS Code to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
 
 Language features can be roughly put into two categories:
 

--- a/api/language-extensions/overview.md
+++ b/api/language-extensions/overview.md
@@ -9,7 +9,11 @@ MetaDescription: Learn how to write a Language Extension (plug-in) to add suppor
 
 # Language Extensions Overview
 
-Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code without extensions doesn't provide built-in language support but offers a set of APIs that enable rich language features. For example, it has a bundled [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension that allows VS Code to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
+Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code doesn't provide built-in language support in the core editor but offers a set of APIs that enable rich language features.
+
+For example, the [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension uses these APIs to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
+
+VS Code bundles some of these extensions with the editor to provide you with rich language support from the start.
 
 Language features can be roughly put into two categories:
 

--- a/api/language-extensions/overview.md
+++ b/api/language-extensions/overview.md
@@ -9,7 +9,7 @@ MetaDescription: Learn how to write a Language Extension (plug-in) to add suppor
 
 # Language Extensions Overview
 
-Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code doesn't provide built-in language support but offers a set of APIs that enable rich language features. For example, it has a bundled [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension that allows VS Code to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
+Visual Studio Code provides smart editing features for different programming languages through Language Extensions. VS Code not only provides built-in language support, such as bat, clojure etc., but also offers a set of APIs that enable rich language features. For example, it has a bundled [HTML](https://github.com/microsoft/vscode/tree/main/extensions/html) extension that allows VS Code to show syntax highlighting for HTML files. Similarly, when you type `console.` and `log` shows up in IntelliSense, it is the [Typescript Language Features](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features) extension at work.
 
 Language features can be roughly put into two categories:
 


### PR DESCRIPTION
Inside "API" outline, "LANGUAGE EXTENSIONS" section, "Overview" article, there is a paragraph on the top.

I was puzzled with sentence "VS Code doesn't provide built-in language support", because we have multiple language extension inside "extensions" at the root of VS Code codebase.

If I'm right, this pr would like to fix it to make this sentence clear~