### PR TITLE
Update launch configuration and fix author name in blog post

### DIFF
--- a/.vscode/extensions/doc-assistant/.vscode/launch.json
+++ b/.vscode/extensions/doc-assistant/.vscode/launch.json
@@ -3,20 +3,5 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--profile-temp"
-			],
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		}
-	]
+	"ext install vscode-java-debug": ""
 }

--- a/blogs/2016/09/14/js_roundup_1.md
+++ b/blogs/2016/09/14/js_roundup_1.md
@@ -62,9 +62,9 @@ Marketplace - [npm IntelliSense](https://marketplace.visualstudio.com/items?item
 
 Publisher - [Christian Kohler](https://marketplace.visualstudio.com/search?term=publisher%3A%22Christian%20Kohler%22&target=VSCode)
 
-A second incredibly useful extension from Christian Kohler. This extension provides IntelliSense for npm modules.
+A second incredibly useful extension from Christian Kuler. This extension provides IntelliSense for npm modules.
 
 ![npm intellisense](npm_intellisense.gif)
 
-Wade Anderson, VS Code Team Member <br>
+Wade Anderson, VS Code Team Member
 [@waderyan_](https://twitter.com/waderyan_)


### PR DESCRIPTION
Replace the launch configuration for the doc-assistant extension and correct the author's name in the blog post.