### PR TITLE
Update your-first-extension.md

### DIFF
--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -54,7 +54,7 @@ Run the **Hello World** command from the Command Palette (`kb(workbench.action.s
 
 You should see the `Hello World from HelloWorld!` notification showing up. Success!
 
-If you aren't able to see the **Hello World** command in the debug window, check the `package.json` file and make sure that `engines.vscode` version is compatible with the installed version of VS Code.
+If you aren't able to see the **Hello World** command in the debug window, make sure the extension was properly compiled by adding `"build": "tsc"` in the `scripts` tag in `package.json` and run `npm run build` or check the `package.json` file and make sure that `engines.vscode` version is compatible with the installed version of VS Code.
 
 ## Developing the extension
 


### PR DESCRIPTION
This update improves the documentation for creating a VS Code extension by ensuring developers properly compile their extension before debugging.

**Changes Made**
Added a build step `"build": "tsc"` in the scripts section of `package.json`.
Updated the documentation to instruct users to run npm run build before debugging to prevent missing module errors.

**Why This Change?**
Without compiling the extension first, users may encounter errors like:
`_Cannot find module 'out/extension.js'_`
This ensures a smoother debugging experience by making it clear that TypeScript files need to be compiled before running the extension.

**Testing**
Verified that `npm run build` successfully compiles TypeScript files into the `out/` directory.
Confirmed that the Hello World command appears in the debug window after building.
