### PR TITLE
Add clarification to `csharp.debug.console` documentation

### DIFF
--- a/docs/csharp/debugger-settings.md
+++ b/docs/csharp/debugger-settings.md
@@ -178,6 +178,14 @@ The `"console"` setting controls what console (terminal) window the target app i
 * `"integratedTerminal"` : the target process will run inside [VS Code's integrated terminal](/docs/terminal/basics.md). Select the **Terminal** tab in the tab group beneath the editor to interact with your application. When using this mode, by default, the Debug Console will not be shown when starting debugging. If using `launch.json`, this can be configured with `internalConsoleOptions`.
 * `"externalTerminal"`: the target process will run inside its own external terminal. When using this mode, you will need to switch focus between Visual Studio Code and the external terminal window.
 
+**Availability**
+
+* `launch.json` ✔️
+* `settings.json` ✔️ as `csharp.debug.console`
+* `launchSettings.json` ❌
+
+> **Note**: The `csharp.debug.console` setting is only used for console projects launched with the `dotnet` debug configuration type.
+
 ### Inputting text into the target process when using internalConsole
 
 When using `internalConsole`, you can input text into Visual Studio Code that will be returned from `Console.ReadLine` and similar APIs that read from `stdin`. To do so, while the program is running, type text into the input box at the bottom of the Debug Console. Pressing `kbstyle(Enter)` will send the text to the target process. Note that if you enter text in this box while your program is stopped under the debugger, this text will be evaluated as a C# expression, not sent to the target process.
@@ -185,12 +193,6 @@ When using `internalConsole`, you can input text into Visual Studio Code that wi
 Example:
 
 ![Example of inputting text to the Console to be set to the target process's standard input](images/debugging/console-input.gif)
-
-**Availability**
-
-* `launch.json` ✔️
-* `settings.json` ✔️ as `csharp.debug.console`
-* `launchSettings.json` ❌
 
 ## launchSettings.json support
 


### PR DESCRIPTION
The console documentation had two issues that this PR addresses:
1. The `csharp.debug.console` setting is only used for console projects, but this was not called out in the documentation
2. The 'availability' section got moved into the 'Inputting text into the target process when using internalConsole', when it should have stayed in the 'Console (terminal) window' section
