### PR TITLE
Fix typos in VS Code v1.106 release notes post

### DIFF
--- a/release-notes/v1_106.md
+++ b/release-notes/v1_106.md
@@ -19,7 +19,7 @@ Welcome to the October 2025 release of Visual Studio Code.
 
 ![Graphic showing the key highlights of the October 2025 release: Agent HQ, Security and trust, and great editor experience.](images/1_106/release-highlights.png)
 
-This releases brings significant updates across three key areas:
+This release brings significant updates across three key areas:
 
 * **Agent HQ** is your single view to kick off, monitor, and review agent sessions, whether they're local or remote, from Copilot or OpenAI Codex
 * **Security and trust** help you stay in control and confidently delegate more tasks to AI
@@ -157,11 +157,11 @@ Chat modes have been renamed to custom agents throughout VS Code to better align
 
 ![Screenshot of the agent picker control.](images/1_106/agent-picker.png)
 
-When you create custom agents, the definition files are now located in `.github/agents` in your workspace. These files can use the `.agents.md` suffix and can also be used as Github Copilot Cloud Agents and CLI Agent.
+When you create custom agents, the definition files are now located in `.github/agents` in your workspace. These files can use the `.agents.md` suffix and can also be used as GitHub Copilot Cloud Agents and CLI Agents.
 
 Use **Chat: New Custom Agent...** to create a new agent and **Chat: Configure Custom Agents...** to manage them.
 
-If you have existing custom chat modes (`.chatmode.md` files in `.github/chatmodes`), they continue to work and are automatically treated as custom agents. When you open a chat agent file in the editor, a info marker appears on the first line with a quick fix to migrate it to a custom agent file.
+If you have existing custom chat modes (`.chatmode.md` files in `.github/chatmodes`), they continue to work and are automatically treated as custom agents. When you open a chat agent file in the editor, an info marker appears on the first line with a quick fix to migrate it to a custom agent file.
 
 ### Custom agent metadata
 
@@ -306,7 +306,7 @@ Auto approval status has moved from being inline inside the chat view to the too
 
 #### Auto approve parser improvements
 
-Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned paranthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
+Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned parenthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
 
 This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter/) into the feature and use a [PowerShell grammar](https://github.com/airbus-cert/tree-sitter-powershell) or a [bash grammar](https://github.com/tree-sitter/tree-sitter-bash) for everything else\*. So, even really complex cases should be correctly extracted:
 
@@ -391,7 +391,7 @@ The `setting(chat.agent.thinkingStyle)` was adjusted to three more common styles
 
 An additional setting, `setting(chat.agent.thinking.collapsedTools)`, adds tool calls into the collapsible thinking UI.
 
-![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](images/1_106/reasoning.png)
+![Screenshot showing reasoning tokens displayed in chat with interleaved tool calls and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](images/1_106/reasoning.png)
 
 ### Inline chat v2 (Preview)
 
@@ -446,7 +446,7 @@ When installing an MCP server, you can now choose whether to install it globally
 
 ### Authentication: Client ID Metadata Document authentication flow
 
-Authentication support for remote MCPs now supports the [Client ID Metadata Document (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) authentication flow, which is the future standard for OAuth in MCP. This flow enables a more secure and scaleable solution to authentication over [Dynamic Client Registiration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) because now authorization servers do not have to worry about issuing client IDs per-client.
+Authentication support for remote MCPs now supports the [Client ID Metadata Document (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) authentication flow, which is the future standard for OAuth in MCP. This flow enables a more secure and scalable solution to authentication over [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) because now authorization servers do not have to worry about issuing client IDs per-client.
 
 When connecting to an MCP server that uses an authorization server that supports CIMD, VS Code will automatically use that flow over DCR.
 
@@ -472,7 +472,7 @@ The chat input now announces the active agent and model in a clearer order so sc
 
 ### Notebook search
 
-Notebooks now supports searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
+Notebooks now support searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
 
 <video src="images/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
 
@@ -567,7 +567,7 @@ If we learned anything when building this feature it's that no one size fits all
 - `setting(terminal.integrated.suggest.selectionMode)` - How the Intellisense popup is focused which determines what `kbstyle(Enter)` and `kbstyle(Tab)` do.
 - (New!) `setting(terminal.integrated.suggest.insertTrailingSpace)` - Insert a trailing space and re-trigger completions after accepting.
 
-If you are don't see the feature yet, make sure you have [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) enabled and enable IntelliSense explicitly in settings via `setting(terminal.integrated.suggest.enabled)`.
+If you don't see the feature yet, make sure you have [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) enabled and enable IntelliSense explicitly in settings via `setting(terminal.integrated.suggest.enabled)`.
 
 Apart from overall polish, this is what is coming to the feature this release:
 
@@ -601,7 +601,7 @@ The `setting(microsoft-authentication.implementation)` setting has been around t
 * `msal-no-broker` - Use MSAL without brokered authentication (introduced recently)
 * `classic` - Use the classic Microsoft authentication flow without MSAL
 
-We will remove the `classic` option since it's usage is very low and most issues with the `msal` option are due to the brokering, which is remedied with `msal-no-broker`.
+We will remove the `classic` option since its usage is very low and most issues with the `msal` option are due to the brokering, which is remedied with `msal-no-broker`.
 
 ### Device code flow for Microsoft authentication
 
@@ -654,7 +654,7 @@ Pylance now helps you clean up modules that still rely on `from module import *`
 
 ### dotenv
 
-There is built in basic support for dotenv files (`.env`), which are commonly used to define environment variables for applications.
+There is built-in basic support for dotenv files (`.env`), which are commonly used to define environment variables for applications.
 
 ## Contributions to extensions
 
@@ -664,7 +664,7 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 * AI-generated PR descriptions (via `setting(githubPullRequests.pullRequestDescription:copilot)`) will respect the repository PR template if there is one.
 * Drafts in the Pull Requests view now render in italics instead of having a `[DRAFT]` prefix.
-* Pull requests can be opened from from a url, for example: `vscode-insiders://github.vscode-pull-request-github/checkout-pull-request?uri=https://github.com/microsoft/vscode-css-languageservice/pull/460`
+* Pull requests can be opened from a URL, for example: `vscode-insiders://github.vscode-pull-request-github/checkout-pull-request?uri=https://github.com/microsoft/vscode-css-languageservice/pull/460`
 
 Review the [changelog for the 0.122.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01220) release of the extension to learn about everything in the release.
 
@@ -729,7 +729,7 @@ export interface AuthenticationSession {
 
 ### Git extension `getRepositoryWorkspace` API
 
-The build in Git extension offers new API for getting a folder that's known to be associated with a git repository remote. This works by caching a repository-remote to folder mapping when the user opens a folder with a git remote.
+The built-in Git extension offers a new API for getting a folder that's known to be associated with a git repository remote. This works by caching a repository-remote to folder mapping when the user opens a folder with a git remote.
 
 ### View containers in Secondary Side Bar
 


### PR DESCRIPTION
Thanks for making these release notes finally editable on GitHub, that's great!

Quick PR to fix the typos and grammar mistakes in [the October 2025 (version 1.106) release notes blog post](https://code.visualstudio.com/updates/v1_106)