### PR TITLE
fix: a logically wrong point.

### DIFF
--- a/api/extension-guides/file-icon-theme.md
+++ b/api/extension-guides/file-icon-theme.md
@@ -203,7 +203,7 @@ Language contributors can define an icon for the language.
 The icon is used if a file icon theme only has a generic file icon for the language.
 
 Language default icons are only shown if:
-- the file icon theme has specific file icons. E.g. `Minimal` does not have specific file icons and therefore does not use the language default icons
+- the file icon theme has specific file icons. E.g. `Minimal` does have specific file icons and therefore does not use the language default icons
 - the file icon theme does not contain an icon for the given language, file extension or file name.
 - the file icon theme does not define `"showLanguageModeIcons":false`
 


### PR DESCRIPTION
Firstly, Our `Minimal` file icon theme [actually have](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/fileicons/vs_minimal-icon-theme.json#L37) specific `file` icons, which is "_file_dark" and then associated in "iconDefinition" section. And then I was confused by the sentence which is shown below:

'the file icon theme has specific file icons. E.g. `Minimal` does not have specific file icons and therefore dose not use the language default icons'

there are two points:

1. `Minimal` does have an association for "file", which I think it means "`Minimal` does have specific file icons"
2. It seems to describe "the file icon theme does not have specific file icons." should be logically right. The original description could be a opposite point to above description "The icon is used if a file icon theme only has a generic file icon for the language"?


Additionally, the `generic file icon` seems to be shown first throughout this article, I can't associate it with anything in this article...

After my thought about it, just one reasonable option left to make it all right is to delete the 'not' word, please look at the files change for detailed
