### PR TITLE
Update prompt and instructions files

### DIFF
--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -46,6 +46,8 @@ The following example demonstrates custom instructions for code generation:
 * Define TypeScript and React coding guidelines in a `.github/typescript-react.instructions.md` file and reference general coding guidelines:
 
     ```markdown
+    ---
+    applyTo: "**/*.ts,**/*.tsx"
     # Project coding standards for TypeScript and React
 
     Apply the [general coding guidelines](./general-coding.intructions.md) to all code.

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -23,7 +23,7 @@ You can define custom instructions in two ways:
 
 The following example demonstrates custom instructions for code generation:
 
-* Define general coding guidelines in a `.github/instructions/general-coding.instructions.md` file:
+* Define general coding guidelines in a `.github/instructions/general-coding.instructions.md` file that apply to all code:
 
     ```markdown
     ---
@@ -43,7 +43,7 @@ The following example demonstrates custom instructions for code generation:
     - Always log errors with contextual information
     ```
 
-* Define TypeScript and React coding guidelines in a `.github/instructions/typescript-react.instructions.md` file and reference general coding guidelines:
+* Define TypeScript and React coding guidelines in a `.github/instructions/typescript-react.instructions.md` file that apply to TypeScript and React code, general coding guidelines are inherited:
 
     ```markdown
     ---
@@ -117,6 +117,15 @@ An instructions file is a Markdown file with the `.instructions.md` file suffix.
     | Property | Description |
     |----------|-------------|
     | `applyTo` | Specify a glob pattern for files to which the instructions are automatically applied. To always include the custom instructions, use the `**` pattern. |
+
+    For example, the following instructions file is always applied:
+
+    ```markdown
+    ---
+    applyTo: "**"
+    ---
+    Add a comment at the end of the file: 'Contains AI-generated edits.'
+    ```
 
 * Body with the instruction content
 

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -43,7 +43,7 @@ The following example demonstrates custom instructions for code generation:
     - Always log errors with contextual information
     ```
 
-* Define TypeScript and React coding guidelines in a `.github/typescript-react.instructions.md` file and reference general coding guidelines:
+* Define TypeScript and React coding guidelines in a `.github/instructions/typescript-react.instructions.md` file and reference general coding guidelines:
 
     ```markdown
     ---

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -23,34 +23,47 @@ You can define custom instructions in two ways:
 
 The following example demonstrates custom instructions for code generation:
 
-```markdown
-# Project coding standards
+* Define general coding guidelines in a `.github/general-coding.instructions.md` file:
 
-## TypeScript Guidelines
-- Use TypeScript for all new code
-- Follow functional programming principles where possible
-- Use interfaces for data structures and type definitions
-- Prefer immutable data (const, readonly)
-- Use optional chaining (?.) and nullish coalescing (??) operators
+    ```markdown
+    ---
+    applyTo: "**"
+    ---
+    # Project general coding standards
 
-## React Guidelines
-- Use functional components with hooks
-- Follow the React hooks rules (no conditional hooks)
-- Use React.FC type for components with children
-- Keep components small and focused
-- Use CSS modules for component styling
+    ## Naming Conventions
+    - Use PascalCase for component names, interfaces, and type aliases
+    - Use camelCase for variables, functions, and methods
+    - Prefix private class members with underscore (_)
+    - Use ALL_CAPS for constants
 
-## Naming Conventions
-- Use PascalCase for component names, interfaces, and type aliases
-- Use camelCase for variables, functions, and methods
-- Prefix private class members with underscore (_)
-- Use ALL_CAPS for constants
+    ## Error Handling
+    - Use try/catch blocks for async operations
+    - Implement proper error boundaries in React components
+    - Always log errors with contextual information
+    ```
 
-## Error Handling
-- Use try/catch blocks for async operations
-- Implement proper error boundaries in React components
-- Always log errors with contextual information
-```
+* Define TypeScript and React coding guidelines in a `.github/typescript-react.instructions.md` file and reference general coding guidelines:
+
+    ```markdown
+    # Project coding standards for TypeScript and React
+
+    Apply the [general coding guidelines](./general-coding.intructions.md) to all code.
+
+    ## TypeScript Guidelines
+    - Use TypeScript for all new code
+    - Follow functional programming principles where possible
+    - Use interfaces for data structures and type definitions
+    - Prefer immutable data (const, readonly)
+    - Use optional chaining (?.) and nullish coalescing (??) operators
+
+    ## React Guidelines
+    - Use functional components with hooks
+    - Follow the React hooks rules (no conditional hooks)
+    - Use React.FC type for components with children
+    - Keep components small and focused
+    - Use CSS modules for component styling
+    ```
 
 ### Instruction files
 

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -23,7 +23,7 @@ You can define custom instructions in two ways:
 
 The following example demonstrates custom instructions for code generation:
 
