### PR TITLE
Add required domain for VS Code Server installation to docs

### DIFF
--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -332,6 +332,7 @@ See [Linux Prerequisites](/docs/remote/linux.md) for details.
 Installation of VS Code Server requires that your local machine has outbound HTTPS (port 443) connectivity to:
 
 - `update.code.visualstudio.com`
+- `vscode.download.prss.microsoft.com`
 - `vscode.blob.core.windows.net`
 - `*.vo.msecnd.net` (Azure CDN)
 


### PR DESCRIPTION
When installing VS Code Server whitelisting the domain `update.code.visualstudio.com` is not enough as it redirects to `vscode.download.prss.microsoft.com` which also must be whitelisted.

Sample log for error:
```
wget https://update.code.visualstudio.com/commit:19e0f9e681ecb8e5c09d8784acaa601316ca4571/cli-alpine-x64/stable
--2025-05-09 13:41:16--  https://update.code.visualstudio.com/commit:19e0f9e681ecb8e5c09d8784acaa601316ca4571/cli-alpine-x64/stable
Resolving proxy-<REDACTED> (proxy-<REDACTED)... <REDACTED>
Connecting to proxy-<REDACTED> (proxy-<REDACTED>)|<REDACTED>|:8080... connected.
Proxy request sent, awaiting response... 302 Found
Location: https://vscode.download.prss.microsoft.com/dbazure/download/stable/19e0f9e681ecb8e5c09d8784acaa601316ca4571/vscode_cli_alpine_x64_cli.tar.gz [following]
--2025-05-09 13:41:16--  https://vscode.download.prss.microsoft.com/dbazure/download/stable/19e0f9e681ecb8e5c09d8784acaa601316ca4571/vscode_cli_alpine_x64_cli.tar.gz
Connecting to proxy-<REDACTED> (proxy-<REDACTED>)|<REDACTED>|:8080... connected.
Proxy tunneling failed: Forbidden
Unable to establish SSL connection.
```