### PR TITLE
append a commonly used issue/reason item to table.

### DIFF
--- a/docs/editor/vscode-web.md
+++ b/docs/editor/vscode-web.md
@@ -198,6 +198,7 @@ Certain keybindings may also work differently in the web.
 | `kb(workbench.action.closeActiveEditor)` for closing an editor doesn't work in web. | `kb(workbench.action.closeActiveEditor)` closes the current tab in browsers. <br> As a workaround, you can use `kbstyle(Ctrl+Shift+Alt+N)` (`kbstyle(Cmd+Shift+Alt+N)` on macOS). |
 | `kb(workbench.action.tasks.build)` will not toggle the favorites bar in the browser. | VS Code for the Web overrides this and redirects to the "Build" menu in the Command Palette. |
 | `kbstyle(Alt+Left)` and `kbstyle(Alt+Right)` should navigate within the editor but may incorrectly trigger tab history navigation. | If focus is outside the editor, these shortcuts trigger tab history navigation instead. |
+| `kb(workbench.action.closeActiveEditor)` will not work as expected, to close the currently activated editor, if it has. | `kb(workbench.action.closeActiveEditor)` invokes a prompt dialog with two options to confirm closing the current tab instead. |
 
 ## Additional browser setup
 


### PR DESCRIPTION
KeyBindings feature is an excellent experience inside VS Code, I have already unconsciously used in my work for a several years, just as usually as drinking water, the one of the most usage of mine is the `CMD+W` shortcut, I use it across my editing work on the code.

But this experience will be constrained in VS Code for the Web, it does not work as in desktop applicaiton since it has a conflict with shortcut of browser itself, while browser has the precedence.

I think it could be nicer to describe it for reader, shall we could append a item?

![image](https://github.com/user-attachments/assets/3a86258e-dea1-4481-b3fe-096a9f85047c)