-* Define general coding guidelines in a `.github/general-coding.instructions.md` file:
+* Define general coding guidelines in a `.github/instructions/general-coding.instructions.md` file:
 
     ```markdown
     ---

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -16,13 +16,8 @@ VS Code supports several types of custom instructions, targeted at different sce
 
 You can define custom instructions in two ways:
 
-1. Using a `.github/copilot-instructions.md` file in your workspace
-2. Directly in your VS Code settings through `settings.json`
-
-If you define custom instructions in both the `.github/copilot-instructions.md` file and in settings, Copilot tries to combine instructions from both sources.
-
-> [!NOTE]
-> Custom instructions for code generation are not used for [code completions](/docs/copilot/ai-powered-suggestions.md) and are only used in [chat](/docs/copilot/chat/copilot-chat.md).
+1. **Instruction files**: specify code-generation instructions in Markdown files for your workspace or [VS Code profile](/docs/configure/profiles.md).
+1. **Settings**: specify instructions in VS Code user or workspace settings.
 
 ### Custom instructions example
 
@@ -57,9 +52,24 @@ The following example demonstrates custom instructions for code generation:
 - Always log errors with contextual information
 ```
 
-### Use a `.github/copilot-instructions.md` file
+### Instruction files
 
-You can store custom instructions in your workspace or repository in a `.github/copilot-instructions.md` file and describe your coding practices, preferred technologies, and project requirements by using Markdown.
+Instruction files enable you to specify custom instructions in Markdown files. You can use these files to define your coding practices, preferred technologies, and project requirements.
+
+There are two types of instruction files:
+
+* `.github/copilot-instructions.md`: a single instruction file that contains all the instructions for your workspace. These instructions are automatically included in every chat request.
+
+* `.instructions.md` files: one or more prompt files that contain custom instructions for specific tasks. You can attach individual prompt files to a chat request, or you can configure them to be automatically included for specific files or folders.
+
+If you specify both types of instruction files, both are included in the chat request. No particular order or priority is applied to the instructions. Make sure to avoid conflicting instructions in the files.
+
+> [!NOTE]
+> Instruction files are only used for code generation and are not used for [code completions](/docs/copilot/ai-powered-suggestions.md).
+
+#### Use a `.github/copilot-instructions.md` file
+
+You can store custom instructions in your workspace or repository in a `.github/copilot-instructions.md` file and describe your coding practices, preferred technologies, and project requirements by using Markdown. These instructions only apply to the workspace where the file is located.
 
 VS Code automatically includes the instructions from the `.github/copilot-instructions.md` file to every chat request and applies them for generating code.
 
@@ -74,11 +84,60 @@ To use a `.github/copilot-instructions.md` file:
     Whitespace between instructions is ignored, so the instructions can be written as a single paragraph, each on a new line, or separated by blank lines for legibility.
 
 > [!NOTE]
-> GitHub Copilot in Visual Studio also detects the `.github/copilot-instructions.md` file. If you have a workspace that you use in both VS Code and Visual Studio, you can use the same file to define custom instructions for both editors.
+> GitHub Copilot in Visual Studio and GitHub.com also detect the `.github/copilot-instructions.md` file. If you have a workspace that you use in both VS Code and Visual Studio, you can use the same file to define custom instructions for both editors.
 
-### Use settings
+#### Use `.instructions.md` files
 
