### PR TITLE
Fix typos in October 2017 release notes

### DIFF
--- a/release-notes/v1_18.md
+++ b/release-notes/v1_18.md
@@ -142,9 +142,9 @@ Speed up your coding with auto imports for JavaScript and TypeScript. The sugges
 
 ![Global symbols are now shown in the suggestion list](images/1_18/ts-auto-import-pre.png)
 
-If you choose one of the suggestion from another file or module, VS Code will automatically add an import for it. In this example, VS Code adds an import for `Hercules` to the top of the file:
+If you choose one of the suggestions from another file or module, VS Code will automatically add an import for it. In this example, VS Code adds an import for `Hercules` to the top of the file:
 
-![After selecting a symbol form a different file, an import is added for it automatically](images/1_18/ts-auto-import-post.png)
+![After selecting a symbol from a different file, an import is added for it automatically](images/1_18/ts-auto-import-post.png)
 
 Auto imports requires TypeScript 2.6+. You can disable auto imports by setting `"typescript.autoImportSuggestions.enabled": false`.
 


### PR DESCRIPTION
This PR fixes two small typos in the October 2017 (v1.18) release notes.

Changes:
- "suggestion" → "suggestions"
- "form" → "from"

These corrections improve grammar and readability without changing the meaning of the documentation.