### PR TITLE
Bring back auto-approval at workspace level

### DIFF
--- a/release-notes/v1_103.md
+++ b/release-notes/v1_103.md
@@ -140,7 +140,6 @@ Early terminal auto-approve settings were introduced last month. This release, t
     ```
 
 - The auto approve reasoning is now logged to the Terminal Output channel. We plan to [surface this in the UI soon](https://github.com/microsoft/vscode/issues/256780).
-- For now auto approve will only be allowed in either User or Remote settings. We do plan to allow their use in workspace settings again in an upcoming release.
 
 ### Track progress with task lists (Experimental)
 


### PR DESCRIPTION
Update release notes to remove note about terminal auto-approval not available at workspace-level

Related issue: https://github.com/microsoft/vscode/issues/260536