### PR TITLE
Remove unrelated para from "AI ... Convert Format String ..." section

### DIFF
--- a/release-notes/v1_100.md
+++ b/release-notes/v1_100.md
@@ -516,8 +516,6 @@ This experience is enabled via the following setting:
 "python.analysis.aiCodeActions": {"convertFormatString": true}
 ```
 
-Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let AI handle the implementation. If you want, you can then use Pylance's **Move Symbol** Code Actions to move it to a different file.
-
 ### GitHub Pull Requests and Issues
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:


### PR DESCRIPTION
This PR removes an unrelated paragraph from the "Contributions to extensions -> Python -> AI Code Actions: Convert Format String (Experimental)" section under the 1.100 release notes. The removal is because it doesn't appear that one should get a new symbol when converting Python string concatenations to f-string or format(), much less a class or function, and "... let AI handle the implementation" -- what would AI implement?