### PR TITLE
Updates to the swift language docs

### DIFF
--- a/docs/languages/images/swift/configure-lldb.png
+++ b/docs/languages/images/swift/configure-lldb.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ec8b01dd598961c1db7b8e676bdb7ce3d7745de7c99c5178171f260a37439a9
-size 58059

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -76,8 +76,9 @@ which can include:
 ![Package swift actions](images/swift/package_actions.png)
 
 > [!IMPORTANT]
-> Before language features can be used you must perform a `swift build` command on your
-project either on the command line or using a task in VS Code. This populates the index in sourcekit-lsp.
+> Prior to Swift 6.1 you must perform a `swift build` command on your project either
+> on the command line or using a task in VS Code Before language features can be used.
+> This populates the index in SourceKit-LSP.
 
 ## Swift tasks
 
@@ -124,16 +125,8 @@ Visual Studio Code provides a rich debugging experience. See the
 more information.
 
 The Swift extension relies on the
-[Code-LLDB extension](https://github.com/vadimcn/vscode-lldb) to enable
+[LLDB DAP extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap) to enable
 debugging support.
-
-> [!IMPORTANT]
-> The Swift extension will prompt you to configure settings for LLDB the first
-> time you launch VS Code. You will need to either apply the configuration
-> globally (user settings) or to your workspace (workspace settings) for the
-> debugger to work properly.
-
-![Configure the Debugger](images/swift/configure-lldb.png)
 
 By default, the extension creates a launch configuration for each executable
 target in your Swift package. You may configure these yourself by adding a
@@ -144,10 +137,9 @@ target in your Swift package. You may configure these yourself by adding a
 {
   "configurations": [
     {
-      "type": "lldb",
+      "type": "swift",
       "name": "Debug swift-executable",
       "request": "launch",
-      "sourceLanguages": ["swift"],
       "args": ["--hello", "world"],
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/.build/debug/swift-executable",

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -77,7 +77,7 @@ which can include:
 
 > [!IMPORTANT]
 > Prior to Swift 6.1 you must perform a `swift build` command on your project either
-> on the command line or using a task in VS Code Before language features can be used.
+> on the command line or using a task in VS Code before language features can be used.
 > This populates the index in SourceKit-LSP.
 
 ## Swift tasks


### PR DESCRIPTION
Updates for new 6.1 release of the toolchain and for lldb-dap being the debugger dependency now