### PR TITLE
Make sure Docker MCP links work

### DIFF
--- a/docs/copilot/customization/mcp-servers.md
+++ b/docs/copilot/customization/mcp-servers.md
@@ -133,7 +133,7 @@ To add an MCP server to your workspace:
 
 </details>
 
-<details id="#_add-an-mcp-server-to-your-user-settings">
+<details id="_add-an-mcp-server-to-your-user-settings">
 <summary>Add an MCP server to your user configuration</summary>
 
 To configure an MCP server for all your workspaces, you can add the server configuration to your user [profile](/docs/configure/profiles.md). This enables you to reuse the same server configuration across multiple projects.


### PR DESCRIPTION
The "Learn more" link isn't scoped properly. Makes it hard for a beginners to follow. https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server-to-your-user-settings

<img width="946" height="443" alt="image" src="https://github.com/user-attachments/assets/05ae85a8-e521-402c-84a9-3b3653ff3f7f" />
