### PR TITLE
Fix grammar in Refactoring documentation

### DIFF
--- a/docs/editing/refactoring.md
+++ b/docs/editing/refactoring.md
@@ -9,7 +9,7 @@ MetaDescription: Refactoring source code in Visual Studio Code.
 
 ![refactoring hero image](images/refactoring/refactoring-hero.png)
 
-For example, a common refactoring used to avoid duplicating code (a maintenance headache) is the [Extract Method](https://refactoring.com/catalog/extractMethod.html) refactoring, where you select source code and pull it out into its own shared method, so that can reuse the code elsewhere.
+For example, a common refactoring used to avoid duplicating code (a maintenance headache) is the [Extract Method](https://refactoring.com/catalog/extractMethod.html) refactoring, where you select source code and pull it out into its own shared method, so that you can reuse the code elsewhere.
 
 Refactorings are provided by a language service. VS Code has built-in support for TypeScript and JavaScript refactoring through the [TypeScript](https://www.typescriptlang.org/) language service. Refactoring support for other programming languages is enabled through VS Code [extensions](/docs/configure/extensions/extension-marketplace.md) that contribute language services.
 


### PR DESCRIPTION
This PR fixes a grammatical error in the Refactoring documentation.

Change:
- "so that can reuse the code elsewhere" → "so that you can reuse the code elsewhere"

This improves readability and corrects the sentence without changing its meaning.