### PR TITLE
Update Podman documentation

### DIFF
--- a/remote/advancedcontainers/docker-options.md
+++ b/remote/advancedcontainers/docker-options.md
@@ -37,6 +37,14 @@ Colima automatically sets up a `colima` [Docker context](https://docs.docker.com
 
 > Note: Colima uses Alpine Linux, which isn't supported by Remote - SSH.
 
+## Podman
+
+[Podman](https://podman.io/) 5+ is mostly compatible with Docker's CLI commands and therefore does work if you update the **Docker Path** setting (via **Dev > Containers: Docker Path** in the Settings editor) to `podman` on Linux, Windows or macOS.
+
+![Docker Path setting](images/platform-options/docker-path-setting.png)
+
+Podman has a [`podman compose` command](https://docs.podman.io/en/latest/markdown/podman-compose.1.html) too but that requires a compose provider that can be either Docker Compose or [Podman Compose](https://github.com/containers/podman-compose).
+
 ## Linux
 
 If you're using Linux on your local machine, or already have a remote Linux machine with SSH access, you can reference the [Docker documentation](https://docs.docker.com/engine/install/) for installing Docker on Linux, with [specific information per distribution](https://docs.docker.com/engine/install/centos/).
@@ -86,29 +94,6 @@ az vm create \
 ```
 
 You can learn more about using Remote - SSH with Dev Containers in the [develop on a remote Docker host](https://code.visualstudio.com/remote/advancedcontainers/develop-remote-host#_connect-using-docker-contexts) documentation.
-
-### Podman
-
-[Podman](https://podman.io/) 1.9+ is mostly compatible with Docker's CLI commands and therefore does work if you update the **Docker Path** setting (via **Dev > Containers: Docker Path** in the Settings editor) to `podman` on Linux.
-
-![Docker Path setting](images/platform-options/docker-path-setting.png)
-
-However, certain tricks like [Docker-from-Docker do not work](https://github.com/containers/libpod/issues/4056#issuecomment-535511841) due to limitations in Podman. This affects the **Dev Containers: Try a Dev Container Sample...** and [Dev Containers: Clone Repository in Container Volume...](/docs/devcontainers/containers.md#quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) commands.
-
-To work around issues with rootless Podman (for example, not respecting a non-root `"remoteUser"` and trying to install the server in `root`), you can set the following:
-
-```json
-"runArgs": [
-  "--userns=keep-id"
-],
-"containerEnv": {
-  "HOME": "/home/node"
-}
-```
-
-`"remoteUser"` can be used when `"HOME"` is set because Dev Containers gives that setting precedence over the home folder it finds in `/etc/passwd`.
-
-Podman also has its own implementation of the Compose Spec with [Podman Compose](https://github.com/containers/podman-compose).
 
 ## Other container engines
 


### PR DESCRIPTION
With the release of Dev Containers v0.399, there is no need to update a devcontainers.json to make it work with Podman (c.f. https://github.com/microsoft/vscode-remote-release/issues/10706).

And commands like “Dev Containers: Try a Dev Container Sample” and “Dev Containers: Clone Repository in Container Volume…” that used to fail with Podman are now fixed (c.f. https://github.com/microsoft/vscode-remote-release/issues/10706)

Also, some Podman details were outdated:
- Podman isn't Linux-only but currently supports Windows and macOS too
- Podman allows `Docker-from-Docker` now (in both rootless and rootful mode)
- Podman supports both Docker-Compose and Podman-Compose (with a priority for Docker-Compose)
