### PR TITLE
Fix code sample of `ignoreSync` contribution point

### DIFF
--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -451,15 +451,6 @@ You can set `ignoreSync` to `true` to prevent the setting from being synchronize
     }
   }
 }
-
-```json
-{
-  "remoteTunnelAccess.machineName": {
-    "type": "string",
-    "default": '',
-    "ignoreSync": true
-  }
-}
 ```
 
 #### Linking to settings


### PR DESCRIPTION
Removes a duplicate example for `ignoreSync` which had invalid JSON and incorrect markdown formatting for a code block.