### PR TITLE
Server is isolated

### DIFF
--- a/docs/remote/remote-overview.md
+++ b/docs/remote/remote-overview.md
@@ -19,7 +19,7 @@ DateApproved: 12/11/2024
 - Access an **existing** development environment from **multiple machines or locations**.
 - Debug an **application running somewhere else** such as a customer site or in the cloud.
 
-**No source code** needs to be on your local machine to get these benefits. Each extension in the [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension) can run commands and other extensions directly inside a container, in WSL, or on a remote machine so that everything feels as it does when you run locally.
+**No source code** needs to be on your local machine to get these benefits. Each extension in the [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension) can run commands and other extensions directly inside a container, in WSL, or on a remote machine so that everything feels as it does when you run locally. The extensions install VS Code Server on the remote OS; the server is independent of any existing VS Code installation on the remote OS.
 
 ![Architecture](images/remote-overview/architecture.png)
 

--- a/docs/remote/remote-overview.md
+++ b/docs/remote/remote-overview.md
@@ -19,7 +19,7 @@ DateApproved: 12/11/2024
 - Access an **existing** development environment from **multiple machines or locations**.
 - Debug an **application running somewhere else** such as a customer site or in the cloud.
 
-**No source code** needs to be on your local machine to get these benefits. Each extension in the [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension) can run commands and other extensions directly inside a container, in WSL, or on a remote machine so that everything feels like it does when you run locally.
+**No source code** needs to be on your local machine to get these benefits. Each extension in the [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension) can run commands and other extensions directly inside a container, in WSL, or on a remote machine so that everything feels as it does when you run locally.
 
 ![Architecture](images/remote-overview/architecture.png)
 

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -11,7 +11,7 @@ DateApproved: 12/11/2024
 
 The **Visual Studio Code Remote - SSH** extension allows you to open a remote folder on any remote machine, virtual machine, or container with a running SSH server and take full advantage of VS Code's feature set. Once connected to a server, you can interact with files and folders anywhere on the remote filesystem.
 
-No source code needs to be on your local machine to gain these benefits since the extension runs commands and other extensions directly on the remote machine.
+No source code needs to be on your local machine to gain these benefits since the extension runs commands and other extensions directly on the remote machine.  The extension will install VS Code Server on the remote OS; the server is independent of any existing VS Code installation on the remote OS.
 
 ![SSH Architecture](images/ssh/architecture-ssh.png)
 

--- a/docs/remote/tunnels.md
+++ b/docs/remote/tunnels.md
@@ -13,7 +13,7 @@ The Visual Studio Code [Remote - Tunnels](https://marketplace.visualstudio.com/i
 
 Tunneling securely transmits data from one network to another via [Microsoft dev tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/overview).
 
-This can eliminate the need for source code to be on your VS Code client machine since the extension runs commands and other extensions directly on the remote machine.
+This can eliminate the need for source code to be on your VS Code client machine since the extension runs commands and other extensions directly on the remote machine.  The extension will install VS Code Server on the remote OS; the server is independent of any existing VS Code installation on the remote OS.
 
 ![Remote Tunnels architecture overview](images/vscode-server/server-arch-latest.png)
 

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -11,7 +11,7 @@ DateApproved: 12/11/2024
 
 The **Visual Studio Code WSL** extension lets you use the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl) as your full-time development environment right from VS Code. You can develop in a Linux-based environment, use Linux-specific toolchains and utilities, and run and debug your Linux-based applications all from the comfort of Windows.
 
-The extension runs commands and other extensions directly in WSL so you can edit files located in WSL or the mounted Windows filesystem (for example `/mnt/c`) without worrying about pathing issues, binary compatibility, or other cross-OS challenges.
+The extension runs commands and other extensions directly in WSL so you can edit files located in WSL or the mounted Windows filesystem (for example `/mnt/c`) without worrying about pathing issues, binary compatibility, or other cross-OS challenges.  The extension will install VS Code Server inside WSL; the server is independent of any existing VS Code installation in WSL.
 
 ![WSL Architecture](images/wsl/architecture-wsl.png)
 


### PR DESCRIPTION
Clarify that the VS Code server installation on the remote system is managed by the client extension,
and independent of regular VS Code installations on the remote server.

fixes microsoft/vscode-remote-release#10523
which has already been closed.

That issue concerned remote-ssh; I have tried to also update the descriptions for tunnels and WSL, though I'm less sure of the latter.  Someone familiar with codespaces and containers might want to make similar changes for them, if appropriate.