### PR TITLE
Update MSYS2 installer links to latest

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -29,7 +29,7 @@ To install the MinGW-w64 toolchain, check out this video or follow the steps bel
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/oC69vlWofJQ" title="Installing MinGW to build C++ code on Windows" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-1. You can download the latest installer from the MSYS2 page or use this [**direct link to the installer**](https://github.com/msys2/msys2-installer/releases/download/2024-12-08/msys2-x86_64-20241208.exe).
+1. You can download the latest installer from the MSYS2 page or use this [**direct link to the installer**](https://github.com/msys2/msys2-installer/releases/download/2025-08-30/msys2-x86_64-20250830.exe).
 
 1. Run the installer and follow the steps of the installation wizard. Note that MSYS2 requires 64 bit Windows 8.1 or newer.
 


### PR DESCRIPTION
The old MSYS2 installer links were pointing to an older version. This PR updates them to the latest stable release.