### PR TITLE
Revert "Adds a blurb about the new Copilot tools added to the Container Tools extension. (#9021)"

### DIFF
--- a/docs/containers/images/overview/chat.png
+++ b/docs/containers/images/overview/chat.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df85f43c0f2d06e422d7d77863c91d3f760d872d66bf6bc03a08c47f15fa3f1a
-size 82336

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -5,7 +5,7 @@ MetaDescription: Tools for developing and debugging with containers, using Visua
 ---
 # Containers in Visual Studio Code
 
-The [Container Tools](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers) extension makes it easy to build, manage, and deploy containerized applications in Visual Studio Code and includes agent tools.
+The [Container Tools](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers) extension makes it easy to build, manage, and deploy containerized applications in Visual Studio Code.
 
 This page provides an overview of the Container Tools extension capabilities; use the side menu to learn more about topics of interest. If you are just getting started with container development, try the [Docker tutorial](https://learn.microsoft.com/visualstudio/docker/tutorials/docker-tutorial) first to understand key Docker concepts.
 
@@ -26,16 +26,6 @@ You can get [IntelliSense](/docs/editing/intellisense.md) by clicking `kb(editor
 ![IntelliSense for Dockerfiles](images/overview/dockerfile-intellisense.png)
 
 In addition, you can use the Problems panel (`kb(workbench.actions.view.problems)`) to view common errors for `Dockerfile` and `docker-compose.yml` files.
-
-## Copilot tools for containers
-
-Container Tools includes agent tools for managing containers and images in chat.
-
-* **Ask about your containers and images**: "Show me my running containers", "List my Docker images"
-* **Get details about specific containers or images**: "What's going on with my nginx container?"
-
-![Container Tools Copilot](images/overview/chat.png)
-
 
 ## Generating Docker files
 


### PR DESCRIPTION
This reverts commit 432dd9ac69d238806e6c9258364ac5985ee82cce (from PR #9021).

The Copilot Container tools have been removed in favor of a single tool that provides the relevant config to Copilot, and allows it to generate its own CLI commands. More on that here: https://github.com/microsoft/vscode-containers/issues/286

Please do NOT merge this yet; we plan on releasing roughly January 26. I will update here when we release.

/cc @fiveisprime @ntrogh