### PR TITLE
chore: Update Known language identifiers

### DIFF
--- a/docs/languages/identifiers.md
+++ b/docs/languages/identifiers.md
@@ -58,71 +58,76 @@ The following table lists known language identifiers:
 
 Language | Identifier
 -------- | ----------
-ABAP | `abap`
-Windows Bat | `bat`
+Agent | `chatagent`
+Batch | `bat`
 BibTeX | `bibtex`
-Clojure | `clojure`
-Coffeescript | `coffeescript`
+Binary | `code-text-binary`
 C | `c`
-C++ | `cpp`
 C# | `csharp`
+C++ | `cpp`
+Clojure | `clojure`
+Code Snippets | `snippets`
+CoffeeScript | `coffeescript`
 Compose | `dockercompose`
 CSS | `css`
 CUDA C++ | `cuda-cpp`
-D | `d`
 Dart | `dart`
-Delphi | `pascal`
 Diff | `diff`
-Dockerfile | `dockerfile`
-Erlang | `erlang`
+Docker | `dockerfile`
+Dotenv | `dotenv`
 F# | `fsharp`
-Git | `git-commit` and `git-rebase`
+Git Commit Message | `git-commit`
+Git Rebase Message | `git-rebase`
 Go | `go`
 Groovy | `groovy`
 Handlebars | `handlebars`
-Haml | `haml`
-Haskell	| `haskell`
+HLSL | `hlsl`
 HTML | `html`
+Ignore | `ignore`
 Ini | `ini`
+Instructions | `instructions`
 Java | `java`
 JavaScript | `javascript`
 JavaScript JSX | `javascriptreact`
 JSON | `json`
+JSON Lines | `jsonl`
 JSON with Comments | `jsonc`
 Julia | `julia`
+Julia Markdown | `juliamarkdown`
 LaTeX | `latex`
 Less | `less`
+Log | `log`
 Lua | `lua`
 Makefile | `makefile`
 Markdown | `markdown`
+MS SQL | `sql`
 Objective-C | `objective-c`
 Objective-C++ | `objective-cpp`
-OCaml | `ocaml`
-Pascal | `pascal`
-Perl | `perl` and `perl6`
+Perl | `perl`
 PHP | `php`
 Plain Text | `plaintext`
 PowerShell | `powershell`
-Pug | `jade`, `pug`
+Prompt | `prompt`
+Properties | `properties`
+Pug | `jade`
 Python | `python`
 R | `r`
-Razor (cshtml) | `razor`
+Raku | `raku`
+Razor | `razor`
+reStructuredText | `restructuredtext`
 Ruby | `ruby`
 Rust | `rust`
-SCSS | `scss` (syntax using curly brackets), `sass` (indented syntax)
+SCSS | `scss`
+Search Result | `search-result`
 ShaderLab | `shaderlab`
-Shell Script (Bash) | `shellscript`
-Slim | `slim`
-SQL | `sql`
-Stylus | `stylus`
-Svelte | `svelte`
+Shell Script | `shellscript`
+Skill | `skill`
 Swift | `swift`
+TeX | `tex`
 TypeScript | `typescript`
 TypeScript JSX | `typescriptreact`
-TeX | `tex`
 Visual Basic | `vb`
-Vue | `vue`
-Vue HTML | `vue-html`
+WebAssembly Text Format | `wat`
 XML | `xml`
 XSL | `xsl`
 YAML | `yaml`


### PR DESCRIPTION
based on comment
* https://github.com/microsoft/vscode/issues/289812#issuecomment-3787979414

https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers

Languages were ripped directly from VSCode's Language Picker

<img width="886" height="606" alt="image" src="https://github.com/user-attachments/assets/85685f8e-9c06-4aad-b5ed-5d67c57c96fe" />

https://github.com/microsoft/vscode/blob/d04cec02c65f5da9aaaab00206253f782c1c66f1/src/vs/workbench/browser/parts/editor/editorStatus.ts#L1172

```regex
^(?!.+"id"|.+"label").+\n?|\t+

"id": "(.+)",\n"label": "(.+)",
$2 | `$1`
```