### PR TITLE
Clarify you can disable Copilot via settings

### DIFF
--- a/docs/copilot/faq.md
+++ b/docs/copilot/faq.md
@@ -60,7 +60,7 @@ See [Use a different GitHub account with Copilot](/docs/copilot/setup.md#use-a-d
 
 ### How can I remove Copilot from VS Code?
 
-To remove Copilot from VS Code, run the **Chat: Hide Copilot** command from the Command Palette (`kb(workbench.action.showCommands)`) or select the **Hide Copilot** option from the Copilot menu in the VS Code title bar. This removes the Copilot menu from the title bar and the Status Bar, and removes the Chat view.
+To remove Copilot from VS Code, run the **Chat: Hide Copilot** command from the Command Palette (`kb(workbench.action.showCommands)`) or select the **Hide Copilot** option from the Copilot menu in the VS Code title bar. This removes the Copilot menu from the title bar and the Status Bar, and removes the Chat view. Alternatively you can change the setting `chat.commandCenter.enabled` to `false`.
 
 If you have already installed the Copilot extensions, you need to first uninstall the Copilot and Copilot Chat extensions from the Extensions view. After that, you can hide the Copilot menu.
 


### PR DESCRIPTION
There are some specific instructions to disable Copilot. However, these instructions don’t work if the user has set `window.titleBarStyle` to `native`. This change documents an alternative that works for all users.