### PR TITLE
chore: add legacy server end of support to v1.99

### DIFF
--- a/release-notes/v1_99.md
+++ b/release-notes/v1_99.md
@@ -464,6 +464,12 @@ For example, the shell could change from zsh to bash.
 
 The list of all the shells that are identifiable are currently listed [here](https://github.com/microsoft/vscode/blob/99e3ae5586a74ab1c554b6a2a50bb9eb3a4ff7fd/src/vscode-dts/vscode.d.ts#L7740-L7750)
 
+## Remote Development
+
+### Linux legacy server support has ended
+
+As of release 1.99, you can no longer connect to these servers. As noted in our [1.97 release](/remote-release-notes/v1_97.md#migration-path-for-linux-legacy-server), users that require additional time to complete migration to a supported Linux distro can provide custom builds of `glibc` and `libstdc++` as a workaround. More info on this workaround can be found in the [FAQ](https://aka.ms/vscode-remote/faq/old-linux) section.
+
 ## Enterprise
 
 ### macOS device management


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-internalbacklog/issues/5286