### PR TITLE
Clarify vscode.dev/redirect is fallback auth endpoint

### DIFF
--- a/docs/setup/network.md
+++ b/docs/setup/network.md
@@ -29,7 +29,7 @@ If you are behind a firewall that needs to allow specific domains used by VS Cod
 * `download.visualstudio.microsoft.com` - Visual Studio download server, provides dependencies for some VS Code extensions (C++, C#)
 * `vscode-sync.trafficmanager.net` - Visual Studio Code Settings Sync service
 * `vscode-sync-insiders.trafficmanager.net` - Visual Studio Code Settings Sync service (Insiders)
-* `vscode.dev/redirect` - Used as a fallback when logging in with GitHub or Microsoft for an extension or Settings Sync
+* `vscode.dev` - Used as a fallback when logging in with GitHub or Microsoft for an extension or Settings Sync (just `vscode.dev/redirect`)
 * `*.vscode-unpkg.net` - Used when loading web extensions
 * `default.exp-tas.com` - Visual Studio Code Experiment Service, used to provide experimental user experiences
 


### PR DESCRIPTION
Updates the network documentation to clarify that only the specific `vscode.dev/redirect` endpoint is used as a fallback for authentication flows, rather than the entire `vscode.dev` domain.

This addresses security concerns from customers who were worried about allowing the entire vscode.dev domain (which has access to local file systems and extensions).

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/6244