### PR TITLE
Replace "&" with "and" in 1.96 release notes

### DIFF
--- a/release-notes/v1_96.md
+++ b/release-notes/v1_96.md
@@ -213,7 +213,7 @@ You can also access this setting by right-clicking in the title area, and select
 
 ### Configure paste and drop behavior
 
-When you drag and drop or copy & paste a file into a text editor, VS Code provides multiple ways to insert it into that file. By default, VS Code tries to insert the file's workspace relative path. Now you can use the drop/paste control to switch how the resource is inserted. Extensions can also provide customized edits, such as in Markdown, which [provides edits that insert Markdown links](https://code.visualstudio.com/updates/v1_67#_markdown-drop-into-editor-to-create-link).
+When you drag and drop or copy and paste a file into a text editor, VS Code provides multiple ways to insert it into that file. By default, VS Code tries to insert the file's workspace relative path. Now you can use the drop/paste control to switch how the resource is inserted. Extensions can also provide customized edits, such as in Markdown, which [provides edits that insert Markdown links](https://code.visualstudio.com/updates/v1_67#_markdown-drop-into-editor-to-create-link).
 
 With the new `setting(editor.pasteAs.preferences)` and `setting(editor.dropIntoEditor.preferences)` settings, you can now specify a preference for which edit type will be used by default. For example, if you'd like copy/paste to always insert the absolute path of pasted files, just set:
 


### PR DESCRIPTION
A pretty minor thing, but the "&" jumped out at me, especially as it was inconsistent with the "and" in "drag and drop"!