### PR TITLE
Fix typo in configuration setting for auto-accept delay in chat edits

### DIFF
--- a/docs/copilot/chat/copilot-edits.md
+++ b/docs/copilot/chat/copilot-edits.md
@@ -78,7 +78,7 @@ If you stage your changes in the Source Control view, any pending edits are auto
 
 When you close VS Code, the status of the pending edits is remembered and restored when you reopen VS Code.
 
-To automatically accept all the suggested edits after a specific delay, configure the `setting(chat.editing.autoAccept)` setting. By hovering over the editor overlay controls, you can cancel the auto-accept countdown. If you automatically accept all edits, it's recommended to still review the changes before committing them in source control.
+To automatically accept all the suggested edits after a specific delay, configure the `setting(chat.editing.autoAcceptDelay)` setting. By hovering over the editor overlay controls, you can cancel the auto-accept countdown. If you automatically accept all edits, it's recommended to still review the changes before committing them in source control.
 
 ## Manage file edit approvals
 


### PR DESCRIPTION
This pull request updates documentation to clarify the correct configuration setting for auto-accepting suggested edits in VS Code Copilot Chat. The change ensures users reference the right setting name when configuring auto-accept delays.

Documentation accuracy:

* Updated the setting name from `setting(chat.editing.autoAccept)` to `setting(chat.editing.autoAcceptDelay)` in `docs/copilot/chat/copilot-edits.md` to accurately reflect the configuration for auto-accepting edits after a delay.