### PR TITLE
Update remote proxy configuration

### DIFF
--- a/docs/devcontainers/containers.md
+++ b/docs/devcontainers/containers.md
@@ -597,7 +597,6 @@ From this point forward, the dotfiles repository will be used whenever a contain
 * The unofficial Ubuntu Docker **snap** package for Linux is **not** supported. Follow the [official Docker install instructions for your distribution](https://docs.docker.com/install/#supported-platforms).
 * Docker Toolbox on Windows is not supported.
 * If you clone a Git repository using SSH and your SSH key has a passphrase, VS Code's pull and sync features may hang when running remotely. Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
-* Local proxy settings are not reused inside the container, which can prevent extensions from working unless the appropriate proxy information is configured (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information).
 * There is an incompatibility between OpenSSH versions on Windows when the ssh-agent runs with version <= 8.8 and the SSH client (on any platform) runs version >= 8.9. The workaround is to upgrade OpenSSH on Windows to 8.9 or later, either using winget or an installer from [Win32-OpenSSH/releases](https://github.com/PowerShell/Win32-OpenSSH/releases). (Note that `ssh-add -l` will work correctly, but `ssh <ssh-server>` will fail with `<ssh-server>: Permission denied (publickey)`. This also affects Git when using SSH to connect to the repository.)
 
 See [here for a list of active issues](https://aka.ms/vscode-remote/containers/issues) related to Containers.

--- a/docs/remote/ssh.md
+++ b/docs/remote/ssh.md
@@ -286,7 +286,6 @@ SSHFS is the most convenient option and does not require any file sync'ing. Howe
 - Older (community supported) Linux distributions require workarounds to install the [needed prerequisites](/docs/remote/linux.md).
 - PuTTY is not supported on Windows.
 - If you clone a Git repository using SSH and your SSH key has a passphrase, VS Code's pull and sync features may hang when running remotely. Either use an SSH key without a passphrase, clone using HTTPS, or run `git push` from the command line to work around the issue.
-- Local proxy settings are not reused on the remote host, which can prevent extensions from working unless the appropriate proxy information is configured on the remote host (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information).
 - See [here for a list of active issues](https://aka.ms/vscode-remote/ssh/issues) related to SSH.
 
 ### Container Tools Extension limitations

--- a/docs/remote/troubleshooting.md
+++ b/docs/remote/troubleshooting.md
@@ -916,6 +916,12 @@ Extensions that access locally attached devices will be unable to connect to the
 
 **Resolution:** None currently. We are investigating the best approach to solve this problem.
 
+### Extensions fail to connect to the internet when installed remotely
+
+Local proxy settings are reused on the remote host by default, which can prevent extensions from working.
+
+**Resolution:** Ensure that the remote host has connectivity to the internet and is configured with the appropriate proxy information (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information). Disable **Http: Use Local Proxy Configuration** in your VS Code [settings](/docs/configure/settings.md).
+
 ## Questions and feedback
 
 ### Reporting issues

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -262,6 +262,12 @@ When the remote VSCode is started from a WSL terminal, the download is done usin
 
 Once the server is up and running the proxy settings on the *Remote* tab are used.
 
+### Extensions can't connect to the internet when installed remotely
+
+Local proxy settings are reused on the remote host by default, which can prevent extensions from working.
+
+**Resolution:** Ensure that WSL has connectivity to the internet and is configured with the appropriate proxy information (for example global `HTTP_PROXY` or `HTTPS_PROXY` environment variables with the appropriate proxy information). Disable **Http: Use Local Proxy Configuration** in your VS Code [settings](/docs/configure/settings.md).
+
 ### Can I force an extension to run locally / remotely ?
 
 Extensions are typically designed and tested to either run locally or remotely, not both. However, if an extension supports it, you can force it to run in a particular location in your `settings.json` file.


### PR DESCRIPTION
VS Code 1.97.0 (microsoft/vscode#237982) added the ability to use the local proxy configuration for remote extensions and enabled this by default.