### PR TITLE
Clean-up docs metadata

### DIFF
--- a/docs/azure/aksextensions.md
+++ b/docs/azure/aksextensions.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: azure
-TOCTitle: Azure Kubernetes Service
 ContentId: 131f9633-5446-4384-96ca-7bff2e3dc0fc
-PageTitle: Working with AKS tools and diagnostics in Visual Studio Code
 DateApproved: 12/2/2022
 MetaDescription: Working with AKS tools and diagnostics in Visual Studio Code
 ---

--- a/docs/azure/containers.md
+++ b/docs/azure/containers.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: azure
-TOCTitle: Containers
 ContentId: 42F8B9F8-BD03-4159-9479-17C5BDE30531
-PageTitle: Working with containers in Visual Studio Code
 DateApproved: 02/1/2024
 MetaDescription: Working with containers in Visual Studio Code.
 ---

--- a/docs/azure/deployment.md
+++ b/docs/azure/deployment.md
@@ -1,8 +1,4 @@
 ---
-Order: 4
-Area: azure
-TOCTitle: Deployment
-PageTitle: Visual Studio Code Azure Tutorials
 ContentId: 90f8dc30-1e71-4ea7-8230-2bf09bfb97d4
 MetaDescription: Visual Studio Code Azure Tutorials
 DateApproved: 02/1/2024

--- a/docs/azure/gettingstarted.md
+++ b/docs/azure/gettingstarted.md
@@ -1,8 +1,4 @@
 ---
-Order: 2
-Area: azure
-TOCTitle: Getting Started
-PageTitle: Azure Tools for Visual Studio Code
 ContentId:
 MetaDescription: Azure Tools for Visual Studio Code Getting Started guide for developers
 DateApproved: 08/21/2024

--- a/docs/azure/kubernetes.md
+++ b/docs/azure/kubernetes.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: azure
-TOCTitle: Kubernetes
 ContentId: d0ece2e4-8dd2-4c0d-a773-604542651c9e
-PageTitle: Working with Kubernetes in Visual Studio Code
 DateApproved: 5/4/2022
 MetaDescription: Working with Kubernetes in Visual Studio Code
 ---

--- a/docs/azure/mongodb.md
+++ b/docs/azure/mongodb.md
@@ -1,8 +1,4 @@
 ---
-Order: 9
-Area: azure
-TOCTitle: MongoDB
-PageTitle: Working with MongoDB in Visual Studio Code
 ContentId: d1187f99-354f-4798-9c19-e432e4ae8572
 MetaDescription: Working with MongoDB in Visual Studio Code
 DateApproved: 11/1/2022

--- a/docs/azure/overview.md
+++ b/docs/azure/overview.md
@@ -1,8 +1,4 @@
 ---
-Order: 1
-Area: azure
-TOCTitle: Overview
-PageTitle: Visual Studio Code Azure Extensions
 ContentId: d2e93075-4cfe-48f4-b05e-f985c86d9713
 MetaDescription: Visual Studio Code Azure Extensions
 DateApproved: 02/1/2024

--- a/docs/azure/remote-debugging.md
+++ b/docs/azure/remote-debugging.md
@@ -1,8 +1,4 @@
 ---
-Order: 10
-Area: azure
-TOCTitle: Remote Debugging for Node.js
-PageTitle: Azure Remote Debugging for Node.js with Visual Studio Code
 ContentId: 09cb23b6-b1e9-4a29-a934-cbc16fe109c7
 MetaDescription: Azure Remote Debugging for Node.js with Visual Studio Code
 DateApproved: 11/1/2022

--- a/docs/azure/resourcesextension.md
+++ b/docs/azure/resourcesextension.md
@@ -1,8 +1,4 @@
 ---
-Order: 3
-Area: azure
-TOCTitle: Resources View
-PageTitle: Azure Resources for Visual Studio Code
 ContentId: fc1e60f9-86a6-47c2-beb6-5289d21f48d1
 MetaDescription: Azure Resources for Visual Studio Code
 DateApproved: 5/5/2025

--- a/docs/azure/vscodeforweb.md
+++ b/docs/azure/vscodeforweb.md
@@ -1,13 +1,8 @@
 ---
-Order: 5
-Area: azure
-TOCTitle: VS Code for the Web - Azure
-PageTitle: Develop and Deploy Azure Applications with VS Code for the Web
 ContentId: 442dd725-5d6c-4b88-9696-95d5ddf5b2b8
 MetaDescription: VS Code for the Web - Azure
 DateApproved: 05/12/2025
 ---
-
 # VS Code for the Web - Azure
 
 VS Code for the Web is a zero-install and browser-based version of Visual Studio Code. The `/azure` (for short) environment, accessible via <https://insiders.vscode.dev/azure>, is a dedicated space for Azure development, allowing you to run, debug, and deploy applications to Azure in seconds.

--- a/docs/configure/accessibility/accessibility.md
+++ b/docs/configure/accessibility/accessibility.md
@@ -1,9 +1,5 @@
 ---
-Order: 23
-Area: editor
-TOCTitle: Accessibility
 ContentId: 62894B41-CC33-400A-8A56-8C761C77B4C7
-PageTitle: Accessibility in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code user accessibility features.  Learn here about the various ways VS Code aids user accessibility.
 ---

--- a/docs/configure/accessibility/voice.md
+++ b/docs/configure/accessibility/voice.md
@@ -1,9 +1,5 @@
 ---
-Order: 24
-Area: editor
-TOCTitle: Voice Interactions
 ContentId: e3bf9098-7b2f-4b23-9e0f-3d2094bad80a
-PageTitle: Using Voice in Visual Studio Code
 DateApproved:
 MetaDescription: Visual Studio Code voice accessibility features. Learn here about the various ways VS Code can be used with voice.
 ---

--- a/docs/configure/command-line.md
+++ b/docs/configure/command-line.md
@@ -1,9 +1,5 @@
 ---
-Order: 19
-Area: editor
-TOCTitle: Command Line Interface
 ContentId: 8faef870-7a5f-4070-ad17-8ba791006912
-PageTitle: The Visual Studio Code command-line interface
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code command-line interface (switches).
 ---

--- a/docs/configure/custom-layout.md
+++ b/docs/configure/custom-layout.md
@@ -1,9 +1,5 @@
 ---
-Order: 25
-Area: editor
-TOCTitle: Custom Layout
 ContentId: 71e2c9c1-fb19-469a-9620-877d4b08fb0d
-PageTitle: Custom layout of Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code custom user interface layout.
 ---

--- a/docs/configure/extensions/extension-marketplace.md
+++ b/docs/configure/extensions/extension-marketplace.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: editor
-TOCTitle: Extension Marketplace
 ContentId: 319916C4-93F2-471F-B448-FD416736C40C
-PageTitle: Managing Extensions in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Discover, add, update, disable and uninstall Visual Studio Code extensions (plug-ins) through the Extension Marketplace.
 ---

--- a/docs/configure/extensions/extension-runtime-security.md
+++ b/docs/configure/extensions/extension-runtime-security.md
@@ -1,13 +1,8 @@
 ---
-Order: 4
-Area: editor
-TOCTitle: Extension Runtime Security
 ContentId: b921a11a-ed69-4716-bc93-589ba8e01e22
-PageTitle: Visual Studio Code Extension Runtime Security
 DateApproved: 05/08/2025
 MetaDescription: Learn about the security measures in place for Visual Studio Code extensions, including permissions, user reliability checks, and Marketplace protections.
 ---
