### PR TITLE
correct markdown code block language ID for proper rendering

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -432,7 +432,7 @@ You must follow the steps on the [MSYS2 website](https://www.msys2.org/) to use 
 
 UCRT on Windows machines is only included in Windows 10 or later. If you are using another version of Windows, run the following command that does not use UCRT:
 
-```MSYS2
+```bash
 pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 ```
 


### PR DESCRIPTION
The wrong language ID `MSYS2` makes the copy button floating in an unexpected position
The URL is https://code.visualstudio.com/docs/cpp/config-mingw


![image](https://github.com/user-attachments/assets/ebdfe38c-3408-4847-a8c7-e2a202f67e01)
