### PR TITLE
Add 'walkthrough' to debugger settings

### DIFF
--- a/docs/csharp/debugger-settings.md
+++ b/docs/csharp/debugger-settings.md
@@ -10,11 +10,112 @@ MetaDescription: Configuring C# debugging
 
 You can configure the C# debugger in Visual Studio Code with a `launch.json`, `launchSettings.json`, or your user `settings.json` file.
 
+## Walkthrough: setting command line arguments
+
+Before we get into the details of all the possible options, lets walkthrough a basic scenario -- setting command line arguments to your program. These steps will also work for updating other basic options like environment variables or the current working directory.
+
+### Approach 1: `launchSettings.json`
+
+For C# Dev Kit, the recommended way to debug is to let C# Dev Kit automatically figure out how to debug from settings in the project file. This means you either don't have a `<workspace_root>/.vscode/launch.json` file, or if you have one you have `"type": "dotnet"` set for the active configuration. For command line arguments, "figure out from the project file" means to pull the value from `<Project-Directory>/Propeties/launchSettings.json`. The advantage of `launchSettings.json` is that it allows settings to be shared between Visual Studio Code, full Visual Studio, and `dotnet run`.
+
+For this case, here are the steps to set the command line arguments:
+1. In workspace explorer view, navigate to the directory of the project (.csproj file) you want to launch
+2. If there isn't a `Properties` directory already, create it
+3. If there isn't a `launchSettings.json` file already, create one, you can use the below text as an example
+4. Change the `commandLineArgs` property to what you would like the command line arguments to be
+
+**Example `launchSettings.json` file**:
+```json
+{
+  "profiles": {
+    "MyLaunchProfileName": {
+      "commandName": "Project",
+      "commandLineArgs": "MyFirstArgument MySecondArgument"
+    }
+  }
+}
+```
+
+### Approach 2: `launch.json`
+
+If you are using the `coreclr` or `clr` debug adapter type in VS Code, command line arguments are stored in your `<workspace_root>/.vscode/launch.json`. To edit them in this case:
+
+1. Open up `<workspace_root>/.vscode/launch.json`
+2. Find the `coreclr` or `clr` launch configuration you want to launch
+3. Edit the `args` property. This can either be a string, or an array of strings
+
+## Configuring launchSettings.json
+
+With C# Dev Kit, you can bring your `launchSettings.json` from Visual Studio to work with Visual Studio Code
+
+Example:
+
+```json
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:59481",
+      "sslPort": 44308
+    }
+  },
+  "profiles": {
+    "EnvironmentsSample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7152;http://localhost:5105",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "EnvironmentsSample-Staging": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7152;http://localhost:5105",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Staging",
+        "ASPNETCORE_DETAILEDERRORS": "1",
+        "ASPNETCORE_SHUTDOWNTIMEOUTSECONDS": "3"
+      }
+    },
+    "EnvironmentsSample-Production": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7152;http://localhost:5105",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}
+```
+
+## Profile Properties
+
+* `commandLineArgs` - The arguments to pass to the target being run.
+* `executablePath` - An absolute or relative path to the executable.
+* `workingDirectory` - Sets the working directory of the command.
+* `launchBrowser` - Set to true if the browser should be launched.
+* `applicationUrl` - A semi-colon delimited list of URL(s) to configure for the web server.
+* `sslPort` - The SSL port to use for the web site.
+* `httpPort` - The HTTP port to use for the web site.
+
+# List of configurable options
+
 Below are common options you may want to change while debugging.
 
-## Configuring VS Code's debugging behavior
-
-### PreLaunchTask
+## PreLaunchTask
 
 The `preLaunchTask` field runs the associated taskName in `tasks.json` before debugging your program. You can get the default build prelaunch task by executing the command **Tasks: Configure Tasks Runner** from the VS Code Command Palette.
 
