### PR TITLE
fix: swap "experimental" settings reference to "preview"

### DIFF
--- a/docs/configure/settings.md
+++ b/docs/configure/settings.md
@@ -340,7 +340,7 @@ Features and their corresponding settings can be in one of the following states.
 
     ![Settings editor filtered with '@tag:experimental' showing experimental settings.](images/settings/settings-editor-experimental.png)
 
-* **Preview** - Preview features and settings have the final functionality but might still be iterated on for stability and polishing. Usually, preview features are disabled by default. In the Settings editor, these settings have an `Preview` label. You can also search experimental settings by entering `@tag:preview` in the search box.
+* **Preview** - Preview features and settings have the final functionality but might still be iterated on for stability and polishing. Usually, preview features are disabled by default. In the Settings editor, these settings have an `Preview` label. You can also search preview settings by entering `@tag:preview` in the search box.
 
     ![Settings editor filtered with '@tag:preview' showing preview settings.](images/settings/settings-editor-preview.png)
 


### PR DESCRIPTION
Replaces an "experimental settings" reference with "preview settings" in the description of the **Preview** state to match the focus of the section (since experimental settings are focused in the previous section).