### PR TITLE
docs: update lineComment examples to reflect current configuration shape

### DIFF
--- a/api/language-extensions/language-configuration-guide.md
+++ b/api/language-extensions/language-configuration-guide.md
@@ -69,11 +69,16 @@ VS Code offers two commands for comment toggling. **Toggle Line Comment** and **
 ```json
 {
   "comments": {
-    "lineComment": "//",
+    "lineComment": {
+      "comment": "//"
+    },
     "blockComment": ["/*", "*/"]
   }
 }
 ```
+
+lineComment can also be specified as a string for simple cases.
+The object form allows additional options such as noIndent.
 
 ## Brackets definition
 


### PR DESCRIPTION
The Language Configuration Guide still documents `comments.lineComment` as a string value. The configuration was expanded to support an object-based format (e.g. `comment`, `noIndent`), and following the current examples produces a warning in VS Code. This change updates the documented examples to reflect the current shape, so users can copy them without running into validation warnings.

Ref: https://github.com/microsoft/vscode-docs/issues/9210