### PR TITLE
Fix incorrect mention of security issues in 1.101.1 release notes

### DIFF
--- a/release-notes/v1_101.md
+++ b/release-notes/v1_101.md
@@ -11,7 +11,7 @@ DownloadVersion: 1.101.1
 
 _Release date: June 12, 2025_
 
-**Update 1.101.1**: The update addresses these security [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22May+2025+Recovery+1%22+).
+**Update 1.101.1**: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22May+2025+Recovery+1%22+).
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 


### PR DESCRIPTION
I've only glanced at them, but the listed issues seem to be "normal" issues to me, not security issues.