### PR TITLE
Revert "Update 1.110 Insiders release notes"

### DIFF
--- a/release-notes/v1_110.md
+++ b/release-notes/v1_110.md
@@ -13,7 +13,7 @@ ProductEdition: Insiders
 
 ![VS Code Insiders banner](images/1_110/vscode-insiders-banner-medium.png)
 
-_Last updated: February 11, 2026_
+_Last updated: February 10, 2026_
 
 These release notes cover the Insiders build of VS Code and continue to evolve as new features are added. To try the latest updates, [download Insiders](https://code.visualstudio.com/insiders).
 To read these release notes online, go to [code.visualstudio.com/updates](https://code.visualstudio.com/updates).
@@ -47,13 +47,7 @@ Navigation End -->
 
 ## February 10, 2026
 
-* Chat tips are now context-aware and automatically hide once you've already used the suggested feature. Ten new tips were added covering custom agents, skills, message queueing, YOLO mode, Mermaid diagrams, GitHub repos, subagents, context usage, and sending to a new chat. [#290019](https://github.com/microsoft/vscode/issues/290019)
-
-* Chat tips now include a hint about message queueing, so you can discover the ability to send follow-up messages while the agent is still responding. The tip is contextually hidden once you've already used the feature. [#293536](https://github.com/microsoft/vscode/issues/293536)
-
 * Chat tips now have a context menu with options to dismiss the current tip and cycle to the next one, or to hide tips entirely. [#293507](https://github.com/microsoft/vscode/issues/293507)
-
-* Terminal shade and block characters now render correctly at all cell sizes by supporting offset variants, fixing visual misalignment where patterns did not tile seamlessly across cells. [#293529](https://github.com/microsoft/vscode/issues/293529)
 
 * Claude Agent now supports image attachments in chat prompts, enabling you to paste or attach images for the agent to analyze. [#293474](https://github.com/microsoft/vscode/issues/293474)
 


### PR DESCRIPTION
Reverts microsoft/vscode-docs#9370