### PR TITLE
variables-reference: Close json code block

### DIFF
--- a/docs/reference/variables-reference.md
+++ b/docs/reference/variables-reference.md
@@ -299,6 +299,7 @@ One easy way to check a variable's runtime value is to create a VS Code [task](/
         }
     ]
 }
+```
 
 ## Related resources
 


### PR DESCRIPTION
The page https://code.visualstudio.com/docs/reference/variables-reference had some weird markup where the "Related resources" section was inside an example code block.
![image](https://github.com/user-attachments/assets/b4caa7a1-a1b3-41e2-b447-faba17b21dbc)

It seems that it was introduced here:
https://github.com/microsoft/vscode-docs/commit/85af33f44a4175578a4d00e3332409d43ae53a8f#diff-92a970470290ad4c8434cfa4028e81c09e079d6f126aba6e61e6bf2706ca7555R306-R310

So, this PR closes the code block