### PR TITLE
chore: add step to rename optional npmrc files

### DIFF
--- a/.pipelines/templates/jobs/build.yml
+++ b/.pipelines/templates/jobs/build.yml
@@ -48,6 +48,12 @@ jobs:
   - script: npm config list
     displayName: List npm properties
 
+  - powershell: |
+      if (Test-Path "$(Pipeline.Workspace)/vscode-website/server/.npmrc.optional") {
+        mv "$(Pipeline.Workspace)/vscode-website/server/.npmrc.optional" "$(Pipeline.Workspace)/vscode-website/server/.npmrc"
+      }
+    displayName: Enforce .npmrc
+
   - task: npmAuthenticate@0
     displayName: Setup NPM Authentication
     inputs:


### PR DESCRIPTION
Reflects work on the website side to use .npmrc files only if a user wants to set up more internal functionality.