### PR TITLE
Update Extension Anatomy with activation events note

### DIFF
--- a/api/get-started/extension-anatomy.md
+++ b/api/get-started/extension-anatomy.md
@@ -14,6 +14,7 @@ In the last topic, you were able to get a basic extension running. How does it w
 The `Hello World` extension does 3 things:
 
 - Registers the [`onCommand`](/api/references/activation-events#onCommand) [**Activation Event**](/api/references/activation-events): `onCommand:helloworld.helloWorld`, so the extension becomes activated when user runs the `Hello World` command.
+  > **Note:** Starting with [VS Code 1.74.0](https://code.visualstudio.com/updates/v1_74#_implicit-activation-events-for-declared-extension-contributions), commands declared in the `commands` section of `package.json` automatically activate the extension when invoked, without requiring an explicit `onCommand` entry in `activationEvents`.
 - Uses the [`contributes.commands`](/api/references/contribution-points#contributes.commands) [**Contribution Point**](/api/references/contribution-points) to make the command `Hello World` available in the Command Palette, and bind it to a command ID `helloworld.helloWorld`.
 - Uses the [`commands.registerCommand`](/api/references/vscode-api#commands.registerCommand) [**VS Code API**](/api/references/vscode-api) to bind a function to the registered command ID `helloworld.helloWorld`.
 


### PR DESCRIPTION
This PR addresses [Issue #7787](https://github.com/microsoft/vscode-docs/issues/7787).

The current documentation states that extensions need to explicitly declare `onCommand` activation events. However, starting from [February 1, 2023](https://github.com/microsoft/vscode-generator-code/commit/366fa08fdaab957e3f1d2e63287899d76eaf6e5d), `yo code` no longer generates these entries, and VS Code Extension Examples removed them on [December 8, 2022](https://github.com/microsoft/vscode-extension-samples/commit/f7c3737b6e116c12e896c71dfe8e59ff3e8b9f3d). This inconsistency between the documentation and the generated project templates caused confusion and led to extra time spent figuring out the change.

This update adds a note to the "Extension Anatomy" section to clarify that `onCommand` activation events are no longer necessary for commands declared in the `commands` section of `package.json`. This ensures the documentation reflects the current behaviour and prevents further misunderstandings.