### PR TITLE
Fix subcommand

### DIFF
--- a/release-notes/v1_106.md
+++ b/release-notes/v1_106.md
@@ -306,7 +306,7 @@ Auto approval status has moved from being inline inside the chat view to the too
 
 #### Auto approve parser improvements
 
-Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned parenthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
+Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo "a`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned parenthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
 
 This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter/) into the feature and use a [PowerShell grammar](https://github.com/airbus-cert/tree-sitter-powershell) or a [bash grammar](https://github.com/tree-sitter/tree-sitter-bash) for everything else\*. So, even really complex cases should be correctly extracted:
 


### PR DESCRIPTION
It appears that the first subcommand on [the VS Code October 2025 (version 1.106) release notes blog post](https://code.visualstudio.com/updates/v1_106) is incomplete, if I'm understanding correctly

But maybe it breaks on the first space too - if so, maybe my PR should change to some words  explaining the breaking on the space.