### PR TITLE
fix: add env var to allow sending content for openai python sdk

### DIFF
--- a/docs/intelligentapps/tracing.md
+++ b/docs/intelligentapps/tracing.md
@@ -378,6 +378,9 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
+import os
+
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 
 # Set up resource
 resource = Resource(attributes={


### PR DESCRIPTION
Without the envionment variable, the body of OpenAI messages won't be captured in the tracing events. After added, the `Input + Output` tab will correctly show the message content:

<img width="2886" height="1539" alt="image" src="https://github.com/user-attachments/assets/b6861072-f1c5-48ba-b5ee-6d85169b06d7" />
