### PR TITLE
docs: clarify workspace trust terminology for untrusted codebases

### DIFF
--- a/docs/copilot/security.md
+++ b/docs/copilot/security.md
@@ -136,7 +136,7 @@ While VS Code includes many security protections, users should remain proactive 
 
 * **Review MCP servers**: Verify that MCP servers come from a trustworthy source and review their configuration before starting them. Enable only MCP servers when you need their functionality.
 
-* **Open new codebases in restricted mode**: Until you've reviewed a project for malicious code like watch tasks or scripts, rely on the Workspace Trust boundary and open it in restricted mode. Opening a workspace in restricted mode also disables agent mode in that workspace.
+* **Open untrusted/foreign codebases in restricted mode**: Until you've reviewed a project for malicious code, rely on the Workspace Trust boundary and open it in restricted mode. Opening a workspace in restricted mode also disables agent mode in that workspace. Remember that any file could be pulled into the context by agent mode, so any file could theoretically cause a prompt injection attack.
 
 * **Consider using dev containers or VMs for isolation**: For enhanced security, run agent mode operations in isolated environments like [dev containers](https://code.visualstudio.com/docs/devcontainers/containers), GitHub Codespaces, or virtual machines to limit potential impact.
 


### PR DESCRIPTION
## Description
   This PR improves the clarity of the workspace trust documentation by:
   - Changing "new codebases" to "untrusted/foreign codebases" for better clarity
   - Adding a security note about agent mode and potential prompt injection attacks
   
   ## Related Issue
   Fixes #8989
   
   ## Changes Made
   - Updated `docs/copilot/security.md` to use more precise terminology
   - Added warning about files being pulled into context by agent mode
   
   ## Testing
   - Reviewed the wording for clarity
   - Ensured the security implications are properly communicated