### PR TITLE
[Docs] Update linux.md - "Ubutun" Typo

### DIFF
--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -279,7 +279,7 @@ The current limit can be viewed by running:
 cat /proc/sys/fs/inotify/max_user_watches
 ```
 
-The limit can be increased to its maximum by editing `/etc/sysctl.conf` (except on Arch Linux and Ubutun 24.10 and later, read below) and adding this line to the end of the file:
+The limit can be increased to its maximum by editing `/etc/sysctl.conf` (except on Arch Linux and Ubuntu 24.10 and later, read below) and adding this line to the end of the file:
 
 ```bash
 fs.inotify.max_user_watches=524288


### PR DESCRIPTION
There is a typo in line 282 - Ubuntu is spelled incorrectly. Saw it because I'm having issues with the app tracking my changes.