### PR TITLE
Add Csharp Inlay hints docs

### DIFF
--- a/docs/csharp/images/navigate-edit/inlay-hints.png
+++ b/docs/csharp/images/navigate-edit/inlay-hints.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc727bb783f6d1b6ef9b89ae1c535e677aa3195bb0e1af0a8738a50a3355406c
+size 92659

--- a/docs/csharp/navigate-edit.md
+++ b/docs/csharp/navigate-edit.md
@@ -61,4 +61,4 @@ Inlay hints are subtle annotations that appear inline in your code to provide ad
 
 ![Inlay hints examples](images/navigate-edit/inlay-hints.png)
 
-To change which inlay hints you want to enable or disable view the `setting(csharp.inlayHints)` settings.
+To change which inlay hints you want to enable or disable, view the `setting(csharp.inlayHints)` settings.

--- a/docs/csharp/navigate-edit.md
+++ b/docs/csharp/navigate-edit.md
@@ -54,3 +54,11 @@ With [smart selection](https://code.visualstudio.com/updates/v1_33#_smart-select
 
 * To expand the selection, use `kb(editor.action.smartSelect.expand)`
 * To shrink the selection, use `kb(editor.action.smartSelect.shrink)`
+
+## Inlay hints
+
+Inlay hints are subtle annotations that appear inline in your code to provide additional context about your code elements. In C#, these hints can show parameter names at call sites, type information for variables, and other helpful details that make your code more readable without having to navigate to the definition. These hints can be particularly helpful when working with methods that have multiple parameters or when type inference makes it less obvious what type a variable is.
+
+![Inlay hints examples](images/navigate-edit/inlay-hints.png)
+
+To change which inlay hints you want to enable or disable view the `setting(csharp.inlayHints)` settings.


### PR DESCRIPTION
Adds a section to navigation and editing to show the C# inlay hints capabilities and settings
Fixes #8397 