### PR TITLE
Add pull request instruction to settings list

### DIFF
--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -244,6 +244,7 @@ To create a user prompt file:
 * `setting(github.copilot.chat.testGeneration.instructions)` _(Experimental)_: set of instructions that will be added to Copilot requests that generate tests.
 * `setting(github.copilot.chat.reviewSelection.instructions)` _(Preview)_: set of instructions that will be added to Copilot requests for reviewing the current editor selection.
 * `setting(github.copilot.chat.commitMessageGeneration.instructions)` _(Experimental)_: set of instructions that will be added to Copilot requests that generate commit messages.
+* `setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)` _(Experimental)_: set of instructions that will be added to Copilot requests that generate pull request titles and descriptions.
 
 ### Prompt files (experimental) settings
 


### PR DESCRIPTION
Add the `setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)` to the settings section.