-
 # Extension runtime security
 
 [Extensions](/docs/configure/extensions/extension-marketplace.md) greatly enhance the functionality of Visual Studio Code. They can also introduce risks, such as malicious code execution and data privacy concerns. The [Visual Studio Marketplace](https://marketplace.visualstudio.com/vscode) has many ways to protect you from bad extensions. In addition, VS Code gives you several indicators of an extension's reliability.

--- a/docs/configure/keybindings.md
+++ b/docs/configure/keybindings.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: getstarted
-TOCTitle: Keyboard Shortcuts
 ContentId: 045980C1-62C7-4E8E-8CE4-BAD722FFE31E
-PageTitle: Visual Studio Code keyboard shortcuts
 DateApproved: 05/08/2025
 MetaDescription: Here you will find the complete list of keyboard shortcuts for Visual Studio Code and how to change them.
 MetaSocialImage: images/keybinding/customization-keybindings-social.png

--- a/docs/configure/locales.md
+++ b/docs/configure/locales.md
@@ -1,8 +1,4 @@
 ---
-Order: 9
-Area: getstarted
-TOCTitle: Display Language
-PageTitle: Visual Studio Code Display Language (Locale)
 ContentId: 413A7FA3-94F8-4FCB-A4A3-F4C1E77EF716
 DateApproved: 05/08/2025
 MetaDescription: How to change the display language (locale) of Visual Studio Code.

--- a/docs/configure/profiles.md
+++ b/docs/configure/profiles.md
@@ -1,9 +1,5 @@
 ---
-Order: 15
-Area: editor
-TOCTitle: Profiles
 ContentId: a65efc48-5a2d-4c7d-bd23-03f0393b53f6
-PageTitle: Profiles in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Expand your development workflow with task integration in Visual Studio Code.
 ---

--- a/docs/configure/settings-sync.md
+++ b/docs/configure/settings-sync.md
@@ -1,9 +1,5 @@
 ---
-Order: 16
-Area: editor
-TOCTitle: Settings Sync
 ContentId: 6cb84e60-6d90-4137-83f6-bdab3438b8f5
-PageTitle: Settings Sync in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Synchronize your user settings across all your Visual Studio Code instances.
 ---

--- a/docs/configure/settings.md
+++ b/docs/configure/settings.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: getstarted
-TOCTitle: Settings
 ContentId: FDA6D86C-FF24-49BC-A1EB-E3BA43130FA0
-PageTitle: Visual Studio Code User and Workspace Settings
 DateApproved: 05/08/2025
 MetaDescription: How to modify Visual Studio Code User and Workspace Settings.
 ---

--- a/docs/configure/telemetry.md
+++ b/docs/configure/telemetry.md
@@ -1,8 +1,4 @@
 ---
-Order: 10
-Area: getstarted
-TOCTitle: Telemetry
-PageTitle: Visual Studio Code Telemetry
 ContentId: 47a2e3b1-24f2-42e6-a6e6-272c2a0f3218
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code collected telemetry and how to opt out.

--- a/docs/configure/themes.md
+++ b/docs/configure/themes.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: getstarted
-TOCTitle: Themes
 ContentId: CAC88BC7-90A5-4384-8A05-2187117C0F72
-PageTitle: Visual Studio Code Themes
 DateApproved: 05/08/2025
 MetaDescription: Changing the color theme in Visual Studio Code. You can use color themes provided by VS Code, the community or create your own new themes.
 ---

--- a/docs/containers/app-service.md
+++ b/docs/containers/app-service.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: containers
-TOCTitle: Deploy to Azure
 ContentId: 044913F5-F99D-4228-A916-0443260AB7FB
-PageTitle: Deploy a containerized app to Azure
 DateApproved: 1/17/2023
 MetaDescription: Using Visual Studio Code, build a container image for your application, push the image to a container registry, and deploy to Azure App Service or Azure Container Apps.
 ---

--- a/docs/containers/bridge-to-kubernetes.md
+++ b/docs/containers/bridge-to-kubernetes.md
@@ -1,13 +1,8 @@
 ---
-Order: 11
-Area: containers
-TOCTitle: Develop with Kubernetes
 ContentId: 80bd336b-0d2d-4d63-a771-8b3ea22a64d3
-PageTitle: Use Bridge to Kubernetes to run and debug locally with Kubernetes
 DateApproved: 02/1/2024
 MetaDescription: Learn how to use Bridge to Kubernetes.
 ---
-
 # Develop with Kubernetes
 
 This page is redirected to https://learn.microsoft.com/visualstudio/bridge/bridge-to-kubernetes-vs-code and only exists to keep the "Develop with Kubernetes" TOC item.

--- a/docs/containers/choosing-dev-environment.md
+++ b/docs/containers/choosing-dev-environment.md
@@ -1,9 +1,5 @@
 ---
-Order: 9
-Area: containers
-TOCTitle: Choose a dev environment
 ContentId: AF3D8F58-8F73-44CD-962C-B7F029E50478
-PageTitle: Choosing an environment for container development
 DateApproved: 1/18/2023
 MetaDescription: Guidance on choosing remote or local environments for developing and debugging containerized apps, using Visual Studio Code.
 ---

--- a/docs/containers/debug-common.md
+++ b/docs/containers/debug-common.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: containers
-TOCTitle: Debug
 ContentId: A1371726-5310-4923-B43B-240F36C6264E
-PageTitle: Debug an app running in a container
 DateApproved: 12/14/2023
 MetaDescription: Debug an app running in a container, using Visual Studio Code.
 ---

--- a/docs/containers/debug-netcore.md
+++ b/docs/containers/debug-netcore.md
@@ -1,7 +1,5 @@
 ---
-Area: containers
 ContentId: B1DF33C0-400C-413D-B60B-D1AA278F6DE3
-PageTitle: Debug a .NET app running in a container
 DateApproved: 12/14/2023
 MetaDescription: Debug a .NET app running in a container, using Visual Studio Code.
 ---

--- a/docs/containers/debug-node.md
+++ b/docs/containers/debug-node.md
@@ -1,11 +1,8 @@
 ---
-Area: containers
 ContentId: F0C800DD-C477-492D-9545-745F570FE042
-PageTitle: Configure and troubleshoot debugging of Node.js apps running in a container
 DateApproved: 12/21/2022
 MetaDescription: How to configure and troubleshoot debugging of Node.js apps running in a container, using Visual Studio Code.
 ---
-
 # Debug Node.js within a container
 
 When adding Docker files to a Node.js project, tasks and launch configurations are added to enable debugging that application within a container. However, due to the large ecosystem surrounding Node.js, those tasks cannot accommodate every application framework or library, which means that some applications will require additional configuration.

--- a/docs/containers/debug-python.md
+++ b/docs/containers/debug-python.md
@@ -1,11 +1,8 @@
 ---
-Area: containers
 ContentId: f9ffec31-9253-4f71-a4eb-79ea7b3a8f55
-PageTitle: Configure and troubleshoot debugging of Python apps running in a container
 DateApproved: 12/21/2021
 MetaDescription: How to configure and troubleshoot debugging of Python apps running in a container, using Visual Studio Code.
 ---
-
 # Debug Python within a container
 
 When adding Docker files to a Python project, tasks and launch configurations are added to enable debugging the application within a container. To accommodate the various scenarios of Python projects, some apps may require additional configuration.

--- a/docs/containers/docker-compose.md
+++ b/docs/containers/docker-compose.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: containers
-TOCTitle: Docker Compose
 ContentId: c63d86a0-48f8-4724-ba24-fa5ce4199632
-PageTitle: Use Docker Compose to work with multiple containers
 DateApproved: 12/21/2022
 MetaDescription: Develop a multi-container app running in containers using Docker Compose and Visual Studio Code.
 ---

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: containers
-TOCTitle: Overview
 ContentId: 4B462667-8915-4BE0-B8D0-EDE51CB2D273
-PageTitle: Container Tools extension for Visual Studio Code
 DateApproved: 12/1/2023
 MetaDescription: Tools for developing and debugging with containers, using Visual Studio Code.
 ---

--- a/docs/containers/quickstart-aspnet-core.md
+++ b/docs/containers/quickstart-aspnet-core.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: containers
-TOCTitle: ASP.NET Core
 ContentId: 29F731D4-C6FE-4742-A1E7-7288FDB81CB9
-PageTitle: Build and run an ASP.NET Core app in a container
 DateApproved: 12/13/2022
 MetaDescription: Develop, build, and debug an ASP.NET Core app in a Docker container, using Visual Studio Code.
 ---

--- a/docs/containers/quickstart-container-registries.md
+++ b/docs/containers/quickstart-container-registries.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: containers
-TOCTitle: Registries
 ContentId: 318A4299-AF24-4ADA-863D-E73B314FC440
-PageTitle: Quickstart - Using container registries
 DateApproved: 12/1/2023
 MetaDescription: Work with container registries in Visual Studio Code
 ---

--- a/docs/containers/quickstart-node.md
+++ b/docs/containers/quickstart-node.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: containers
-TOCTitle: Node.js
 ContentId: A963901F-BF3F-455F-AD75-AB54EAE72BEF
-PageTitle: Build and run a Node.js app in a container
 DateApproved: 12/13/2022
 MetaDescription: Develop, build, and debug a Node.js app in a container, using Visual Studio Code.
 ---

--- a/docs/containers/quickstart-python.md
+++ b/docs/containers/quickstart-python.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: containers
-TOCTitle: Python
 ContentId: 3a9bc520-95e2-416e-a0ac-5be02a38c4c3
-PageTitle: Build and run a Python app in a container
 DateApproved: 12/1/2023
 MetaDescription: Develop, build, and debug a Python app in a container, using Visual Studio Code.
 ---

--- a/docs/containers/reference.md
+++ b/docs/containers/reference.md
@@ -1,9 +1,5 @@
 ---
-Order: 10
-Area: containers
-TOCTitle: Customize
 ContentId: 6784FBBE-9EE4-44A8-AC48-A52617EB1968
-PageTitle: Reference for Visual Studio Code Container Tools extension properties and tasks.
 DateApproved: 4/18/2022
 MetaDescription: Reference for Docker build and Docker run tasks and properties in the Visual Studio Code Container Tools extension.
 ---

--- a/docs/containers/ssh.md
+++ b/docs/containers/ssh.md
@@ -1,7 +1,5 @@
 ---
-Area: containers
 ContentId: DDE07043-BA8C-4D75-B392-ABACC31F6EA8
-PageTitle: Connect to Docker engine running on a remote machine
 DateApproved: 11/21/2022
 MetaDescription: Connect via SSH to Docker engine running on a remote machine and use the remote machine as a development environment for Visual Studio Code.
 ---

--- a/docs/containers/troubleshooting.md
+++ b/docs/containers/troubleshooting.md
@@ -1,8 +1,4 @@
 ---
-Order: 12
-Area: containers
-TOCTitle: Tips and Tricks
-PageTitle: Visual Studio Code container development troubleshooting Tips and Tricks
 ContentId: 79bb60fd-5248-43d2-8801-34b9fc2ec543
 MetaDescription: Visual Studio Code container development troubleshooting tips and tricks
 DateApproved: 12/21/2022

--- a/docs/containers/tutorial-django-push-to-registry.md
+++ b/docs/containers/tutorial-django-push-to-registry.md
@@ -1,13 +1,9 @@
 ---
-Area: containers
-TOCTitle: Push Django Images to a Registry
 ContentId: 4eb2543d-84a7-4e11-b835-0d238ce7ed7a
-PageTitle: Push Django images to a registry in Visual Studio Code
 DateApproved: 1/17/2023
 MetaDescription: How to push a Django image to a container registry using the VS Code Container Tools extension
 MetaSocialImage: ../python/images/tutorial/python-social.png
 ---
-
 # Push Django images to a registry
 
 In this tutorial, you take a container image of a Python Django app you built locally and deploy it to Azure Container Registry (ACR) or Docker Hub.

--- a/docs/copilot/chat/mcp-servers.md
+++ b/docs/copilot/chat/mcp-servers.md
@@ -4,7 +4,6 @@ DateApproved: 05/08/2025
 MetaDescription: Learn how to configure and use Model Context Protocol (MCP) servers with GitHub Copilot in Visual Studio Code.
 MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
-
 # Use MCP servers in VS Code (Preview)
 
 Model Context Protocol (MCP) is an open standard that enables AI models to interact with external tools and services through a unified interface. In VS Code, MCP support enhances GitHub Copilot's agent mode by allowing you to connect any MCP-compatible server to your agentic coding workflow. This article guides you through setting up MCP servers and using tools with agent mode in Visual Studio Code.

--- a/docs/copilot/guides/debug-with-copilot.md
+++ b/docs/copilot/guides/debug-with-copilot.md
@@ -4,7 +4,6 @@ DateApproved: 05/08/2025
 MetaDescription: Learn how to use GitHub Copilot in Visual Studio Code to set up debugging configurations and fix issues during debugging.
 MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
-
 # Debug with GitHub Copilot
 
 GitHub Copilot can help improve your debugging workflow in Visual Studio Code. Copilot can assist with the setup of the debug configuration for your project and provide suggestions for fixing issues discovered during debugging. This article gives an overview of how to use Copilot for debugging applications in VS Code.

--- a/docs/copilot/guides/test-with-copilot.md
+++ b/docs/copilot/guides/test-with-copilot.md
@@ -4,7 +4,6 @@ DateApproved: 05/08/2025
 MetaDescription: Learn how to use GitHub Copilot in Visual Studio Code to write, debug, and fix tests.
 MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
-
 # Test with GitHub Copilot
 
 Writing and maintaining tests is a crucial but often time-consuming part of software development. GitHub Copilot streamlines this process by helping you write, debug, and fix tests more efficiently in Visual Studio Code. This article shows you how to leverage Copilot's testing capabilities to improve your testing workflow and increase test coverage in your projects.

--- a/docs/cpp/build-with-cmake.md
+++ b/docs/cpp/build-with-cmake.md
@@ -1,13 +1,8 @@
 ---
-Order: 7
-Area: cpp
-TOCTitle: Build with CMake
 ContentId: eaef83f6-294a-4bb6-a2fe-bc8ffb3b33bf
-PageTitle: Build with CMake
 DateApproved: 12/6/2022
 MetaDescription: Learn how to use CMake with Visual Studio Code
 ---
-
 # Build with CMake
 
 This page redirects to https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/README.md and only exists to present the "Build with CMake" TOC entry.

--- a/docs/cpp/cmake-linux.md
+++ b/docs/cpp/cmake-linux.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: cpp
-TOCTitle: CMake Tools on Linux
 ContentId: 86543311-5452-4b1f-a44c-03cc3df04c3f
-PageTitle: Get started with CMake Tools on Linux
 DateApproved: 6/11/2020
 MetaDescription: Get started with the CMake Tools Visual Studio Code extension on Linux
 ---

--- a/docs/cpp/cmake-quickstart.md
+++ b/docs/cpp/cmake-quickstart.md
@@ -1,9 +1,5 @@
 ---
-Order: 9
-Area: cpp
-TOCTitle: CMake Quick Start
 ContentId: 55b5d15c-a020-4808-941f-e0255751a5f7
-PageTitle: Create a CMake project with the CMake Quick Start
 DateApproved: 5/29/2024
 MetaDescription: Create a Hello World project by using the CMake Quick Start in the CMake Tools Visual Studio Code extension
 ---

--- a/docs/cpp/colorization-cpp.md
+++ b/docs/cpp/colorization-cpp.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: cpp
-TOCTitle: Enhanced colorization
 ContentId: 2C406EA6-87DC-4A2D-AEC2-90BAA491697C
-PageTitle: Enhanced colorization in Visual Studio Code C++ projects
 DateApproved: 2/23/2023
 MetaDescription: How to customize semantic colorization of C++ code in Visual Studio Code.
 ---

--- a/docs/cpp/config-clang-mac.md
+++ b/docs/cpp/config-clang-mac.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: cpp
-TOCTitle: Clang on macOS
 ContentId: 6ef32219-81ad-4d73-84b8-8d4384a45f8a
-PageTitle: Configure VS Code for Clang/LLVM on macOS
 DateApproved: 12/14/2023
 MetaDescription: Configure the C++ extension in Visual Studio Code to target Clang/LLVM
 ---

--- a/docs/cpp/config-linux.md
+++ b/docs/cpp/config-linux.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: cpp
-TOCTitle: GCC on Linux
 ContentId: 8ba2e5c6-cb57-4513-bc02-c8b73e6956ad
-PageTitle: Get Started with C++ on Linux in Visual Studio Code
 DateApproved: 5/13/2022
 MetaDescription: Configure the C++ extension in Visual Studio Code to target g++ and GDB on Linux
 ---

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: cpp
-TOCTitle: GCC on Windows
 ContentId: 7efec972-6556-4526-8aa8-c73b3319d612
-PageTitle: Get Started with C++ and MinGW-w64 in Visual Studio Code
 DateApproved: 12/14/2023
 MetaDescription: Configuring the C++ extension in Visual Studio Code to target g++ and gdb on a MinGW-w64 installation
 ---

--- a/docs/cpp/config-msvc.md
+++ b/docs/cpp/config-msvc.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: cpp
-TOCTitle: Microsoft C++ on Windows
 ContentId: c8b779d6-79e2-49d6-acfc-430d7ac3a299
-PageTitle: Configure Visual Studio Code for Microsoft C++
 DateApproved: 3/7/2023
 MetaDescription: Configure the C++ extension in Visual Studio Code to target Microsoft C++ on Windows.
 ---

--- a/docs/cpp/config-wsl.md
+++ b/docs/cpp/config-wsl.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: cpp
-TOCTitle: GCC on Windows Subsystem for Linux
 ContentId: dc79a06a-6665-478c-9298-a1fc9cf8010d
-PageTitle: Get Started with C++ and Windows Subsystem for Linux in Visual Studio Code
 DateApproved: 5/13/2022
 MetaDescription: Configuring the C++ extension in Visual Studio Code to target g++ and GDB on WSL installation with Ubuntu
 ---

--- a/docs/cpp/configure-intellisense-crosscompilation.md
+++ b/docs/cpp/configure-intellisense-crosscompilation.md
@@ -1,9 +1,5 @@
 ---
-Order: 16
-Area: cpp
-TOCTitle: Configure IntelliSense for cross-compiling
 ContentId: 381b7ce1-5766-49b0-ad26-f9eedae70e63
-PageTitle: Configure IntelliSense for C++ cross-compilation
 DateApproved: 1/17/2023
 MetaDescription: Configure Visual Studio Code c_cpp_properties.json to get IntelliSense when you are compiling for a different platform
 ---

--- a/docs/cpp/configure-intellisense.md
+++ b/docs/cpp/configure-intellisense.md
@@ -1,9 +1,5 @@
 ---
-Order: 15
-Area: cpp
-TOCTitle: Configure IntelliSense
 ContentId: bf494c65-12b4-4506-ab6c-1fad76d7ccf1
-PageTitle: Configure C/C++ IntelliSense
 DateApproved: 11/6/2023
 MetaDescription: Configure Visual Studio Code IntelliSense in the C/C++ extension
 ---

--- a/docs/cpp/cpp-debug.md
+++ b/docs/cpp/cpp-debug.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: cpp
-TOCTitle: Debugging
 ContentId: 9150091A-6F3A-46B9-881B-B8FD788FA705
-PageTitle: Debug C++ in Visual Studio Code
 DateApproved: 5/21/2020
 MetaDescription: How to debug C++ programs in Visual Studio Code.
 ---

--- a/docs/cpp/cpp-ide.md
+++ b/docs/cpp/cpp-ide.md
@@ -1,9 +1,5 @@
 ---
-Order: 10
-Area: cpp
-TOCTitle: Editing and Navigating
 ContentId: 61D63E54-67E2-4743-B5CB-C6E7F582982A
-PageTitle: Features for editing and navigating C++ code in VS Code such as
 DateApproved: 1/16/2024
 MetaDescription: How to edit and navigate C++ source files in Visual Studio Code.
 ---

--- a/docs/cpp/cpp-refactoring.md
+++ b/docs/cpp/cpp-refactoring.md
@@ -1,9 +1,5 @@
 ---
-Order: 12
-Area: cpp
-TOCTitle: Refactoring
 ContentId: 5b5da770-b59f-4eca-94a3-78e824d16b52
-PageTitle: Refactoring C++ code
 DateApproved: 1/16/2024
 MetaDescription: How to refactor C++ source files in Visual Studio Code.
 ---

--- a/docs/cpp/enable-logging-cpp.md
+++ b/docs/cpp/enable-logging-cpp.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: cpp
-TOCTitle: Logging
 ContentId: EC8DC085-A0E4-4401-B41F-6497EDD49352
-PageTitle: How to enable logging in the Visual Studio Code C/C++ extension
 DateApproved: 7/25/2019
 MetaDescription: How to enable logging in the Visual Studio Code C/C++ extension
 ---

--- a/docs/cpp/faq-cpp.md
+++ b/docs/cpp/faq-cpp.md
@@ -1,9 +1,5 @@
 ---
-Order: 16
-Area: cpp
-TOCTitle: FAQ
 ContentId: 652c9cec-b8fa-4597-a894-f2ea9a095c31
-PageTitle: C/C++ extension FAQ
 DateApproved: 1/17/2023
 MetaDescription: Frequently asked questions about the C/C++ extension in Visual Studio Code.
 ---

--- a/docs/cpp/introvideos-cpp.md
+++ b/docs/cpp/introvideos-cpp.md
@@ -1,13 +1,8 @@
 ---
-Order: 1
-Area: cpp
-TOCTitle: Intro Videos
 ContentId: a7a9837e-f515-4644-8dae-b5d44715e63f
-PageTitle: Introductory Videos for C++ in Visual Studio Code
 DateApproved: 4/13/2021
 MetaDescription: Get started with C++ in Visual Studio Code by watching these introductory videos
 ---
-
 # Introductory Videos for C++
 
 Get started with C++ in Visual Studio Code by watching these introductory videos! These videos are designed to help you set up C++ IntelliSense and build and debug C++ projects in VS Code. After watching these quick tutorials, you'll be able to enjoy VS Code's rich C++ feature set.

--- a/docs/cpp/launch-json-reference.md
+++ b/docs/cpp/launch-json-reference.md
@@ -1,9 +1,5 @@
 ---
-Order: 13
-Area: cpp
-TOCTitle: Configure debugging
 ContentId: 8cb0c932-d5f2-41e7-b297-5fd100ce4e0c
-PageTitle: Configure launch.json for C/C++ debugging in Visual Studio Code
 DateApproved: 6/10/2021
 MetaDescription: Configure launch.json for C/C++ debugging in Visual Studio Code
 ---

--- a/docs/cpp/lldb-mi.md
+++ b/docs/cpp/lldb-mi.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: cpp
-TOCTitle: Setup Help for LLDB-MI
 ContentId: 1e84d196-397f-4dbb-9746-06f15766d83e
-PageTitle: How to set up debugging on macOS with LLDB-MI
 DateApproved: 2/12/2020
 MetaDescription: How to set up debugging on macOS with LLDB-MI
 ---

--- a/docs/cpp/natvis.md
+++ b/docs/cpp/natvis.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: cpp
-TOCTitle: Natvis framework
 ContentId: F684A0E8-0AEB-4CA9-83E2-891CC012EA8B
-PageTitle: The Natvis framework provides custom views for native C++ objects
 DateApproved: 7/25/2019
 MetaDescription: Learn how the Natvis framework provides custom views for native C++ objects in Visual Studio Code
 ---

--- a/docs/cpp/pipe-transport.md
+++ b/docs/cpp/pipe-transport.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: cpp
-TOCTitle: Pipe transport
 ContentId: 59BE5FF7-563F-4044-A562-294E75A75F96
-PageTitle: Pipe transport for remote communication in C++ projects
 DateApproved: 7/25/2019
 MetaDescription: How to set up pipe transport for debugging C++ code in Visual Studio Code.
 ---

--- a/docs/csharp/build-tools.md
+++ b/docs/csharp/build-tools.md
@@ -1,13 +1,8 @@
 ---
-Order: 8
-Area: csharp
-TOCTitle: Build Tools
 ContentId: 1d35afc9-2439-48bf-84e5-547446d89239
-PageTitle: C# Build Tools for Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: C# Build Tools for Visual Studio
 ---
-
 # Build Tools
 
 This document is an overview of how to build your C# projects and solutions in the C# tools for Visual Studio Code. It covers the features provided by the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension.

--- a/docs/csharp/cs-dev-kit-faq.md
+++ b/docs/csharp/cs-dev-kit-faq.md
@@ -1,13 +1,8 @@
 ---
-Order: 12
-Area: csharp
-TOCTitle: FAQ
 ContentId: edd2c270-152c-419d-b5d9-06f2f95979cd
-PageTitle: C# Dev Kit extension FAQ
 DateApproved: 5/3/2024
 MetaDescription: C# Dev Kit extension Frequently Asked Questions (FAQ)
 ---
-
 # C# Dev Kit FAQ
 
 Use this FAQ (Frequently Asked Questions) topic to learn more about the C# Dev Kit extension and troubleshoot issues you may be experiencing.

--- a/docs/csharp/debugger-settings.md
+++ b/docs/csharp/debugger-settings.md
@@ -1,11 +1,8 @@
 ---
-Area: csharp
 ContentId: 34c5ba31-5844-4eca-8fef-dabb6e917314
-PageTitle: Configuring C# debugging
 DateApproved: 6/6/2023
 MetaDescription: Configuring C# debugging
 ---
-
 # Configuring C# debugging
 
 You can configure the C# debugger in Visual Studio Code with a `launch.json`, `launchSettings.json`, or your user `settings.json` file.

--- a/docs/csharp/debugging.md
+++ b/docs/csharp/debugging.md
@@ -1,14 +1,9 @@
 ---
-Order: 10
-Area: csharp
-TOCTitle: Run and Debug
 ContentId: f4507411-1780-4b80-8816-657c09585c19
-PageTitle: Debugging C# in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: See how you can run and debug your C# source code
 MetaSocialImage:
 ---
-
 # Debugging
 
 You can debug C# applications in Visual Studio Code using the [Microsoft C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension.

--- a/docs/csharp/formatting-linting.md
+++ b/docs/csharp/formatting-linting.md
@@ -1,13 +1,8 @@
 ---
-Order: 6
-Area: csharp
-TOCTitle: Formatting and Linting
 ContentId: 34c5ba31-5844-4eca-8fef-dabb6e917314
-PageTitle: Formatting and linting C# code in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: Formatting and linting C# source code in Visual Studio Code
 ---
-
 # Formatting and Linting
 
 You can format your C# source code using the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit), a lightweight extension to enhance your C# development experience in Visual Studio Code.

--- a/docs/csharp/get-started.md
+++ b/docs/csharp/get-started.md
@@ -1,13 +1,8 @@
 ---
-Order: 2
-Area: csharp
-TOCTitle: Get Started
 ContentId: cdf9809e-0569-4aaf-937e-e247507d9609
-PageTitle: Get started with C# and .NET in Visual Studio Code
 DateApproved: 5/3/2024
 MetaDescription: Getting Started with C# and .NET Development in Visual Studio Code
 ---
-
 # Getting Started with C# in VS Code
 
 This getting started guide introduces you to C# and .NET for Visual Studio Code through the following tasks:

--- a/docs/csharp/intellicode.md
+++ b/docs/csharp/intellicode.md
@@ -1,13 +1,8 @@
 ---
-Order: 4
-Area: csharp
-TOCTitle: IntelliCode
 ContentId: 0a0fd079-c56b-413c-8394-b166cd76be38
-PageTitle: IntelliCode for C# in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: IntelliCode for C# in Visual Studio Code
 ---
-
 # IntelliCode for C# Dev Kit
 
 For users of the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension in Visual Studio Code, the [IntelliCode for C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscodeintellicode-csharp) extension is available to provide IntelliCode support. Predictions of up to a whole-line of code, along with ranking methods and properties in the IntelliSense list are available for C# Dev Kit users.

--- a/docs/csharp/introvideos-csharp.md
+++ b/docs/csharp/introvideos-csharp.md
@@ -1,13 +1,8 @@
 ---
-Order: 1
-Area: csharp
-TOCTitle: Intro Videos
 ContentId: 14819e24-7ddf-4202-8e2a-d6fed961bff7
-PageTitle: Introductory Videos for C# in Visual Studio Code
 DateApproved: 12/12/2023
 MetaDescription: Get started with C# in Visual Studio Code by watching these introductory videos
 ---
-
 # Introductory Videos for C# in VS Code
 
 Get started with C# in Visual Studio Code by watching these introductory videos! These videos are designed to help you set up [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) and build and debug C# projects in VS Code. After watching these quick tutorials, you'll be able to enjoy VS Code's rich C# feature set.

--- a/docs/csharp/navigate-edit.md
+++ b/docs/csharp/navigate-edit.md
@@ -1,13 +1,8 @@
 ---
-Order: 3
-Area: csharp
-TOCTitle: Navigate and Edit
 ContentId: 2061194e-c34d-4ab0-a135-088bee575314
-PageTitle: C# language features in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: C# language features such as Go to Definition and Smart selection in Visual Studio Code
 ---
-
 # Navigate and Edit
 
 The navigation and editing tools described in this overview are enabled by the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension, a lightweight extension to enhance your C# development experience in Visual Studio Code.

--- a/docs/csharp/package-management.md
+++ b/docs/csharp/package-management.md
@@ -1,13 +1,8 @@
 ---
-Order: 9
-Area: csharp
-TOCTitle: Package Management
 ContentId: 6e7d5ecf-d7aa-44b5-abc0-2257a2075906
-PageTitle: C# package management with NuGet in Visual Studio Code
 DateApproved: 12/13/2024
 MetaDescription: C# package management with NuGet in Visual Studio Code
 ---
-
 # NuGet in Visual Studio Code
 
 NuGet is the package manager for .NET. It defines how packages for .NET are created, hosted, and consumed, while providing the tools for each of those functions. NuGet also manages the dependency tree on behalf of a project, so you only need to focus on the packages that you're directly using in a project.

--- a/docs/csharp/project-management.md
+++ b/docs/csharp/project-management.md
@@ -1,13 +1,8 @@
 ---
-Order: 7
-Area: csharp
-TOCTitle: Project Management
 ContentId: 90d72255-dbe2-402a-aecc-a6edd12aadba
-PageTitle: Manage C# projects in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: Manage C# projects in Visual Studio Code
 ---
-
 # Project management
 
 When you create a C# application in Visual Studio Code, you start with a **project**. A project contains all files (such as source code, images, etc.) that are compiled into an executable, library, or website.  All of your related projects can then be stored in a container called a **solution**.  This article shows you how you can maintain all your projects and their respective files via the **Solution Explorer** view.

--- a/docs/csharp/refactoring.md
+++ b/docs/csharp/refactoring.md
@@ -1,13 +1,8 @@
 ---
-Order: 5
-Area: csharp
-TOCTitle: Refactoring
 ContentId: 76b55a1a-9666-417b-8f13-1de3fd6f36e9
-PageTitle: C# Quick Actions and Refactorings in Visual Studio Code
 DateApproved: 6/6/2023
 MetaDescription: C# Quick Actions and Refactorings in Visual Studio Code
 ---
-
 # C# Quick Actions and Refactorings
 
 Visual Studio Code gives you many ways to refactor your source code as well as Quick Fixes to generate code and fix issues while you're coding. To access them, click on the 'light bulb' icon that appears or use the command **Quick Fix** command `kb(editor.action.quickFix)` to display a list of Quick Fixes and refactoring options.  You can also right-click the editor and select **Refactor** `kb(editor.action.refactor)` to only display refactoring options.

--- a/docs/csharp/signing-in.md
+++ b/docs/csharp/signing-in.md
@@ -1,11 +1,8 @@
 ---
-Area: csharp
 ContentId: 44aa6759-14dd-41ba-b48c-dc5ba3a6e8de
-PageTitle: Signing in to C# Dev Kit
 DateApproved: 6/6/2023
 MetaDescription: Signing in to C# Dev Kit
 ---
-
 # Signing in to C# Dev Kit
 
 In this article, you'll learn:

--- a/docs/csharp/testing.md
+++ b/docs/csharp/testing.md
@@ -1,13 +1,8 @@
 ---
-Order: 11
-Area: csharp
-TOCTitle: Testing
 ContentId: 0e62b3c9-6c13-4a71-a942-63d37c8f47d1
-PageTitle: Testing C# with C# Dev Kit in Visual Studio Code
 DateApproved: 3/12/2025
 MetaDescription: Testing C# with C# Dev Kit in Visual Studio Code
 ---
-
 # Testing with C# Dev Kit
 
 Testing in C# in Visual Studio Code is enabled by the C# Dev Kit extension. It's a lightweight extension to enhance your C# development experience.

--- a/docs/datascience/azure-machine-learning.md
+++ b/docs/datascience/azure-machine-learning.md
@@ -1,14 +1,9 @@
 ---
-Order: 8
-Area: datascience
-TOCTitle: Azure Machine Learning
 ContentId: 47979929-10b2-4e4d-acf3-00b32893ad1b
-PageTitle: Azure Machine Learning in Visual Studio Code
 DateApproved: 1/9/2023
 MetaDescription: Learn how to build machine learning applications in Azure Machine Learning using the Visual Studio Code extension
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Azure Machine Learning in VS Code
 
 Azure Machine Learning is a cloud-based environment you can use to train, deploy, automate, manage, and track machine learning models. For more information on Azure Machine Learning, see [What is Azure Machine Learning?](https://learn.microsoft.com/azure/machine-learning/overview-what-is-azure-machine-learning)

--- a/docs/datascience/data-science-tutorial.md
+++ b/docs/datascience/data-science-tutorial.md
@@ -1,14 +1,9 @@
 ---
-Order: 3
-Area: datascience
-TOCTitle: Data Science Tutorial
 ContentId: 3c7ae641-e45c-4892-9d8c-7f22bdc549dd
-PageTitle: Python and Data Science Tutorial in Visual Studio Code
 DateApproved: 1/9/2023
 MetaDescription: Python data science tutorial demonstrating the use of common data science and machine learning libraries with Visual Studio code Jupyter Notebook support.
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Data Science in VS Code tutorial
 
 This tutorial demonstrates using Visual Studio Code and the Microsoft Python extension with common data science libraries to explore a basic data science scenario. Specifically, using passenger data from the Titanic, you will learn how to set up a data science environment, import and clean data, create a machine learning model for predicting survival on the Titanic, and evaluate the accuracy of the generated model.

--- a/docs/datascience/data-wrangler-quick-start.md
+++ b/docs/datascience/data-wrangler-quick-start.md
@@ -1,13 +1,8 @@
 ---
-Order: 5
-Area: datascience
-TOCTitle: Data Wrangler Quick Start
 ContentId: 0227288a-2698-47bd-b97a-3a1736acb473
-PageTitle: Getting Started with Data Wrangler in VS Code
 DateApproved: 04/04/2024
 MetaDescription: A quick start guide to get you up and running with the Data Wrangler extension in Visual Studio Code.
 ---
-
 # Quick Start Guide for Data Wrangler in VS Code
 
 [Data Wrangler](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.datawrangler) is a code-centric data viewing and cleaning tool that is integrated into VS Code and VS Code Jupyter Notebooks. It provides a rich user interface to view and analyze your data, show insightful column statistics and visualizations, and automatically generate Pandas code as you clean and transform the data.

--- a/docs/datascience/data-wrangler.md
+++ b/docs/datascience/data-wrangler.md
@@ -1,13 +1,8 @@
 ---
-Order: 6
-Area: datascience
-TOCTitle: Data Wrangler
 ContentId: 8488ca7b-6f92-4894-9029-1bae431784e9
-PageTitle: Working with Data Wrangler in VS Code
 DateApproved: 04/04/2024
 MetaDescription: Full documentation on working with the Data Wrangler extension in Visual Studio Code.
 ---
-
 # Getting Started with Data Wrangler in VS Code
 
 [Data Wrangler](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.datawrangler) is a code-centric data viewing and cleaning tool that is integrated into VS Code and VS Code Jupyter Notebooks. It provides a rich user interface to view and analyze your data, show insightful column statistics and visualizations, and automatically generate Pandas code as you clean and transform the data.

--- a/docs/datascience/jupyter-kernel-management.md
+++ b/docs/datascience/jupyter-kernel-management.md
@@ -1,14 +1,9 @@
 ---
-Order: 9
-Area: datascience
-TOCTitle: Manage Jupyter Kernels
 ContentId: 3b6da7e6-c449-4c62-a019-9202412aac04
-PageTitle: Manage Jupyter Kernels in Visual Studio Code
 DateApproved: 8/7/2023
 MetaDescription: Descriptions of kernel selection options and tutorials on managing different types of kernels when working with Jupyter Notebooks in Visual Studio Code.
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Manage Jupyter Kernels in VS Code
 
 The Visual Studio Code notebooks' kernel picker helps you to pick specific kernels for your notebooks. You can open the kernel picker by clicking on **Select Kernel** on the upper right-hand corner of your notebook or through the Command Palette with the **Notebook: Select Notebook Kernel** command.

--- a/docs/datascience/jupyter-notebooks.md
+++ b/docs/datascience/jupyter-notebooks.md
@@ -1,14 +1,9 @@
 ---
-Order: 2
-Area: datascience
-TOCTitle: Jupyter Notebooks
 ContentId: 17345073-cb40-448c-a312-28982900f132
-PageTitle: Working with Jupyter Notebooks in Visual Studio Code
 DateApproved: 1/9/2023
 MetaDescription: Working with Jupyter Notebooks in Visual Studio Code.
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Jupyter Notebooks in VS Code
 
 [Jupyter](https://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython Notebook) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a **notebook**. Visual Studio Code supports working with Jupyter Notebooks natively, and through [Python code files](/docs/python/jupyter-support-py.md). This topic covers the native support available for Jupyter Notebooks and demonstrates how to:

--- a/docs/datascience/notebooks-web.md
+++ b/docs/datascience/notebooks-web.md
@@ -1,14 +1,9 @@
 ---
-Order: 10
-Area: datascience
-TOCTitle: Jupyter Notebooks on the web
 ContentId: 0faf5b06-ddad-4594-8d5e-fa409c7da82c
-PageTitle: Jupyter Notebooks on the web
 DateApproved: 1/9/2023
 MetaDescription: Working with Jupyter notebooks on the web with Visual Studio Code.
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Jupyter Notebooks on the web
 
 Visual Studio Code supports working with [Jupyter Notebooks](https://jupyter-notebook.readthedocs.io/en/latest/) on the desktop, and extends to various browser-based platforms like [GitHub Codespaces](https://github.com/features/codespaces) and [VS Code for the Web](/docs/setup/vscode-web.md).

--- a/docs/datascience/overview.md
+++ b/docs/datascience/overview.md
@@ -1,13 +1,8 @@
 ---
-Order: 1
-Area: datascience
-TOCTitle: Overview
 ContentId: 23ce059e-95ec-4eaa-975c-d4cf76159516
-PageTitle: Doing Data Science in Visual Studio Code
 DateApproved: 1/9/2023
 MetaDescription: Doing Data Science in Visual Studio Code.
 ---
-
 # Data Science in Visual Studio Code
 
 You can do all of your data science work within VS Code. Use Jupyter Notebooks and the [Interactive Window](/docs/python/jupyter-support-py.md) to start analyzing and visualizing your data in minutes! Power your Python coding experience with IntelliSense support and build, train, and deploy machine learning models to the cloud or the edge with Azure Machine Learning service.

--- a/docs/datascience/python-interactive.md
+++ b/docs/datascience/python-interactive.md
@@ -1,14 +1,9 @@
 ---
-Order: 4
-Area: datascience
-TOCTitle: Python Interactive
 ContentId: 09645514-3c23-49ec-8e27-71831bc06ce7
-PageTitle: Working with Jupyter code cells in the Python Interactive window
 DateApproved: 1/9/2023
 MetaDescription: Working with Jupyter code cells in the Python Interactive window
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # How to use Python Interactive in Jupyter
 
 This page is redirected to /docs/python/jupyter-support-py.md and only exists to keep the "Python Interactive" TOC item.

--- a/docs/datascience/pytorch-support.md
+++ b/docs/datascience/pytorch-support.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: datascience
-TOCTitle: PyTorch Support
 ContentId: 7B5266AD-3D3E-491F-BD7C-B883C592D943
-PageTitle: PyTorch Development in Visual Studio Code
 DateApproved: 1/9/2023
 MetaDescription: This topic highlights some of the PyTorch features available within Visual Studio Code.
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/debugtest/port-forwarding.md
+++ b/docs/debugtest/port-forwarding.md
@@ -1,9 +1,5 @@
 ---
-Order: 26
-Area: editor
-TOCTitle: Port Forwarding
 ContentId: d7a80c88-c091-4d13-9240-d432c12407a7
-PageTitle: Port forwarding local services with VS Code
 DateApproved: 05/08/2025
 MetaDescription: Make your local web services accessible over the internet with Visual Studio Code
 ---

--- a/docs/debugtest/tasks.md
+++ b/docs/debugtest/tasks.md
@@ -1,9 +1,5 @@
 ---
-Order: 14
-Area: editor
-TOCTitle: Tasks
 ContentId: F5EA1A52-1EF2-4127-ABA6-6CEF5447C608
-PageTitle: Tasks in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Expand your development workflow with task integration in Visual Studio Code.
 ---

--- a/docs/debugtest/testing.md
+++ b/docs/debugtest/testing.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: editor
-TOCTitle: Testing
 ContentId: d44f1a5c-5454-4037-92d5-c2bf5d4cffed
-PageTitle: Testing in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: One of the great things in Visual Studio Code is testing support. Automatically discover tests in your project, run and debug your tests, and get test coverage results.
 ---

--- a/docs/devcontainers/attach-container.md
+++ b/docs/devcontainers/attach-container.md
@@ -1,8 +1,4 @@
 ---
-Order: 10
-Area: devcontainers
-TOCTitle: Attach to Container
-PageTitle: Attach to a running container using Visual Studio Code Remote Development
 ContentId: ed14ef07-f44c-4675-b95b-cb5faffc7abb
 MetaDescription: Attach to a running container using Visual Studio Code Remote Development
 DateApproved: 05/08/2025

--- a/docs/devcontainers/containers-advanced.md
+++ b/docs/devcontainers/containers-advanced.md
@@ -1,8 +1,4 @@
 ---
-Order: 12
-Area: devcontainers
-TOCTitle: Advanced Containers
-PageTitle: Advanced Container Configuration
 ContentId: f180ac25-1d59-47ec-bad2-3ccbf214bbd8
 MetaDescription: Advanced setup for using the VS Code Dev Containers extension
 DateApproved: 05/08/2025

--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -1,8 +1,4 @@
 ---
-Order: 3
-Area: devcontainers
-TOCTitle: Overview
-PageTitle: Developing inside a Container using Visual Studio Code Remote Development
 ContentId: 7ec8a02b-2eb7-45c1-bb16-ddeaac694ff6
 MetaDescription: Developing inside a Container using Visual Studio Code Remote Development
 DateApproved: 05/08/2025

--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -1,8 +1,4 @@
 ---
-Order: 11
-Area: devcontainers
-TOCTitle: Create a Dev Container
-PageTitle: Create a development container using Visual Studio Code Remote Development
 ContentId: bae55561-1032-40d4-b6a6-47054da96098
 MetaDescription: Create a development container using Visual Studio Code Remote Development
 DateApproved: 05/08/2025

--- a/docs/devcontainers/devcontainer-cli.md
+++ b/docs/devcontainers/devcontainer-cli.md
@@ -1,8 +1,4 @@
 ---
-Order: 14
-Area: devcontainers
-TOCTitle: Dev Container CLI
-PageTitle: Installing and working with the devcontainer CLI
 ContentId: 8946213d-716e-41ca-955f-944a41c70353
 MetaDescription: Documentation on using the development container (dev container) command-line interface
 DateApproved: 05/08/2025

--- a/docs/devcontainers/devcontainerjson-reference.md
+++ b/docs/devcontainers/devcontainerjson-reference.md
@@ -1,8 +1,4 @@
 ---
-Order: 13
-Area: devcontainers
-TOCTitle: devcontainer.json
-PageTitle: devcontainer.json reference
 ContentId: 52eaec33-21c6-410c-8e10-1ee3658a854f
 MetaDescription: devcontainer.json reference
 DateApproved: 05/08/2025

--- a/docs/devcontainers/faq.md
+++ b/docs/devcontainers/faq.md
@@ -1,8 +1,4 @@
 ---
-Order: 16
-Area: devcontainers
-TOCTitle: FAQ
-PageTitle: Visual Studio Code Dev Containers Frequently Asked Questions
 ContentId: c4784db6-ab00-4ac7-bca8-88edb638c593
 MetaDescription: Visual Studio Code troubleshooting tips and tricks for Dev Containers
 DateApproved: 05/08/2025

--- a/docs/devcontainers/tips-and-tricks.md
+++ b/docs/devcontainers/tips-and-tricks.md
@@ -1,8 +1,4 @@
 ---
-Order: 15
-Area: devcontainers
-TOCTitle: Tips and Tricks
-PageTitle: Visual Studio Code Dev Containers Tips and Tricks
 ContentId: c4784db6-ab00-4ac7-bca8-88edb638c593
 MetaDescription: Visual Studio Code Remote Development troubleshooting tips and tricks for Dev Containers
 DateApproved: 05/08/2025

--- a/docs/devcontainers/tutorial.md
+++ b/docs/devcontainers/tutorial.md
@@ -1,8 +1,4 @@
 ---
-Order: 8
-Area: devcontainers
-TOCTitle: Tutorial
-PageTitle: Get started with development Containers in Visual Studio Code
 ContentId: 8e1fb9e0-1a67-4e0c-a21b-c5ab9a6d979c
 MetaDescription: Get started with development Containers in Visual Studio Code
 DateApproved: 05/08/2025

--- a/docs/editing/codebasics.md
+++ b/docs/editing/codebasics.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: editor
-TOCTitle: Basic Editing
 ContentId: DE4EAE2F-4542-4363-BB74-BE47D64141E6
-PageTitle: Basic editing in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about the basic editing features of Visual Studio Code. Search, multiple selection, code formatting.
 MetaSocialImage: images/codebasics/code-basics-social.png

--- a/docs/editing/editingevolved.md
+++ b/docs/editing/editingevolved.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: editor
-TOCTitle: Code Navigation
 ContentId: 8966BBFD-C66D-4283-9DCA-8CAC0179886E
-PageTitle: Code Navigation in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code is a first class editor - but it's also so much more with features such as IntelliSense and smart code navigation.
 ---

--- a/docs/editing/intellisense.md
+++ b/docs/editing/intellisense.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: editor
-TOCTitle: IntelliSense
 ContentId: 80f4fa1e-d4c5-42cf-8b12-4b8e88c41c3e
-PageTitle: IntelliSense in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription:  Learn about Visual Studio Code IntelliSense (intelligent code completion).
 ---

--- a/docs/editing/refactoring.md
+++ b/docs/editing/refactoring.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: editor
-TOCTitle: Refactoring
 ContentId: 481dfd3a-d847-4ed3-b37b-7fc8d234a4c2
-PageTitle: Refactoring source code in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Refactoring source code in Visual Studio Code.
 ---

--- a/docs/editing/userdefinedsnippets.md
+++ b/docs/editing/userdefinedsnippets.md
@@ -1,9 +1,5 @@
 ---
-Order: 17
-Area: editor
-TOCTitle: Snippets
 ContentId: 79CD9B45-97FF-48B1-8DD5-2555F56206A6
-PageTitle: Snippets in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: It is easy to add code snippets to Visual Studio Code both for your own use or to share with others on the public Extension Marketplace. TextMate .tmSnippets files are supported.
 ---

--- a/docs/editing/workspaces/multi-root-workspaces.md
+++ b/docs/editing/workspaces/multi-root-workspaces.md
@@ -1,9 +1,5 @@
 ---
-Order: 22
-Area: editor
-TOCTitle: Multi-root Workspaces
 ContentId: 8d55f6b8-977f-4c26-a888-f3d8d982dd2d
-PageTitle: Multi-root Workspaces in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: You can open and work on multiple project folders in Visual Studio Code with multi-root workspaces.
 ---

--- a/docs/editing/workspaces/workspace-trust.md
+++ b/docs/editing/workspaces/workspace-trust.md
@@ -1,9 +1,5 @@
 ---
-Order: 21
-Area: editor
-TOCTitle: Workspace Trust
 ContentId: 51280c26-f78b-4f9c-997f-8350bd6ed07f
-PageTitle: Visual Studio Code Workspace Trust security
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code Workspace Trust folder security
 ---

--- a/docs/editing/workspaces/workspaces.md
+++ b/docs/editing/workspaces/workspaces.md
@@ -1,9 +1,5 @@
 ---
-Order: 20
-Area: editor
-TOCTitle: Workspaces
 ContentId: 0144ad9a-14df-41b5-9629-cbba7dbfc396
-PageTitle: Workspaces in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code workspaces
 ---

--- a/docs/editor/glob-patterns.md
+++ b/docs/editor/glob-patterns.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: editor
-TOCTitle: Glob Patterns Reference
 ContentId: c2d81f09-3c24-4659-8aa0-9ca24ef4950d
-PageTitle: Visual Studio Code glob patterns reference
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code glob patterns reference
 ---

--- a/docs/editor/portable.md
+++ b/docs/editor/portable.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: editor
-TOCTitle: Portable Mode
 ContentId: A5C839C4-67E9-449C-94B8-4B310FCAAB1B
-PageTitle: Portable Mode in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code supports a Portable mode that enables moving your installation and related data to a different location.
 ---

--- a/docs/editor/whyvscode.md
+++ b/docs/editor/whyvscode.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: editor
-TOCTitle: Why VS Code
 ContentId: FF543B32-703C-4894-9A3B-2B5BFAF8B6B8
-PageTitle: Why Visual Studio Code?
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code provides developers with a new choice of tool that combines the simplicity of a code editor with the best tooling for their core edit-build-debug cycle. Visual Studio Code is available for macOS, Linux, and Windows.
 ---

--- a/docs/intelligentapps/bulkrun.md
+++ b/docs/intelligentapps/bulkrun.md
@@ -3,7 +3,6 @@ ContentId: 1124d141-e893-4780-aba7-b6ca13628bc5
 DateApproved: 12/11/2024
 MetaDescription: Run a set of prompts in an imported dataset, individually or in a full batch towards the selected genAI models and parameters.
 ---
-
 # Run multiple prompts in bulk
 
 The bulk run feature in AI Toolkit enables you to run multiple prompts in batch. When you use the playground, you can only run one prompt manually at a time, in the order they're listed.

--- a/docs/intelligentapps/evaluation.md
+++ b/docs/intelligentapps/evaluation.md
@@ -3,7 +3,6 @@ ContentId: 3342b8ef-72fe-4cca-baad-64ee57c05b5f
 DateApproved: 12/11/2024
 MetaDescription: Import a dataset with LLMs or SLMs output or rerun it for the queries. Run evaluation job for the popular evaluators like F1 score, relevance, coherence, similarity... find, visualize, and compare the evaluation results in tables or charts.
 ---
-
 # Model evaluation
 
 AI engineers often need to evaluate models with different parameters or prompts for comparing to ground truth and compute evaluator values from the comparisons. AI Toolkit lets you perform evaluations with minimal effort by uploading a prompts dataset.

--- a/docs/intelligentapps/faq.md
+++ b/docs/intelligentapps/faq.md
@@ -3,7 +3,6 @@ ContentId: c35d24d0-5d2c-493d-9635-10601a13848e
 DateApproved: 12/11/2024
 MetaDescription: Find answers to frequently asked questions (FAQ) using AI Toolkit. Get troubleshooting recommendations.
 ---
-
 # AI Toolkit FAQ
 
 ## Models

--- a/docs/intelligentapps/finetune.md
+++ b/docs/intelligentapps/finetune.md
@@ -3,7 +3,6 @@ ContentId: 5b6626b8-98a9-497e-bbc6-e2274885be56
 DateApproved: 12/11/2024
 MetaDescription: Use custom dataset to fine-tune a generative AI model in the Azure cloud or locally with GPUs. Deploy the fine-tuned model to the Azure cloud or download incremental files from fine-tuned model.
 ---
-
 # Fine-tune models
 
 Fine-tune AI model is a common practice that allows you to use your custom dataset to run **fine-tune** jobs on a pre-trained model in a computing environment with GPUs. AI Toolkit currently supports fine-tuning SLMs on local machine with GPU or in the cloud (Azure Container App) with GPU.

--- a/docs/intelligentapps/modelconversion.md
+++ b/docs/intelligentapps/modelconversion.md
@@ -3,7 +3,6 @@ ContentId: 2452fb1c-7636-44d3-a52d-00923844d384
 DateApproved: 05/13/2025
 MetaDescription: Model Conversion Quickstart in AI Toolkit.
 ---
-
 # Convert a model with AI Toolkit for VS Code (Preview)
 
 Model conversion is an integrated development environment designed to help developers and AI engineers to convert, quantize, optimize and evaluate the pre-built machine learning models on your local Windows platform. It offers a streamlined, end-to-end experience for models converted from sources like Hugging Face, optimizing them and enabling inference on local devices powered by NPUs, GPUs, and CPUs.

--- a/docs/intelligentapps/models.md
+++ b/docs/intelligentapps/models.md
@@ -3,7 +3,6 @@ ContentId: 52ad40fe-f352-4e16-a075-7a9606c5df3b
 DateApproved: 12/11/2024
 MetaDescription: Find a popular generative AI model by publisher and source. Bring your own model that is hosted with a URL, or select an Ollama model.
 ---
-
 # Models in AI Toolkit
 
 AI Toolkit supports a broad range of generative AI models. Both Small Language Models (SLM) and Large Language Models (LLM) are supported.

--- a/docs/intelligentapps/overview.md
+++ b/docs/intelligentapps/overview.md
@@ -3,7 +3,6 @@ ContentId: 164299e8-d27d-40b9-8b8d-a6e05df8ac69
 DateApproved: 12/11/2024
 MetaDescription: Develop and test AI apps with AI Toolkit for Visual Studio Code. Inference test, batch run, evaluate, fine-tune and deploy LLMs and SLMs.
 ---
-
 # AI Toolkit for Visual Studio Code
 
 AI Toolkit for Visual Studio Code is an extension to help developers and AI engineers to easily build AI apps through developing and testing with generative AI models locally or in the cloud. AI Toolkit supports most genAI models on the market.

--- a/docs/intelligentapps/playground.md
+++ b/docs/intelligentapps/playground.md
@@ -3,7 +3,6 @@ ContentId: e919aee8-fd2e-401b-9d83-0ff6f98b23ba
 DateApproved: 12/11/2024
 MetaDescription: Chat with selected generative AI model in playground. Change system prompt and parameters. Add attachment for Multi-Modal models. Keep chat history.
 ---
-
 # AI Toolkit playground
 
 The AI Toolkit playground enables you to interact with your AI models and try different prompts with different model parameter settings. You can also use the playground to interact with multi-modal models that support attachment of different input formats.

--- a/docs/intelligentapps/reference/FileStructure.md
+++ b/docs/intelligentapps/reference/FileStructure.md
@@ -3,7 +3,6 @@ ContentId: fea54c41-e5bb-49e2-89bd-518af096ba8e
 DateApproved: 05/13/2025
 MetaDescription: Model Conversion reference about project structure.
 ---
-
 # Model conversion file structure
 This article explains the file structure generated during model conversion workflows and the purpose of each folder and file, including cache handling, history tracking, inference and so on.
 

--- a/docs/intelligentapps/reference/ManualModelConversion.md
+++ b/docs/intelligentapps/reference/ManualModelConversion.md
@@ -3,7 +3,6 @@ ContentId: d40f8c19-a7a4-4d53-9303-b9cb128af591
 DateApproved: 05/13/2025
 MetaDescription: Model Conversion reference about manual model conversion.
 ---
-
 # Convert models to ONNX format
 
 The AI Toolkit supports the [Open Neural Network Exchange](https://onnx.ai) (ONNX) format for running models locally. ONNX is an open standard for representing machine learning models, defining a common set of operators and a file format that enables models to run across various hardware platforms.

--- a/docs/intelligentapps/reference/SetupWithoutAITK.md
+++ b/docs/intelligentapps/reference/SetupWithoutAITK.md
@@ -3,7 +3,6 @@ ContentId: 8493ea9e-061a-4519-b807-57bd320cc60c
 DateApproved: 05/13/2025
 MetaDescription: Model Conversion reference about setup environment.
 ---
-
 # Setup model conversion environment manually
 This article introduces how to manually set up Python environments for model conversion across different hardware targets, including CPU, QNN, AMD NPU, and Intel NPU.
 

--- a/docs/intelligentapps/reference/TemplateProject.md
+++ b/docs/intelligentapps/reference/TemplateProject.md
@@ -3,7 +3,6 @@ ContentId: 8dfdd336-fbbf-440c-9bc1-3f98a1787dfc
 DateApproved: 05/13/2025
 MetaDescription: Model Conversion reference about setup template project.
 ---
-
 # Set up a template project in model conversion
 This article introduces how to set up and customize a template project in model conversion, guiding you through editing configuration files like sample.json, model_project.config, and others to suit your specific model, dataset, and workflow needs.
 

--- a/docs/introvideos/basics.md
+++ b/docs/introvideos/basics.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Getting started
 ContentId: baf150cd-6daf-4604-87db-a7c70a6706a7
-PageTitle:  Getting started with Visual Studio Code
 DateApproved: 5/4/2022
 MetaDescription: Download and learn the basics of Visual Studio Code.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/codeediting.md
+++ b/docs/introvideos/codeediting.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Code Editing
 ContentId: 826efeef-6803-49bd-a500-06c6c42cda19
-PageTitle: Edit and run code in Visual Studio Code
 DateApproved: 11/16/2021
 MetaDescription: Learn the basics of editing and running code in VS Code.
 MetaSocialImage:

--- a/docs/introvideos/configure.md
+++ b/docs/introvideos/configure.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Personalize
 ContentId: d9583ed0-aaf6-4ce1-9a27-bbfb0017b6be
-PageTitle: Personalize Visual Studio Code
 DateApproved: 10/5/2021
 MetaDescription: Learn how to personalize Visual Studio Code with themes.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/customize.md
+++ b/docs/introvideos/customize.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Customize
 ContentId: 3e36b1fa-cefc-4a07-9773-e672da5881a2
-PageTitle: Customize Visual Studio Code with settings and keyboard shortcuts
 DateApproved: 10/11/2021
 MetaDescription: Learn how to customize your Visual Studio Code with settings and keyboard shortcuts.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/debugging.md
+++ b/docs/introvideos/debugging.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Debugging
 ContentId: cf275b3d-c1d8-4a55-b2eb-a8a744882b6a
-PageTitle: Introduction to Debugging in Visual Studio Code
 DateApproved: 9/9/2024
 MetaDescription: Debugging is a core feature of Visual Studio Code. Learn how to configure and use the Node.js debugger in this introductory video.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/extend.md
+++ b/docs/introvideos/extend.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: introvideos
-TOCTitle: Extend
 ContentId: c720387b-e6db-4b40-865f-0c0a814b0b12
-PageTitle: Extensions in Visual Studio Code
 DateApproved: 10/5/2021
 MetaDescription: Use extensions in Visual Studio Code to add new features, themes, and more.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/productivity.md
+++ b/docs/introvideos/productivity.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Productivity
 ContentId: 9b79fbb2-f7d1-4b54-a4ad-e5ccb0ebd891
-PageTitle: Visual Studio Code productivity tips
 DateApproved: 11/18/2021
 MetaDescription: Become a Visual Studio Code power user with these productivity tips.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/introvideos/versioncontrol.md
+++ b/docs/introvideos/versioncontrol.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: introvideos
-TOCTitle: Version Control
 ContentId: 2447F8EB-15F1-4279-B621-126C7B8EBF4B
-PageTitle: Version control in Visual Studio Code
 DateApproved: 5/31/2022
 MetaDescription: Learn how to use Git version control basics in Visual Studio Code.
 MetaSocialImage: images/opengraph/introvideos-social.png

--- a/docs/java/extensions.md
+++ b/docs/java/extensions.md
@@ -1,9 +1,5 @@
 ---
-Order: 13
-Area: java
-TOCTitle: Extensions
 ContentId: 6076911c-276b-41a3-8510-0022c03c0ef6
-PageTitle: Java extensions for Visual Studio Code
 DateApproved: 1/4/2022
 MetaDescription: Popular Java extensions for Visual Studio Code
 ---

--- a/docs/java/java-build.md
+++ b/docs/java/java-build.md
@@ -1,14 +1,9 @@
 ---
-Order: 6
-Area: java
-TOCTitle: Build Tools
 ContentId: 6ba93ee8-33d7-483a-a3b0-82241cedecbf
-PageTitle: Maven and Gradle support for Java in Visual Studio Code
 DateApproved: 12/10/2021
 MetaDescription: Maven and Gradle support for Java in Visual Studio Code
 MetaSocialImage:
 ---
-
 # Java build tools in VS Code
 
 This document is an overview of how to work with your Java build tools in Visual Studio Code. It covers the [Maven for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven) and [Gradle for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle) extensions as well as other tools.

--- a/docs/java/java-debugging.md
+++ b/docs/java/java-debugging.md
@@ -1,14 +1,9 @@
 ---
-Order: 7
-Area: java
-TOCTitle: Run and Debug
 ContentId: 929e5410-3bfe-4107-b331-565afe5d341f
-PageTitle: Run and Debug Java in Visual Studio Code
 DateApproved: 12/9/2021
 MetaDescription: See how you can run and debug your Java source code locally, and in the cloud.
 MetaSocialImage:
 ---
-
 # Running and debugging Java
 
 Visual Studio Code allows you to debug Java applications through the [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) extension. It's a lightweight Java debugger based on [Java Debug Server](https://github.com/microsoft/java-debug), which extends the [Language Support for Java™ by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java).

--- a/docs/java/java-editing.md
+++ b/docs/java/java-editing.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: java
-TOCTitle: Navigate and Edit
 ContentId: 843e139a-9e3c-4b4f-95d1-32a9a7480e8e
-PageTitle: Navigate and edit Java Source Code in Visual Studio Code
 DateApproved: 12/9/2021
 MetaDescription: Navigate and edit Java Source Code in Visual Studio Code
 ---

--- a/docs/java/java-faq.md
+++ b/docs/java/java-faq.md
@@ -1,9 +1,5 @@
 ---
-Order: 14
-Area: java
-TOCTitle: FAQ
 ContentId: 2ad03b46-0779-4c9a-897e-6e6b628f598a
-PageTitle: Java on Visual Studio Code FAQ and Wiki
 DateApproved: 8/31/2021
 MetaDescription: Java on Visual Studio Code Frequent Asked Questions and Troubleshooting Guide
 ---

--- a/docs/java/java-gui.md
+++ b/docs/java/java-gui.md
@@ -1,13 +1,8 @@
 ---
-Order: 12
-Area: java
-TOCTitle: GUI Applications
 ContentId: 517db620-d166-4f72-99c1-fa046710dffe
-PageTitle: Develop Java GUI Applications in Visual Studio Code
 DateApproved: 10/11/2022
 MetaDescription: How to develop Java GUI Applications (JavaFX, AWT, Swing) in Visual Studio Code
 ---
-
 # Working with GUI applications in VS Code
 
 You can develop Java GUI applications in Visual Studio Code easily. To achieve that, you need to install the [Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack), which includes all the required extensions to develop Java GUI applications.

--- a/docs/java/java-linting.md
+++ b/docs/java/java-linting.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: java
-TOCTitle: Formatting and Linting
 ContentId: dd4fa82e-0021-404c-87e4-3b69f1e12463
-PageTitle: Formatting, linting, and code analysis for Java in Visual Studio Code
 DateApproved: 12/12/2021
 MetaDescription: Formatting, linting, and code analysis for Java in Visual Studio Code
 ---

--- a/docs/java/java-on-azure.md
+++ b/docs/java/java-on-azure.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: java
-TOCTitle: Deploy Java Apps
 ContentId: 01210769-05be-4854-9482-13e342850ad7
-PageTitle: Deploy Java Web Apps
 DateApproved: 10/18/2022
 MetaDescription: How to deploy Java applications to Azure with Visual Studio Code
 ---

--- a/docs/java/java-project.md
+++ b/docs/java/java-project.md
@@ -1,14 +1,9 @@
 ---
-Order: 5
-Area: java
-TOCTitle: Project Management
 ContentId: 251cba68-c77f-4ac6-a5de-1fab8dcca867
-PageTitle: Java project management in Visual Studio Code
 DateApproved: 4/25/2022
 MetaDescription: Lightweight Mode, Maven Support, Java Package and Dependency Management in Visual Studio Code
 MetaSocialImage:
 ---
-
 # Managing Java Projects in VS Code
 
 The [Project Manager for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency) extension helps you to manage your Java projects and their dependencies. It also helps you to create new Java projects, packages, and classes. To get the complete Java language support in Visual Studio Code, you can install the [Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack), which includes the Project Manager for Java extension.

--- a/docs/java/java-refactoring.md
+++ b/docs/java/java-refactoring.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: java
-TOCTitle: Refactoring
 ContentId: 36ee3e12-9bcc-4f01-9672-857ad2733c2d
-PageTitle: Java code refactoring and Source Actions for Visual Studio Code
 DateApproved: 12/9/2021
 MetaDescription: Java code refactoring and Source Actions for Visual Studio Code
 ---

--- a/docs/java/java-spring-apps.md
+++ b/docs/java/java-spring-apps.md
@@ -1,12 +1,8 @@
 ---
-Area: java
-TOCTitle: Java Spring Apps
 ContentId: d34d8d3a-2093-4c67-a0a8-e02525fae8ab
-PageTitle: Build and Deploy Java Spring Boot Apps to Azure Spring Cloud with Visual Studio Code
 DateApproved: 3/2/2023
 MetaDescription: Java Spring app tutorial showing how to build and deploy a Java Spring Boot microservices to Azure Spring Cloud with Visual Studio Code
 ---
-
 # Java on Azure Spring Apps
 
 > **Note**: Azure Spring Apps is the new name for the Azure Spring Cloud service.

--- a/docs/java/java-spring-boot.md
+++ b/docs/java/java-spring-boot.md
@@ -1,13 +1,8 @@
 ---
-Order: 9
-Area: java
-TOCTitle: Spring Boot
 ContentId: d37118cf-1b5b-4aee-9727-52fcfcac16bd
-PageTitle: Spring Boot support in Visual Studio Code
 DateApproved: 12/22/2021
 MetaDescription: Spring Boot extensions for Java developer using Visual Studio Code editor.
 ---
-
 # Spring Boot in Visual Studio Code
 
 Visual Studio Code is an ideal lightweight development environment for Spring Boot application developers and there are several useful VS Code extensions including:

--- a/docs/java/java-testing.md
+++ b/docs/java/java-testing.md
@@ -1,14 +1,9 @@
 ---
-Order: 8
-Area: java
-TOCTitle: Testing
 ContentId: 82be3b78-2c09-4571-abec-69f95f111e0f
-PageTitle: Java Testing in Visual Studio Code
 DateApproved: 2/11/2022
 MetaDescription: See how you can test your Java code in Visual Studio Code.
 MetaSocialImage:
 ---
-
 # Testing Java with Visual Studio Code
 
 Testing Java in Visual Studio Code is enabled by the [Test Runner for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test) extension. It's a lightweight extension to run and debug Java test cases.

--- a/docs/java/java-tomcat-jetty.md
+++ b/docs/java/java-tomcat-jetty.md
@@ -1,13 +1,8 @@
 ---
-Order: 10
-Area: java
-TOCTitle: Application Servers
 ContentId: 4f5e169c-d91d-46b7-8c36-b695b5862313
-PageTitle: Working with application servers in Visual Studio Code
 DateApproved: 12/142021
 MetaDescription: Tomcat, Jetty and Open Liberty extensions for Java developer using Visual Studio Code.
 ---
-
 # Working with Application Servers in VS Code
 
 Visual Studio Code is a code editor-centric development tool, so it doesn't come with any embedded application server. For most servers, you will need to deploy them using the command line, and then use the appropriate debugger [configuration](/docs/java/java-debugging.md#configure) if you want to attach to it.

--- a/docs/java/java-tutorial.md
+++ b/docs/java/java-tutorial.md
@@ -1,13 +1,8 @@
 ---
-Order: 1
-Area: java
-TOCTitle: Getting Started
 ContentId: 12d8264b-643f-4745-a7ea-8433dedb1331
-PageTitle: Getting Started with Java in Visual Studio Code
 DateApproved: 1/4/2022
 MetaDescription: Java tutorial showing basic Java language support in the Visual Studio Code editor
 ---
-
 # Getting Started with Java in VS Code
 
 This tutorial shows you how to write and run Hello World program in Java with Visual Studio Code. It also covers a few advanced features, which you can explore by reading other documents in this section.

--- a/docs/java/java-webapp.md
+++ b/docs/java/java-webapp.md
@@ -1,12 +1,8 @@
 ---
-Area: java
-TOCTitle: Java Web App
 ContentId: 98ddf1d3-6a8e-4b0f-a44d-e57cfdf2348c
-PageTitle: Build and Deploy Java Web Apps to the cloud with Visual Studio Code
 DateApproved: 3/2/2023
 MetaDescription: Java web app tutorial showing how to build and deploy a Java web app to Azure with Visual Studio Code
 ---
-
 # Java Web Apps with Visual Studio Code
 
 This tutorial shows you how to create a Java web application with Visual Studio Code. You'll learn how to deploy a Java web application to a Linux Tomcat server in Azure App Service.

--- a/docs/languages/cpp.md
+++ b/docs/languages/cpp.md
@@ -1,9 +1,5 @@
 ---
-Order: 9
-Area: languages
-TOCTitle: C++
 ContentId: D06C8C5C-2D3A-4B2E-B31F-12F1907E6402
-PageTitle: C++ programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Find out how to get the best out of Visual Studio Code and C++.
 MetaSocialImage: images/cpp/languages-cpp-social.png

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -1,9 +1,5 @@
 ---
-Order: 19
-Area: languages
-TOCTitle: C#
 ContentId: 40C8AAC1-C00D-4E91-8877-737A598346B6
-PageTitle: C# programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Find out how to get the best out of Visual Studio Code and C#.
 MetaSocialImage: images/csharp/languages-csharp-social.png

--- a/docs/languages/css.md
+++ b/docs/languages/css.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: languages
-TOCTitle: CSS, SCSS and Less
 ContentId: 039882CB-B5C4-46BD-A8D5-DB24A5E82706
-PageTitle: CSS, SCSS, and Less support in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Find out how Visual Studio Code can support your CSS, SCSS and Less development.
 ---

--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -1,9 +1,5 @@
 ---
-Order: 20
-Area: languages
-TOCTitle: .NET
 ContentId: AFFD7BDB-925E-4D02-828D-4E14360C70DA
-PageTitle: .NET and Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get started writing and debugging .NET apps with Visual Studio Code.
 ---

--- a/docs/languages/emmet.md
+++ b/docs/languages/emmet.md
@@ -1,9 +1,5 @@
 ---
-Order: 18
-Area: editor
-TOCTitle: Emmet
 ContentId: baf4717c-ea52-486e-9ea3-7bf1c4134dad
-PageTitle: Emmet in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Using Emmet abbreviations inside Visual Studio Code.
 ---

--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -1,9 +1,5 @@
 ---
-Order: 17
-Area: languages
-TOCTitle: Go
 ContentId: 6f06908a-6694-4fad-ac1e-fc6d9c5747ca
-PageTitle: Go with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Go.
 ---

--- a/docs/languages/html.md
+++ b/docs/languages/html.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: languages
-TOCTitle: HTML
 ContentId: 43095EAF-4B93-407C-A6F9-6DB173D79088
-PageTitle: HTML Programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get the best out of Visual Studio Code for HTML development
 ---

--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -1,8 +1,5 @@
 ---
-Area: languages
-TOCTitle: Language Identifiers
 ContentId: 3f773ade-7e71-4fb9-9bb9-d9e0b20fa799
-PageTitle: Visual Studio Code language identifiers
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code language mode identifiers
 ---

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -1,9 +1,5 @@
 ---
-Order: 10
-Area: languages
-TOCTitle: Java
 ContentId: 080fd21f-92b7-4491-9ab2-6eb9a3bb0793
-PageTitle: Java in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Java.
 ---

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -1,13 +1,8 @@
 ---
-Order: 2
-Area: languages
-TOCTitle: JavaScript
 ContentId: F54BB3D4-76FB-4547-A9D0-F725CEBB905C
-PageTitle: JavaScript Programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get the best out of Visual Studio Code for JavaScript development
 ---
-
 # JavaScript in Visual Studio Code
 
 Visual Studio Code includes built-in JavaScript IntelliSense, debugging, formatting, code navigation, refactorings, and many other advanced language features.

--- a/docs/languages/jsconfig.md
+++ b/docs/languages/jsconfig.md
@@ -1,9 +1,5 @@
 ---
-Order:
-Area: languages
-TOCTitle: Appendix - jsconfig.json
 ContentId: 201cd81d-523c-4f62-b1f5-ed26c091657b
-PageTitle: jsconfig.json Reference
 DateApproved: 05/08/2025
 MetaDescription: View the reference for jsconfig.json.
 ---

--- a/docs/languages/json.md
+++ b/docs/languages/json.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: languages
-TOCTitle: JSON
 ContentId: FB3B14D9-A59A-4968-ACFC-5FB5D4E9B70E
-PageTitle: JSON editing in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Edit JSON files in Visual Studio Code
 ---

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -1,9 +1,5 @@
 ---
-Order: 13
-Area: languages
-TOCTitle: Julia
 ContentId: d7ec8e7c-de5e-42b3-86df-a48660f1f6e1
-PageTitle: Julia in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about working with the Julia programming language in Visual Studio Code.
 ---

--- a/docs/languages/markdown.md
+++ b/docs/languages/markdown.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: languages
-TOCTitle: Markdown
 ContentId: 47A8BA5A-A103-4B61-B5FB-185C15E54C52
-PageTitle: Markdown editing with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get the best out of Visual Studio Code for Markdown
 ---

--- a/docs/languages/overview.md
+++ b/docs/languages/overview.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: languages
-TOCTitle: Overview
 ContentId: AC888642-FBE5-43E5-9DC2-47B197717940
-PageTitle: Language Support in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: In Visual Studio Code we have support for all common languages including smart code completion and debugging.
 ---

--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: languages
-TOCTitle: PHP
 ContentId: DD4E5A59-1586-4A5D-8047-3D58B2FE6937
-PageTitle: PHP Programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code editor features (syntax highlighting, snippets, linting) and extensions for PHP.
 ---

--- a/docs/languages/polyglot.md
+++ b/docs/languages/polyglot.md
@@ -1,9 +1,5 @@
 ---
-Order: 21
-Area: languages
-TOCTitle: Polyglot
 ContentId: 4bbd7ad1-8420-4ddd-a86f-442497e597b1
-PageTitle: Polyglot Programming with Notebooks in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Polyglot Notebooks for multiple programming languages in Visual Studio Code.
 ---

--- a/docs/languages/powershell.md
+++ b/docs/languages/powershell.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: languages
-TOCTitle: PowerShell
 ContentId: 8688bb6d-793e-4a37-aed2-5af4cfe89940
-PageTitle: PowerShell editing with Visual Studio Code
 DateApproved: 02/20/2025
 MetaDescription: Learn about using PowerShell in Visual Studio Code
 ---

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -1,9 +1,5 @@
 ---
-Order: 12
-Area: languages
-TOCTitle: Python
 ContentId: c2cb770d-571d-4edf-9eb9-b5b8977c21a0
-PageTitle: Python in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code as a Python IDE (code completion, debugging, linting).
 ---

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -1,13 +1,8 @@
 ---
-Order: 14
-Area: languages
-TOCTitle: R
 ContentId: 1eb31e23-be14-4613-be84-621a51cb59d7
-PageTitle: R in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about working with the R programming language in Visual Studio Code.
 ---
-
 # R in Visual Studio Code
 
 The [R programming language](https://www.r-project.org/) is a dynamic language built for statistical computing and graphics. R is commonly used in statistical analysis, scientific computing, machine learning, and data visualization.

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -1,9 +1,5 @@
 ---
-Order: 15
-Area: languages
-TOCTitle: Ruby
 ContentId: 33c079a7-f8d5-48fc-9d92-16be760b42ab
-PageTitle: Ruby with Visual Studio Code
 DateApproved: 19/09/2024
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Ruby.
 ---

--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -1,9 +1,5 @@
 ---
-Order: 16
-Area: languages
-TOCTitle: Rust
 ContentId: 643d022e-9370-4ca5-bccd-c3a583c5df75
-PageTitle: Rust with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Rust.
 ---

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -1,8 +1,4 @@
 ---
-Order: 22
-Area: languages
-TOCTitle: Swift
-PageTitle: Swift with Visual Studio Code
 DateApproved: 2/19/2025
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, testing) for Swift.
 ---

--- a/docs/languages/tsql.md
+++ b/docs/languages/tsql.md
@@ -1,9 +1,5 @@
 ---
-Order: 18
-Area: languages
-TOCTitle: T-SQL
 ContentId: 5325cf50-e4c7-11e6-bf01-fe55135034f3
-PageTitle: Transact-SQL with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code editor features (code completion, debugging, snippets, linting) for Transact-SQL.
 ---

--- a/docs/languages/typescript.md
+++ b/docs/languages/typescript.md
@@ -1,14 +1,9 @@
 ---
-Order: 6
-Area: languages
-TOCTitle: TypeScript
 ContentId: 05C114DF-4FDC-4C65-8954-58F5F293FAFD
-PageTitle: TypeScript Programming with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get the best out editing TypeScript with Visual Studio Code.
 MetaSocialImage: images/typescript/typescript-social.png
 ---
-
 # TypeScript in Visual Studio Code
 
 [TypeScript](https://www.typescriptlang.org) is a typed superset of JavaScript that compiles to plain JavaScript. It offers classes, modules, and interfaces to help you build robust components.

--- a/docs/nodejs/angular-tutorial.md
+++ b/docs/nodejs/angular-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: nodejs
-TOCTitle: Angular Tutorial
 ContentId: f6b7b0c2-ccbe-4e5f-8f2e-6c1ecea52f69
-PageTitle: Angular TypeScript Tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Angular TypeScript tutorial showing IntelliSense, debugging, and code navigation support in the Visual Studio Code editor.
 MetaSocialImage: images/angular/Welcome-to-app.png

--- a/docs/nodejs/browser-debugging.md
+++ b/docs/nodejs/browser-debugging.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: nodejs
-TOCTitle: Browser Debugging
 ContentId: d0e271da-0372-4ab9-a2ab-b7add855bd5a
-PageTitle: Debug Browser Apps using Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: The Visual Studio Code editor includes browser debugging support. Set breakpoints, step-in, inspect variables and more.
 MetaSocialImage: ../editor/images/debugging/debugging-social.png

--- a/docs/nodejs/debugging-recipes.md
+++ b/docs/nodejs/debugging-recipes.md
@@ -1,9 +1,5 @@
 ---
-Order: 10
-Area: nodejs
-TOCTitle: Debugging Recipes
 ContentId: 215832f9-d5bd-4cea-8cea-bfc4dc7ff7d1
-PageTitle: JavaScript Debugging Recipes for Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription:  Learn more about how to setup debugging in Visual Studio Code with debugging recipes
 MetaSocialImage: ../editor/images/debugging/debugging-social.png

--- a/docs/nodejs/extensions.md
+++ b/docs/nodejs/extensions.md
@@ -1,9 +1,5 @@
 ---
-Order: 12
-Area: nodejs
-TOCTitle: Extensions
 ContentId: 3224f624-a3fc-4eeb-81d1-eb653a90a6fc
-PageTitle: JavaScript Extensions in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn more about installing and integrating JavaScript and Node.js extensions in the Visual Studio Code editor.
 ---

--- a/docs/nodejs/nodejs-debugging.md
+++ b/docs/nodejs/nodejs-debugging.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: nodejs
-TOCTitle: Node.js Debugging
 ContentId: 3AC4DBB5-1469-47FD-9CC2-6C94684D4A9D
-PageTitle: Debug Node.js Apps using Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: The Visual Studio Code editor includes Node.js debugging support. Set breakpoints, step-in, inspect variables and more.
 MetaSocialImage: ../editor/images/debugging/debugging-social.png

--- a/docs/nodejs/nodejs-deployment.md
+++ b/docs/nodejs/nodejs-deployment.md
@@ -1,8 +1,4 @@
 ---
-Order: 4
-Area: nodejs
-TOCTitle: Deploy Node.js Apps
-PageTitle: Node.js Deployment with Visual Studio Code
 ContentId: 856a4a73-a4b4-4418-b88d-1f65d0ba7824
 MetaDescription: Node.js Deployment to Azure with Visual Studio Code
 DateApproved: 05/08/2025

--- a/docs/nodejs/nodejs-tutorial.md
+++ b/docs/nodejs/nodejs-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: nodejs
-TOCTitle: Node.js Tutorial
 ContentId: ED394CD2-D09E-4E3A-96AD-6D3D8337BA9D
-PageTitle: Build Node.js Apps with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: The Visual Studio Code editor has great support for writing and debugging Node.js applications. This tutorial takes you from Hello World to a full Express web application.
 MetaSocialImage: images/nodejs/runtimes-node-social.png

--- a/docs/nodejs/profiling.md
+++ b/docs/nodejs/profiling.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: nodejs
-TOCTitle: Performance Profiling
 ContentId: 3DAE803B-D479-4143-976F-B69F00A73891
-PageTitle: Performance Profiling JavaScript in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn more about profiling your JavaScript performance in the Visual Studio Code editor.
 ---

--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: nodejs
-TOCTitle: React Tutorial
 ContentId: 2dd2eeff-2eb3-4a0c-a59d-ea9a0b10c468
-PageTitle: React JavaScript Tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: React JavaScript tutorial showing IntelliSense, debugging, and code navigation support in the Visual Studio Code editor.
 ---

--- a/docs/nodejs/vuejs-tutorial.md
+++ b/docs/nodejs/vuejs-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: nodejs
-TOCTitle: Vue Tutorial
 ContentId: 85ce0bcc-d2b8-4b7c-b744-5eddce9a8d00
-PageTitle: Vue JavaScript Tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Vue JavaScript tutorial showing IntelliSense, debugging, and code navigation support in the Visual Studio Code editor.
 ---

--- a/docs/nodejs/working-with-javascript.md
+++ b/docs/nodejs/working-with-javascript.md
@@ -1,8 +1,4 @@
 ---
-Order: 1
-Area: nodejs
-TOCTitle: Working with JavaScript
-PageTitle: Working with JavaScript in Visual Studio Code
 ContentId: 3e5af2a6-7669-4b5d-b19f-78077af14fda
 DateApproved: 05/08/2025
 MetaDescription: Working with JavaScript in Visual Studio Code

--- a/docs/python/debugging.md
+++ b/docs/python/debugging.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: python
-TOCTitle: Debugging
 ContentId: 3d9e6bcf-eae8-4c94-b857-89225b5c4ab5
-PageTitle: Debugging configurations for Python apps in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Details on configuring the Visual Studio Code debugger for different Python applications.
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/editing.md
+++ b/docs/python/editing.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: python
-TOCTitle: Editing Code
 ContentId: 0ccb0e35-c4b2-4001-91bf-79ff1618f601
-PageTitle: Editing Python Code in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Editing Python in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/environments.md
+++ b/docs/python/environments.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: python
-TOCTitle: Environments
 ContentId: 8fe4ca8b-fc70-4216-86c7-2c11b6c14cc6
-PageTitle: Using Python Environments in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Configuring Python Environments in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/formatting.md
+++ b/docs/python/formatting.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: python
-TOCTitle: Formatting
 ContentId: c5039182-eee4-47ff-a2a8-dc28f4bc2cbc
-PageTitle: Formatting Python in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Formatting Python in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/jupyter-support-py.md
+++ b/docs/python/jupyter-support-py.md
@@ -1,14 +1,9 @@
 ---
-Order: 10
-Area: python
-TOCTitle: Python Interactive
 ContentId: C26E4F82-C6CD-4C52-818F-31A95F58207E
-PageTitle: Working with Jupyter code cells in the Python Interactive window
 DateApproved: 05/08/2025
 MetaDescription: Working with Jupyter code cells in the Python Interactive window
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Python Interactive window
 
 [Jupyter](https://jupyter-notebook.readthedocs.io/en/latest/) (formerly IPython Notebook) is an open-source project that lets you easily combine Markdown text and executable Python source code on one canvas called a **notebook**. Visual Studio Code supports working with [Jupyter Notebooks natively](/docs/datascience/jupyter-notebooks.md), as well as through Python code files. This topic covers the support offered through Python code files and demonstrates how to:

--- a/docs/python/linting.md
+++ b/docs/python/linting.md
@@ -1,14 +1,9 @@
 ---
-Order: 5
-Area: python
-TOCTitle: Linting
 ContentId: 0ccb0e35-c4b2-4001-91bf-79ff1618f601
-PageTitle: Linting Python in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Linting Python in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Linting Python in Visual Studio Code
 
 Linting highlights semantic and stylistic problems in your Python source code, which often helps you identify and correct subtle programming errors or coding practices that can lead to errors. For example, linting can detect the use of an undefined variable, calls to undefined functions, missing parentheses, and even more subtle issues such as attempting to redefine built-in types or functions. Linting is distinct from [Formatting](/docs/python/formatting.md) because linting analyzes how the code runs and detects errors, whereas formatting only restructures how code appears.

--- a/docs/python/python-on-azure.md
+++ b/docs/python/python-on-azure.md
@@ -1,9 +1,5 @@
 ---
-Order: 15
-Area: python
-TOCTitle: Deploy Python Apps
 ContentId: 12bf713e-5f20-46ac-81bb-8e05565aba3a
-PageTitle: Deploy Python Web Apps
 DateApproved: 05/08/2025
 MetaDescription: How to deploy Python applications to Azure with Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/python-quick-start.md
+++ b/docs/python/python-quick-start.md
@@ -1,14 +1,9 @@
 ---
-Order: 1
-Area: python
-TOCTitle: Quick Start
 ContentId: c7134463-4fdd-4674-8685-77c94472902c
-PageTitle: Quick Start Guide for Python in VS Code
 DateApproved: 05/08/2025
 MetaDescription: A quick start guide to get you up and coding with the Python extension in Visual Studio Code.
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Quick Start Guide for Python in VS Code
 
 The Python extension makes Visual Studio Code an excellent Python editor, works on any operating system, and is usable with a variety of Python interpreters.

--- a/docs/python/python-tutorial.md
+++ b/docs/python/python-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: python
-TOCTitle: Tutorial
 ContentId: 77828f36-ae45-4887-b25c-34545edd52d3
-PageTitle: Get Started Tutorial for Python in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: A Python hello world tutorial using the Python extension in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/python-web.md
+++ b/docs/python/python-web.md
@@ -1,9 +1,5 @@
 ---
-Order: 16
-Area: python
-TOCTitle: Python in the Web
 ContentId: 366e4bbf-fa87-4813-9dfc-6c831b20a4d2
-PageTitle: Run and Debug Python in the Web
 DateApproved: 05/08/2025
 MetaDescription: Run and Debug Python code in the Web.
 ---

--- a/docs/python/run.md
+++ b/docs/python/run.md
@@ -1,14 +1,9 @@
 ---
-Order: 3
-Area: python
-TOCTitle: Run Python Code
 ContentId:
-PageTitle: Running Python Code in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Running Python Code in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png
 ---
-
 # Running Python code in Visual Studio Code
 
 Whether you are experimenting with smaller lines of Python code in the REPL or ready to run a Python script, the Python extension offers multiple ways to run your code.

--- a/docs/python/settings-reference.md
+++ b/docs/python/settings-reference.md
@@ -1,9 +1,5 @@
 ---
-Order: 17
-Area: python
-TOCTitle: Settings Reference
 ContentId: d256dc5c-95e9-4c02-a82f-947bf34a3517
-PageTitle: Settings Reference for Python
 DateApproved: 3/6/2023
 MetaDescription: Settings Reference for the Python extension in Visual Studio Code
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/testing.md
+++ b/docs/python/testing.md
@@ -1,9 +1,5 @@
 ---
-Order: 9
-Area: python
-TOCTitle: Testing
 ContentId: 9480bef3-4dfc-4671-a454-b9252567bc60
-PageTitle: Testing Python in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Testing Python in Visual Studio Code including the Test Explorer
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/tutorial-create-containers.md
+++ b/docs/python/tutorial-create-containers.md
@@ -1,9 +1,5 @@
 ---
-Order: 14
-Area: python
-TOCTitle: Create containers
 ContentId: 4e45a3f6-b72d-4647-82a5-22f7ee593d47
-PageTitle: Create containers for Python web apps in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: How to create containers for Python web apps using the VS Code Container Tools extension
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/python/tutorial-django.md
+++ b/docs/python/tutorial-django.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: python
-TOCTitle: Django Tutorial
 ContentId: 3c0948f9-85a5-4dd4-a461-59788dbfce4c
-PageTitle: Python and Django tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Python Django tutorial demonstrating IntelliSense, code navigation, and debugging for both code and templates in Visual Studio Code, the best Python IDE.
 ---

--- a/docs/python/tutorial-fastapi.md
+++ b/docs/python/tutorial-fastapi.md
@@ -1,9 +1,5 @@
 ---
-Order: 12
-Area: python
-TOCTitle: FastAPI Tutorial
 ContentId: 0d32bced-91aa-5c2e-e569-6fc7995370ae
-PageTitle: Python and FastAPI tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Python FastAPI tutorial showing IntelliSense and debugging support in Visual Studio Code, the best Python IDE.
 ---

--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -1,9 +1,5 @@
 ---
-Order: 13
-Area: python
-TOCTitle: Flask Tutorial
 ContentId: 593d2dd6-20f0-4ad3-8ecd-067cc47ee217
-PageTitle: Python and Flask Tutorial in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Python Flask tutorial showing IntelliSense, debugging, and code navigation support in Visual Studio Code, the best Python IDE.
 MetaSocialImage: images/tutorial/python-social.png

--- a/docs/reference/tasks-appendix.md
+++ b/docs/reference/tasks-appendix.md
@@ -1,7 +1,5 @@
 ---
-TOCTitle: Tasks Appendix
 ContentId: 6DCA48F5-0566-4AEB-9C4C-CCBBA2945347
-PageTitle: Visual Studio Code Tasks Appendix
 DateApproved: 05/08/2025
 MetaDescription: Additional info for using task runners in Visual Studio Code.
 ---

--- a/docs/remote/codespaces.md
+++ b/docs/remote/codespaces.md
@@ -1,8 +1,4 @@
 ---
-Order: 5
-Area: remote
-TOCTitle: GitHub Codespaces
-PageTitle: Developing with GitHub Codespaces
 ContentId: 8d30ed21-208f-4b4e-8510-5a4a33c42618
 MetaDescription: Using GitHub Codespaces
 DateApproved: 05/08/2025

--- a/docs/remote/dev-containers.md
+++ b/docs/remote/dev-containers.md
@@ -1,8 +1,4 @@
 ---
-Order: 3
-Area: remote
-TOCTitle: Dev Containers
-PageTitle: Developing inside a Container using Visual Studio Code Remote Development
 ContentId: 4f0942be-6808-4252-8940-b9e9688792af
 MetaDescription: Developing inside a Container using Visual Studio Code Remote Development
 DateApproved: 05/08/2025

--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -1,8 +1,4 @@
 ---
-Order: 17
-Area: remote
-TOCTitle: FAQ
-PageTitle: Visual Studio Code Remote Development Frequently Asked Questions
 ContentId: 66bc3337-5fe1-4dac-bde1-a9302ff4c0cb
 MetaDescription: Visual Studio Code Remote Development Frequently Asked Questions (FAQ) for SSH, Containers, and WSL
 DateApproved: 05/08/2025

--- a/docs/remote/linux.md
+++ b/docs/remote/linux.md
@@ -1,8 +1,4 @@
 ---
-Order:
-Area: remote
-TOCTitle: Linux Prerequisites
-PageTitle: Linux Prerequisites for Visual Studio Code Remote Development
 ContentId: 7ec8dedf-0659-437e-98f1-2d27f5e243eb
 MetaDescription: Linux Prerequisites for VS Code Remote - SSH, Dev Containers, and WSL extensions
 DateApproved: 05/08/2025

--- a/docs/remote/remote-overview.md
+++ b/docs/remote/remote-overview.md
@@ -1,8 +1,4 @@
 ---
-Order: 1
-Area: remote
-TOCTitle: Overview
-PageTitle: Visual Studio Code Remote Development
 ContentId: eceea3f0-feee-47c2-8b65-1f1b0825355b
 MetaDescription: Visual Studio Code Remote Development
 DateApproved: 05/08/2025

--- a/docs/remote/ssh-tutorial.md
+++ b/docs/remote/ssh-tutorial.md
@@ -1,8 +1,4 @@
 ---
-Order: 8
-Area: remote
-TOCTitle: SSH Tutorial
-PageTitle: Connect over SSH with Visual Studio Code
 ContentId: beb86509-a36f-4e3b-a32e-b3d8c3966dd7
 MetaDescription: Connect over SSH with Visual Studio Code
 DateApproved: 05/08/2025

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -1,8 +1,4 @@
 ---
-Order: 2
-Area: remote
-TOCTitle: SSH
-PageTitle: Developing on Remote Machines using SSH and Visual Studio Code
 ContentId: 42e65445-fb3b-4561-8730-bbd19769a160
 MetaDescription: Developing on Remote Machines or VMs using Visual Studio Code Remote Development and SSH
 DateApproved: 05/08/2025

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -1,8 +1,4 @@
 ---
-Order: 16
-Area: remote
-TOCTitle: Tips and Tricks
-PageTitle: Visual Studio Code Remote Development Troubleshooting Tips and Tricks
 ContentId: 42e65445-fb3b-4561-8730-bbd19769a160
 MetaDescription: Visual Studio Code Remote Development troubleshooting tips and tricks for SSH, Containers, and the Windows Subsystem for Linux (WSL)
 DateApproved: 05/08/2025

--- a/docs/remote/tunnels.md
+++ b/docs/remote/tunnels.md
@@ -1,8 +1,4 @@
 ---
-Order: 7
-Area: remote
-TOCTitle: Tunnels
-PageTitle: Remote Tunnels
 ContentId: 5d33c1af-b4e6-4894-aae1-acf95ee3ffa8
 MetaDescription: Using the Visual Studio Code Remote Tunnels extension
 DateApproved: 05/08/2025

--- a/docs/remote/vscode-server.md
+++ b/docs/remote/vscode-server.md
@@ -1,8 +1,4 @@
 ---
-Order: 6
-Area: remote
-TOCTitle: VS Code Server
-PageTitle: Visual Studio Code Server
 ContentId: d750ab6d-82c2-4e64-8fbb-7888e1374381
 MetaDescription: Using Visual Studio Code Server
 DateApproved: 05/08/2025

--- a/docs/remote/wsl-tutorial.md
+++ b/docs/remote/wsl-tutorial.md
@@ -1,8 +1,4 @@
 ---
-Order: 10
-Area: remote
-TOCTitle: WSL Tutorial
-PageTitle: Work in Windows Subsystem for Linux with Visual Studio Code
 ContentId: 44988826-46b8-498a-b1c9-f821378c2870
 MetaDescription: Work in Windows Subsystem for Linux with Visual Studio Code
 DateApproved: 05/08/2025

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -1,8 +1,4 @@
 ---
-Order: 4
-Area: remote
-TOCTitle: Windows Subsystem for Linux
-PageTitle: Developing in the Windows Subsystem for Linux with Visual Studio Code
 ContentId: 79bcdbf9-d6a5-4e04-bbee-e7bb71f09f0a
 MetaDescription: Using Visual Studio Code Remote Development with the Windows Subsystem for Linux (WSL)
 DateApproved: 05/08/2025

--- a/docs/setup/additional-components.md
+++ b/docs/setup/additional-components.md
@@ -1,9 +1,5 @@
 ---
-Order: 7
-Area: setup
-TOCTitle: Additional Components
 ContentId: 243B79C2-819F-4257-B80D-2CD9CCB04C84
-PageTitle: Setting up additional components to use with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Setting up additional components to use with Visual Studio Code.
 ---

--- a/docs/setup/enterprise.md
+++ b/docs/setup/enterprise.md
@@ -1,9 +1,5 @@
 ---
-Order: 8
-Area: setup
-TOCTitle: Enterprise
 ContentId: 936ab8e0-3bbe-4842-bb17-ea314665c20a
-PageTitle: Visual Studio Code enterprise support
 DateApproved: 05/08/2025
 MetaDescription: Learn about Visual Studio Code's enterprise support features, such as group policies or restricting allowed extensions.
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: setup
-TOCTitle: Linux
 ContentId: 7FDF94DB-3527-4296-BE1C-493495B89408
-PageTitle: Running Visual Studio Code on Linux
 DateApproved: 05/08/2025
 MetaDescription: Get Visual Studio Code up and running on Linux.
 ---

--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: setup
-TOCTitle: macOS
 ContentId: EEADB50A-F5E3-41E9-89DA-35F165196691
-PageTitle: Running Visual Studio Code on macOS
 DateApproved: 05/08/2025
 MetaDescription: Get Visual Studio Code up and running on Mac (macOS).
 ---

--- a/docs/setup/network.md
+++ b/docs/setup/network.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: setup
-TOCTitle: Network
 ContentId: 84F36EDE-4D66-4A2E-B4D1-F020C73EB2AD
-PageTitle: Setup Visual Studio Code's Network Connection
 DateApproved: 05/08/2025
 MetaDescription: Setup VS Code's Network Connection.
 ---

--- a/docs/setup/raspberry-pi.md
+++ b/docs/setup/raspberry-pi.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: setup
-TOCTitle: Raspberry Pi
 ContentId: E059E35A-8AD0-4D4A-9BE1-E23D45D75C1C
-PageTitle: Running Visual Studio Code on Raspberry Pi OS
 DateApproved: 05/08/2025
 MetaDescription: Get Visual Studio Code up and running on Raspberry Pi OS.
 ---

--- a/docs/setup/setup-overview.md
+++ b/docs/setup/setup-overview.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: setup
-TOCTitle: Overview
 ContentId: FC5262F3-D91D-4665-A5D2-BCBCCF66E53A
-PageTitle: Setting up Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get Visual Studio Code up and running.
 MetaSocialImage: images/quicksetup/quick-setup-social.png

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -1,9 +1,5 @@
 ---
-Order: 9
-Area: setup
-TOCTitle: Uninstall
 ContentId: 435486d3-ad55-4a31-a087-d108f75ba669
-PageTitle: Uninstall Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Uninstall Visual Studio Code and clean up.
 ---

--- a/docs/setup/vscode-web.md
+++ b/docs/setup/vscode-web.md
@@ -1,9 +1,5 @@
 ---
-Order: 11
-Area: editor
-TOCTitle: VS Code for the Web
 ContentId: d665a790-1da1-4f45-bc0f-c09822528e55
-PageTitle: Visual Studio Code for the Web
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code for the Web and the vscode.dev URL
 ---

--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: setup
-TOCTitle: Windows
 ContentId: 4670C281-5761-46E6-8C46-10D523946FFB
-PageTitle: Running Visual Studio Code on Windows
 DateApproved: 05/08/2025
 MetaDescription: Get Visual Studio Code up and running on Windows
 ---

--- a/docs/sourcecontrol/faq.md
+++ b/docs/sourcecontrol/faq.md
@@ -1,8 +1,4 @@
 ---
-Order: 16
-Area: sourcecontrol
-TOCTitle: FAQ
-PageTitle: Source Control, Git & GitHub in VS Code Frequently Asked Questions
 ContentId: 431b4458-34c4-4aba-a0ee-eaddf7cd91a1
 MetaDescription: Visual Studio Code's Frequently Asked Questions (FAQ) for Source Control, Git & GitHub in VS Code
 DateApproved: 05/08/2025

--- a/docs/sourcecontrol/github.md
+++ b/docs/sourcecontrol/github.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: sourcecontrol
-TOCTitle: Collaborate on GitHub
 ContentId: bd1be8cf-b745-4737-be48-db381ec3acc6
-PageTitle: Collaborate on GitHub
 DateApproved: 05/08/2025
 MetaDescription: Working with GitHub Pull Requests and Issues in Visual Studio Code
 ---

--- a/docs/sourcecontrol/intro-to-git.md
+++ b/docs/sourcecontrol/intro-to-git.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: sourcecontrol
-TOCTitle: Introduction to Git
 ContentId: b3e4717d-81e2-4bfa-a022-c37aab950bce
-PageTitle: Introduction to Git in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Get started with Git in Visual Studio Code and take control of your code! Our beginner's guide covers everything you need to know, from setting up a repository to committing changes and collaborating with others. Learn Git today and streamline your development workflow.
 ---

--- a/docs/sourcecontrol/overview.md
+++ b/docs/sourcecontrol/overview.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: sourcecontrol
-TOCTitle: Overview
 ContentId: 7E22CCC0-2AB8-4729-A4C9-BE2B16853820
-PageTitle: Source Control with Git in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code source control management with integrated Git support.
 ---

--- a/docs/terminal/advanced.md
+++ b/docs/terminal/advanced.md
@@ -1,9 +1,5 @@
 ---
-Order: 6
-Area: terminal
-TOCTitle: Advanced
 ContentId: D458AFDC-C001-43FD-A4BB-9474767B2C04
-PageTitle: Advanced Terminal Usage in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code's integrated terminal has several advanced features.
 ---

--- a/docs/terminal/appearance.md
+++ b/docs/terminal/appearance.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: terminal
-TOCTitle: Appearance
 ContentId: F1AA7F3E-E078-4C02-B2DE-EC3F5F36F751
-PageTitle: Terminal Appearance in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code's integrated terminal allows customizing its appearance in various ways.
 ---

--- a/docs/terminal/basics.md
+++ b/docs/terminal/basics.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: terminal
-TOCTitle: Terminal Basics
 ContentId: 7B4DC928-2414-4FC7-9C76-E4A13D6675FE
-PageTitle: Integrated Terminal in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code has an integrated terminal to enable working in your shell of choice without leaving the editor.
 ---

--- a/docs/terminal/getting-started.md
+++ b/docs/terminal/getting-started.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: terminal
-TOCTitle: Getting Started Tutorial
 ContentId: 7B4DC928-2414-4FC7-9C76-E4A13D6675FE
-PageTitle: Getting started with the integrated terminal
 DateApproved: 05/08/2025
 MetaDescription: Learn how to get started running shell commands with the integrated terminal in Visual Studio Code.
 ---

--- a/docs/terminal/profiles.md
+++ b/docs/terminal/profiles.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: terminal
-TOCTitle: Terminal Profiles
 ContentId: 1a9d76e8-9c8c-446e-974e-d71570e7d62a
-PageTitle: Terminal Profiles in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code's integrated terminal allows configuring various profiles to make launching various shells easier.
 ---

--- a/docs/terminal/shell-integration.md
+++ b/docs/terminal/shell-integration.md
@@ -1,13 +1,8 @@
 ---
-Order: 4
-Area: terminal
-TOCTitle: Shell Integration
 ContentId: a6a1652b-c0d8-4054-a2da-feb915eef2cc
-PageTitle: Terminal Shell Integration in Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Visual Studio Code's embedded terminal can integrate with some shells to enhance the capabilities of the terminal.
 ---
-
 # Terminal Shell Integration
 
 Visual Studio Code has the ability to integrate with common shells, allowing the terminal to understand more about what's actually happening inside the shell. This additional information enables some useful features such as [working directory detection](#current-working-directory-detection) and command detection, [decorations](#command-decorations-and-the-overview-ruler), and [navigation](#command-navigation).

--- a/docs/typescript/typescript-compiling.md
+++ b/docs/typescript/typescript-compiling.md
@@ -1,9 +1,5 @@
 ---
-Order: 2
-Area: typescript
-TOCTitle: Compiling
 ContentId: 59543856-da91-4a0d-9a98-9d5f2bf70c71
-PageTitle: TypeScript Compiling with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about TypeScript compiling with Visual Studio Code.
 ---

--- a/docs/typescript/typescript-debugging.md
+++ b/docs/typescript/typescript-debugging.md
@@ -1,9 +1,5 @@
 ---
-Order: 5
-Area: typescript
-TOCTitle: Debugging
 ContentId: 19c60eb6-662b-444a-92f6-009642cc1e5b
-PageTitle: TypeScript debugging with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: TypeScript debugging with Visual Studio Code.
 MetaSocialImage: ../languages/images/typescript/typescript-social.png

--- a/docs/typescript/typescript-editing.md
+++ b/docs/typescript/typescript-editing.md
@@ -1,9 +1,5 @@
 ---
-Order: 3
-Area: typescript
-TOCTitle: Editing
 ContentId: db5139eb-9623-4d0b-8180-8b495e2b8b06
-PageTitle: TypeScript editing with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about TypeScript editing with Visual Studio Code.
 ---

--- a/docs/typescript/typescript-refactoring.md
+++ b/docs/typescript/typescript-refactoring.md
@@ -1,9 +1,5 @@
 ---
-Order: 4
-Area: typescript
-TOCTitle: Refactoring
 ContentId: ff7a9f28-26b2-4ac6-8c16-1a16182bb6ca
-PageTitle: TypeScript refactoring with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: Learn about TypeScript refactorings supported by Visual Studio Code.
 ---

--- a/docs/typescript/typescript-tutorial.md
+++ b/docs/typescript/typescript-tutorial.md
@@ -1,9 +1,5 @@
 ---
-Order: 1
-Area: typescript
-TOCTitle: Tutorial
 ContentId: cb4f3742-733c-49d8-96db-d4bf8403bf64
-PageTitle: TypeScript tutorial with Visual Studio Code
 DateApproved: 05/08/2025
 MetaDescription: TypeScript tutorial with Visual Studio Code.
 MetaSocialImage: ../languages/images/typescript/typescript-social.png


### PR DESCRIPTION
Remove metadata fields that are now handled through the `toc.json` file: Order, Area, TocTitle, PageTitle