### PR TITLE
Correct port forwarding terminology to reverse port forwarding

### DIFF
--- a/docs/debugtest/port-forwarding.md
+++ b/docs/debugtest/port-forwarding.md
@@ -11,7 +11,7 @@ MetaDescription: Make your local web services accessible over the internet with 
 
 Support for port forwarding is built into Visual Studio Code via [Microsoft dev tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/overview), no extension required. When running a local web service, you can use the **Ports** view to make the service accessible to others over the internet.
 
-## How to use local port forwarding
+## How to use port forwarding
 
 First, you need to have a service you want to forward. If you don't have one yet but do have Node.js installed, you can run this command to start up a server on port 3000:
 

--- a/docs/debugtest/port-forwarding.md
+++ b/docs/debugtest/port-forwarding.md
@@ -7,7 +7,7 @@ PageTitle: Port forwarding local services with VS Code
 DateApproved: 03/05/2025
 MetaDescription: Make your local web services accessible over the internet with Visual Studio Code
 ---
-# Remote Port Forwarding
+# Port Forwarding
 
 Support for port forwarding is built into Visual Studio Code via [Microsoft dev tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/overview), no extension required. When running a local web service, you can use the **Ports** view to make the service accessible to others over the internet.
 

--- a/docs/debugtest/port-forwarding.md
+++ b/docs/debugtest/port-forwarding.md
@@ -7,7 +7,7 @@ PageTitle: Port forwarding local services with VS Code
 DateApproved: 03/05/2025
 MetaDescription: Make your local web services accessible over the internet with Visual Studio Code
 ---
-# Local Port Forwarding
+# Remote Port Forwarding
 
 Support for port forwarding is built into Visual Studio Code via [Microsoft dev tunnels](https://learn.microsoft.com/azure/developer/dev-tunnels/overview), no extension required. When running a local web service, you can use the **Ports** view to make the service accessible to others over the internet.
 


### PR DESCRIPTION

The current documentation labels the port forwarding feature as "Local Port Forwarding," which suggests tunneling from a local machine to a remote service. However, the described behavior—exposing a local service (e.g., port 5555 on the user's machine) to the internet via a public URL—is reverse port forwarding. This PR updates the title and , aligning with standard networking definitions. The change clarifies that it exposes local services externally, not the other way around, and adjusts the remote machine question for consistency.

