### PR TITLE
complete the code sample.

### DIFF
--- a/api/extension-guides/language-model-tutorial.md
+++ b/api/extension-guides/language-model-tutorial.md
@@ -80,6 +80,8 @@ Open the `src/extension.ts` file and change the `registerCommand` method so that
 
 ```ts
 const disposable = vscode.commands.registerCommand('code-tutor.annotate', () => {
+  vscode.window.showInformationMessage('Hello World from Code Tutor');
+});
 ```
 
 Run the extension by pressing `kbstyle(F5)`. This will open a new VS Code instance with the extension installed. Open the Command Palette by pressing `kb(workbench.action.showCommands)`, and search for "tutor". You should see the "Tutor Annotations" command.


### PR DESCRIPTION
In the tutorial for language model, a very good simple code snippet is not completed, it should be completed with a implementation of the `code-tutor.annotate` command.