### PR TITLE
Fix todo list setting reference in agent mode documentation

### DIFF
--- a/docs/copilot/chat/chat-agent-mode.md
+++ b/docs/copilot/chat/chat-agent-mode.md
@@ -324,7 +324,7 @@ To have a better overview of the individual tasks that the agent is working on, 
 
 <video src="images/agent-mode/chat-todo-list.mp4" title="Video that shows the todo list in chat." autoplay loop controls muted></video>
 
-You can configure the visibility and position of the todo list control with the `setting(chat.todoListWidget.position)` setting.
+You can configure the visibility and position of the todo list control with the `setting(chat.agent.todoList.position)` setting.
 
 ## Use instructions to get AI edits that follow your coding style
 

--- a/docs/copilot/reference/copilot-settings.md
+++ b/docs/copilot/reference/copilot-settings.md
@@ -86,7 +86,7 @@ The team is continuously working on improving Copilot in VS Code and adding new 
 | `setting(chat.tools.global.autoApprove)`<br/>Automatically approve all tools - this setting [disables critical security protections](/docs/copilot/security.md). | `false` |
 | `setting(chat.agent.thinkingStyle)` _(Experimental)_<br/>Configure how thinking tokens are presented in chat. | `fixedScrolling` |
 | `setting(chat.mcp.autoStart)` _(Experimental)_<br/>Automatically start MCP servers when MCP configuration changes are detected. | `newAndOutdated` |
-| `setting(chat.todoListWidget.position)` _(Experimental)_<br/>Configure the visibility and position of the todo list control in chat. | `false` |
+| `setting(chat.agent.todoList.position)` _(Experimental)_<br/>Configure the visibility and position of the todo list control in chat. | `"default"` |
 | `setting(github.copilot.chat.newWorkspaceCreation.enabled)` _(Experimental)_<br/>Enable the agent mode tool for scaffolding a new workspace in chat. | `true` |
 | `setting(github.copilot.chat.agent.thinkingTool:true)` _(Experimental)_<br/>Enable the thinking tool in agent mode. | `false` |
 | `setting(github.copilot.chat.virtualTools.threshold)` _(Experimental)_<br/>Tool count over which virtual tools should be used. Virtual tools group similar sets of tools together and enable the model to activate them on-demand. Enables you to go beyond the limit of 128 tools for a chat request. | `128` |


### PR DESCRIPTION
The setting for controlling the visibility and position of the todo list control in chat has been renamed.

**Documentation updates for todo list setting:**

* Updated the configuration key for the todo list widget from `chat.todoListWidget.position` to `chat.agent.todoList.position` in both the usage documentation (`chat-agent-mode.md`) and the settings reference (`copilot-settings.md`). 

* Updated the default value for the `chat.agent.todoList.position` in the settings reference to `"default"`.