### PR TITLE
Just say "expand and collapse" since tool sets will not actually be expandable

### DIFF
--- a/release-notes/v1_103.md
+++ b/release-notes/v1_103.md
@@ -78,7 +78,7 @@ We've totally revamped the tool picker this iteration and adopted a new componen
 
 Notable features:
 
-* Expand or collapse tool sets, MCP servers, extension contributed tools, and more
+* Expand and collapse
 * Configuration options moved to the title bar
 * Sticky scrolling
 * Icon rendering


### PR DESCRIPTION
due to a candidate.