### PR TITLE
Revert "Remove preview moniker for MCP support"

### DIFF
--- a/api/extension-guides/mcp.md
+++ b/api/extension-guides/mcp.md
@@ -17,8 +17,8 @@ VS Code extensions can also register MCP server configurations programmatically 
 
 Instead of using MCP servers to extend the chat functionality, you can also [contribute language model tools](/api/extension-guides/tools) directly within your extension. This approach is useful if you want to deeply integrate with VS Code by using extension APIs or to avoid that users have to install and run an MCP server in a separate process.
 
-> [!NOTE]
-> MCP support in VS Code is available starting from VS Code 1.99.
+> [!IMPORTANT]
+> MCP support in VS Code is currently in preview.
 
 ## Register an MCP server
 

--- a/docs/copilot/chat/mcp-servers.md
+++ b/docs/copilot/chat/mcp-servers.md
@@ -4,11 +4,14 @@ DateApproved: 06/12/2025
 MetaDescription: Learn how to configure and use Model Context Protocol (MCP) servers with GitHub Copilot in Visual Studio Code.
 MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
-# Use MCP servers in VS Code
+# Use MCP servers in VS Code (Preview)
 
 Model Context Protocol (MCP) servers enable you to expand your chat experience in VS Code with extra tools for connecting to databases, invoking APIs, or performing specialized tasks.
 Model Context Protocol (MCP) is an open standard that enables AI models to interact with external tools and services through a unified interface.
 This article guides you through setting up MCP servers and using tools with agent mode in Visual Studio Code.
+
+> [!NOTE]
+> MCP support in VS Code is currently in preview.
 
 ## Prerequisites
 
@@ -59,7 +62,7 @@ MCP is still a relatively new standard, and the ecosystem is rapidly evolving. A
 ## Enable MCP support in VS Code
 
 > [!NOTE]
-> MCP support in VS Code is available starting from VS Code 1.99.
+> MCP support in agent mode in VS Code is available starting from VS Code 1.99 and is currently in preview.
 
 To enable MCP support in VS Code, enable the `setting(chat.mcp.enabled)` setting.
 

--- a/docs/copilot/reference/copilot-settings.md
+++ b/docs/copilot/reference/copilot-settings.md
@@ -51,9 +51,7 @@ The team is continuously working on improving Copilot in VS Code and adding new 
 * `setting(chat.agent.maxRequests)`: Maximum number of requests that Copilot can make in agent mode (default: 15)
 * `setting(github.copilot.chat.agent.autoFix)`: Automatically diagnose and fix issues in the generated code changes (default: `true`)
 * `setting(github.copilot.chat.agent.runTasks)`: Run workspace tasks when using agent mode (default: `true`)
-* `setting(chat.mcp.enabled)` : Enable Model Context Protocol (MCP) support in VS Code. This enables adding tools from MCP servers in agent mode.
-* `setting(chat.mcp.discovery.enabled)`: Enable automatic discovery of MCP servers defined in other tools.
-* `setting(mcp)`: MCP server configuration. Contains a JSON object with the list of MCP servers, similar to the `mcp.json` file format. More details about [defining MCP servers in settings](/docs/copilot/chat/mcp-servers.md#add-an-mcp-server-to-your-user-settings).
+* `setting(chat.mcp.enabled)` _(Preview)_: Enable Model Context Protocol (MCP) support in VS Code. This enables adding tools from MCP servers in agent mode.
 * `setting(github.copilot.chat.codesearch.enabled)` _(Preview)_: When using `#codebase` in the prompt, Copilot automatically discovers relevant files to be edited.
 * `setting(chat.implicitContext.enabled)` _(Experimental)_: Configure if the active editor should be automatically added as context to the chat prompt.
 * `setting(github.copilot.chat.agent.thinkingTool:true)` _(Experimental)_: Enable the thinking tool in agent mode.


### PR DESCRIPTION
Reverts microsoft/vscode-docs#8482