### PR TITLE
docs: fix duplicate word in activation events

### DIFF
--- a/api/references/activation-events.md
+++ b/api/references/activation-events.md
@@ -229,7 +229,7 @@ This activation event is emitted and interested extensions will be activated **s
 
 ## onTaskType
 
-`onTaskType:type` is emitted emitted whenever tasks of a certain type need to be listed or resolved.
+`onTaskType:type` is emitted whenever tasks of a certain type need to be listed or resolved.
 
 ```json
 "activationEvents": [


### PR DESCRIPTION
## Summary\n- remove a duplicated word in the onTaskType activation event description\n\n## Related issue\n- N/A\n\n## Guideline alignment\n- https://github.com/microsoft/vscode-docs/blob/main/CONTRIBUTING.md\n\n## Validation\n- Not run (doc-only change)