### PR TITLE
Fix invalid hash in link

### DIFF
--- a/release-notes/v1_100.md
+++ b/release-notes/v1_100.md
@@ -450,7 +450,7 @@ Thanks to a community contribution, we now have a context menu in the disassembl
 
 ### JavaScript debugger Network view
 
-Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
+Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#_experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
 
 ## Languages
 


### PR DESCRIPTION
The link to the experimental network view section of the v1.93 Updates page is incorrect. Specifically, the hash portion of the URL is missing a leading underscore.