### PR TITLE
Fix toc link for JS/TS paste

### DIFF
--- a/release-notes/v1_96.md
+++ b/release-notes/v1_96.md
@@ -16,7 +16,7 @@ DownloadVersion: 1.96.0
 Welcome to the November 2024 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
 
 * [Overtype mode](#overtype-mode) - Switch between overwrite or insert mode in the editor
-* [Add imports on paste](#configure-paste-and-drop-behavior) - Automatically add missing TS/JS imports when pasting code
+* [Add imports on paste](#paste-with-imports-for-javascript-and-typescript) - Automatically add missing TS/JS imports when pasting code
 * [Test coverage](#attributable-coverage) - Quickly filter which code is covered by a specific test
 * [Move views](#move-views-between-primary-and-secondary-side-bar) - Easily move views between the Primary and Secondary Side Bar
 * [Terminal ligatures](#ligature-support) - Use ligatures in the terminal


### PR DESCRIPTION
I think should link to the specific JS/TS section here instead of the paste preferences settings