### PR TITLE
Fix grammar in JSON completions section

### DIFF
--- a/release-notes/July_2016.md
+++ b/release-notes/July_2016.md
@@ -89,7 +89,7 @@ The integrated terminal had several changes related to polish and compatibility 
 
 ### JSON completions
 
-There has been some small improvements for the JSON completions:
+There have been some small improvements for JSON completions:
 
 - In schema based JSON documents, we offer completions for empty arrays, objects and string if we know the type of a property but the schema doesn't describe any defaults.
 - Completion support for the `$schema` property and values.


### PR DESCRIPTION
This PR fixes a grammatical issue in the JSON completions section.

Change:
- "There has been some small improvements for the JSON completions" → "There have been some small improvements for JSON completions"

This improves grammatical correctness and readability without changing the meaning of the documentation.