### PR TITLE
Update language-model.md with correct supported lm families

### DIFF
--- a/api/extension-guides/language-model.md
+++ b/api/extension-guides/language-model.md
@@ -73,7 +73,7 @@ Once you've built the prompt for the language model, you first select the langua
 
 To select the language model, you can specify the following properties: `vendor`, `id`, `family`, or `version`. Use these properties to either broadly match all models of a given vendor or family, or select one specific model by its ID. Learn more about these properties in the [API reference](/api/references/vscode-api#LanguageModelChat).
 
-> **Note**: Currently, `gpt-4o`, `gpt-4o-mini`, `o1-preview`, `o1-mini`, `claude-3.5-sonnet`, `gemini-1.5-pro` are supported for the language model family. If you are unsure what model to use, we recommend `gpt-4o` for it's performance and quality. For interactions directly in the editor, we recommend `gpt-4o-mini` for it's performance.
+> **Note**: Currently, `gpt-4o`, `gpt-4o-mini`, `o1`, `o1-mini`, `claude-3.5-sonnet` are supported for the language model family. If you are unsure what model to use, we recommend `gpt-4o` for it's performance and quality. For interactions directly in the editor, we recommend `gpt-4o-mini` for it's performance.
 
 If there are no models that match the specified criteria, the `selectChatModels` method returns an empty array. Your extension must appropriately handle this case.
 


### PR DESCRIPTION
Hi, there are 2 issues with the current documentation: 
1. `o1-preview` is not available as a model family, it is called `o1`.
2. `gemini-1.5-pro` is not available. 

See the following screenshot which returns from:
```
await vscode.lm.selectChatModels({
            vendor: "copilot",
        });
```
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/b2c7146e-3a29-48a2-8f94-3ee0cd8e6fe2" />
