### PR TITLE
doc: correct message in task-provider.md

### DIFF
--- a/api/extension-guides/task-provider.md
+++ b/api/extension-guides/task-provider.md
@@ -118,7 +118,7 @@ The `ShellExecution` executes the `rake compile` command in the shell that is sp
 
 ## CustomExecution
 
-In general, it is best to use a `ShellExecution` or `ProcessExecution` because they are simple. However, if your task requires a lot of saved state between runs, doesn't work well as a separate script or process, or requires extensive handling of output a `CustomExecution` might be a good fit. Existing uses of `CustomExecution` are usually for complex build systems. A `CustomExecution` has only a callback which is executed at the time that the task is run. This allows for greater flexibility in what the task can do, but it also means that the task provider is responsible for any process management and output parsing that needs to happen. The task provider is also responsible for implementing `Pseudoterminal` and returning it from the `CustomExecution` callback.
+In general, it is best to use a `ShellExecution` or `ProcessExecution` because they are simple. However, if your task requires a lot of saved state between runs, doesn't work well as a separate script or process, or requires extensive handling of output a `CustomExecution` might be a good fit. Existing uses of `CustomExecution` are usually for complex build systems. A `CustomExecution` has only a callback which is executed at the time that the task is run. This allows for greater flexibility in what the task can do, but it also means that the task provider is responsible for any process management and output parsing that needs to happen. The task provider is also responsible for implementing a `Pseudoterminal` and returning it from the `CustomExecution` callback.
 
 ```typescript
 return new vscode.Task(definition, vscode.TaskScope.Workspace, `${flavor} ${flags.join(' ')}`,
@@ -128,4 +128,4 @@ return new vscode.Task(definition, vscode.TaskScope.Workspace, `${flavor} ${flag
   }));
 ```
 
-The full example, including the implementation of `Pseudoterminal` is at [https://github.com/microsoft/vscode-extension-samples/tree/main/task-provider-sample/src/customTaskProvider.ts](https://github.com/microsoft/vscode-extension-samples/tree/main/task-provider-sample/src/customTaskProvider.ts).
+The full example, including the implementation of `CustomBuildTaskTerminal` is at [https://github.com/microsoft/vscode-extension-samples/tree/main/task-provider-sample/src/customTaskProvider.ts](https://github.com/microsoft/vscode-extension-samples/tree/main/task-provider-sample/src/customTaskProvider.ts).


### PR DESCRIPTION
- it's actually the implementation of CustomBuildTaskTerminal not Pseudoterminal that is found. 
- without this change, it made it look like Pseudoterminal was a custom class when it's actually part of the API.