### PR TITLE
Update Remote-SSH docs for deprecated setting

### DIFF
--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -62,7 +62,7 @@ Installation of VS Code Server requires that your local machine have outbound HT
 * `update.code.visualstudio.com`
 * `*.vo.msecnd.net` (Azure CDN)
 
-By default, the Remote - SSH will attempt to download on the remote host, but if you enable `remote.SSH.allowLocalServerDownload`, the extension will fall back to downloading VS Code Server locally and transferring it remotely once a connection is established.
+By default, the Remote - SSH will attempt to download on the remote host, and fail back to downloading VS Code Server locally and transferring it remotely once a connection is established. You can change this behavior with the `setting(remote.SSH.localServerDownload)` setting to always download locally and then transfer it, or to never download locally.
 
 The Dev Containers extension always downloads locally and transfers into the container.
 

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -335,7 +335,7 @@ Installation of VS Code Server requires that your local machine has outbound HTT
 - `vscode.blob.core.windows.net`
 - `*.vo.msecnd.net` (Azure CDN)
 
-By default, the Remote - SSH will attempt to download on the remote host, but if you enable `remote.SSH.allowLocalServerDownload`, the extension will fall back to downloading VS Code Server locally and transferring it remotely once a connection is established.
+By default, the Remote - SSH will attempt to download on the remote host, and fail back to downloading VS Code Server locally and transferring it remotely once a connection is established. You can change this behavior with the `setting(remote.SSH.localServerDownload)` setting to always download locally and then transfer it, or to never download locally.
 
 You can install extensions manually without an internet connection using the **Extensions: Install from VSIX...** command, but if you use the extension panel to install extensions, your local machine and VS Code Server server will need outbound HTTPS (port 443) access to:
 


### PR DESCRIPTION
The setting `remote.SSH.allowLocalServerDownload` is now deprecated and has been replaced by `remote.SSH.localServerDownload`.
