### PR TITLE
Add Dart to Known Language identifiers

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -73,6 +73,7 @@ Compose | `dockercompose`
 CSS | `css`
 CUDA C++ | `cuda-cpp`
 D | `d`
+Dart | `dart`
 Delphi | `pascal`
 Diff | `diff`
 Dockerfile | `dockerfile`


### PR DESCRIPTION
`dart` is a known language identifier but it is not currently listed as such in `docs/languages/identifiers.md`