-You can also configure custom code-generation instructions in your user or workspace settings. The following table lists the settings for each type of custom instruction.
+You can also create one or more `.instructions.md` files to store custom instructions for specific tasks. For example, you can create instruction files for different programming languages, frameworks, or project types.
+
+VS Code supports two types of scopes for instruction files:
+
+* **Workspace instructions files**: are only available within the workspace and are stored in the `.github/instructions` folder of the workspace.
+* **User instruction files**: are available across multiple workspaces and are stored in the current [VS Code profile](/docs/configure/profiles.md).
+
+An instructions file is a Markdown file with the `.instructions.md` file suffix. The structure of the file
+
+The instruction file consists of two sections:
+
+* (Optional) Header with metadata (frontmatter syntax)
+
+    | Property | Description |
+    |----------|-------------|
+    | `applyTo` | Specify a glob pattern for files to which the instructions are automatically applied. To always include the custom instructions, use the `**` pattern. |
+
+* Body with the instruction content
+
+    Specify the custom instructions in natural language by using Markdown formatting. You can use headings, lists, and code blocks to structure the instructions.
+
+    You can reference other instruction files by using Markdown links. Use relative paths to reference these files, and ensure that the paths are correct based on the location of the instruction file.
+
+To create an instructions file:
+
+1. Run the **Chat: New Instruction File** command from the Command Palette (`kb(workbench.action.showCommands)`).
+
+1. Choose the location where the instruction file should be created.
+
+    User instruction files are stored in the [current profile folder](/docs/configure/profiles.md). You can sync your user instruction files across multiple devices by using [Settings Sync](/docs/configure/settings-sync.md). Make sure to configure the **Prompts** setting in the **Settings Sync: Configure** command.
+
+    Workspace instruction files are, by default, stored in the `.github/instructions` folder of your workspace. Add more instruction folders for your workspace with the `setting(chat.instructionsFilesLocations)` setting.
+
+1. Enter a name for your instruction file.
+
+1. Author the custom instructions by using Markdown formatting.
+
+    Within a workspace instruction file, reference additional workspace files as Markdown links (`[index](../index.ts)`), or as `#file:../index.ts` references within the instruction file.
+
+To use an instructions file for a chat prompt, you can either:
+
+* In the Chat view, select **Add Context** > **Instructions** and select the instruction file from the Quick Pick.
+* Run the **Chat: Attach Instructions** command from the Command Palette (`kb(workbench.action.showCommands)`) and select the instruction file from the Quick Pick.
+* Configure the `applyTo` property in the instruction file header to automatically apply the instructions to specific files or folders.
+
+### Specify custom instructions in settings
+
+You can also configure custom instructions in your user or workspace settings. There are specific settings for different scenarios. The instructions are automatically applied for the specific task.
+
+The following table lists the settings for each type of custom instruction.
 
 | Type of instruction | Setting name |
 |----------------------|--------------|
