### PR TITLE
Update the container documentation for better Podman support

### DIFF
--- a/remote/advancedcontainers/docker-options.md
+++ b/remote/advancedcontainers/docker-options.md
@@ -109,7 +109,7 @@ userns = "keep-id"
 After that you will need to restart Podman add the following to your `devcontainer.json` to prevent Podman from attempting to create directories in `root`
 
 ```json
-	"containerUser": "vscode"
+"containerUser": "vscode"
 ```
 
 Podman also has its own implementation of the Compose Spec with [Podman Compose](https://github.com/containers/podman-compose).

--- a/remote/advancedcontainers/docker-options.md
+++ b/remote/advancedcontainers/docker-options.md
@@ -97,6 +97,8 @@ However, certain tricks like [Docker-from-Docker do not work](https://github.com
 
 To work around issues where Podman lacks permissions to create a directory in the new devcontainer, you can set Podman to build images with the Docker format, disable labling containers with SELinux, and maintain the user's UID and GID
 
+In `~/.config/containers/containers.conf`:
+
 ```toml
 [containers]
 env = [

--- a/remote/advancedcontainers/docker-options.md
+++ b/remote/advancedcontainers/docker-options.md
@@ -95,18 +95,24 @@ You can learn more about using Remote - SSH with Dev Containers in the [develop 
 
 However, certain tricks like [Docker-from-Docker do not work](https://github.com/containers/libpod/issues/4056#issuecomment-535511841) due to limitations in Podman. This affects the **Dev Containers: Try a Dev Container Sample...** and [Dev Containers: Clone Repository in Container Volume...](/docs/devcontainers/containers.md#quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) commands.
 
-To work around issues with rootless Podman (for example, not respecting a non-root `"remoteUser"` and trying to install the server in `root`), you can set the following:
+To work around issues where Podman lacks permissions to create a directory in the new devcontainer, you can set Podman to build images with the Docker format, disable labling containers with SELinux, and maintain the user's UID and GID
 
-```json
-"runArgs": [
-  "--userns=keep-id"
-],
-"containerEnv": {
-  "HOME": "/home/node"
-}
+```toml
+[containers]
+env = [
+  "BUILDAH_FORMAT=docker"
+]
+label = false
+userns = "keep-id"
 ```
 
-`"remoteUser"` can be used when `"HOME"` is set because Dev Containers gives that setting precedence over the home folder it finds in `/etc/passwd`.
+After that you will need to restart Podman add the following to your `devcontainer.json` to prevent Podman from attempting to create directories in `root`
+
+```json
+	"containerUser": "vscode"
+```
+
+Podman also has its own implementation of the Compose Spec with [Podman Compose](https://github.com/containers/podman-compose).
 
 Podman also has its own implementation of the Compose Spec with [Podman Compose](https://github.com/containers/podman-compose).
 


### PR DESCRIPTION
I found the instructions for using Podman with Devcontainers weren't working for me and other users. I had permission errors where after building the container Podman would try to make directories in the container and not be able to. This fix worked for me and is made up of fixes from other people so I imagine I'm not the only one with these issues. If there's a better way to achieve this functionality or formatting problems with my changes please let me know. I just want this to be more easily accessible information.