### PR TITLE
revert: remove fake bracket colorization entry -- generated by mock feature

### DIFF
--- a/release-notes/v1_110.md
+++ b/release-notes/v1_110.md
@@ -13,7 +13,7 @@ ProductEdition: Insiders
 
 ![VS Code Insiders banner](images/1_110/vscode-insiders-banner-medium.png)
 
-_Last updated: February 13, 2026_
+_Last updated: February 12, 2026_
 
 These release notes cover the Insiders build of VS Code and continue to evolve as new features are added. To try the latest updates, [download Insiders](https://code.visualstudio.com/insiders).
 To read these release notes online, go to [code.visualstudio.com/updates](https://code.visualstudio.com/updates).
@@ -31,7 +31,6 @@ Happy Coding!
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
-      <li><a href="#february-13-2026">February 13, 2026</a></li>
       <li><a href="#february-12-2026">February 12, 2026</a></li>
       <li><a href="#february-11-2026">February 11, 2026</a></li>
       <li><a href="#february-10-2026">February 10, 2026</a></li>
@@ -47,10 +46,6 @@ Happy Coding!
   </nav>
   <div class="notes-main">
 Navigation End -->
-
-## February 13, 2026
-
-* Bracket pair colorization performance has been optimized for large files. The computation now uses an incremental approach that reuses cached subtree results and only recomputes affected ranges, reducing computation time after edits in deeply nested structures. [#295080](https://github.com/microsoft/vscode/issues/295080)
 
 ## February 12, 2026
 


### PR DESCRIPTION
This was a feature request just for testing the auto release notes feature. Not actual docs. 

Removes the February 13, 2026 entry about bracket pair colorization performance from `release-notes/v1_110.md`, including the TOC link and the section content.

I've renamed the label I look for in the workflows to `mock-feature` for testing cc/ @ntrogh 