### PR TITLE
Clarify instructions to remove Copilot (command palette)

### DIFF
--- a/docs/copilot/faq.md
+++ b/docs/copilot/faq.md
@@ -60,7 +60,7 @@ See [Use a different GitHub account with Copilot](/docs/copilot/setup.md#use-a-d
 
 ### How can I remove Copilot from VS Code?
 
-To remove Copilot from VS Code, select the **Hide Copilot** option from the Copilot menu in the VS Code title bar. This removes the Copilot menu from the title bar and the Status Bar, and removes the Chat view.
+To remove Copilot from VS Code, run the **Chat: Hide Copilot** command from the Command Palette (`kb(workbench.action.showCommands)`) or select the **Hide Copilot** option from the Copilot menu in the VS Code title bar. This removes the Copilot menu from the title bar and the Status Bar, and removes the Chat view.
 
 If you have already installed the Copilot extensions, you need to first uninstall the Copilot and Copilot Chat extensions from the Extensions view. After that, you can hide the Copilot menu.
 


### PR DESCRIPTION
Clarifies the instructions to remove Copilot. Particularly, adds a mention to the actual command ("Chat: Hide Copilot") that can be run in the command palette to disable copilot.

This change may help people that want to disable Copilot entirely because, despite the menu option is mentioned in a lot of issues, similar issues are being raised on a regular basis:
- https://github.com/microsoft/vscode/issues/257770
- https://github.com/microsoft/vscode/issues/257329
- https://github.com/microsoft/vscode/issues/257117
- https://github.com/microsoft/vscode/issues/256932
- https://github.com/microsoft/vscode/issues/255559
- https://github.com/microsoft/vscode/issues/253245
- https://github.com/microsoft/vscode/issues/251564
- https://github.com/microsoft/vscode/issues/251334
- https://github.com/microsoft/vscode/issues/249615
- https://github.com/microsoft/vscode/issues/249314
- https://github.com/microsoft/vscode/issues/247020
- https://github.com/microsoft/vscode/issues/245691
- https://github.com/microsoft/vscode/issues/242096
- https://github.com/microsoft/vscode/issues/241293
- https://github.com/microsoft/vscode/issues/237819