### PR TITLE
Fix Refined Snippet API in 1.98 release notes

### DIFF
--- a/release-notes/v1_98.md
+++ b/release-notes/v1_98.md
@@ -601,7 +601,7 @@ Here's an example that leverages `detail` and the `learnMore` proposal:
 
 ### Refined Snippet API
 
-You can now control the whitespace normalization when inserting snippets. This applies to the [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API and to the [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API and control is the indentation of additional lines of snippets are adjusted or not
+You can now control the whitespace normalization when inserting snippets. This applies to the [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API and to the [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API and control if the indentation of additional lines of snippets are adjusted or not.
 
 ```js
 const snippet = `This is an indented


### PR DESCRIPTION
Added a full stop at the end, and changed to what I assume the sentence was supposed to say.