### PR TITLE
Escape special characters so '<folder-name>' renders as expected

### DIFF
--- a/docs/editing/userdefinedsnippets.md
+++ b/docs/editing/userdefinedsnippets.md
@@ -92,7 +92,7 @@ Most user-defined snippets are scoped to a single language, and so are defined i
 
 ### Project snippet scope
 
-You can also have a global snippets file (JSON with file suffix `.code-snippets`) scoped to your project. Project-folder snippets are created with the **New Snippets file for '<folder-name>'...** option in the **Snippets: Configure Snippets** dropdown menu and are located at the root of the project in a `.vscode` folder. Project snippet files are useful for sharing snippets with all users working in that project. Project-folder snippets are similar to global snippets and can be scoped to specific languages through the `scope` property.
+You can also have a global snippets file (JSON with file suffix `.code-snippets`) scoped to your project. Project-folder snippets are created with the **New Snippets file for '\<folder-name\>'...** option in the **Snippets: Configure Snippets** dropdown menu and are located at the root of the project in a `.vscode` folder. Project snippet files are useful for sharing snippets with all users working in that project. Project-folder snippets are similar to global snippets and can be scoped to specific languages through the `scope` property.
 
 ## Snippet syntax
 


### PR DESCRIPTION
This PR escapes the `<` and `>` characters so they properly render in the documentation.

This ensures that the documentation displays: `<folder-name>` instead of an empty string.