### PR TITLE
Update terminal inline chat to mention correct directional key

### DIFF
--- a/docs/copilot/copilot-chat.md
+++ b/docs/copilot/copilot-chat.md
@@ -236,7 +236,7 @@ To start Inline Chat in the terminal, press the `kb(inlinechat.start)` keyboard 
 
 Once a command is suggested, use **Run** (`kb(workbench.action.terminal.chat.runCommand)`) to run the command in the terminal, or **Insert** (`kb(workbench.action.terminal.chat.insertCommand)`) to insert the command into the terminal.
 
-Optionally, you can edit the command directly in the Copilot response before running it by placing the cursor in the response or by pressing `kbstyle(Ctrl+down)`, `kbstyle(Tab)`, `kbstyle(Tab)` on Windows & Linux, or `kbstyle(Cmd+down)`, `kbstyle(Tab)`, `kbstyle(Tab)` on macOS.
+Optionally, you can edit the command directly in the Copilot response before running it by placing the cursor in the response or by pressing `kbstyle(Ctrl+up)`, `kbstyle(Tab)`, `kbstyle(Tab)` on Windows & Linux, or `kbstyle(Cmd+up)`, `kbstyle(Tab)`, `kbstyle(Tab)` on macOS.
 
 ## Smart actions
 


### PR DESCRIPTION
This PR updates the ccomand to select the chat response from `Ctrl` + `down`, to `Ctrl` + `up`, which appears to be the correct command