### PR TITLE
Fix typo in instructions

### DIFF
--- a/docs/copilot/copilot-customization.md
+++ b/docs/copilot/copilot-customization.md
@@ -174,7 +174,7 @@ The following example demonstrates custom instructions for code generation:
     ---
     # Project coding standards for TypeScript and React
 
-    Apply the [general coding guidelines](./general-coding.intructions.md) to all code.
+    Apply the [general coding guidelines](./general-coding.instructions.md) to all code.
 
     ## TypeScript Guidelines
     - Use TypeScript for all new code


### PR DESCRIPTION
* Fix typo (`intructions` -> `instructions`)