### PR TITLE
Improve multi-cursor documentation: add missing tip and enhance clarity

### DIFF
--- a/docs/editing/codebasics.md
+++ b/docs/editing/codebasics.md
@@ -18,7 +18,7 @@ Being able to keep your hands on the keyboard when writing code is crucial for h
 
 ## Multiple selections (multi-cursor)
 
-VS Code supports multiple cursors for fast simultaneous edits. You can add secondary cursors (rendered thinner) with `kbstyle(Alt+Click)`. Each cursor operates independently based on the context it sits in. A common way to add more cursors is with `kb(editor.action.insertCursorBelow)` or `kb(editor.action.insertCursorAbove)` that insert cursors below or above.
+VS Code supports multiple cursors for fast, simultaneous edits. You can add secondary cursors (rendered thinner) with `kbstyle(Alt+Click)`. Each cursor operates independently based on the context it sits in. A common way to add more cursors is with `kb(editor.action.insertCursorBelow)` or `kb(editor.action.insertCursorAbove)` that insert cursors below or above.
 
 > [!NOTE]
 > Your graphics card driver (for example NVIDIA) might overwrite these default shortcuts.
@@ -26,6 +26,11 @@ VS Code supports multiple cursors for fast simultaneous edits. You can add secon
 ![Multi-cursor](images/codebasics/multicursor.gif)
 
 `kb(editor.action.addSelectionToNextFindMatch)` selects the word at the cursor, or the next occurrence of the current selection.
+
+>[!TIP]
+> You can skip the next matching occurrence while using multi-cursor find by running
+> `kb(editor.action.moveSelectionToNextFindMatch)`. This helps you avoid adding unwanted
+> selections when editing repeated text.
 
 ![Multi-cursor-next-word](images/codebasics/multicursor-word.gif)
 


### PR DESCRIPTION
This pull request makes two small but helpful documentation improvements in
docs/editing/codebasics.md:

✔ Added a missing multi-cursor tip

Introduced a new > [!TIP] block describing how to skip the next matching occurrence using
editor.action.moveSelectionToNextFindMatch.
This improves usability for users working with multi-cursor find.

✔ Improved readability in the multi-cursor section

A minor wording improvement was made to enhance clarity and consistency across the documentation.

These changes only update documentation and do not affect any product behavior.

## Checklist

- [x] Documentation only (no source code changes)
- [x] Follows VS Code docs callout format
- [x] All links and formatting validated
- [x] Branch created from fork and compares against `main`
