### PR TITLE
Redirecting to julialang.org/install for recommended way of installin…

### DIFF
--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -15,7 +15,7 @@ Most of these features work out of the box, while some may require basic configu
 
 ## Getting started
 
-1. Install Julia for your platform: [https://julialang.org/downloads](https://julialang.org/downloads).
+1. Install Julia for your platform: [https://julialang.org/install](https://julialang.org/install).
 2. Install VS Code for your platform: [https://code.visualstudio.com/download](https://code.visualstudio.com/download).
 3. Open the Julia extension on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=julialang.language-julia) and press **Install**; or manually install by doing the following steps:
     1. Start VS Code.


### PR DESCRIPTION
The recommended way to install julia is through juliaup.
This patch modifies the plugin readme to point to the updated instructions