### PR TITLE
docs: Fix grammar in chat-agent-mode.md

### DIFF
--- a/docs/copilot/chat/chat-agent-mode.md
+++ b/docs/copilot/chat/chat-agent-mode.md
@@ -6,7 +6,7 @@ MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
 # Use agent mode in VS Code
 
-With chat _agent mode_ in Visual Studio Code, you can use natural language define a high-level task and to start an agentic code editing session to accomplish that task. In agent mode, Copilot autonomously plans the work needed and determines the relevant files and context. It then makes edits to your codebase and invokes tools to accomplish the request you made. Agent mode monitors the outcome of edits and tools, and iterates to resolve any issues that arise.
+With chat _agent mode_ in Visual Studio Code, you can use natural language to define a high-level task and to start an agentic code editing session to accomplish that task. In agent mode, Copilot autonomously plans the work needed and determines the relevant files and context. It then makes edits to your codebase and invokes tools to accomplish the request you made. Agent mode monitors the outcome of edits and tools, and iterates to resolve any issues that arise.
 
 > [!TIP]
 > If you don't yet have a Copilot subscription, you can use Copilot for free by signing up for the [Copilot Free plan](https://github.com/github-copilot/signup) and get a monthly limit of completions and chat interactions.


### PR DESCRIPTION
- Change "With chat _agent mode_ in Visual Studio Code, you can use natural language define a high-level task" -> "With chat _agent mode_ in Visual Studio Code, you can use natural language **to** define a high-level task"