@@ -115,15 +174,19 @@ The following code snippet shows how to define a set of instructions in the `set
 
 * Don't refer to external resources in the instructions, such as specific coding standards.
 
-* Make it easy to share custom instructions with your team or across projects by storing your instructions in an external file. You can also version control the file to track changes over time.
+* Split instructions into multiple files. This approach is useful for organizing instructions by topic or type of task.
 
-* Split instructions into multiple files and add multiple file references to your settings. This approach is useful for organizing instructions by topic or type of task.
+* Make it easy to share custom instructions with your team or across projects by storing your instructions in instruction files. You can also version control the files to track changes over time.
+
+* Use the `applyTo` property in the instruction file header to automatically apply the instructions to specific files or folders.
+
+* Reference custom instructions in your prompt files to keep your prompts clean and focused, and to avoid duplicating instructions for different tasks.
 
 ## Reusable prompt files (experimental)
 
 Prompt files allow you to craft complete prompts in Markdown files, which you can then reference in chat. Unlike custom instructions that supplement your existing prompts, prompt files are standalone prompts that you can store within your workspace and share with others. With prompt files, you can create reusable templates for common tasks, store domain expertise in your codebase, and standardize AI interactions across your team.
 
-VS Code supports two types of prompts:
+VS Code supports two types of scopes for prompt files:
 
 * **Workspace prompt files**: are only available within the workspace and are stored in the `.github/prompts` folder of the workspace.
 * **User prompt files**: are available across multiple workspaces and are stored in the current [VS Code profile](/docs/configure/profiles.md).
@@ -292,7 +355,16 @@ To save a chat request as a prompt file:
 
 ### Custom instructions settings
 
+* `setting(chat.promptFiles)` _(Experimental)_: enable reusable prompt and instruction files.
+
 * `setting(github.copilot.chat.codeGeneration.useInstructionFiles)`: controls whether code instructions from `.github/copilot-instructions.md` are added to Copilot requests.
+
+* `setting(chat.instructionsFilesLocations)` _(Experimental)_: a list of folders where instruction files are located. Relative paths are resolved from the root folder(s) of your workspace. Supports glob patterns for file paths.
+
+    | Setting value | Description |
+    |---------------|-------------|
+    | `["/path/to/folder"]` | Enable instruction files for a specific path. Specify one or more folders where instruction files are located. Relative paths are resolved from the root folder(s) of your workspace.<br/>By default, `.github/copilot-instructions` is added but disabled. |
+
 * `setting(github.copilot.chat.codeGeneration.instructions)` _(Experimental)_: set of instructions that will be added to Copilot requests that generate code.
 * `setting(github.copilot.chat.testGeneration.instructions)` _(Experimental)_: set of instructions that will be added to Copilot requests that generate tests.
 * `setting(github.copilot.chat.reviewSelection.instructions)` _(Preview)_: set of instructions that will be added to Copilot requests for reviewing the current editor selection.
@@ -301,9 +373,9 @@ To save a chat request as a prompt file:
 
 ### Prompt files (experimental) settings
 
-* `setting(chat.promptFiles)` _(Experimental)_: enable reusable prompt files.
+* `setting(chat.promptFiles)` _(Experimental)_: enable reusable prompt and instruction files.
 
-* `setting(chat.promptFilesLocations)` _(Experimental)_: a list of folders where prompt files are located. You can specify one or more folders where prompt files are located. Relative paths are resolved from the root folder(s) of your workspace. Supports glob patterns for file paths.
+* `setting(chat.promptFilesLocations)` _(Experimental)_: a list of folders where prompt files are located. Relative paths are resolved from the root folder(s) of your workspace. Supports glob patterns for file paths.
 
     | Setting value | Description |
     |---------------|-------------|

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -108,9 +108,7 @@ VS Code supports two types of scopes for instruction files:
 * **Workspace instructions files**: are only available within the workspace and are stored in the `.github/instructions` folder of the workspace.
 * **User instruction files**: are available across multiple workspaces and are stored in the current [VS Code profile](/docs/configure/profiles.md).
 
-An instructions file is a Markdown file with the `.instructions.md` file suffix. The structure of the file
-
-The instruction file consists of two sections:
+An instructions file is a Markdown file with the `.instructions.md` file suffix. The instruction file consists of two sections:
 
 * (Optional) Header with metadata (frontmatter syntax)
 
@@ -332,7 +330,7 @@ To sync your user prompt files, enable Settings Sync for prompt and instruction 
 
 1. Make sure you have [Settings Sync](/docs/configure/settings-sync.md) enabled.
 
-1. Run **Settings Sync: Configure** from the Command Palette (`kb(workbench.action.showCommands)`)
+1. Run **Settings Sync: Configure** from the Command Palette (`kb(workbench.action.showCommands)`).
 
 1. Select **Prompts** from the list of settings to sync.
 

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -19,56 +19,7 @@ You can define custom instructions in two ways:
 1. **Instruction files**: specify code-generation instructions in Markdown files for your workspace or [VS Code profile](/docs/configure/profiles.md).
 1. **Settings**: specify instructions in VS Code user or workspace settings.
 
-### Custom instructions example
-
-The following example demonstrates custom instructions for code generation:
-
-* Define general coding guidelines in a `.github/instructions/general-coding.instructions.md` file that apply to all code:
-
-    ```markdown
-    ---
-    applyTo: "**"
-    ---
-    # Project general coding standards
-
-    ## Naming Conventions
-    - Use PascalCase for component names, interfaces, and type aliases
-    - Use camelCase for variables, functions, and methods
-    - Prefix private class members with underscore (_)
-    - Use ALL_CAPS for constants
-
-    ## Error Handling
-    - Use try/catch blocks for async operations
-    - Implement proper error boundaries in React components
-    - Always log errors with contextual information
-    ```
-
-* Define TypeScript and React coding guidelines in a `.github/instructions/typescript-react.instructions.md` file that apply to TypeScript and React code, general coding guidelines are inherited:
-
-    ```markdown
-    ---
-    applyTo: "**/*.ts,**/*.tsx"
-    ---
-    # Project coding standards for TypeScript and React
-
-    Apply the [general coding guidelines](./general-coding.intructions.md) to all code.
-
-    ## TypeScript Guidelines
-    - Use TypeScript for all new code
-    - Follow functional programming principles where possible
-    - Use interfaces for data structures and type definitions
-    - Prefer immutable data (const, readonly)
-    - Use optional chaining (?.) and nullish coalescing (??) operators
-
-    ## React Guidelines
-    - Use functional components with hooks
-    - Follow the React hooks rules (no conditional hooks)
-    - Use React.FC type for components with children
-    - Keep components small and focused
-    - Use CSS modules for component styling
-    ```
-
-### Instruction files
+### Use instruction files
 
 Instruction files enable you to specify custom instructions in Markdown files. You can use these files to define your coding practices, preferred technologies, and project requirements.
 
@@ -190,6 +141,55 @@ The following code snippet shows how to define a set of instructions in the `set
     }
   ],
 ```
+
+### Custom instructions example
+
+The following example demonstrates custom instructions for code generation:
+
+* Define general coding guidelines in a `.github/instructions/general-coding.instructions.md` file that apply to all code:
+
+    ```markdown
+    ---
+    applyTo: "**"
+    ---
+    # Project general coding standards
+
+    ## Naming Conventions
+    - Use PascalCase for component names, interfaces, and type aliases
+    - Use camelCase for variables, functions, and methods
+    - Prefix private class members with underscore (_)
+    - Use ALL_CAPS for constants
+
+    ## Error Handling
+    - Use try/catch blocks for async operations
+    - Implement proper error boundaries in React components
+    - Always log errors with contextual information
+    ```
+
+* Define TypeScript and React coding guidelines in a `.github/instructions/typescript-react.instructions.md` file that apply to TypeScript and React code, general coding guidelines are inherited:
+
+    ```markdown
+    ---
+    applyTo: "**/*.ts,**/*.tsx"
+    ---
+    # Project coding standards for TypeScript and React
+
+    Apply the [general coding guidelines](./general-coding.intructions.md) to all code.
+
+    ## TypeScript Guidelines
+    - Use TypeScript for all new code
+    - Follow functional programming principles where possible
+    - Use interfaces for data structures and type definitions
+    - Prefer immutable data (const, readonly)
+    - Use optional chaining (?.) and nullish coalescing (??) operators
+
+    ## React Guidelines
+    - Use functional components with hooks
+    - Follow the React hooks rules (no conditional hooks)
+    - Use React.FC type for components with children
+    - Keep components small and focused
+    - Use CSS modules for component styling
+    ```
 
 ### Tips for defining custom instructions
 

--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -123,15 +123,10 @@ The following code snippet shows how to define a set of instructions in the `set
 
 Prompt files allow you to craft complete prompts in Markdown files, which you can then reference in chat. Unlike custom instructions that supplement your existing prompts, prompt files are standalone prompts that you can store within your workspace and share with others. With prompt files, you can create reusable templates for common tasks, store domain expertise in your codebase, and standardize AI interactions across your team.
 
