### PR TITLE
docs: clarify local MCP server risk in callout

### DIFF
--- a/docs/copilot/customization/mcp-servers.md
+++ b/docs/copilot/customization/mcp-servers.md
@@ -60,7 +60,7 @@ VS Code supports the following MCP capabilities:
 ## Add an MCP server
 
 > [!CAUTION]
-> MCP servers can run arbitrary code on your machine. Only add servers from trusted sources, and review the publisher and server configuration before starting it. VS Code prompts you to confirm that you [trust the MCP server](#mcp-server-trust) when you start an MCP server for the first time. Read the [Security documentation](/docs/copilot/security.md) for using AI in VS Code to understand the implications.
+> Local MCP servers can run arbitrary code on your machine. Only add servers from trusted sources, and review the publisher and server configuration before starting it. VS Code prompts you to confirm that you [trust the MCP server](#mcp-server-trust) when you start an MCP server for the first time. Read the [Security documentation](/docs/copilot/security.md) for using AI in VS Code to understand the implications.
 
 ### Add an MCP server from the GitHub MCP server registry
 


### PR DESCRIPTION
Updates the security warning to specify "Local MCP servers" instead of "MCP servers" since only local MCP servers (using `command`/`stdio` transport) can execute arbitrary code on the user's machine, not remote HTTP-based MCP servers. The current generic wording unnecessarily scares users away from safe remote MCP servers and hinders adoption of the MCP ecosystem.