### PR TITLE
Add instructions for escaping special characters in glob patterns

### DIFF
--- a/docs/editor/glob-patterns.md
+++ b/docs/editor/glob-patterns.md
@@ -34,3 +34,5 @@ We implemented our own [glob matching library](https://github.com/microsoft/vsco
 ### Why does my glob pattern not work?
 
 Make sure that on Windows you are using `/` to separate paths and not `\`. Glob patterns in VS Code require `/` for separating paths but they will both match on `/` and `\` in paths.
+
+If you're trying to match a special character like `[` or `]` literally, you can escape it with a single character range to avoid it being interpreted in pattern matching. Backslashes do not escape them. For example, to match files under `src/routes/post/[id]/`, you would use the pattern `src/routes/post/[[]id[]]/**`.


### PR DESCRIPTION
I was struggling getting the `applyTo` front matter working with GitHub Copilot's custom instructions. You can see the [Copilot docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#using-one-or-more-instructionsmd-files-1) about how to use that property. I discovered it was because I needed to match square brackets literally in the path of files I was trying to include. Some frameworks explicitly depend on square brackets in file paths for certain functionality - in the case of SvelteKit, it uses them in file-based routing to differentiate params between routes.

I've added some instructions to the FAQs in the docs for troubleshooting glob issues. I'm happy to move it around or make any edits but I think it would be really useful to have for others trying to get glob patterns to work in similar projects.

Thank you!