### PR TITLE
complete the jsonc code sample

### DIFF
--- a/api/extension-guides/file-icon-theme.md
+++ b/api/extension-guides/file-icon-theme.md
@@ -197,7 +197,9 @@ Language contributors can define an icon for the language.
           "dark": "./icons/latex-dark.png"
         }
       }
-  ]
+    ]
+  }
+}
 ```
 
 The icon is used if a file icon theme only has a generic file icon for the language.


### PR DESCRIPTION
When I went through the `File Icon Theme` article tonight, I found that there is a code sample about defining an default icon for `latex` language, it seems to be un-completion. Let me complete it by enclosing the curly braces!