### PR TITLE
Add icons for Markdown headers

### DIFF
--- a/api/references/icons-in-labels.md
+++ b/api/references/icons-in-labels.md
@@ -744,6 +744,12 @@ VS Code extensions can use these icons in labels, views, and trees.
 |<i class="codicon codicon-symbol-field"></i>|symbol-field|
 |<i class="codicon codicon-symbol-file"></i>|symbol-file|
 |<i class="codicon codicon-symbol-folder"></i>|symbol-folder|
+|<i class="codicon codicon-symbol-header-one"></i>|symbol-header-one|
+|<i class="codicon codicon-symbol-header-two"></i>|symbol-header-two|
+|<i class="codicon codicon-symbol-header-three"></i>|symbol-header-three|
+|<i class="codicon codicon-symbol-header-four"></i>|symbol-header-four|
+|<i class="codicon codicon-symbol-header-five"></i>|symbol-header-five|
+|<i class="codicon codicon-symbol-header-six"></i>|symbol-header-six|
 |<i class="codicon codicon-symbol-function"></i>|symbol-function|
 |<i class="codicon codicon-symbol-interface"></i>|symbol-interface|
 |<i class="codicon codicon-symbol-key"></i>|symbol-key|

--- a/api/references/theme-color.md
+++ b/api/references/theme-color.md
@@ -1228,6 +1228,12 @@ The theme colors for symbol icons that appears in the Outline view, breadcrumb n
 - `symbolIcon.typeParameterForeground`: The foreground color for type parameter symbols.
 - `symbolIcon.unitForeground`: The foreground color for unit symbols.
 - `symbolIcon.variableForeground`: The foreground color for variable symbols.
+- `symbolIcon.headerOneForeground`: The foreground color for first-level headers.
+- `symbolIcon.headerTwoForeground`: The foreground color for second-level headers.
+- `symbolIcon.headerThreeForeground`: The foreground color for third-level headers.
+- `symbolIcon.headerFourForeground`: The foreground color for fourth-level headers.
+- `symbolIcon.headerFiveForeground`: The foreground color for fifth-level headers.
+- `symbolIcon.headerSixForeground`: The foreground color for sixth-level headers.
 
 ## Debug Icons colors
 


### PR DESCRIPTION
Docs associated with https://github.com/microsoft/vscode/pull/298857, updated to reflect the changes made. See that PR for more details on the specific changes added.