-A prompt file is a Markdown file that mimics the existing format of writing prompts in chat (for example, `Rewrite #file:x.ts`). This allows blending natural language instructions, additional context, and even linking to other prompt files as dependencies.
-
-> [!TIP]
-> Reference additional context files like API specs or documentation by using Markdown links to provide Copilot with more complete information.
-
 VS Code supports two types of prompts:
 
-* **Workspace prompt files**: stored in a Markdown file within your workspace and only available in that workspace.
-* **User prompt files**: stored in a Markdown file in your profile folder and available for use across multiple workspaces.
+* **Workspace prompt files**: are only available within the workspace and are stored in the `.github/prompts` folder of the workspace.
+* **User prompt files**: are available across multiple workspaces and are stored in the current [VS Code profile](/docs/configure/profiles.md).
 
 Common use cases include:
 
@@ -140,12 +135,44 @@ Common use cases include:
 * **Team collaboration**: document patterns and guidelines with references to specs and documentation.
 * **Onboarding**: create step-by-step guides for complex processes or project-specific patterns.
 
+### Prompt file structure
+
+A prompt file is a Markdown file with the `.prompt.md` file suffix.
+
+The prompt file consists of two sections:
+
+* (Optional) Header with metadata (frontmatter syntax)
+
+    | Property | Description |
+    |----------|-------------|
+    | `mode` | The chat mode to use when running the prompt: `ask`, `edit`, or `agent` (default). |
+    | `tools` | The list of tools that can be used in agent mode. Array of tool names, for example `terminalLastCommand` or `githubRepo`. The tool name is shown when you type `#` in the chat input field.<br/>If a given tool is not available, it is ignored when running the prompt. |
+    | `description` | A short description of the prompt. |
+
+* Body with the prompt content
+
+    Prompt files mimic the format of writing prompts in chat. This allows blending natural language instructions, additional context, and even linking to other prompt files as dependencies. You can use Markdown formatting to structure the prompt content, including headings, lists, and code blocks.
+
+You can reference other prompt files or instruction files by using Markdown links. Use relative paths to reference these files, and ensure that the paths are correct based on the location of the prompt file.
+
+Within a prompt file, you can reference variables by using the `${variableName}` syntax. You can reference the following variables:
+
+* Workspace variables - `${workspaceFolder}`, `${workspaceFolderBasename}`
+* Selection variables - `${selection}`, `${selectedText}`
+* File context variables - `${file}`, `${fileBasename}`, `${fileDirname}`, `${fileBasenameNoExtension}`
+* Input variables - `${input:variableName}`, `${input:variableName:placeholder}` (pass values to the prompt from the chat input field)
+
 ### Prompt file examples
 
