### PR TITLE
Clarify usage of instructions files

### DIFF
--- a/docs/copilot/customization/custom-instructions.md
+++ b/docs/copilot/customization/custom-instructions.md
@@ -137,7 +137,7 @@ To use a `.github/copilot-instructions.md` file:
 
 Instead of using a single instructions file that applies to all chat requests, you can create multiple `.instructions.md` files that apply to specific file types or tasks. For example, you can create instructions files for different programming languages, frameworks, or project types.
 
-By using the `applyTo` frontmatter property in the instructions file header, you can specify a glob pattern to define which files the instructions should be applied to automatically.
+By using the `applyTo` frontmatter property in the instructions file header, you can specify a glob pattern to define which files the instructions should be applied to automatically. Instructions files are used when creating or modifying files and are typically not applied for read operations.
 
 Alternatively, you can manually attach an instructions file to a specific chat prompt by using the **Add Context** > **Instructions** option in the Chat view.
 


### PR DESCRIPTION
Add a note explaining that instructions files are applied during file creation or modification, and are not used for read operations.

Fixes https://github.com/microsoft/vscode-docs/issues/8724