### PR TITLE
fix Chromium link in Settings Sync docs

### DIFF
--- a/docs/configure/settings-sync.md
+++ b/docs/configure/settings-sync.md
@@ -177,7 +177,7 @@ Towards the top of the logs from the previous command, you will see something to
 [9699:0626/093542.027660:VERBOSE1:key_storage_linux.cc(122)] Selected backend for OSCrypt: GNOME_LIBSECRET
 ```
 
-We rely on Chromium's oscrypt module to discover and store encryption key information in the keyring. Chromium supports [a number of different desktop environments](https://source.chromium.org/chromium/chromium/src/+/main:base/nix/xdg_util.cc;l=146-169). Outlined below are some popular desktop environments and troubleshooting steps that may help if the keyring is misconfigured.
+We rely on Chromium's oscrypt module to discover and store encryption key information in the keyring. Chromium supports [a number of different desktop environments](https://source.chromium.org/chromium/chromium/src/+/main:base/nix/xdg_util.cc;l=196-221;drc=502b6c6b6ba9f62ddc2d8a8b39d024627950edb8;bpv=1;bpt=0). Outlined below are some popular desktop environments and troubleshooting steps that may help if the keyring is misconfigured.
 
 #### GNOME or UNITY (or similar)
 


### PR DESCRIPTION
In the Settings Sync docs, we link to some Linux Desktop Environment detection logic from the Chromium codebase. However, the link isn't associated with a particular commit, and the Chromium file has since changed and the highlighted line numbers point elsewhere now. This changes the link to a commit-specific link and points the highlighting where it should go.

We added the link in #6431, which is dated Jun 26, 2023. Here's the [version of the Chromium file from that time](https://source.chromium.org/chromium/chromium/src/+/main:base/nix/xdg_util.cc;l=146-169;bpv=1;bpt=0;drc=153865a15b33852de58d6356625be98e6266202c).