### PR TITLE
Fix grammatical error in Output Channel section

### DIFF
--- a/api/extension-capabilities/common-capabilities.md
+++ b/api/extension-capabilities/common-capabilities.md
@@ -85,7 +85,7 @@ Extensions can use the [`window.showOpenDialog`](/api/references/vscode-api#wind
 
 ## Output Channel
 
-The Output Panel displays a collection of [`OutputChannel`](/api/references/vscode-api#OutputChannel), which are great for logging purpose. You can easily take advantage of it with the [`window.createOutputChannel`](/api/references/vscode-api#window.createOutputChannel) API.
+The Output Panel displays a collection of [`OutputChannel`](/api/references/vscode-api#OutputChannel), which are great for logging purposes. You can easily take advantage of it with the [`window.createOutputChannel`](/api/references/vscode-api#window.createOutputChannel) API.
 
 ## Progress API
 


### PR DESCRIPTION
Corrected 'logging purpose' to 'logging purposes' for grammatical accuracy.