### PR TITLE
Clarify unpublished extension availability

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -175,7 +175,7 @@ Once unpublished, the extension's Availability status is changed to **Unpublishe
 ![Unpublished extension](images/publishing-extension/unpublished-extension.png)
 
 > [!NOTE]
-> When you unpublish an extension, the Marketplace preserves the extension statistics. The extension remains publicly discoverable and available via an existing, authenticated API.
+> When you unpublish an extension, the Marketplace preserves the extension statistics. The extension remains publicly discoverable and available via an existing API.
 
 ## Removing extensions
 


### PR DESCRIPTION
Update to https://github.com/microsoft/vscode-docs/pull/8712.

The API supports authentication; however, authentication is not required to see unpublished public extensions.

Merge this PR at will.

@mariaghiondea, @isidorn, @seaniyer, @Tyriar, @ntrogh