### PR TITLE
location is restricted in a limited area for debug toolbar as `floating`

### DIFF
--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -144,7 +144,7 @@ In addition, the **debug status** appears in the Status Bar showing the active d
 
 ## Debug actions
 
-Once a debug session starts, the **Debug toolbar** will appear on the top of the editor.
+Once a debug session starts, the **Debug toolbar** will appear on the top of the window.
 
 ![Debug Actions](images/debugging/toolbar.png)
 
@@ -157,7 +157,7 @@ Once a debug session starts, the **Debug toolbar** will appear on the top of the
 | Restart <br> `kb(workbench.action.debug.restart)`           | Terminate the current program execution and start debugging again using the current run configuration.                                                             |
 | Stop <br> `kb(workbench.action.debug.stop)`                 | Terminate the current program execution.                                                                                                                            |
 
->**Tip**: Use the setting `setting(debug.toolBarLocation)` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the **Run and Debug** view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area.
+>**Tip**: Use the setting `setting(debug.toolBarLocation)` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the **Run and Debug** view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area with a limited maximum distance to top edge.
 
 ### Run mode
 

--- a/docs/editor/debugging.md
+++ b/docs/editor/debugging.md
@@ -157,7 +157,7 @@ Once a debug session starts, the **Debug toolbar** will appear on the top of the
 | Restart <br> `kb(workbench.action.debug.restart)`           | Terminate the current program execution and start debugging again using the current run configuration.                                                             |
 | Stop <br> `kb(workbench.action.debug.stop)`                 | Terminate the current program execution.                                                                                                                            |
 
->**Tip**: Use the setting `setting(debug.toolBarLocation)` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the **Run and Debug** view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area with a limited maximum distance to top edge.
+>**Tip**: Use the setting `setting(debug.toolBarLocation)` to control the location of the debug toolbar. It can be the default `floating`, `docked` to the **Run and Debug** view, or `hidden`. A `floating` debug toolbar can be dragged horizontally and also down to the editor area (up to a certain distance from the top edge).
 
 ### Run mode
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f968e1a1-6845-4277-9b01-0d9f96f61219)


the location of debug toolbar has a limit `top` value of property of CSS, actually. As shown below: 

![20241023-221353](https://github.com/user-attachments/assets/709cad04-b2c9-4e22-a5ee-ee6ba20af928)

Perhaps it could be more fit for us to describe more for currently technically implement.

In addition, `editor` may not be appropriate because debug toolbar would appear outside the `editor`, therefore `window` could be right~