### PR TITLE
Fix the language client cleanup in the language server guide

### DIFF
--- a/api/language-extensions/language-server-extension-guide.md
+++ b/api/language-extensions/language-server-extension-guide.md
@@ -146,9 +146,9 @@ import {
   TransportKind
 } from 'vscode-languageclient/node';
 
-let client: LanguageClient;
+let client: LanguageClient | undefined;
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   // The server is implemented in node
   let serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
   // The debug options for the server
@@ -185,14 +185,12 @@ export function activate(context: ExtensionContext) {
   );
 
   // Start the client. This will also launch the server
-  client.start();
+  await client.start();
 }
 
-export function deactivate(): Thenable<void> | undefined {
-  if (!client) {
-    return undefined;
-  }
-  return client.stop();
+export async function deactivate() {
+  await client?.dispose();
+  client = undefined
 }
 ```
 


### PR DESCRIPTION
The method `client.stop()` stops the language server. The method `client.dispose()` does a bit more: It sets an internal state to disposing, then stops the client, then sets this internal state to disposed. If one of these states is set, the client refuses to start again.

This matters if the client is exposed via other means. For example, it’s common to implement a restart command. If a user would restart a language server while the extension is being deactivated, that would be a race condition.

This change also sets the client to `undefined` after deactivation.

Also `client.start()` is awaited, since it’s asynchronous. I don’t know if this actually matters.