### PR TITLE
Update polyglot.md

### DIFF
--- a/docs/languages/polyglot.md
+++ b/docs/languages/polyglot.md
@@ -55,7 +55,7 @@ To learn about all the features, visit the VS Code Marketplace [Polyglot Noteboo
 To use Polyglot Notebooks in VS Code, you will need:
 
 - [Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) extension
-- [.NET 7 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
 
 ### Why do I need the .NET SDK?
 

--- a/docs/languages/polyglot.md
+++ b/docs/languages/polyglot.md
@@ -59,7 +59,7 @@ To use Polyglot Notebooks in VS Code, you will need:
 
 ### Why do I need the .NET SDK?
 
-The Polyglot Notebooks extension is powered by .NET Interactive, which is a cutting edge and innovative engine built on .NET technology that can run multiple languages and share variables between them. In Polyglot Notebooks, this engine behaves as the notebook's kernel and is the reason that the .NET 7 SDK is required.
+The Polyglot Notebooks extension is powered by .NET Interactive, which is a cutting edge and innovative engine built on .NET technology that can run multiple languages and share variables between them. In Polyglot Notebooks, this engine behaves as the notebook's kernel and is the reason that the .NET 9 SDK is required.
 
 ## Getting started
 


### PR DESCRIPTION
.NET 9 SDK is now required for Polyglot Notebooks

![image](https://github.com/user-attachments/assets/86877c49-4d84-498a-a03f-1b3eea34dbf6)
