### PR TITLE
chore(sitemap): update references and remove outdated URL

### DIFF
--- a/build/sitemap.xml
+++ b/build/sitemap.xml
@@ -31,11 +31,6 @@
         <priority>0.70</priority>
     </url>
     <url>
-        <loc>https://code.visualstudio.com/learntocode</loc>
-        <changefreq>weekly</changefreq>
-        <priority>0.70</priority>
-    </url>
-    <url>
         <loc>https://code.visualstudio.com/migrate-from-brackets</loc>
         <changefreq>weekly</changefreq>
         <priority>0.70</priority>
@@ -181,7 +176,7 @@
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://code.visualstudio.com/docs/getstarted/keybindings</loc>
+        <loc>https://code.visualstudio.com/docs/editor/keybindings</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
@@ -426,7 +421,7 @@
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://code.visualstudio.com/docs/editor/variables-reference</loc>
+        <loc>https://code.visualstudio.com/docs/reference/variables-reference</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>


### PR DESCRIPTION
### Motivation

Ensures the sitemap reflects accurate and up-to-date documentation links.

### Changes

- Removed https://code.visualstudio.com/learntocode
- Updated https://code.visualstudio.com/docs/getstarted/keybindings to https://code.visualstudio.com/docs/editor/keybindings
- Updated https://code.visualstudio.com/docs/editor/variables-reference to https://code.visualstudio.com/docs/reference/variables-reference

### Misc.

Is there a way to indicate redirects? Search engines have the old URLs indexed, particularly https://code.visualstudio.com/docs/editor/variables-reference and https://code.visualstudio.com/docs/getstarted/keybindings.