### PR TITLE
Replace hanging "and" with "."

### DIFF
--- a/release-notes/v1_101.md
+++ b/release-notes/v1_101.md
@@ -184,7 +184,7 @@ To define and use a custom chat mode, follow these steps:
 1. Define a custom mode by using the **Chat: Configure Chat Modes** command from the Command Palette.
 1. Provide the instructions and available tools for your custom chat mode in the `*.chatprompt.md` file that is created.
 1. In the Chat view, select the chat mode from the chat mode dropdown list.
-1. Submit your chat prompt and
+1. Submit your chat prompt.
 
 ![Screenshot of the custom chat mode selected in the Chat view.](images/1_101/custom-chat-mode-view.png)
 


### PR DESCRIPTION
Regarding the 1.101 release notes, "Custom chat modes (Preview)" section, this PR proposes replacing the hanging "and" there with a dot (`.`). It seems that additional words are unnecessary, and this is borne out by a previous iteration of that section (https://github.com/microsoft/vscode-docs/blame/cd87b04560378c3e34678b16b6d35cbbd696ae06/release-notes/v1_101.md#L177) which has only 3 words for the affected line.