### PR TITLE
[vnext] Fix some typos in release notes for v1.104

### DIFF
--- a/release-notes/v1_104.md
+++ b/release-notes/v1_104.md
@@ -351,7 +351,7 @@ VS Code now reads MCP server instructions and will include them in its base prom
 
 ### Cross-App Autodiscovery Off by Default
 
-VS Code by default has automatically discovered MCP servers installed in other apps, such as those in Claudee Code. As MCP support has matured in VS Code, we've now disabled this behavior, but it can be re-enabled using the setting `setting(chat.mcp.discovery.enabled)`.
+VS Code by default has automatically discovered MCP servers installed in other apps, such as those in Claude Code. As MCP support has matured in VS Code, we've now disabled this behavior, but it can be re-enabled using the setting `setting(chat.mcp.discovery.enabled)`.
 
 ### MCP access setting
 
@@ -532,7 +532,7 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 * Side Bar content collapses on narrow windows
 * Pull request and issue webviews restore after reload
-* The new "TODO" code action let's you delegate directly to the Copilot coding agent
+* The new "TODO" code action lets you delegate directly to the Copilot coding agent
 * Submodules can be ignored with `setting(githubPullRequests.ignoreSubmodules)`
 
 Review the [changelog for the 0.118.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01180) release of the extension to learn about everything in the release.

--- a/release-notes/v1_104.md
+++ b/release-notes/v1_104.md
@@ -687,7 +687,7 @@ Contributions to `vscode`:
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
   * fix: memory leak in pattern input widget [PR #258152](https://github.com/microsoft/vscode/pull/258152)
   * fix: memory leak in codelens controller [PR #263136](https://github.com/microsoft/vscode/pull/263136)
-  * fix: memory leak in accessibilty signal scheduler [PR #263147](https://github.com/microsoft/vscode/pull/263147)
+  * fix: memory leak in accessibility signal scheduler [PR #263147](https://github.com/microsoft/vscode/pull/263147)
   * fix: memory leak in QuickDiffModel [PR #265007](https://github.com/microsoft/vscode/pull/265007)
 * [@swordjjjkkk (Truman)](https://github.com/swordjjjkkk): Display Tab Indexes in VSCode [PR #209196](https://github.com/microsoft/vscode/pull/209196)
 * [@terreng (Terren)](https://github.com/terreng): Implement new option to control title scrollbar visibility [PR #246161](https://github.com/microsoft/vscode/pull/246161)

--- a/release-notes/v1_104.md
+++ b/release-notes/v1_104.md
@@ -335,7 +335,7 @@ A new chat editor is opened with the coding agent's progress shown in real-time.
 
 ### Editing Auto Approve
 
-The agent will now as you for confirmation before making edits to certain files. This is useful to prevent an agent which may have received malicious instructions from causing immediate negative side-effects on your machine.
+The agent will now ask you for confirmation before making edits to certain files. This is useful to prevent an agent which may have received malicious instructions from causing immediate negative side-effects on your machine.
 
 Common system folders, dotfiles, and files outside your workspace will require confirmation by default. You can customize patterns where confirmation is requested with the setting `setting(chat.tools.edits.autoApprove)`.
 


### PR DESCRIPTION
Fixes a typo in text added in https://github.com/microsoft/vscode-docs/pull/8880.

Edit: + some others