### PR TITLE
Correct the action description to create a worktree

### DIFF
--- a/docs/sourcecontrol/branches-worktrees.md
+++ b/docs/sourcecontrol/branches-worktrees.md
@@ -121,7 +121,7 @@ To create a new worktree in VS Code:
 
     ![Screenshot showing the Source Control Repositories view with multiple repositories listed.](images/branches-worktrees/source-control-view-repositories.png)
 
-1. Click on your repository and open the **More Actions (...)** menu. Choose **Worktrees** > **Create Worktree**.
+1. Select your repository, open the **More Actions (...)** menu, and choose **Worktrees** > **Create Worktree**.
 
     ![Screenshot showing the worktree context menu in the Source Control Repositories view.](images/branches-worktrees/worktree-create.png)
 


### PR DESCRIPTION
The current description of the action to create a Worktree is wrong (the worktree menu doesn't appear on a right-click on the repository name)