### PR TITLE
Replace broken links with working links

### DIFF
--- a/docs/azure/aksextensions.md
+++ b/docs/azure/aksextensions.md
@@ -9,15 +9,15 @@ MetaDescription: Working with AKS tools and diagnostics in Visual Studio Code
 ---
 # AKS tools and diagnostics in VS Code
 
-This document will walk you through some of the ways you can interact with your AKS clusters directly from Visual Studio Code. [Azure Kubernetes Services](https://azure.microsoft.com/services/kubernetes-service/#overview) is a fully managed [Kubernetes](https://azure.microsoft.com/topic/what-is-kubernetes/#overview) service. Azure Kubernetes Service (AKS) offers serverless Kubernetes, a continuous integration and continuous delivery (CI/CD) experience, with enterprise-grade security and governance. Azure Kubernetes Service (AKS) is an open-source system for automating deployment, scaling, and management of containerized applications. 
+This document will walk you through some of the ways you can interact with your AKS clusters directly from Visual Studio Code. [Azure Kubernetes Services](https://azure.microsoft.com/services/kubernetes-service/#overview) is a fully managed [Kubernetes](https://azure.microsoft.com/topic/what-is-kubernetes/#overview) service. Azure Kubernetes Service (AKS) offers serverless Kubernetes, a continuous integration and continuous delivery (CI/CD) experience, with enterprise-grade security and governance. Azure Kubernetes Service (AKS) is an open-source system for automating deployment, scaling, and management of containerized applications.
 
 We will show you how to run [diagnostic health-checks](https://learn.microsoft.com/azure/aks/concepts-diagnostics) on your AKS cluster, launch [AKS Periscope](https://github.com/azure/aks-periscope) for more in-depth troubleshooting, deploy [Azure Service Operator](https://github.com/Azure/azure-service-operator), or generate [GitHub Actions Starter Workflows](https://github.com/actions/starter-workflows).
 
 ## Before you begin
 
-The [AKS VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-aks-tools) has parent dependency on [Kubernetes VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools). 
+The [AKS VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-aks-tools) has parent dependency on [Kubernetes VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools).
 
-You will need to download the [Kubernetes VS Code extension](https://code.visualstudio.com/docs/azure/kubernetes). 
+You will need to download the [Kubernetes VS Code extension](https://code.visualstudio.com/docs/azure/kubernetes).
 
 You can follow this guide on an existing AKS cluster or you can [create AKS cluster](https://learn.microsoft.com/azure/aks/learn/quick-kubernetes-deploy-portal).
 
@@ -101,11 +101,11 @@ For more information, visit [AKS Periscope](https://github.com/Azure/aks-perisco
 
 **Configuring a Storage Account**
 
-Running the AKS Periscope requires you to have a storage account associated with the Diagnostic settings of your AKS cluster. 
+Running the AKS Periscope requires you to have a storage account associated with the Diagnostic settings of your AKS cluster.
 
-If you have only one storage account associated with the Diagnostic settings of your AKS cluster, the collected logs will be stored in the associated storage account by default. 
+If you have only one storage account associated with the Diagnostic settings of your AKS cluster, the collected logs will be stored in the associated storage account by default.
 
-If you have more than one storage account associated with the Diagnostics settings of your AKS cluster, then the extension will prompt you to choose the storage account for saving collected logs. 
+If you have more than one storage account associated with the Diagnostics settings of your AKS cluster, then the extension will prompt you to choose the storage account for saving collected logs.
 
 If you don't have a storage account configured in the Diagnostic settings, you can follow these instructions to enable it:
 
@@ -172,7 +172,7 @@ Congratulations! You now know how to navigate through this VS Code extension.
 
 ## Next steps
 
-* [Azure Extensions](/docs/azure/extensions.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
+* [Azure Extensions](/docs/azure/overview.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
 * [Azure Kubernetes Service Diagnostics (preview) overview](https://learn.microsoft.com/azure/aks/concepts-diagnostics)
 * [Azure Service Operator](https://azure.github.io/azure-service-operator/#azure-service-operator-v2) - Learn about Azure Service Operator.
 * [AKS Periscope](https://github.com/azure/aks-periscope)

--- a/docs/azure/kubernetes.md
+++ b/docs/azure/kubernetes.md
@@ -72,5 +72,5 @@ Congratulations! Now your app is successfully running in Azure Kubernetes Servic
 ## Next steps
 
 * [Overview of Bridge to Kubernetes](https://learn.microsoft.com/visualstudio/bridge/overview-bridge-to-kubernetes) - Learn more about Bridge to Kubernetes, a rapid, iterative Kubernetes development experience for teams.
-* [Azure Extensions](/docs/azure/extensions.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
+* [Azure Extensions](/docs/azure/overview.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
 * [Deploying to Azure](/docs/azure/deployment.md) - Learn step-by-step how to deploy your application to Azure.

--- a/docs/azure/mongodb.md
+++ b/docs/azure/mongodb.md
@@ -83,6 +83,6 @@ Choose **Create a New Cluster** from the dashboard and choose **Azure** as the C
 
 ## Next steps
 
-* [Azure Extensions](/docs/azure/extensions.md) - The Visual Studio Marketplace has hundreds of VS Code extensions for Azure and the cloud.
+* [Azure Extensions](/docs/azure/overview.md) - The Visual Studio Marketplace has hundreds of VS Code extensions for Azure and the cloud.
 * [Deploying to Azure](/docs/azure/deployment.md) - Learn step-by-step how to deploy your application to Azure.
 * [Working with Docker](/docs/azure/docker.md) - Put your application in a Docker container for easy reuse and deployment.

--- a/docs/azure/remote-debugging.md
+++ b/docs/azure/remote-debugging.md
@@ -50,5 +50,5 @@ When you're ready to end your remote debugging session, disconnect from the debu
 ## Next steps
 
 * [Logpoints](/docs/debugtest/debugging.md#logpoints) - Use Logpoints to log to the console without "breaking" in the debugger.
-* [Azure Extensions](/docs/azure/extensions.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
+* [Azure Extensions](/docs/azure/overview.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
 * [Deploying to Azure](/docs/azure/deployment.md) - Learn step-by-step how to deploy your application to Azure.

--- a/docs/configure/settings-sync.md
+++ b/docs/configure/settings-sync.md
@@ -53,7 +53,7 @@ If you already synced from a machine and turning on sync from another machine, y
 
 ## Configuring synced data
 
-Machine settings (with `machine` or `machine-overridable` [scopes](/updates/v1_34.md#machinespecific-settings)) are not synchronized by default, since their values are specific to a given machine. You can also add or remove settings you want to this list from the Settings editor or using the setting `setting(settingsSync.ignoredSettings)`.
+Machine settings (with `machine` or `machine-overridable` [scopes](/release-notes/v1_34.md#Machine-specific-settings)) are not synchronized by default, since their values are specific to a given machine. You can also add or remove settings you want to this list from the Settings editor or using the setting `setting(settingsSync.ignoredSettings)`.
 
 ![Settings Sync ignored settings](images/settings-sync/sync-ignored-settings.png)
 

--- a/docs/containers/app-service.md
+++ b/docs/containers/app-service.md
@@ -93,6 +93,6 @@ In the previous section, the image is pushed to a remote container registry. Now
 
 Read on to learn more about
 
-- [Azure Extensions](/docs/azure/extensions.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
+- [Azure Extensions](/docs/azure/overview.md) - The VS Code Marketplace has hundreds of extensions for Azure and the cloud.
 - [Deploying to Azure](/docs/azure/deployment.md) - Learn step-by-step how to deploy your application to Azure.
 - [Working with MongoDB](/docs/azure/mongodb.md) - Create, manage, and query MongoDB databases from within VS Code.

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -127,7 +127,7 @@ Example `launch.json` configuration for debugging a .NET application using `Dock
 
 ### node object properties
 
-> These properties are the same as those described in the [VS Code documentation](/docs/nodejs/nodejs-debugging-configuration.md#launch-configuration-attributes) for attaching a debugger to Node.js applications. All properties passed in the `node` object will be passed on to the Node.js debug adaptor, even if not specifically listed below.
+> These properties are the same as those described in the [VS Code documentation](/docs/nodejs/nodejs-debugging.md#launch-configuration-attributes) for attaching a debugger to Node.js applications. All properties passed in the `node` object will be passed on to the Node.js debug adaptor, even if not specifically listed below.
 
 | Property | Description | Default |
 | --- | --- | --- |

--- a/docs/cpp/cmake-linux.md
+++ b/docs/cpp/cmake-linux.md
@@ -21,7 +21,7 @@ If you have any trouble, please file an issue for this tutorial in the [VS Code 
 
 To complete this tutorial on Ubuntu, install the following:
 
-1. [Visual Studio Code](/download).
+1. [Visual Studio Code](https://code.visualstudio.com/download).
 1. [C++ extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). Install the C/C++ extension by searching for 'c++' in the **Extensions** view (`kb(workbench.view.extensions)`).
 
     ![C/C++ extension](images/cpp/cpp-extension.png)

--- a/docs/cpp/config-linux.md
+++ b/docs/cpp/config-linux.md
@@ -19,7 +19,7 @@ If you have trouble, feel free to file an issue for this tutorial in the [VS Cod
 
 To successfully complete this tutorial, you must do the following:
 
-1. Install [Visual Studio Code](/download).
+1. Install [Visual Studio Code](https://code.visualstudio.com/download).
 1. Install the [C++ extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). You can install the C/C++ extension by searching for 'c++' in the Extensions view (`kb(workbench.view.extensions)`).
 
     ![C/C++ extension](images/cpp/cpp-extension.png)

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -19,7 +19,7 @@ If you have any problems, feel free to file an issue for this tutorial in the [V
 
 To successfully complete this tutorial, you must do the following steps:
 
-1. Install [Visual Studio Code](/download).
+1. Install [Visual Studio Code](https://code.visualstudio.com/download).
 
 1. Install the [C/C++ extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). You can install the C/C++ extension by searching for 'C++' in the Extensions view (`kb(workbench.view.extensions)`).
 

--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -19,7 +19,7 @@ If you have any problems, feel free to file an issue for this tutorial in the [V
 
 To successfully complete this tutorial, you must do the following:
 
-1. Install [Visual Studio Code](/download).
+1. Install [Visual Studio Code](https://code.visualstudio.com/download).
 
 1. Install the [C/C++ extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). You can install the C/C++ extension by searching for 'c++' in the Extensions view (`kb(workbench.view.extensions)`).
 

--- a/docs/cpp/config-wsl.md
+++ b/docs/cpp/config-wsl.md
@@ -23,7 +23,7 @@ If you have any problems, feel free to file an issue for this tutorial in the [V
 
 To successfully complete this tutorial, you must do the following steps:
 
-1. Install [Visual Studio Code](/download).
+1. Install [Visual Studio Code](https://code.visualstudio.com/download).
 
 1. Install the [WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl).
 

--- a/docs/cpp/configure-intellisense-crosscompilation.md
+++ b/docs/cpp/configure-intellisense-crosscompilation.md
@@ -73,7 +73,7 @@ Given the settings above, your `c_cpp_configuration.json` file will look somethi
 
 ## Next steps
 
-- For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-default-settings-cpp.md).
+- For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-cpp-settings.md).
 - If you have trouble configuring the settings, please start a discussion at [GitHub discussions](https://github.com/microsoft/vscode-cpptools/discussions), or if you find an issue that needs to be fixed, file an issue at [GitHub issues](https://github.com/microsoft/vscode-cpptools/issues).
 - Explore the [c_cpp_properties schema](/docs/cpp/c-cpp-properties-schema-reference.md).
 - Review the [Overview of the C++ extension](/docs/languages/cpp.md).

--- a/docs/cpp/configure-intellisense.md
+++ b/docs/cpp/configure-intellisense.md
@@ -201,7 +201,7 @@ You can select the pin icon on the right of any item in the language status bar 
 
 ## Next steps
 
-* For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-default-settings-cpp.md).
+* For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-cpp-settings.md).
 * If you have trouble configuring the settings, please start a discussion at [GitHub discussions](https://github.com/microsoft/vscode-cpptools/discussions), or if you find an issue that needs to be fixed, file an issue at [GitHub issues](https://github.com/microsoft/vscode-cpptools/issues).
 * Explore the [c_cpp_properties schema](/docs/cpp/c-cpp-properties-schema-reference.md).
 * Review the [Overview of the C++ extension](/docs/languages/cpp.md).

--- a/docs/java/extensions.md
+++ b/docs/java/extensions.md
@@ -98,7 +98,7 @@ The Azure extensions for Visual Studio Code provide seamless integration with Az
 * The [Azure Tools Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack) provides a rich set of extensions that makes it easy to discover and interact with Azure services to power your applications.
 * The [Azure Resource Manager Tools](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools) provide a rich editing experience for Azure Resource Manager deployment templates and template language expressions. For example, IntelliSense for TLE function names, parameter references, signature help, Go to Definition, Peek Definition, and Peek References as well as Errors and Warnings, making it quick and easy to author Azure Resource Manager templates in VS Code.
 
-Visit [Azure Extensions](/docs/azure/extensions.md) to find more Azure extensions.
+Visit [Azure Extensions](/docs/azure/overview.md) to find more Azure extensions.
 
 ## Search for other Java extensions
 

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -49,7 +49,7 @@ If you have already installed VS Code and want to add Java support to it, we rec
 
 Alternatively, you can add Java language support to VS Code by installing the popular Java extensions by yourself.
 
-> [Download VS Code](/download) - If you haven't downloaded VS Code yet, quickly install for your platform (Windows, macOS, Linux).
+> [Download VS Code](https://code.visualstudio.com/download) - If you haven't downloaded VS Code yet, quickly install for your platform (Windows, macOS, Linux).
 
 There are also other popular Java extensions you can pick for your own needs, including:
 

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -123,7 +123,7 @@ These attributes are only available for launch configurations of request type `l
 * `program` - an absolute path to the Node.js program to debug.
 * `args` - arguments passed to the program to debug. This attribute is of type array and expects individual arguments as array elements.
 * `cwd` - launch the program to debug in this directory.
-* `runtimeExecutable` - absolute path to the runtime executable to be used. Default is `node`. See section [Launch configuration support for 'npm' and other tools](/docs/nodejs/nodejs-debugging-configuration.md#launch-configuration-support-for-npm-and-other-tools).
+* `runtimeExecutable` - absolute path to the runtime executable to be used. Default is `node`. See section [Launch configuration support for 'npm' and other tools](/docs/nodejs/nodejs-debugging.md#launch-configuration-support-for-npm-and-other-tools).
 * `runtimeArgs` - optional arguments passed to the runtime executable.
 * `runtimeVersion` - if "[nvm](https://github.com/creationix/nvm)" (or "[nvm-windows](https://github.com/coreybutler/nvm-windows)") or "[nvs](https://github.com/jasongin/nvs)" is used for managing Node.js versions, this attribute can be used to select a specific version of Node.js. See section [Multi version support](/docs/nodejs/nodejs-debugging.md#multi-version-support) below.
 * `env` - optional environment variables. This attribute expects environment variables as a list of string typed key/value pairs.


### PR DESCRIPTION
- The invalid extensions.md link was replaced with with the azure extensions information in overview.md for every instance
- replaced download link with VSCode download page for every instance
- replaced /updates/v1_34.md#machinespecific-settings with /release-notes/v1_34.md#Machine-specific-settings for every instance