### PR TITLE
Refresh Copilot Setup and FAQ

### DIFF
--- a/docs/copilot/faq.md
+++ b/docs/copilot/faq.md
@@ -27,25 +27,30 @@ Learn more about [billing for GitHub Copilot](https://docs.github.com/billing/ma
 
 ### My Copilot subscription is not detected in VS Code
 
-- To use Copilot Chat in Visual Studio Code, you must be signed into Visual Studio Code with the same GitHub ID that has access to GitHub Copilot. If your Copilot subscription is associated with another GitHub account, you might have to sign out of your GitHub account and sign in with another account. Use the **Accounts** menu in the Activity bar for signing out of your current GitHub account.
+- To use Copilot Chat in Visual Studio Code, you must be signed into Visual Studio Code with a GitHub ID that has access to GitHub Copilot. If your Copilot subscription is associated with another GitHub account, you might have to sign out of your GitHub account and sign in with another account. Use the **Accounts** menu in the Activity Bar for signing out of your current GitHub account.
 
 - Verify that your Copilot subscription is still active in [GitHub Copilot settings](https://github.com/settings/copilot).
 
 ### How can I switch accounts for Copilot
 
-To switch to another GitHub account for using Copilot, first sign out of your GitHub account in VS Code, and then sign in with another account.
+To switch to another GitHub account for using Copilot:
 
-1. Sign out of your current GitHub account in VS Code:
+1. Open the Extensions view from the Activity Bar ( or use `kb(workbench.view.extensions)`) and enter *GitHub Copilot* in the search box.
 
-    Select the **Accounts** menu in the Activity Bar, and then select **Sign out** for the account you're currently signed in with for Copilot.
+    ![Extensions view in VS Code, showing the GitHub Copilot extension.](images/faq/copilot-extensions.png)
 
-    ![Accounts menu in VS Code, showing the option to sign out of the current GitHub account.](images/setup/vscode-accounts-menu-signout.png)
+    > [!NOTE]
+    > There are two Copilot extensions: GitHub Copilot and GitHub Copilot Chat.
 
-1. Sign in to GitHub in VS Code:
+1. For the **GitHub Copilot** extension, select the gear icon, and then select **Account Preferences**.
 
-    Select the **Accounts** menu in the Activity Bar, and then select **Sign in with GitHub to use GitHub Copilot**.
+    ![Accounts menu in VS Code, showing the option to sign out of the current GitHub account.](images/faq/extension-account-preferences.png)
 
-    ![Accounts menu in VS Code, showing the option to sign in with GitHub to use GitHub Copilot.](images/setup/vscode-accounts-menu.png)
+1. From the Account Preferences Quick Pick, choose an existing account or select **Use a new account...** to sign in with a different GitHub account.
+
+    ![Accounts menu in VS Code, showing the option to sign in with GitHub to use GitHub Copilot.](images/faq/account-preferences-quick-pick.png)
+
+1. Repeat these steps for the **GitHub Copilot Chat** extension.
 
 ## General
 

--- a/docs/copilot/images/faq/account-preferences-quick-pick.png
+++ b/docs/copilot/images/faq/account-preferences-quick-pick.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26a470fbf4fb3ed3c5e0ad8296827e834e350dd5ba0df02a562b5765867903a2
+size 46171

--- a/docs/copilot/images/faq/copilot-extensions.png
+++ b/docs/copilot/images/faq/copilot-extensions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:024128eed686dcbe60b74171dd8b3c0e8f0698f059adc963cd9e6e9d1fb870d9
+size 101601

--- a/docs/copilot/images/faq/extension-account-preferences.png
+++ b/docs/copilot/images/faq/extension-account-preferences.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1184f4fcd60b4514c897e4629de7e17c6168ec982d32ebd4cb7d0c24e351ca
+size 285166

--- a/docs/copilot/images/setup/command-center-open-chat.png
+++ b/docs/copilot/images/setup/command-center-open-chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:917664012d14d6438cdd007645ed1f730187ae681d3f3ff72e8a8a6c1449ec50
+size 141668

--- a/docs/copilot/images/setup/copilot-chat-menu-command-center.png
+++ b/docs/copilot/images/setup/copilot-chat-menu-command-center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a73b417275c508d7f9d8e7cc4b3c08473a06ac1334634deb2901927821ed364
+size 59735

--- a/docs/copilot/images/setup/copilot-status-menu.png
+++ b/docs/copilot/images/setup/copilot-status-menu.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e084f8530afd1011d5f64c311a6edefd475a2fe03f21f4ff12dad53e8389e77b
-size 56150

--- a/docs/copilot/images/setup/vscode-chat-view.png
+++ b/docs/copilot/images/setup/vscode-chat-view.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aae23b6369a701e9b74281fe0d224c09529a1d8e319cfc9c6b228c1560f4ecb7
-size 72997

--- a/docs/copilot/images/setup/vscode-status-bar-copilot-active.png
+++ b/docs/copilot/images/setup/vscode-status-bar-copilot-active.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a659dbbd239757b63152ea7ba03ed3fa52c807438e2bd9f9737523f5683e9c60
-size 6680

--- a/docs/copilot/setup.md
+++ b/docs/copilot/setup.md
@@ -16,14 +16,12 @@ For an overview of what you can do with GitHub Copilot in VS Code, see the [GitH
 
 ## Step 1: Set up your GitHub Copilot subscription
 
-If you want to use GitHub Copilot, you either need an active subscription for GitHub Copilot in your personal account, or you need to be assigned a seat in a subscription managed by an organization or enterprise.
+If you want to use GitHub Copilot, you either need an active subscription for GitHub Copilot in your personal account, or you need to be assigned a seat in a subscription managed by an organization or enterprise. Learn more about [billing for GitHub Copilot](https://docs.github.com/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot).
 
 | Account type | Instructions |
 | ------------ | ------------ |
-| Personal account | Set up a subscription to **GitHub Copilot Individual** with your personal GitHub account. You can [activate a one-time 30-day trial to evaluate GitHub Copilot](https://github.com/github-copilot/signup).<br/><br/>If you didn't yet activate your free trial for Copilot, the GitHub Copilot extension notifies you in VS Code.<br/>![Copilot sign up notification in VS Code](images/setup/copilot-access-toast.png) |
-| Member of an organization | You need to be assigned a seat by an organization owner.<br/><br/>You can request access to **GitHub Copilot Business** from the [GitHub Copilot settings](https://github.com/settings/copilot) for your personal account.<br/>![Screenshot of Copilot settings, showing how to request access from an organization.](images/setup/request-cfb-access-settings.png) |
-
-Learn more about [billing for GitHub Copilot](https://docs.github.com/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot).
+| Personal account | Set up a subscription to **GitHub Copilot Individual** with your personal GitHub account. You can [activate a one-time 30-day trial to evaluate GitHub Copilot](https://github.com/github-copilot/signup).<br/><br/>If you didn't yet activate your free trial for Copilot, the GitHub Copilot extension notifies you in VS Code.<br/><br/>![Copilot sign up notification in VS Code](images/setup/copilot-access-toast.png) |
+| Member of an organization | You need to be assigned a seat by an organization owner.<br/><br/>You can request access to **GitHub Copilot Business** from the [GitHub Copilot settings](https://github.com/settings/copilot) for your personal account.<br/><br/>![Screenshot of Copilot settings, showing how to request access from an organization.](images/setup/request-cfb-access-settings.png) |
 
 ## Step 2: Install the GitHub Copilot extension
 
@@ -35,7 +33,7 @@ When you install the GitHub Copilot extension, the [GitHub Copilot Chat](https:/
 
 ## Step 3: Sign in to GitHub
 
-To use GitHub Copilot in Visual Studio Code, you must be signed into Visual Studio Code with the same GitHub account that has access to GitHub Copilot.
+To use GitHub Copilot in Visual Studio Code, you must be signed into Visual Studio Code with a GitHub account that has access to GitHub Copilot.
 
 If you didn't previously authorize VS Code in your GitHub account, you're prompted to sign in to GitHub in VS Code:
 
@@ -53,19 +51,15 @@ Now that you've signed up for GitHub Copilot and activated the extension, let's 
 
 1. Open Visual Studio Code.
 
-1. Notice the GitHub Copilot icon in the status bar, which indicates that GitHub Copilot is active.
+1. Notice the GitHub Copilot icon next to the Command Center that gives you quick access to Copilot functionality in VS Code.
 
-    ![Screenshot showing the VS Code status bar, highlighting the Copilot icon that indicates Copilot is active.](./images/setup/vscode-status-bar-copilot-active.png)
+    ![Screenshot showing the GitHub Copilot icon in the Command Center in VS Code.](./images/setup/copilot-chat-menu-command-center.png)
 
-1. Select the GitHub Copilot icon to open the Copilot status.
+1. Select the Copilot icon and select **Open Chat** to open the Chat view.
 
-    The GitHub Copilot status should show **Ready**.
+    The Copilot Chat view should open in the Secondary Side Bar, where you can chat with Copilot.
 
-    ![Screenshot showing the GitHub Copilot status menu in VS Code, indicating that the Copilot status is ready.](./images/setup/copilot-status-menu.png)
-
-1. You should also see the Chat view in the Activity Bar, which you can use to chat with Copilot.
-
-    ![Screenshot showing the Chat view in the Activity Bar in VS Code.](./images/setup/vscode-chat-view.png)
+    ![Screenshot showing the Chat view in the Activity Bar in VS Code.](./images/setup/command-center-open-chat.png)
 
 ## Sign out of GitHub Copilot
 


### PR DESCRIPTION
- Update Setup to reference the Copilot menu next to the Command Center and Chat view in Secondary Side Bar

- Update FAQ to include setting account preferences for switching GH account for Copilot