### PR TITLE
Configuration structure "servers" and "inputs" types were switched?

### DIFF
--- a/docs/copilot/customization/mcp-servers.md
+++ b/docs/copilot/customization/mcp-servers.md
@@ -195,9 +195,9 @@ MCP server configuration is saved in the `mcp.json` JSON file (`mcp.json`).
 
 The configuration file has two main sections:
 
-* **`"servers": {}`**: contains the list of MCP servers and their configurations - depending on the server type, different fields are required.
+* **`"servers": []`**: contains the list of MCP servers and their configurations - depending on the server type, different fields are required.
 
-* **`"inputs": []`**: optional placeholders for sensitive information like API keys.
+* **`"inputs": {}`**: optional placeholders for sensitive information like API keys.
 
 You can use [predefined variables](/docs/reference/variables-reference.md) in the server configuration, for example to refer to the workspace folder (`${workspaceFolder}`).
 


### PR DESCRIPTION
`servers` "contains the list of MCP servers"

while `inputs` is "optional placeholders for sensitive information like API keys"

So the former is clearly a list and I'm guessing the latter is an object of key/value pairs and the types were just switched by mistake