### PR TITLE
Document the ability to copy a chat session or individual messages

### DIFF
--- a/docs/copilot/chat/copilot-chat.md
+++ b/docs/copilot/chat/copilot-chat.md
@@ -146,8 +146,7 @@ Chat supports vision capabilities, which means you can attach an image as contex
 
 ## Chat history
 
-As you iterate and send multiple chat prompts in a chat session, VS Code uses the history of chat prompts and responses as context for your current chat prompt. This means that you can ask follow-up questions or clarify your previous question without having to repeat the context. For example, you can ask "How does *this*
-differ from ...", "Now add a test case", "explain in more detail", and more.
+As you iterate and send multiple chat prompts in a chat session, VS Code uses the history of chat prompts and responses as context for your current chat prompt. This means that you can ask follow-up questions or clarify your previous question without having to repeat the context. For example, you can ask "How does *this* differ from ...", "Now add a test case", "explain in more detail", and more.
 
 At any time, you can create a new chat session by using the **New Chat** (`+`) button (`kb(workbench.action.chat.newChat)`) in the Chat view. This can be useful if you want to move to a different topic and avoid the previous context and history.
 
@@ -155,7 +154,7 @@ To view the history of chat sessions, select the **Show Chats...** button in the
 
 ![Screenshot of the Chat view with the Show Chats... button highlighted](images/copilot-chat/copilot-chat-view-show-chats.png)
 
-You can export all prompts and responses for a chat session in a JSON file with the **Chat: Export Chat...** command in the Command Palette.
+You can export all prompts and responses for a chat session in a JSON file with the **Chat: Export Chat...** command in the Command Palette. You can also copy a specific chat prompt or response to the clipboard in markdown format, by Ctrl + right-clicking the message and selecting "Copy", or copy the entire chat session by Ctrl + right-clicking the Chat view and selecting "Copy All".
 
 ## Edit a previous chat request (Experimental)
 


### PR DESCRIPTION
This change adds documentation for the ability to copy a chat session (or individual messages within) as markdown.