@@ -194,9 +295,9 @@ Example:
 
 ![Example of inputting text to the Console to be set to the target process's standard input](images/debugging/console-input.gif)
 
-## launchSettings.json support
+## `launchSettingsProfile` and `launchSettingsFilePath`
 
-In addition to `launch.json`, launch options can be configured through a `launchSettings.json` file. The advantage of `launchSettings.json` is that it allows settings to be shared between Visual Studio Code, full Visual Studio, and `dotnet run`.
+While full support for `launchSettings.json` requires use of a launch configuration with `"type": "dotnet"`, the `coreclr` and `clr` debugger types also support a limited subset of `launchSettings.json` functionality. This is useful for users who want to use the same settings in both Visual Studio Code and full Visual Studio.
 
 To configure which `launchSettings.json` profile to use (or to prevent it from being used), set the `launchSettingsProfile` option:
 
@@ -221,9 +322,9 @@ Which would then, for example, use `myVariableName` from this example `launchSet
 
 If `launchSettingsProfile` is NOT specified, the first profile with `"commandName": "Project"` will be used.
 
-If `launchSettingsProfile` is set to null/an empty string, then Properties/launchSettings.json will be ignored.
+If `launchSettingsProfile` is set to null/an empty string, then `Properties/launchSettings.json` will be ignored.
 
-By default, the debugger will search for `launchSettings.json` in {cwd}/Properties/launchSettings.json. To customize this path, set `launchSettingsFilePath`:
+By default, the debugger will search for `launchSettings.json` in `{cwd}/Properties/launchSettings.json`. To customize this path, set `launchSettingsFilePath`:
 
 ```json
    "launchSettingsFilePath": "${workspaceFolder}/<Relative-Path-To-Project-Directory/Properties/launchSettings.json"
@@ -509,73 +610,6 @@ Example:
 * `launch.json` ✔️
 * `settings.json` ❌
 * `launchSettings.json` ✔️ as `useSSL`
-
-## Configuring launchSettings.json
-
-With C# Dev Kit, you can bring your `launchSettings.json` from Visual Studio to work with Visual Studio Code
-
-Example:
-
-```json
-{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:59481",
-      "sslPort": 44308
-    }
-  },
-  "profiles": {
-    "EnvironmentsSample": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7152;http://localhost:5105",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "EnvironmentsSample-Staging": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7152;http://localhost:5105",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Staging",
-        "ASPNETCORE_DETAILEDERRORS": "1",
-        "ASPNETCORE_SHUTDOWNTIMEOUTSECONDS": "3"
-      }
-    },
-    "EnvironmentsSample-Production": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7152;http://localhost:5105",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Production"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    }
-  }
-}
-```
-
-## Profile Properties
-
-* `commandLineArgs` - The arguments to pass to the target being run.
-* `executablePath` - An absolute or relative path to the executable.
-* `workingDirectory` - Sets the working directory of the command.
-* `launchBrowser` - Set to true if the browser should be launched.
-* `applicationUrl` - A semi-colon delimited list of URL(s) to configure for the web server.
-* `sslPort` - The SSL port to use for the web site.
-* `httpPort` - The HTTP port to use for the web site.
 
 ## See Also
 

--- a/docs/csharp/debugger-settings.md
+++ b/docs/csharp/debugger-settings.md
@@ -10,19 +10,19 @@ MetaDescription: Configuring C# debugging
 
 You can configure the C# debugger in Visual Studio Code with a `launch.json`, `launchSettings.json`, or your user `settings.json` file.
 
-## Walkthrough: setting command line arguments
+## Walkthrough: setting command-line arguments
 
-Before we get into the details of all the possible options, lets walkthrough a basic scenario -- setting command line arguments to your program. These steps will also work for updating other basic options like environment variables or the current working directory.
+Before we get into the details of all the possible options, let's walk through a basic scenario: setting command-line arguments to your program. These steps also work for updating other basic options like environment variables or the current working directory.
 
 ### Approach 1: `launchSettings.json`
 
-For C# Dev Kit, the recommended way to debug is to let C# Dev Kit automatically figure out how to debug from settings in the project file. This means you either don't have a `<workspace_root>/.vscode/launch.json` file, or if you have one you have `"type": "dotnet"` set for the active configuration. For command line arguments, "figure out from the project file" means to pull the value from `<Project-Directory>/Propeties/launchSettings.json`. The advantage of `launchSettings.json` is that it allows settings to be shared between Visual Studio Code, full Visual Studio, and `dotnet run`.
+For C# Dev Kit, the recommended way to debug is to let C# Dev Kit automatically figure out how to debug from settings in the project file. This means that you either don't have a `<workspace_root>/.vscode/launch.json` file, or if you have one, you have `"type": "dotnet"` set for the active configuration. For command-line arguments, "figure out from the project file" means to pull the value from `<Project-Directory>/Propeties/launchSettings.json`. The advantage of `launchSettings.json` is that it allows settings to be shared between Visual Studio Code, full Visual Studio, and `dotnet run`.
 
-For this case, here are the steps to set the command line arguments:
-1. In workspace explorer view, navigate to the directory of the project (.csproj file) you want to launch
+For this case, here are the steps to set the command-line arguments:
+1. In workspace Explorer view, navigate to the directory of the project (.csproj file) you want to launch
 2. If there isn't a `Properties` directory already, create it
 3. If there isn't a `launchSettings.json` file already, create one, you can use the below text as an example
-4. Change the `commandLineArgs` property to what you would like the command line arguments to be
+4. Change the `commandLineArgs` property to what you would like the command-line arguments to be
 
 **Example `launchSettings.json` file**:
 ```json
@@ -38,7 +38,7 @@ For this case, here are the steps to set the command line arguments:
 
 ### Approach 2: `launch.json`
 
-If you are using the `coreclr` or `clr` debug adapter type in VS Code, command line arguments are stored in your `<workspace_root>/.vscode/launch.json`. To edit them in this case:
+If you are using the `coreclr` or `clr` debug adapter type in VS Code, command-line arguments are stored in your `<workspace_root>/.vscode/launch.json`. To edit them in this case:
 
 1. Open up `<workspace_root>/.vscode/launch.json`
 2. Find the `coreclr` or `clr` launch configuration you want to launch
@@ -101,12 +101,12 @@ Example:
 }
 ```
 
-## Profile Properties
+## Profile properties
 
 * `commandLineArgs` - The arguments to pass to the target being run.
 * `executablePath` - An absolute or relative path to the executable.
 * `workingDirectory` - Sets the working directory of the command.
-* `launchBrowser` - Set to true if the browser should be launched.
+* `launchBrowser` - Set to `true` if the browser should be launched.
 * `applicationUrl` - A semi-colon delimited list of URL(s) to configure for the web server.
 * `sslPort` - The SSL port to use for the web site.
 * `httpPort` - The HTTP port to use for the web site.


### PR DESCRIPTION
The current C# debugger-settings.md is mostly a long list of options without a walkthrough. To better guide users on how to use launchSettings.json. This PR:

1. Adds a walkthrough so this is hopefully more understandable. 
2. Moves the 'Configuring launchSettings.json file' up to the top after the walkthrough
3. Clarifies the 'launchSettings.json support' section, since we didn't do a great job there explaining those options were for `coreclr`/`clr`

These changes are based on feedback in https://github.com/dotnet/vscode-csharp/issues/8184