### PR TITLE
Tweak Copilot coding agent information in v1.102 release notes

### DIFF
--- a/release-notes/v1_102.md
+++ b/release-notes/v1_102.md
@@ -489,15 +489,25 @@ We now properly support Git Bash path completions for folders and files. Additio
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
 
-Deeper integration has been made between the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension and the [Copilot coding agent](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent), allowing you to begin, view, and manage coding agent sessions directly from VS Code.
+Deeper integration has been made between the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension and [Copilot coding agent](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent), allowing you to begin, view, and manage coding agent sessions directly from VS Code.
 
-These features require your workspace is open to a repository that has [the Copilot coding agent enabled](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/enabling-copilot-coding-agent).
+These features require that your workspace is open to a repository that has [the Copilot coding agent enabled](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/enabling-copilot-coding-agent).
 
 Review the [changelog for the 0.114.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01140) release of the extension to learn about everything in the release.
 
+#### Start a coding agent session (Preview)
+
+Ask Copilot to continue a local change in the background by invoking the `#copilotCodingAgent` tool in chat.
+
+This tool automatically pushes pending changes to a remote branch and initiates a coding agent session from that branch along with the user's instruction.
+
+![Screenshot showing handing off a session to Copilot coding agent](images/1_102/coding-agent-start.png)
+
+**Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the agent enabled.
+
 #### Status tracking
 
-We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new coding agent changes.
+We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new changes.
 
 ![Screenshot showing status of multiple coding agent pull requests](images/1_102/coding-agent-status.png)
 
@@ -512,16 +522,6 @@ You can now view the session log of a coding agent session directly in VS Code. 
 The `#activePullRequest` tool returns information about the pull request, such as its title, description, and status for use in chat, and now you can also use it to get the coding agent session information.
 
 This tool is automatically attached to chat when opening a pull request created through the coding agent experience, so you can maintain the context and keep working on the pull request if needed to.
-
-#### Start a coding agent session (Preview)
-
-Delegate the remainder of a local change to coding agent by invoking the `#copilotCodingAgent` tool in chat.
-
-This tool automatically pushes pending changes to a remote branch and initiates a coding agent session from that branch along with the user's instruction.
-
-![Screenshot showing handing off a session to the coding agent.](images/1_102/coding-agent-start.png)
-
-**Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the coding agent enabled.
 
 ### Python
 


### PR DESCRIPTION
This PR makes a bunch of small changes to the changelog for v1.102 where we talk about the enhanced integration with Copilot coding agent. It:

* Re-orders starting new sessions from Copilot coding agent to the top
* Drops `the` from `the Copilot coding agent`
* Tweaks a few bits of a grammar here and there