### PR TITLE
fix: add header id and fix broken link

### DIFF
--- a/docs/copilot/chat/chat-sessions.md
+++ b/docs/copilot/chat/chat-sessions.md
@@ -98,7 +98,7 @@ To save a chat session as a reusable prompt:
 
 1. Review and edit the generated prompt file as needed, then save it to your workspace.
 
-## Context-isolated subagents
+## Context-isolated subagents {#context-isolated-subagents}
 
 A subagent enables you to delegate tasks to an isolated, autonomous agent within your chat session. Subagents operate independently from the main chat session and have their own context window. This is useful to optimize  context management for complex multi-step tasks like research or analysis.
 


### PR DESCRIPTION
This pull request makes a minor documentation update by adding an anchor to the "Context-isolated subagents" section heading. This change helps improve navigation and linking within the documentation.
Update the id of the isolated subagents header to work correctly both in md and the documentation (currently broken).

EDIT: to confirm that there is an issue needing fixing: 
1. Go to https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure
2. click on the subagent link in the "infer" section.
Expected: go directly to here: https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents
Actual: takes me to https://code.visualstudio.com/docs/copilot/chat/chat-sessions
which is the start of page.