-* Document a reusable task for generating a form:
+* Prompt for a reusable task to generate a React form:
 
     ```markdown
-    Your goal is to generate a new React form component.
+    ---
+    mode: 'agent'
+    tools: ['githubRepo', 'codebase']
+    description: 'Generate a new React form component'
+    ---
+    Your goal is to generate a new React form component based on the templates in #githubRepo contoso/react-templates.
 
     Ask for the form name and fields if not provided.
 
@@ -161,36 +188,47 @@ Common use cases include:
     * Customize UX-friendly validation rules
     ```
 
-* Document reusable security practices for REST APIs, which can be used to do security reviews of REST APIs:
+* Prompt for performing a security review of a REST API:
 
     ```markdown
-    Secure REST API review:
+    ---
+    mode: 'edit'
+    description: 'Perform a REST API security review'
+    ---
+    Perform a REST API security review:
+
     * Ensure all endpoints are protected by authentication and authorization
     * Validate all user inputs and sanitize data
     * Implement rate limiting and throttling
     * Implement logging and monitoring for security events
-    …
     ```
+
+> [!TIP]
+> Reference additional context files like API specs or documentation by using Markdown links to provide Copilot with more complete information.
 
 ### Create a workspace prompt file
 
-Workspace prompt files are stored in your workspace and are only available in that workspace. Workspace prompt files are stored in the `.github/prompts` directory of your workspace.
+Workspace prompt files are stored in your workspace and are only available in that workspace.
+
+By default, prompt files are located in the `.github/prompts` directory of your workspace. You can specify additional prompt file locations with the `setting(chat.promptFilesLocations)` setting.
 
 To create a workspace prompt file:
 
-1. Set the `setting(chat.promptFiles)` setting to `true` for the `.github/prompts` directory.
+1. Run the **Chat: New Prompt File** command from the Command Palette (`kb(workbench.action.showCommands)`).
 
-1. Create a `.prompt.md` file in the `.github/prompts` directory of your workspace.
+1. Choose the location where the prompt file should be created.
 
-    By default, prompt files are located in the `.github/prompts` directory of your workspace. You can specify additional prompt file locations with the `setting(chat.promptFilesLocations)` setting.
+    By default, only the `.github/prompts` folder is available. Add more prompt folders for your workspace with the `setting(chat.promptFilesLocations)` setting.
 
-    Alternatively, use the **Chat: Create Prompt** command from the Command Palette (`kb(workbench.action.showCommands)`) to create a prompt.
+1. Enter a name for your prompt file.
+
+    Alternatively, you can directly create a `.prompt.md` file in the prompts folder of your workspace.
 
 1. Author the chat prompt by using Markdown formatting.
 
     Within a prompt file, reference additional workspace files as Markdown links (`[index](../index.ts)`), or as `#file:../index.ts` references within the prompt file.
 
