### PR TITLE
Change setting name for advanced settings display

### DIFF
--- a/release-notes/v1_109.md
+++ b/release-notes/v1_109.md
@@ -820,9 +820,9 @@ Previously, VS Code would always restore all open editors when reopening a works
 
 ### Advanced settings
 
-**Setting**: `setting(workbench.settings.showAdvancedSettings)`
+**Setting**: `setting(workbench.settings.alwaysShowAdvancedSettings)`
 
-You can now configure VS Code to always show advanced settings in the Settings editor without having to apply the `@tag:advanced` filter each time. Enable the `setting(workbench.settings.showAdvancedSettings)` setting to have advanced settings visible by default.
+You can now configure VS Code to always show advanced settings in the Settings editor without having to apply the `@tag:advanced` filter each time. Enable the `setting(workbench.settings.alwaysShowAdvancedSettings)` setting to have advanced settings visible by default.
 
 ### Import profiles via drag and drop
 


### PR DESCRIPTION
Updated the setting name for always showing advanced settings in the Settings editor.