### PR TITLE
Fix "experimental network view" link in 1.100 release notes

### DIFF
--- a/release-notes/v1_100.md
+++ b/release-notes/v1_100.md
@@ -440,7 +440,7 @@ Thanks to a community contribution, we now have a context menu in the disassembl
 
 ### JavaScript debugger Network view
 
-Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
+Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#_experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
 
 ## Languages
 


### PR DESCRIPTION
This PR just adds a missing underscore to the "experimental network view" link in the 1.100 release notes.