-    You can also reference other `.prompt.md` files to create a hierarchy of prompts, with reusable prompts that can be shared across multiple prompt files.
+    You can also reference other `.prompt.md` files to create a hierarchy of prompts. You can also reference [instructions files](#custom-instructions) in the same way.
 
 ### Create a user prompt file
 
@@ -198,34 +236,57 @@ User prompt files are stored in your [user profile](/docs/configure/profiles.md)
 
 To create a user prompt file:
 
-1. Select the **Chat: Create User Prompt** command from the Command Palette (`kb(workbench.action.showCommands)`).
+1. Select the **Chat: New Prompt File** command from the Command Palette (`kb(workbench.action.showCommands)`).
+
+1. Select **User Data Folder** as the location for the prompt file.
+
+    If you use multiple [VS Code profiles](/docs/configure/profiles.md), the prompt file is created in the current profile's user data folder.
 
 1. Enter a name for your prompt file.
 
 1. Author the chat prompt by using Markdown formatting.
 
-    You can also reference other `.prompt.md` user prompt files to create a hierarchy of prompts, with reusable prompts that can be shared across multiple prompt files.
+    You can also reference other user prompt files or user instruction files.
 
-> [!TIP]
-> User prompt files can be synced across multiple devices with [Settings Sync](/docs/configure/settings-sync.md). Make sure to enable support for prompt files in your Settings Sync configuration. Select **Settings Sync: Configure** from the Command Palette, and make sure **Prompts** is selected.
+#### Sync user prompt files across devices
+
+VS Code can sync your user prompt files across multiple devices by using [Settings Sync](/docs/configure/settings-sync.md).
+
+To sync your user prompt files, enable Settings Sync for prompt and instruction files:
+
+1. Make sure you have [Settings Sync](/docs/configure/settings-sync.md) enabled.
+
+1. Run **Settings Sync: Configure** from the Command Palette (`kb(workbench.action.showCommands)`)
+
+1. Select **Prompts** from the list of settings to sync.
 
 ### Use a prompt file in chat
 
-To use a prompt file as a chat prompt, attach it to your chat request as context:
+You have multiple options to run a prompt file:
 
-1. Open the Chat view in VS Code (`kb(workbench.action.chat.open)`).
+* Run the **Chat: Run Prompt** command from the Command Palette (`kb(workbench.action.showCommands)`) and select a prompt file from the Quick Pick.
 
-1. Select **Attach Context** in the chat input field, and then select **Prompt...**.
+* In the Chat view, type `/` followed by the prompt file name in the chat input field.
 
-    Alternatively, use the **Chat: Use Prompt** command from the Command Palette (`kb(workbench.action.showCommands)`).
+    This option enables you to pass additional information in the chat input field. For example, `/create-react-form` or `/create-react-form: formName=MyForm`.
 
-1. Choose a prompt file from the Quick Pick to attach it to your chat request.
+* Open the prompt file in the editor, and press the play button in the editor title area. You can choose to run the prompt in the current chat session or open a new chat session.
 
-    You can use prompt files in any of the chat modes (ask, edit, or agent mode).
+    This option is useful for quickly testing and iterating on your prompt files.
 
-1. Optionally, attach additional context files required for the task or include more instructions in the chat prompt.
+### Save a chat request as a prompt file
 
-    To use the prompt file as-is, send the chat prompt without any additional instructions.
+You can save the latest chat request as a prompt file. This option is useful for creating reusable prompts based on your recent interactions in chat.
+
+To save a chat request as a prompt file:
+
+1. Enter a chat request in the Chat view.
+
+1. Enter `/save` in the chat input field.
+
+    VS Code generates a prompt file, which contains the latest chat request and its response.
+
+1. Review and edit the generated prompt file and save it in your prompts folder.
 
 ## Settings
 


### PR DESCRIPTION
Updating documentation for prompt and instruction files:

- Instructions files
  - `.instructions.md` files
  - User and workspace instructions files
  - Sync with Settings Sync
  - Add `applyTo` metadata to automatically assign to specific files
  - Commands for creating instructions files
 
- Prompt files
  - User and workspace prompt files
  - Metadata fields for mode, description, tools
  - Template variables
  - Run from editor with play button
  - Run with /<prompt>
  - Save prompt with /save
  - Commands for creating and running prompt files