### PR TITLE
Unify indent spaces in a git config snippet

### DIFF
--- a/docs/sourcecontrol/overview.md
+++ b/docs/sourcecontrol/overview.md
@@ -247,9 +247,9 @@ You can use VS Code's diff and merge capabilities even when using Git from comma
 [difftool "default-difftool"]
     cmd = code --wait --diff $LOCAL $REMOTE
 [merge]
-  tool = code
+    tool = code
 [mergetool "code"]
-  cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
+    cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
 ```
 
 This uses the `--diff` option that can be passed to VS Code to compare two files side by side. The merge tool will be used the next time Git discovers a merge conflict.


### PR DESCRIPTION
Among the four git configs ([web link](https://code.visualstudio.com/docs/sourcecontrol/overview#_vs-code-as-git-difftool-and-mergetool)), two used 4-space indent and the other two used 2-space indent.

This PR unifies them to 4-space indent.