### PR TITLE
Switch broken Twitter link for Bluesky link

### DIFF
--- a/blogs/2021/10/11/webview-ui-toolkit.md
+++ b/blogs/2021/10/11/webview-ui-toolkit.md
@@ -9,7 +9,7 @@ Author: David Dossett
 
 # Webview UI Toolkit for Visual Studio Code
 
-October 11, 2021 by David Dossett, [@david_dossett](https://twitter.com/david_dossett) and Hawk Ticehurst, [@hawkticehurst](https://twitter.com/hawkticehurst)
+October 11, 2021 by David Dossett, [@david_dossett](https://twitter.com/david_dossett) and Hawk Ticehurst, [@hawkticehurst](https://bsky.app/profile/hawkticehurst.com)
 
 We're so excited to announce the public preview of the [Webview UI Toolkit for Visual Studio Code](https://github.com/microsoft/vscode-webview-ui-toolkit). With this toolkit, extensions developers can quickly and easily create [webview-based extensions](https://code.visualstudio.com/api/extension-guides/webview) in Visual Studio Code that look, feel, and act like the editor itself.
 


### PR DESCRIPTION
Working on some website updates today and just realized there's an old blog post with a broken link pointing to my Twitter account (that I deleted like 3 years ago). Update the link to my Bluesky account.