### PR TITLE
Fix typo in chat-agent-mode.md for auto-accept delay setting

### DIFF
--- a/docs/copilot/chat/chat-agent-mode.md
+++ b/docs/copilot/chat/chat-agent-mode.md
@@ -284,7 +284,7 @@ If you stage your changes in the Source Control view, any pending edits are auto
 
 When you close VS Code, the status of the pending edits is remembered and restored when you reopen VS Code.
 
-To automatically accept all the suggested edits after a specific delay, configure the `setting(chat.editing.autoAccept)` setting. By hovering over the editor overlay controls, you can cancel the auto-accept countdown. If you automatically accept all edits, it's recommended to still review the changes before committing them in source control.
+To automatically accept all the suggested edits after a specific delay, configure the `setting(chat.editing.autoAcceptDelay)` setting. By hovering over the editor overlay controls, you can cancel the auto-accept countdown. If you automatically accept all edits, it's recommended to still review the changes before committing them in source control.
 
 ## Manage file edit approvals
 


### PR DESCRIPTION
Corrected the setting name from `setting(chat.editing.autoAccept)` to `setting(chat.editing.autoAcceptDelay)` in `docs/copilot/chat/chat-agent-mode.md` to accurately reflect the configuration option for setting the auto-accept delay.