### PR TITLE
Update C++ TOC and update settings links

### DIFF
--- a/docs/cpp/configure-intellisense-crosscompilation.md
+++ b/docs/cpp/configure-intellisense-crosscompilation.md
@@ -75,5 +75,5 @@ Given the settings above, your `c_cpp_configuration.json` file will look somethi
 
 - For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-default-settings-cpp.md).
 - If you have trouble configuring the settings, please start a discussion at [GitHub discussions](https://github.com/microsoft/vscode-cpptools/discussions), or if you find an issue that needs to be fixed, file an issue at [GitHub issues](https://github.com/microsoft/vscode-cpptools/issues).
-- Explore the [c_cpp_properties schema](/docs/cpp/c-cpp-properties-schema-reference.md).
+- Explore the [c_cpp_properties schema](/docs/cpp/customize-cpp-settings.md).
 - Review the [Overview of the C++ extension](/docs/languages/cpp.md).

--- a/docs/cpp/configure-intellisense.md
+++ b/docs/cpp/configure-intellisense.md
@@ -25,7 +25,7 @@ If you don't have IntelliSense configured, the C/C++ extension shows a yellow in
 
 To configure, select the status bar indicator, which brings up the [configuration Quick Pick](#option-1-select-a-configuration-option-through-the-configuration-quick-pick). The Quick Pick can help you select or install a C/C++ compiler.
 
-If you do not see a status bar indicator, you can also check your project's `c_cpp_properties.json` file. This file stores all of your IntelliSense configuration settings. Navigate to this file by selecting **C/C++: Edit Configurations (UI)** from the Command Palette (`kb(workbench.action.showCommands)`). Check the `IntelliSense mode` to find your configuration. To learn more about the `c_cpp_properties.json` file, you can review the [schema reference](/docs/cpp/c-cpp-properties-schema-reference.md).
+If you do not see a status bar indicator, you can also check your project's `c_cpp_properties.json` file. This file stores all of your IntelliSense configuration settings. Navigate to this file by selecting **C/C++: Edit Configurations (UI)** from the Command Palette (`kb(workbench.action.showCommands)`). Check the `IntelliSense mode` to find your configuration. To learn more about the `c_cpp_properties.json` file, you can review the [schema reference](/docs/cpp/customize-cpp-settings.md).
 
 ![Command Palette filtered on C/C++ Edit Configurations command](images/intellisense/edit-configurations-ui.png)
 
@@ -59,7 +59,7 @@ You can edit the `c_cpp_properties.json` file directly to customize your configu
 
 Use the `compilerPath` variable to add a compiler. This variable is the full path of the compiler you're using to build your project. For example, when using the default install path for GCC on Linux, the compiler path is `/usr/bin/gcc`.
 
-For more information about the `c_cpp_properties.json` file, review the [schema reference](/docs/cpp/c-cpp-properties-schema-reference.md).
+For more information about the `c_cpp_properties.json` file, review the [schema reference](/docs/cpp/customize-cpp-settings.md).
 
 Select the sample below based on your operating system for a `c_cpp_configuration.json` file:
 
@@ -203,5 +203,5 @@ You can select the pin icon on the right of any item in the language status bar 
 
 * For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-default-settings-cpp.md).
 * If you have trouble configuring the settings, please start a discussion at [GitHub discussions](https://github.com/microsoft/vscode-cpptools/discussions), or if you find an issue that needs to be fixed, file an issue at [GitHub issues](https://github.com/microsoft/vscode-cpptools/issues).
-* Explore the [c_cpp_properties schema](/docs/cpp/c-cpp-properties-schema-reference.md).
+* Explore the [c_cpp_properties schema](/docs/cpp/customize-cpp-settings.md).
 * Review the [Overview of the C++ extension](/docs/languages/cpp.md).

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -269,17 +269,35 @@
     "area": "cpp",
     "topics": [
       ["Intro Videos", "/docs/cpp/introvideos-cpp"],
-      ["GCC on Linux", "/docs/cpp/config-linux"],
-      ["GCC on Windows", "/docs/cpp/config-mingw"],
-      ["GCC on Windows Subsystem for Linux", "/docs/cpp/config-wsl"],
-      ["Clang on macOS", "/docs/cpp/config-clang-mac"],
-      ["Microsoft C++ on Windows", "/docs/cpp/config-msvc"],
-      ["Build with CMake", "/docs/cpp/build-with-cmake"],
-      ["CMake Tools on Linux", "/docs/cpp/cmake-linux"],
-      ["CMake Quick Start", "/docs/cpp/cmake-quickstart"],
+      ["", "", {
+        "name": "Getting Started",
+        "area": "cpp",
+        "topics": [
+          ["GCC on Linux", "/docs/cpp/config-linux"],
+        ["GCC on Windows", "/docs/cpp/config-mingw"],
+        ["GCC on Windows Subsystem for Linux", "/docs/cpp/config-wsl"],
+        ["Clang on macOS", "/docs/cpp/config-clang-mac"],
+        ["Microsoft C++ on Windows", "/docs/cpp/config-msvc"]
+        ]
+      }],
+      ["", "", {
+        "name": "Build with CMake",
+        "area": "cpp",
+        "topics": [
+          ["CMake Quick Start", "/docs/cpp/cmake-quickstart"],
+          ["Build with CMake", "/docs/cpp/build-with-cmake"],
+          ["CMake Tools on Linux", "/docs/cpp/cmake-linux"]
+        ]
+      }],
       ["Editing and Navigating", "/docs/cpp/cpp-ide"],
-      ["Debugging", "/docs/cpp/cpp-debug"],
-      ["Configure Debugging", "/docs/cpp/launch-json-reference"],
+      ["", "", {
+        "name": "Debugging",
+        "area": "cpp",
+        "topics": [
+          ["Debugging", "/docs/cpp/cpp-debug"],
+          ["Configure Debugging", "/docs/cpp/launch-json-reference"],
+        ]
+      }],
       ["Refactoring", "/docs/cpp/cpp-refactoring"],
       ["Settings", "/docs/cpp/customize-default-settings-cpp"],
       ["Configure IntelliSense", "/docs/cpp/configure-intellisense"],


### PR DESCRIPTION
Removed references to the settings page (which has changed names at this point) and updated the TOC since now an additional level of nesting is supported. The debugging docs have been put under one header - this will be updated more as these docs are changed. I will double check with the CMake team about the CMake docs