### PR TITLE
docs: fix broken link and some minor typos 

### DIFF
--- a/docs/azure/vscodeforweb.md
+++ b/docs/azure/vscodeforweb.md
@@ -67,7 +67,7 @@ To get started:
 
 The following are commonly used scenarios for the `\azure` environment.
 
-* [Using Azure AI Foundry to create a model deployment and open your code in VS Code]((https://ai.azure.com))
+* [Using Azure AI Foundry to create a model deployment and open your code in VS Code](https://ai.azure.com)
 
     1. From the Azure AI Foundry portal, select the best model for your use case, including o3, o4-mini or MAI-DS-R1 from Foundry Models. In this case, we’ll use gpt-4o-mini as an example model for an agent workflow.
 

--- a/docs/configure/keybindings.md
+++ b/docs/configure/keybindings.md
@@ -6,7 +6,7 @@ MetaSocialImage: images/keybinding/customization-keybindings-social.png
 ---
 # Keyboard shortcuts for Visual Studio Code
 
-Visual Studio Code lets you perform most tasks directly from the keyboard. This article explains how you can modify the default keyboard shorts that come with VS Code.
+Visual Studio Code lets you perform most tasks directly from the keyboard. This article explains how you can modify the default keyboard shortcuts that come with VS Code.
 
 > [!NOTE]
 > If you visit this page on a Mac, you will see the keyboard shortcuts for the Mac. If you visit using Windows or Linux, you will see the keys for that platform. If you need the keyboard shortcuts for another platform, hover your mouse over the key you are interested in.

--- a/docs/sourcecontrol/overview.md
+++ b/docs/sourcecontrol/overview.md
@@ -321,7 +321,7 @@ The Diff editor has a separate gutter in the middle, which enables you to **Stag
 ![Screenshot of the Diff editor, showing the Stage and Revert controls in the gutter](images/overview/diffEditor-stage-revert-demo.gif)
 
 > [!TIP]
-> You can diff any two files by first right-clicking on a file in the Explorer view and selecting **Select for Compare** and then right-click on the second file to compare with and select **Compare with Selected**. Alternatively, open the Command Palette (`kb(workbench.action.showCommands)`), and select ay of the **File: Compare** commands. Learn more about the different options to [compare files in VS Code](/docs/editing/codebasics.md#compare-files).
+> You can diff any two files by first right-clicking on a file in the Explorer view and selecting **Select for Compare** and then right-click on the second file to compare with and select **Compare with Selected**. Alternatively, open the Command Palette (`kb(workbench.action.showCommands)`), and select any of the **File: Compare** commands. Learn more about the different options to [compare files in VS Code](/docs/editing/codebasics.md#compare-files).
 
 ### Accessible Diff Viewer
 


### PR DESCRIPTION
This PR includes the following fixes: 

- Fix a broken link in `docs/azure/vscodeforweb.md`.
- Correct typos in `docs/configure/keybindings.md` and `docs/sourcecontrol/overview.md`.