### PR TITLE
Remove mention of chat.editing.alwaysSaveWithGeneratedChanges

### DIFF
--- a/docs/copilot/copilot-edits.md
+++ b/docs/copilot/copilot-edits.md
@@ -225,7 +225,6 @@ The following list contains the settings related to Copilot Edits. You can confi
 
 * `setting(chat.editing.confirmEditRequestRemoval)` - ask for confirmation before undoing an edit (default: `true`)
 * `setting(chat.editing.confirmEditRequestRetry)` - ask for confirmation before performing a redo of the last edit (default: `true`)
-* `setting(chat.editing.alwaysSaveWithGeneratedChanges)` - automatically save generated changes from Copilot Edits to disk (default: `false`)
 * `setting(chat.agent.enabled)` <i class="codicon codicon-beaker"></i> - enable or disable agent mode in Copilot Edits (default: `false`)
 * `setting(chat.editing.autoAcceptDelay)` - configure a delay after which suggested edits are automatically accepted, use zero to disable auto-accept (default: 0)
 * `setting(github.copilot.chat.edits.codesearch.enabled)` _(preview)_ - let Copilot find the right files by adding `#codebase` to your prompt, similar to how agent mode works (default: `false`)


### PR DESCRIPTION
Setting was removed in https://github.com/microsoft/vscode/pull/238447