### PR TITLE
Fix incorrect npx argument when connecting MCP server of perplexity example

### DIFF
--- a/docs/copilot/chat/mcp-servers.md
+++ b/docs/copilot/chat/mcp-servers.md
@@ -91,7 +91,7 @@ To add an MCP server to your workspace:
                 "command": "npx",
                 "args": [
                     "-y",
-                    "@modelcontextprotocol/server-perplexity-ask"
+                    "server-perplexity-ask"
                 ],
                 "env": {
                     "PERPLEXITY_API_KEY": "${input:perplexity-key}"


### PR DESCRIPTION
This PR fixes a incorrect npx package name in the mcp example code.

### In this docs Page : https://code.visualstudio.com/docs/copilot/chat/mcp-servers

### The original block was:
```
{
  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
  "inputs": [
    {
      "type": "promptString",
      "id": "perplexity-key",
      "description": "Perplexity API Key",
      "password": true
    }
  ],
  "servers": {
    // https://github.com/ppl-ai/modelcontextprotocol/
    "Perplexity": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-perplexity-ask"],
      "env": {
        "PERPLEXITY_API_KEY": "${input:perplexity-key}"
      }
    }
  }
}
```

### This code block has Error: 
![image](https://github.com/user-attachments/assets/6b1f783a-655e-4bd4-bf13-df032fbe305e)

### Reason of Error:
According to [perplexity mcp server Official Docs](https://github.com/ppl-ai/modelcontextprotocol/), npx package name of perplexity mcp server is `server-perplexity-ask`.

like this block:
```
{
  "mcpServers": {
    "perplexity-ask": {
      "command": "npx",
      "args": [
        "-y",
        "server-perplexity-ask"
      ],
      "env": {
        "PERPLEXITY_API_KEY": "YOUR_API_KEY_HERE"
      }
    }
  }
}
```

### It has been resolved to: 
```
{
  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
  "inputs": [
    {
      "type": "promptString",
      "id": "perplexity-key",
      "description": "Perplexity API Key",
      "password": true
    }
  ],
  "servers": {
    // https://github.com/ppl-ai/modelcontextprotocol/
    "Perplexity": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "server-perplexity-ask"],
      "env": {
        "PERPLEXITY_API_KEY": "${input:perplexity-key}"
      }
    }
  }
}
```