### PR TITLE
Fix doc mentions tests in the "Generate documentation" section

### DIFF
--- a/docs/copilot/copilot-smart-actions.md
+++ b/docs/copilot/copilot-smart-actions.md
@@ -25,7 +25,7 @@ When you rename a symbol in your code, Copilot suggests a new name based on the 
 Use Copilot to generate code documentation for multiple languages.
 
 1. Open your application code file.
-1. Optionally, select the code you want to test.
+1. Optionally, select the code you want to document.
 1. Right-click and select **Copilot** > **Generate Docs**.
 
     ![Inline chat /doc example to generate documentation code comments for a calculator class](images/copilot-smart-actions/inline-chat-doc-example.png)


### PR DESCRIPTION
It was probably a copy paste error, as the sentence with "test" is just below in the section about tests