### PR TITLE
Add post-VS Code Dev Days resources to blog

### DIFF
--- a/blogs/2025/08/27/vscode-dev-days.md
+++ b/blogs/2025/08/27/vscode-dev-days.md
@@ -12,6 +12,8 @@ Author: Katie Savage, Cynthia Zanoni
 
 August 26th, 2025 by [Katie Savage](https://github.com/katiesavage) and [Cynthia Zanoni](https://x.com/cynthiazanoni)
 
+> *VS Code Dev Days is over, but you can view our [virtual event on demand](https://www.youtube.com/live/ujSgVqC94TQ?si=oe1QOjpU3RRqq0Ez) or check out the [free training and workshop content](https://github.com/microsoft/VS-Code-Dev-Days/tree/main).*
+
 AI has become core to the developer experience in VS Code, shipping features like agent mode, next edit suggestions, and full MCP spec support in just the past six months. We've loved seeing how the community has embraced these AI features to transform their developer workflows. But with this rapid era of change, we also recognize that there is a lot to learn to effectively use these tools. We are excited to share that, together with our amazing community, we’re running 60+ global, in-person events to re-introduce you to VS Code as an AI-powered editor and upskill you on the latest features.
 
 Find an event near you and register today: <https://aka.ms/VSCode/DevDays>.


### PR DESCRIPTION
VS Code Dev Days are over. Adding a note and post-event resources to the top of the blog post.