### PR TITLE
Tweak logLevel in esbuild.js examples

### DIFF
--- a/api/extension-guides/web-extensions.md
+++ b/api/extension-guides/web-extensions.md
@@ -531,7 +531,7 @@ async function main() {
 		platform: 'browser',
 		outdir: 'dist/web',
 		external: ['vscode'],
-		logLevel: 'silent',
+		logLevel: 'warning',
 		// Node.js global to browser globalThis
 		define: {
 			global: 'globalThis',
@@ -597,6 +597,7 @@ const esbuildProblemMatcherPlugin = {
 		build.onEnd((result) => {
 			result.errors.forEach(({ text, location }) => {
 				console.error(`✘ [ERROR] ${text}`);
+        if (location == null) return;
 				console.error(`    ${location.file}:${location.line}:${location.column}:`);
 			});
 			console.log('[watch] build finished');

--- a/api/working-with-extensions/bundling-extension.md
+++ b/api/working-with-extensions/bundling-extension.md
@@ -46,7 +46,7 @@ async function main() {
 		platform: 'node',
 		outfile: 'dist/extension.js',
 		external: ['vscode'],
-		logLevel: 'silent',
+		logLevel: 'warning',
 		plugins: [
 			/* add to the end of plugins array */
 			esbuildProblemMatcherPlugin,
@@ -73,6 +73,7 @@ const esbuildProblemMatcherPlugin = {
 		build.onEnd((result) => {
 			result.errors.forEach(({ text, location }) => {
 				console.error(`✘ [ERROR] ${text}`);
+                if (location == null) return;
 				console.error(`    ${location.file}:${location.line}:${location.column}:`);
 			});
 			console.log('[watch] build finished');


### PR DESCRIPTION
I see no good reason to not display esbuild's warnings. This led me to:

https://github.com/evanw/esbuild/issues/4023

Also, when enabling `ts-check` in the provided example, there's a missing check for location being `null`. I fixed that too.