### PR TITLE
Update blog post titles, author field, and other metadata

### DIFF
--- a/blogs/2016/02/01/introducing_insiders_build.md
+++ b/blogs/2016/02/01/introducing_insiders_build.md
@@ -1,17 +1,15 @@
 ---
 Order:
-TOCTitle: The Insiders Build
-PageTitle: Introducing the Insiders Build
+TOCTitle: The Insiders build
+PageTitle: Introducing VS Code Insiders
 MetaDescription: insiders build
 MetaSocialImage: /assets/blogs/2016/02/01/opengraph_insiders.png
 Date: 2016-02-01
 ShortDescription: VS Code has its roots in the web (built using TypeScript and Node.js) and one thing we love about cloud based applications is that they are always up to date. Update the service and all of your users are instantly on the latest fixes and features, with no user interaction.
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-
-# Introducing the Insiders Build
-
-February 1, 2016 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 VS Code has its roots in the web (built using TypeScript and Node.js) and one thing we love about cloud based applications is that they are always up to date. Update the service and all of your users are instantly on the latest fixes and features, with no user interaction.
 

--- a/blogs/2016/02/23/introducing-chrome-debugger-for-vs-code.md
+++ b/blogs/2016/02/23/introducing-chrome-debugger-for-vs-code.md
@@ -1,16 +1,16 @@
 ---
 Order:
 TOCTitle: Introducing Chrome Debugging
-PageTitle: Introducing Chrome Debugging for VS Code
+PageTitle: Introducing Chrome debugging for VS Code
 MetaDescription: Chrome debugger extension for Visual Studio Code
 Date: 2016-02-23
 ShortDescription: Since the first release of Visual Studio Code, one of our focuses has been to simplify the daily workflow for developers by enabling them to debug their code directly from the editor. We started out with .NET and Node.js debugging, and today we are taking the next step by introducing our Chrome Debugger for Visual Studio Code.
-Author: Andy Sterland
+Authors:
+  - name: Andy Sterland
+    social: https://twitter.com/AndySterland    
+  - name: Kenneth Auchenberg
+    social: https://twitter.com/auchenberg
 ---
-
-# Introducing Chrome Debugging for VS Code
-
-February 23, 2016 by [Andy Sterland](https://twitter.com/AndySterland) and [Kenneth Auchenberg](https://twitter.com/auchenberg)
 
 Since the first release of Visual Studio Code, one of our focuses has been to simplify the daily workflow for developers by enabling them to debug their code directly from the editor. We started out with .NET and Node.js debugging, and today we are taking the next step by introducing our Chrome Debugger for Visual Studio Code.
 

--- a/blogs/2016/03/07/Feb2016Release.md
+++ b/blogs/2016/03/07/Feb2016Release.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: February 2016 Release
-PageTitle: Visual Studio February 2016 Release
+PageTitle: February 2016 release
 MetaDescription: Announcing the Visual Studio Code February 2016 Release
 Date: 2016-03-07
 ShortDescription: Announcing the February 2016 Release of VS Code
-Author: Chris Dias
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-
-# February 2016 Release
-
-March 7, 2016 by The VS Code Team, [@code](https://twitter.com/code)
 
 Today we are releasing the February 2016 build of Visual Studio Code. This release brings many improvements to your development experience, including:
 

--- a/blogs/2016/03/11/ExtensionsRoundup.md
+++ b/blogs/2016/03/11/ExtensionsRoundup.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Extensions Roundup
-PageTitle: Visual Studio Code Extensions Roundup
+PageTitle: VS Code extensions
 MetaDescription: New, useful, and interesting extensions in Visual Studio Code.
 Date: 2016-03-17
 ShortDescription: New, useful, and interesting extensions in Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# VS Code Extensions
-
-March 17, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 In November 2015, we open sourced Visual Studio Code and introduced the [extensions API](https://code.visualstudio.com/docs/extensionAPI/vscode-api). The VS Code extensions [Marketplace](https://marketplace.visualstudio.com/VSCode) has over 850 extensions. Many new languages (Go, PowerShell, PHP, Python) and frameworks (Apache Cordova, React Native) are now supported.
 

--- a/blogs/2016/03/14/Feb2016Recovery.md
+++ b/blogs/2016/03/14/Feb2016Recovery.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: February 2016 Recovery Release
-PageTitle: Visual Studio Code February 2016 Recovery Release
+PageTitle: February 2016 recovery release
 MetaDescription: Visual Studio Code February 2016 Recovery Release
 Date: 2016-03-14
 ShortDescription: The February 2016 Recovery Release of VS Code
-Author: Chris Dias
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-
-# February 2016 Recovery Release
-
-March 14, 2016 by The VS Code Team, [@code](https://twitter.com/code)
 
 If we find critical issues after a major update, we do what we call a "recovery" release. Today we're updating the February 2016 build with fixes for the following four issues:
 

--- a/blogs/2016/04/14/vscode-1.0.md
+++ b/blogs/2016/04/14/vscode-1.0.md
@@ -1,17 +1,15 @@
 ---
 Order:
 TOCTitle: 1.0 Release
-PageTitle: Visual Studio Code 1.0 Release
+PageTitle: Visual Studio Code 1.0!
 MetaDescription: Visual Studio Code releases 1.0.
 Date: 2016-04-14
 ShortDescription: Visual Studio Code releases 1.0.
-Author: PJ Meyer
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 MetaSocialImage: /assets/blogs/2016/04/14/header.png
 ---
-
-# Visual Studio Code 1.0!
-
-April 14, 2016 by The VS Code Team, [@code](https://twitter.com/code)
 
 ![header graphic](header.png)
 

--- a/blogs/2016/05/04/extension-roundup-may.md
+++ b/blogs/2016/05/04/extension-roundup-may.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Extensions Roundup
-PageTitle: Visual Studio Code Extensions Roundup May 2016
+PageTitle: Extensions roundup
 MetaDescription: New, useful, and interesting extensions in Visual Studio Code for May 2016.
 Date: 2016-05-04
 ShortDescription: New, useful, and interesting extensions in Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# Extensions Roundup
-
-May 4, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 The Visual Studio Code Extension [Marketplace](https://marketplace.visualstudio.com/VSCode) does a great job of highlighting **Featured**, **Most Popular** and **Newly Added** extensions and we encourage you to browse the site to see what's new and what plug-ins other developers are using. In our extension roundups, we like to call out extensions that we've found interesting and useful.
 

--- a/blogs/2016/05/09/April2016Release.md
+++ b/blogs/2016/05/09/April2016Release.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: April 2016 Release
-PageTitle: Visual Studio April 2016 Release
+PageTitle: April 2016 release
 MetaDescription: Announcing the Visual Studio Code April 2016 Release
 Date: 2016-05-09
 ShortDescription: Announcing the April 2016 Release of VS Code
-Author: Chris Dias
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-
-# April 2016 Release
-
-May 9, 2016 by The VS Code Team, [@code](https://twitter.com/code)
 
 Today we are releasing the April 2016 build of Visual Studio Code. This is our first monthly release after our 1.0 announcement last month and we really appreciate your support and feedback.
 

--- a/blogs/2016/05/23/evolution-of-insiders.md
+++ b/blogs/2016/05/23/evolution-of-insiders.md
@@ -1,19 +1,17 @@
 ---
 Order:
 TOCTitle: Evolution of VS Code Insiders
-PageTitle: Evolution of Visual Studio Code Insiders
+PageTitle: Evolution of VS Code Insiders
 MetaDescription: Evolution of the Visual Studio Code Insiders Build
 MetaSocialImage: /assets/blogs/2016/11/30/opengraph_insiders.png
 Date: 2016-05-23
 ShortDescription: Evolution of the Insiders Build
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
 
-# Evolution of the Insiders Build
-
-May 23, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
-
-Today over five thousand developers use the Visual Studio Code [Insiders Build](https://code.visualstudio.com/blogs/2016/02/01/introducing_insiders_build) for early access to new features and to validate bug fixes. We love the Insiders build because we get valuable feedback and usage insights prior to each Stable release. Thank you for your help!
+Today over five thousand developers use the Visual Studio Code [Insiders](https://code.visualstudio.com/blogs/2016/02/01/introducing_insiders_build) for early access to new features and to validate bug fixes. We love the Insiders build because we get valuable feedback and usage insights prior to each Stable release. Thank you for your help!
 
 Initially, we released an Insiders build once per month, a few days before the Stable release. Over time, we increased the frequency of Insiders builds and today we ship new Insiders builds roughly once a week.
 

--- a/blogs/2016/06/27/common-language-protocol.md
+++ b/blogs/2016/06/27/common-language-protocol.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: The Language Server Protocol
-PageTitle: Common Language Server Protocol
+PageTitle: A common protocol for languages
 MetaDescription: A Common Language Server Protocol for any tool and any language.
 Date: 2016-06-27
 ShortDescription: Common Language Server Protocol
-Author: PJ Meyer
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-
-# A Common Protocol for Languages
-
-June 27, 2016 by The VS Code Team, [@code](https://twitter.com/code)
 
 Visual Studio Code is an editor for any developer, no matter what programming language you use.  Between languages bundled in the tool or extensions in the [Marketplace](https://marketplace.visualstudio.com/VSCode), we have support for over [150 languages](/blogs/2016/04/14/vscode-1.0.md).  We’re also committed to developing VS Code in the open, and making the components that power VS Code available and open source.  One of our most notable components is the [Monaco editor](https://github.com/microsoft/monaco-editor), but another technology that powers VS Code is an [open, JSON-based protocol](https://github.com/microsoft/language-server-protocol) that anyone can use to add support for a new programming language to VS Code by implementing a "language server".
 

--- a/blogs/2016/07/29/extensions-roundup-git.md
+++ b/blogs/2016/07/29/extensions-roundup-git.md
@@ -1,15 +1,14 @@
 ---
 Order:
 TOCTitle: Extensions Roundup - Fun with Git
-PageTitle: Visual Studio Code Extensions Roundup - Git August 2016
+PageTitle: Extensions roundup, fun with Git
 MetaDescription: Extensions to super power your Git workflow.
 Date: 2016-08-02
 ShortDescription: Extensions to super power your Git workflow.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# Extensions Roundup - Fun with Git
-
-August 2, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 The first extension I built for Visual Studio Code was called [Git Blame](https://marketplace.visualstudio.com/items?itemName=waderyan.gitblame). It lets you quickly see which developer most recently modified the currently selected line ("blame"). It was simple and effective. Since the time when I built this extension, there have been many more awesome Git extensions added to the VS Code [Marketplace](https://marketplace.visualstudio.com/VSCode). Here are some of my favorite.
 

--- a/blogs/2016/08/15/introvideos.md
+++ b/blogs/2016/08/15/introvideos.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Intro Videos
-PageTitle: Visual Studio Code Introductory Videos
+PageTitle: Announcing intro videos
 MetaDescription: We want to help people get going with VS Code. Watch our new introductory videos to jump start your work with VS Code.
 Date: 2016-08-15
 ShortDescription: Watch our new intro videos to jump start your work with VS Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# Announcing Intro Videos
-
-August 15, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 On the product team, we're constantly trying to make Visual Studio Code better. We spend hours in interviews, usability studies, and interacting with you online.
 

--- a/blogs/2016/08/19/goodbyeuservoice.md
+++ b/blogs/2016/08/19/goodbyeuservoice.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Goodbye User Voice
-PageTitle: Goodbye User Voice
+PageTitle: Goodbye User Voice, hello GitHub Reactions!
 MetaDescription: Visual Studio Code is closing User Voice in favor of GitHub reactions.
 Date: 2016-08-23
 ShortDescription: Visual Studio Code is closing User Voice in favor of GitHub reactions.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# Goodbye User Voice, Hello GitHub Reactions!
-
-August 23, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 ## Feedback Channels
 

--- a/blogs/2016/08/22/introducing-ios-web-debugging-for-vs-code-on-windows-and-mac.md
+++ b/blogs/2016/08/22/introducing-ios-web-debugging-for-vs-code-on-windows-and-mac.md
@@ -1,15 +1,14 @@
 ---
 Order:
 TOCTitle: iOS Web Debugging
-PageTitle: Introducing iOS Web Debugging for VS Code on Windows and Mac
+PageTitle: iOS web debugging on Windows and Mac
 MetaDescription: iOS Web Debugging for VS Code on Windows and Mac
 Date: 2016-08-24
 ShortDescription: Today debugging websites running on iOS devices are limited to a subset of developers, as the Safari Web Inspector (Safari DevTools) requires an instance of desktop Safari which only is available for macOS users. With our new debugger we are aiming to change that, as our iOS Web Debugger for Visual Studio Code works both on Mac and Windows.
-Author: Kenneth Auchenberg
+Authors:
+  - name: Kenneth Auchenberg
+    social: https://twitter.com/auchenberg
 ---
-# iOS Web Debugging on Windows and Mac
-
-August 24, 2016 by [Kenneth Auchenberg](https://twitter.com/auchenberg)
 
 ## Update
 

--- a/blogs/2016/09/08/icon-themes.md
+++ b/blogs/2016/09/08/icon-themes.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: File Icon Themes
-PageTitle: File and Folder Icons in Visual Studio Code
+PageTitle: File and folder icons in VS Code
 MetaDescription: File and Folder Icons in Visual Studio Code
 Date: 2016-09-08
 ShortDescription: The Visual Studio Code Explorer now supports file and folder icons. VS Code ships with two icon themes and more are available on the Marketplace.
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-
-# File and Folder Icons in VS Code!
-
-September 8, 2016 by Chris Dias,  [@chrisdias](https://twitter.com/chrisdias)
 
 ## Rebellion. Revolt. Uprising.
 

--- a/blogs/2016/09/14/js_roundup_1.md
+++ b/blogs/2016/09/14/js_roundup_1.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: JavaScript Extensions Part 1
-PageTitle: Visual Studio Code JavaScript Extensions Part 1 Sep 2016
+PageTitle: JavaScript extensions, part 1
 MetaDescription: Essential JavaScript extensions for Visual Studio Code.
 Date: 2016-09-14
 ShortDescription: Essential JavaScript extensions for Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# JavaScript Extensions Part 1
-
-September 14, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 > This is part one in a series on JavaScript extensions.
 

--- a/blogs/2016/10/31/js_roundup_2.md
+++ b/blogs/2016/10/31/js_roundup_2.md
@@ -1,15 +1,14 @@
 ---
 Order:
 TOCTitle: JavaScript Extensions Part 2
-PageTitle: Visual Studio Code JavaScript Extensions Part 2 Oct 2016
+PageTitle: JavaScript extensions, part 2
 MetaDescription: Essential JavaScript extensions for Visual Studio Code.
 Date: 2016-10-31
 ShortDescription: Essential JavaScript extensions for Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# JavaScript Extensions Part 2
-
-October 31, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 Visual Studio Code has excellent support for JavaScript out of the box. As with other languages, JavaScript is powered by a language service. The [JavaScript language service](https://github.com/microsoft/TypeScript/wiki/JavaScript-Language-Service-in-Visual-Studio) is implemented by the TypeScript team, allowing JavaScript developers to leverage the best IntelliSense experience.
 

--- a/blogs/2016/11/15/formatters-best-practices.md
+++ b/blogs/2016/11/15/formatters-best-practices.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Creating a Formatter Extension
-PageTitle: Creating a Formatter Extension
+PageTitle: Creating a formatter extension
 MetaDescription: Best practices for creating a Visual Studio Code formatter extension.
 Date: 2016-11-21
 ShortDescription: Best practices for creating a Visual Studio Code formatter extension.
-Author: Johannes Rieken
+Authors:
+  - name: Johannes Rieken
+    social: https://twitter.com/johannesrieken
 ---
-
-# Creating a Formatter Extension
-
-November 21, 2016 by Johannes Rieken, [@johannesrieken](https://twitter.com/johannesrieken)
 
 Since its introduction, the Visual Studio Code extension API has provided support for source code formatters. The first language extensions we built, for example TypeScript, C# and Go, used the formatting API. We wrote this blog to explain the best practices for implementing formatters.
 

--- a/blogs/2016/11/3/rollback.md
+++ b/blogs/2016/11/3/rollback.md
@@ -1,16 +1,14 @@
 ---
 Order:
-TOCTitle: 1.7 Rollback Incident Report
-PageTitle: Visual Studio Code 1.7 Rollback Incident Report
+TOCTitle: 1.7 rollback incident report
+PageTitle: 1.7 rollback incident report
 MetaDescription: Visual Studio Code 1.7 Rollback Incident Report
 Date: 2016-11-03
 ShortDescription: Visual Studio Code 1.7 Rollback Incident Report
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# 1.7 Rollback Incident Report
-
-November 3, 2016 by Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 Last night Wednesday November 2nd, we rolled back the 1.7 release of Visual Studio Code to 1.6.1. If you had upgraded to 1.7, you would have been prompted to update back to 1.6.1. This morning we implemented a mitigation fix and created a new release and you should now be on VS Code 1.7.1. If you are not sure what version you are on, you can [find the version information](/docs/supporting/faq.md#how-do-i-find-what-version-of-vs-code-i-am-using) in the About dialog.
 

--- a/blogs/2016/11/30/hot-exit-in-insiders.md
+++ b/blogs/2016/11/30/hot-exit-in-insiders.md
@@ -1,17 +1,15 @@
 ---
 Order:
-TOCTitle: Hot Exit Comes to Insiders
-PageTitle: Hot Exit Comes to Insiders
+TOCTitle: Hot exit comes to Insiders
+PageTitle: Hot exit comes to Insiders
 MetaDescription: Unsaved changes are now remembered between Visual Studio Code sessions.
 MetaSocialImage: /assets/blogs/2016/11/30/opengraph_insiders.png
 Date: 2016-11-30
 ShortDescription: Unsaved changes are now remembered between Visual Studio Code sessions.
-Author: Daniel Imms
+Authors:
+  - name: Daniel Imms
+    social: https://twitter.com/Tyriar
 ---
-
-# Hot Exit Comes to Insiders
-
-November 30, 2016 by Daniel Imms, [@Tyriar](https://twitter.com/Tyriar)
 
 The ability to have Visual Studio Code remember unsaved changes when you exit (hot exit) has been a long requested feature, in fact it's currently [number #3](https://github.com/microsoft/vscode/issues/101) in terms of 👍 reactions on GitHub. We've been working on an implementation for some time and it is now enabled by default in the Insiders build!
 

--- a/blogs/2016/12/12/roundup-customize.md
+++ b/blogs/2016/12/12/roundup-customize.md
@@ -1,16 +1,14 @@
 ---
 Order:
 TOCTitle: Customize VS Code Extension Roundup
-PageTitle: Customize Visual Studio Code Extension Roundup
+PageTitle: Customize VS Code extension roundup
 MetaDescription: Extensions to customize Visual Studio Code.
 Date: 2016-12-12
 ShortDescription: Extensions to customize Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-
-# Customize VS Code Extension Roundup
-
-December 12, 2016 - Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 You can customize Visual Studio Code in many ways. Install a new theme, add a snippet pack, or tweak your settings and keyboard shortcuts. We built VS Code to be flexible so you can make it work the way you do. You can install an extension from the VS Code [Marketplace](https://marketplace.visualstudio.com/vscode) or create your own (see [here](https://code.visualstudio.com/docs/extensions/overview) to get started writing an extension in JavaScript or TypeScript). In this blog, I want to highlight a few of my favorite extensions for customizing VS Code.
 

--- a/blogs/2017/01/15/connect-nina-e2e.md
+++ b/blogs/2017/01/15/connect-nina-e2e.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Node.js Development with Visual Studio Code and Azure
-PageTitle: Node.js Development with Visual Studio Code and Azure
+TOCTitle: Node.js development with VS Code and Azure
+PageTitle: Node.js development with VS Code and Azure
 MetaDescription: Node.js Development with Visual Studio Code and Azure
-Date: 2017-01-15
+Date: 2017-01-04
 ShortDescription: Node.js Development with Visual Studio Code and Azure
-Author: Jonathan Carter
+Authors:
+  - name: Jonathan Carter
+    social: https://twitter.com/LostInTangent
 ---
-# Node.js Development with Visual Studio Code and Azure
-
-January, 4 2017 - Jonathan Carter, [@lostintangent](https://twitter.com/LostInTangent)
 
 Between Visual Studio Code and Azure, we're trying to contribute to simplifying and improving the overall developer experience of building, debugging and deploying Node.js applications. At [Node Interactive North America 2016](events.linuxfoundation.org/events/node-interactive), I was excited to be able to demo some of the work we've been doing recently based on community feedback, and this article tries to capture that workflow for folks who are interested in trying it out and/or are looking for a little more detail than I was able to cover in my talk.
 

--- a/blogs/2017/02/08/syntax-highlighting-optimizations.md
+++ b/blogs/2017/02/08/syntax-highlighting-optimizations.md
@@ -1,15 +1,13 @@
 ---
 Order:
-TOCTitle: Optimizations in Syntax Highlighting
-PageTitle: Optimizations in Syntax Highlighting, a Visual Studio Code Story
+TOCTitle: Optimizations in syntax highlighting
+PageTitle: Optimizations in syntax highlighting
 MetaDescription: Optimizations in tokenization and syntax highlighting in the Visual Studio Code/Monaco editor
 Date: 2017-02-08
-Author: Alexandru Dima
 MetaSocialImage: /assets/blogs/2017/02/08/syntax-highlighting-optimizations-social.png
+Authors:
+  - name: Alexandru Dima
 ---
-# Optimizations in Syntax Highlighting
-
-February 8, 2017 - Alexandru Dima
 
 Visual Studio Code version 1.9 includes a cool performance improvement that we've been working on and I wanted to tell its story.
 

--- a/blogs/2017/02/12/code-lens-roundup.md
+++ b/blogs/2017/02/12/code-lens-roundup.md
@@ -1,15 +1,14 @@
 ---
 Order:
 TOCTitle: Extensions using CodeLens
-PageTitle: Visual Studio Code Extensions using CodeLens
+PageTitle: Extensions using CodeLens
 MetaDescription: Visual Studio Code Extensions using CodeLens
 Date: 2017-02-12
 ShortDescription: Visual Studio Code Extensions using CodeLens
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# Extensions using CodeLens
-
-February 12, 2017 Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 CodeLens is a popular feature in Visual Studio Code. The essence of the feature is "actionable contextual information interspersed" in your source code. That's quite a mouthful. Let me break it down for you.
 

--- a/blogs/2017/03/07/extension-pack-roundup.md
+++ b/blogs/2017/03/07/extension-pack-roundup.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Extension Packs
-PageTitle: Visual Studio Code Extension Packs
+TOCTitle: Extension packs
+PageTitle: Extension packs
 MetaDescription: Learn how to create and use Extension Packs in Visual Studio Code.
 Date: 2017-03-07
 ShortDescription: Learn how to create and use Extension Packs in Visual Studio Code.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# Extension Packs
-
-March 07, 2017 Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 If you have followed our blog for the last year, you'll notice I write an Extension Roundup blog once a month. I like to write these blogs to let you know about the cool extensions being created in the community and to inspire you to create your own. I often put a theme around the Roundup blog: something like JavaScript extensions or CodeLens extensions (last month).
 

--- a/blogs/2017/04/10/sublime-text-roundup.md
+++ b/blogs/2017/04/10/sublime-text-roundup.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Sublime Text Extension Roundup
-PageTitle: Sublime Text Extension Roundup
+TOCTitle: Sublime Text extension roundup
+PageTitle: Sublime Text extension roundup
 MetaDescription: Learn about VS Code extensions to add features that are missing from Sublime Text.
 Date: 2017-04-10
 ShortDescription: Learn about VS Code extensions to add features that are missing from Sublime Text.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# Sublime Text Extension Roundup
-
-April 10, 2017 Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 I'm a big fan of Sublime Text. It was my [go to editor](https://www.youtube.com/watch?v=OnkYnm-WiVo&t=15s) for my first few years of programming. Naturally, I now like VS Code more, but sometimes I miss things from Sublime Text.
 

--- a/blogs/2017/05/10/build-2017-demo.md
+++ b/blogs/2017/05/10/build-2017-demo.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Build 2017 Demo
-PageTitle: Build 2017 Demo
+TOCTitle: Build 2017 demo
+PageTitle: Build 2017 demo
 MetaDescription: Build 2017 Demo Visual Studio Code - Conquering the Cloud with an editor and a CLI
 Date: 2017-05-10
 ShortDescription: Build 2017 Demo Visual Studio Code - Conquering the Cloud with an editor and a CLI
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-# Build 2017 Demo
-
-May 10, 2017 Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 Below are links to the samples, tools, and extensions demonstrated in the Build 2017 VS Code talk.
 

--- a/blogs/2017/06/20/great-looking-editor-roundup.md
+++ b/blogs/2017/06/20/great-looking-editor-roundup.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Fresh Paint
-PageTitle: Fresh Paint - Give Visual Studio Code a New Look
+TOCTitle: Fresh paint
+PageTitle: Fresh paint, give VS Code a new look
 MetaDescription: Give VS Code a new look with these popular extensions, color themes, file icon themes and more.
 Date: 2017-06-20
 ShortDescription: Give VS Code a new look with these popular extensions, color themes, file icon themes and more.
-Author: Wade Anderson
+Authors:
+  - name: Wade Anderson
+    social: https://twitter.com/waderyan_
 ---
-# Fresh Paint - Give VS Code a New Look
-
-June 20, 2017 Wade Anderson, [@waderyan_](https://twitter.com/waderyan_)
 
 Having a great looking editor is a necessity for any full-time developer. We spend a lot of time in our editor and we like to keep things fresh and interesting!
 

--- a/blogs/2017/08/07/emmet.md
+++ b/blogs/2017/08/07/emmet.md
@@ -1,15 +1,14 @@
 ---
 Order:
 TOCTitle: Emmet 2.0
-PageTitle: Emmet 2.0 in Visual Studio Code
+PageTitle: Emmet 2.0 in VS Code
 MetaDescription: New Emmet 2.0 brings a better Emmet experience inside VS Code.
 Date: 2017-08-07
 ShortDescription: New Emmet 2.0 brings a better Emmet experience inside VS Code.
-Author: Ramya Rao
+Authors:
+  - name: Ramya Rao
+    social: https://twitter.com/ramyanexus
 ---
-# Emmet 2.0 in Visual Studio Code
-
-August 7, 2017 Ramya Rao, [@ramyanexus](https://twitter.com/ramyanexus)
 
 In the July 2017 release of Visual Studio Code (version 1.15), we're shipping a better Emmet experience which has been in preview for the past 2 releases.
 

--- a/blogs/2017/09/28/java-debug.md
+++ b/blogs/2017/09/28/java-debug.md
@@ -1,15 +1,13 @@
 ---
 Order:
-TOCTitle: Java Debugging
-PageTitle: Using Visual Studio Code to Debug Java Applications
+TOCTitle: Java debugging
+PageTitle: Using VS Code to debug Java applications
 MetaDescription: Java Development with VS Code
 Date: 2017-09-28
 ShortDescription: Using VS Code to Debug Java Applications
-Author: Xiaokai He
+Authors:
+  - name: Xiaokai He
 ---
-# Using VS Code to Debug Java Applications
-
-September 28, 2017 Xiaokai He
 
 For Java developers on Visual Studio Code, the [Language Support for Java™ by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) extension has been great for providing language features such as IntelliSense and project support. At the same time, we've also heard feedback that users would also like Java debugging. Today, we're excited to announce our ongoing collaboration with Red Hat and enabling Java developers to debug Java applications with a new lightweight [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) based on [Java Debug Server](https://github.com/microsoft/java-debug).
 

--- a/blogs/2017/10/03/terminal-renderer.md
+++ b/blogs/2017/10/03/terminal-renderer.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Integrated Terminal Performance
-PageTitle: Integrated Terminal Performance Improvements
+TOCTitle: Integrated terminal performance
+PageTitle: Integrated terminal performance improvements
 MetaDescription: Explore the performance improvements made to Visual Studio Code's integrated terminal renderer in version 1.17
 Date: 2017-10-03
 ShortDescription: Explore the performance improvements made to Visual Studio Code's integrated terminal renderer in version 1.17
-Author: Daniel Imms
+Authors:
+  - name: Daniel Imms
+    social: https://twitter.com/Tyriar
 ---
-# Integrated Terminal Performance Improvements
-
-October 3, 2017 Daniel Imms, [@Tyriar](https://twitter.com/Tyriar)
 
 The rendering engine of the Integrated Terminal has been completely re-written with performance in mind for the upcoming version 1.17 of Visual Studio Code. In this version, we move away from a DOM-based rendering system to using the HTML [canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas) element.
 

--- a/blogs/2017/10/24/theicon.md
+++ b/blogs/2017/10/24/theicon.md
@@ -1,16 +1,15 @@
 ---
 Order:
-TOCTitle: The Icon Journey
-PageTitle: The Icon Journey
+TOCTitle: The icon journey
+PageTitle: The icon journey
 MetaDescription: Summary of feedback about the new icons and next steps
 MetaSocialImage: /assets/blogs/2017/10/24/blueicon.png
 Date: 2017-10-24
 ShortDescription: Summary of feedback about the new icons and next steps
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-# The Icon Journey
-
-October 24, 2017 Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 ## TL;DR
 

--- a/blogs/2017/11/15/live-share.md
+++ b/blogs/2017/11/15/live-share.md
@@ -1,16 +1,15 @@
 ---
 Order:
 TOCTitle: Introducing Live Share
-PageTitle: Introducing Visual Studio Live Share
+PageTitle: Introducing Live Share
 MetaDescription: Real-time collaborative development
 MetaSocialImage: /assets/blogs/2017/11/15/ls-social-resized.png
 Date: 2017-11-15
 ShortDescription: Real-time collaborative development
-Author: Amanda Silver
+Authors:
+  - name: Amanda Silver
+    social: https://twitter.com/amandaksilver
 ---
-# Introducing Visual Studio Live Share
-
-November 15, 2017 Amanda Silver, [@amandaksilver](https://twitter.com/amandaksilver)
 
 >**Update (May 7, 2018):** Visual Studio Live Share is now publicly available. You can [get started using Live Share](https://visualstudio.microsoft.com/services/live-share) today!
 

--- a/blogs/2017/11/16/connect.md
+++ b/blogs/2017/11/16/connect.md
@@ -1,16 +1,15 @@
 ---
 Order:
 TOCTitle: Connect 2017
-PageTitle: Visual Studio Code 2.6M Users, 12 months of momentum and more to come.
+PageTitle: VS Code at Connect(); 2017
 MetaDescription: Visual Studio Code 2.6M Users, 12 months of momentum and more to come.
 MetaSocialImage: /assets/blogs/2017/11/16/connect-social.png
-Date: 2017-11-16
+Date: 2017-11-15
 ShortDescription: Visual Studio Code 2.6M Users, 12 months of momentum and more to come. A summary of news from Connect(); 2017
-Author: Sean McBreen
+Authors:
+  - name: Sean McBreen
+    social: https://twitter.com/nz_sean
 ---
-# Visual Studio Code at Connect(); 2017
-
-November 15, 2017 Sean McBreen, [@nz_sean](https://twitter.com/nz_sean)
 
 On the day of our annual developer conference ([tune in here](https://www.microsoft.com/en-us/connectevent) if you missed it), we thought it would be cool to reflect on a few things highlighted today and touch on some things that have happened for Visual Studio Code in the last 12 months, for example:
 

--- a/blogs/2017/12/20/chrome-debugging.md
+++ b/blogs/2017/12/20/chrome-debugging.md
@@ -1,16 +1,15 @@
 ---
 Order:
 TOCTitle: What's New for Chrome Debugging
-PageTitle: What's New for Chrome debugging in VS Code
+PageTitle: What's new for Chrome debugging
 MetaDescription: What's New for Chrome debugging in Visual Studio Code
 MetaSocialImage: /assets/blogs/2017/12/20/social_paused.png
 Date: 2017-12-20
 ShortDescription: Learn what's new with Chrome debugging in Visual Studio Code
-Author: Kenneth Auchenberg
+Authors:
+  - name: Kenneth Auchenberg
+    social: https://twitter.com/auchenberg
 ---
-# What's new for Chrome debugging
-
-December 20, 2017 by [Kenneth Auchenberg](https://twitter.com/auchenberg)
 
 Over the recent months, we have been busy improving the Chrome debugging experience for Visual Studio Code, and today we are happy to release three new features that we think will make client-side JavaScript debugging in VS Code easier and more reliable.
 

--- a/blogs/2018/03/23/text-buffer-reimplementation.md
+++ b/blogs/2018/03/23/text-buffer-reimplementation.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Text Buffer Reimplementation
-PageTitle: Text Buffer Reimplementation, a Visual Studio Code Story
+TOCTitle: Text buffer reimplementation
+PageTitle: Text buffer reimplementation
 MetaDescription: Text Buffer Reimplementation in the Visual Studio Code/Monaco editor
 Date: 2018-03-23
-Author: Peng Lyu
+Authors:
+  - name: Peng Lyu
+    social: https://twitter.com/njukidreborn
 MetaSocialImage:
 ---
-# Text Buffer Reimplementation
-
-March 23, 2018 by Peng Lyu, [@njukidreborn](https://twitter.com/njukidreborn)
 
 The Visual Studio Code 1.21 release includes a brand new text buffer implementation which is much more performant, both in terms of speed and memory usage. In this blog post, I'd like to tell the story of how we selected and designed the data structures and algorithms that led to those improvements.
 

--- a/blogs/2018/04/25/bing-settings-search.md
+++ b/blogs/2018/04/25/bing-settings-search.md
@@ -1,16 +1,15 @@
 ---
 Order:
-TOCTitle: Settings Search
+TOCTitle: Settings search
 PageTitle: Bing-powered settings search in VS Code
 MetaDescription: Improving settings search in VS Code with Bing
 MetaSocialImage: /assets/blogs/2018/04/25/SocialImg.gif
 Date: 2018-04-25
 ShortDescription: Improving settings search in VS Code with Bing
-Author: Rob Lourens
+Authors:
+  - name: Rob Lourens
+    social: https://twitter.com/roblourens
 ---
-# Bing-powered settings search in VS Code
-
-April 25, 2018 by Rob Lourens [@roblourens](https://twitter.com/roblourens) and Ankith Karat [ankar@microsoft.com](mailto:ankar@microsoft.com)
 
 Have you ever had trouble finding a certain setting in VS Code? You're not alone. Looking across common GitHub issues, StackOverflow questions, tweets, and user studies that we've done, we've seen many users having issues finding settings. This is no surprise given that VS Code includes more than 400 settings out of the box, and with extensions installed, many users can have significantly more. If you include typical user mistakes such as typos and the challenge of picking the right search terms, users have a hard time.
 

--- a/blogs/2018/05/07/live-share-public-preview.md
+++ b/blogs/2018/05/07/live-share-public-preview.md
@@ -1,16 +1,15 @@
 ---
 Order:
-TOCTitle: Live Share Preview
-PageTitle: Announcing the Visual Studio Live Share Public Preview
+TOCTitle: Live Share preview
+PageTitle: Announcing the Live Share public preview
 MetaDescription: Real-time collaborative development
 MetaSocialImage: /assets/blogs/2017/11/15/ls-social-resized.png
 Date: 2018-05-07
 ShortDescription: Real-time collaborative development
-Author: Amanda Silver
+Authors:
+  - name: Amanda Silver
+    social: https://twitter.com/amandaksilver
 ---
-# Visual Studio Live Share Public Preview
-
-May 7, 2018 Amanda Silver, [@amandaksilver](https://twitter.com/amandaksilver)
 
 We are excited to announce the public preview of Visual Studio Live Share! At [Connect last November](https://code.visualstudio.com/blogs/2017/11/15/live-share), we showed how Live Share enables real-time collaborative editing and debugging from the comfort of your favorite tools. Since then, we’ve worked with thousands of developers worldwide, resolved hundreds of issues, and addressed top feature requests such as [adding support for Linux](https://github.com/MicrosoftDocs/live-share/issues/24). We’ve benefited greatly from all the feedback thus far, thank you! Today, we’re excited to announce that every developer using Visual Studio and Visual Studio Code can [get started with Live Share today](https://aka.ms/vsls)!
 

--- a/blogs/2018/07/12/introducing-logpoints-and-auto-attach.md
+++ b/blogs/2018/07/12/introducing-logpoints-and-auto-attach.md
@@ -6,11 +6,10 @@ MetaDescription: Introducing Logpoints and auto-attach to make debugging easier 
 MetaSocialImage: /assets/blogs/2018/07/12/debugger.png
 Date: 2018-07-12
 ShortDescription: Introducing Logpoints and auto-attach to make debugging easier and simpler to use
-Author: Kenneth Auchenberg
+Authors:
+  - name: Kenneth Auchenberg
+    social: https://twitter.com/auchenberg
 ---
-# Introducing Logpoints and auto-attach
-
-July 12, 2018 Kenneth Auchenberg, [@auchenberg](https://twitter.com/auchenberg)
 
 Over the past few months we have been busy improving the debugging experience in Visual Studio Code, and in this post, I'm going to talk about how we think about debugging, present the feedback we heard from our users, and explain the steps we are taking to make debugging easier and simpler in VS Code.
 

--- a/blogs/2018/08/07/debug-adapter-protocol-website.md
+++ b/blogs/2018/08/07/debug-adapter-protocol-website.md
@@ -6,11 +6,10 @@ MetaDescription: A new home for the Debug Adapter Protocol
 MetaSocialImage: /assets/blogs/2018/08/07/with-DAP.png
 Date: 2018-08-07
 ShortDescription: The new Debug Adapter Protocol website
-Author: André Weinand
+Authors:
+  - name: André Weinand
+    social: https://twitter.com/weinand
 ---
-# New home for the Debug Adapter Protocol
-
-August 7, 2018 André Weinand, [@weinand](https://twitter.com/weinand)
 
 One goal of the July milestone was to move the **Debug Adapter Protocol** -- which was hiding itself in a somewhat obscure [GitHub project](https://github.com/microsoft/vscode-debugadapter-node) -- to a more prominent website (see feature request [#19636](https://github.com/microsoft/vscode/issues/19636)).
 

--- a/blogs/2018/09/10/introducing-github-pullrequests.md
+++ b/blogs/2018/09/10/introducing-github-pullrequests.md
@@ -1,16 +1,15 @@
 ---
 Order:
 TOCTitle: GitHub Pull Requests
-PageTitle: Introducing GitHub Pull Requests for Visual Studio Code
+PageTitle: GitHub Pull Requests in VS Code
 MetaDescription: Introducing GitHub Pull Requests for Visual Studio Code
 MetaSocialImage: /assets/blogs/2018/09/10/github_pr_hero.png
 Date: 2018-09-10
 ShortDescription: Introducing GitHub Pull Requests for Visual Studio Code
-Author: Kenneth Auchenberg
+Authors:
+  - name: Kenneth Auchenberg
+    social: https://twitter.com/auchenberg
 ---
-# GitHub Pull Requests in Visual Studio Code
-
-September 10, 2018 Kenneth Auchenberg, [@auchenberg](https://twitter.com/auchenberg)
 
 Like many other open-source projects, the [Visual Studio Code community collaborates](https://github.com/microsoft/vscode) through [pull requests](https://github.com/microsoft/vscode/pulls) to land fixes and new features. Starting this past spring, our team has been working to bring you a new integrated pull request experience so that you can collaborate, comment, review, and validate GitHub pull requests directly from within Visual Studio Code.
 

--- a/blogs/2018/09/12/engineering-with-azure-pipelines.md
+++ b/blogs/2018/09/12/engineering-with-azure-pipelines.md
@@ -1,16 +1,15 @@
 ---
 Order:
 TOCTitle: Using Azure Pipelines
-PageTitle: Visual Studio Code using Azure Pipelines
+PageTitle: VS Code using Azure Pipelines
 MetaDescription: Visual Studio Code using Azure Pipelines
 MetaSocialImage: /assets/blogs/2018/09/12/social_pipelines.png
 Date: 2018-09-12
 ShortDescription: Improved Engineering with Azure Pipelines
-Author: João Moreno
+Authors:
+  - name: João Moreno
+    social: https://twitter.com/joaomoreno
 ---
-# Visual Studio Code using Azure Pipelines
-
-September 12, 2018 João Moreno, [@joaomoreno](https://twitter.com/joaomoreno)
 
 One of my responsibilities as a developer on the Visual Studio Code team is to maintain and improve our build and continuous integration (CI) infrastructure. Given the latest feature announcements from [Azure Pipelines](https://aka.ms/azurecicd), the Visual Studio Code team has dramatically changed how we leverage Microsoft's technologies to provide a better collaboration platform for both our developers as well as our users. In this blog post, I'll guide you through a bit of Visual Studio Code's history, focusing on our CI processes and tools and how they have changed over time.
 

--- a/blogs/2018/11/26/event-stream.md
+++ b/blogs/2018/11/26/event-stream.md
@@ -1,13 +1,14 @@
 ---
 Order:
-TOCTitle: Event-Stream Package Security Update
-PageTitle: Event-Stream Package Security Update
-MetaDescription: Event-Stream Package Security Update
+TOCTitle: Event-stream package security update
+PageTitle: Event-stream package security update
+MetaDescription: Event-stream package security update
 Date: 2018-11-26
-ShortDescription: Event-Stream Package Security Update
-Author: Kai Maetzel
+ShortDescription: Event-stream package security update
+Authors:
+  - name: Kai Maetzel
+    social: https://twitter.com/kaimaetzel
 ---
-# Event-Stream Package Security Update
 
 **Updated**: June 23, 2019
 
@@ -21,8 +22,6 @@ Below is the current list of blocked extensions:
 * `MaxGotovkin.tslens`
 
 ---
-
-November 26, 2018 Kai Maetzel, [@kaimaetzel](https://twitter.com/kaimaetzel)
 
 You might already have heard that the popular event-stream NPM package includes a malicious dependency. The details can be found in the following GitHub issue: [https://github.com/dominictarr/event-stream/issues/116](https://github.com/dominictarr/event-stream/issues/116). This vulnerability has been in existence for about two months but was only recently discovered.
 

--- a/blogs/2018/12/04/rich-navigation.md
+++ b/blogs/2018/12/04/rich-navigation.md
@@ -1,15 +1,14 @@
 ---
 Order:
-TOCTitle: Rich Code Navigation
-PageTitle: Rich Code Navigation
-MetaDescription: First look at a rich code navigation experience in Visual Studio
+TOCTitle: Rich code navigation
+PageTitle: First look at a rich code navigation experience
+MetaDescription: First look at a rich code navigation experience in Visual Studio Code
 Date: 2018-12-04
-ShortDescription: First look at a rich code navigation experience in Visual Studio
-Author: Jonathan Carter
+ShortDescription: First look at a rich code navigation experience in Visual Studio Code
+Authors:
+  - name: Jonathan Carter
+    social: https://twitter.com/LostInTangent
 ---
-# First look at a rich code navigation experience
-
-December 4, 2018 Jonathan Carter, [@lostintangent](https://twitter.com/LostInTangent)
 
 Pull requests are a critical collaboration tool for millions of developers every day, facilitating asynchronous code reviews and the distribution of knowledge amongst teams and open-source communities. Because of this widespread utility and adoption, any advancement to the PR review workflow can have a significant impact on developer productivity, product quality and release velocity.
 

--- a/blogs/2019/02/19/lsif.md
+++ b/blogs/2019/02/19/lsif.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: Language Server Index Format
-PageTitle: Language Server Index Format
+PageTitle: The Language Server Index Format (LSIF)
 MetaDescription: Rich Code Navigation without Checkout
 Date: 2019-02-19
 ShortDescription: Rich Code Navigation without Checkout
-Author: Dirk Bäumer
+Authors:
+  - name: Dirk Bäumer
 ---
-# The Language Server Index Format (LSIF)
-
-February 19, 2019 by Dirk Bäumer
 
 ## Rich code navigation without checkout
 

--- a/blogs/2019/05/02/remote-development.md
+++ b/blogs/2019/05/02/remote-development.md
@@ -1,16 +1,15 @@
 ---
 Order: 
-TOCTitle: Remote Development
-PageTitle: Remote Development with Visual Studio Code
+TOCTitle: Remote development
+PageTitle: Remote development with VS Code
 MetaDescription: VS Code remote support for WSL, Containers, and SSH
 MetaSocialImage: /assets/blogs/2019/05/02/social-remote.png
 Date: 2019-05-02
-ShortDescription: Remote Development with Visual Studio Code
-Author: Chris Dias
+ShortDescription: Remote development with VS Code
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-# Remote Development with VS Code
-
-May 2, 2019 by The VS Code Team, [@code](https://twitter.com/code)
 
 ## TL;DR
 

--- a/blogs/2019/05/23/strict-null.md
+++ b/blogs/2019/05/23/strict-null.md
@@ -1,16 +1,15 @@
 ---
 Order: 
 TOCTitle: Strict null checking
-PageTitle: Strict null checking the Visual Studio Code codebase
+PageTitle: Strict null checking VS Code
 MetaDescription: Strict null checking the Visual Studio Code codebase
 MetaSocialImage: /assets/blogs/2019/05/23/social-strict-null.png
 Date: 2019-05-23
 ShortDescription: Strict null checking
-Author: Matt Bierner
+Authors:
+  - name: Matt Bierner
+    social: https://hachyderm.io/@mattbierner
 ---
-# Strict null checking Visual Studio Code
-
-May 23, 2019 by Matt Bierner, [@mattbierner](https://hachyderm.io/@mattbierner)
 
 ## Safety permits speed
 

--- a/blogs/2019/07/25/remote-ssh.md
+++ b/blogs/2019/07/25/remote-ssh.md
@@ -1,16 +1,15 @@
 ---
 Order: 
 TOCTitle: Remote SSH
-PageTitle: Remote SSH access with Visual Studio Code
+PageTitle: Remote SSH with VS Code
 MetaDescription: Remote SSH access with Visual Studio Code
 MetaSocialImage: /assets/blogs/2019/07/25/social-remote-ssh.png
 Date: 2019-07-25
 ShortDescription: Remote SSH
-Author: Sana Ajani
+Authors:
+  - name: Sana Ajani
+    social: https://twitter.com/sana_ajani
 ---
-# Remote SSH with Visual Studio Code
-
-July 25, 2019 by Sana Ajani, [@sana_ajani](https://twitter.com/sana_ajani)
 
 ## Remote - SSH: Easy, smooth, and (like) local
 

--- a/blogs/2019/09/03/wsl2.md
+++ b/blogs/2019/09/03/wsl2.md
@@ -1,16 +1,15 @@
 ---
 Order: 
 TOCTitle: WSL 2
-PageTitle: Using WSL 2 with Visual Studio Code
+PageTitle: WSL 2 with VS Code
 MetaDescription: Using WSL 2 with Visual Studio Code
 MetaSocialImage: /assets/blogs/2019/09/03/social-wsl2.png
 Date: 2019-09-03
 ShortDescription: WSL 2 with VS Code
-Author: Matt Hernandez
+Authors:
+  - name: Matt Hernandez
+    social: https://twitter.com/fiveisprime
 ---
-# WSL 2 with Visual Studio Code
-
-September 3, 2019 by Matt Hernandez, [@fiveisprime](https://twitter.com/fiveisprime)
 
 It's been a couple of months since the initial betas for the [Windows Subsystem for Linux 2](https://devblogs.microsoft.com/commandline/announcing-wsl-2) (WSL 2) were launched and I wanted to share a bit about what this is all about and how this will help you be more productive. I've been using the beta since it landed in [Windows Insiders](https://insider.windows.com/getting-started/) and I quickly switched over to using WSL 2 exclusively in my daily development tasks.
 

--- a/blogs/2019/10/03/remote-ssh-tips-and-tricks.md
+++ b/blogs/2019/10/03/remote-ssh-tips-and-tricks.md
@@ -1,16 +1,15 @@
 ---
 Order: 
-TOCTitle: SSH Tips and Tricks
-PageTitle: Visual Studio Code Remote SSH Tips and Tricks
+TOCTitle: SSH tips and tricks
+PageTitle: Remote SSH tips and tricks
 MetaDescription: Visual Studio Code Remote-SSH Tips and Tricks
 MetaSocialImage: /assets/blogs/2019/10/03/social-remote-ssh.png
 Date: 2019-10-03
 ShortDescription: Remote SSH Tips and Tricks with Visual Studio Code
-Author: Sana Ajani
+Authors:
+  - name: Sana Ajani
+    social: https://twitter.com/sana_ajani
 ---
-# Remote SSH: Tips and Tricks
-
-October 3, 2019 by Sana Ajani, [@sana_ajani](https://twitter.com/sana_ajani)
 
 In a previous [Remote SSH blog post](/blogs/2019/07/25/remote-ssh.md), we went over how to set up a Linux virtual machine and connect to the VM using the [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) in Visual Studio Code. In this blog post, we'll go into some tips and tricks that you can use to get the most out of your remote setup.
 

--- a/blogs/2019/10/31/inspecting-containers.md
+++ b/blogs/2019/10/31/inspecting-containers.md
@@ -1,16 +1,15 @@
 ---
 Order: 
 TOCTitle: Inspecting Containers
-PageTitle: Inspecting Docker Containers with Visual Studio Code
+PageTitle: Inspecting containers with VS Code
 MetaDescription: Inspecting Docker Containers with Visual Studio Code
 MetaSocialImage: /assets/blogs/2019/10/31/social-remote-containers.png
 Date: 2019-10-31
 ShortDescription: Inspecting Docker Containers with Visual Studio Code
-Author: Bowden Kelly
+Authors:
+  - name: Bowden Kelly
+    social: https://twitter.com/bowdenk7
 ---
-# Inspecting Containers with VS Code
-
-October 31, 2019 by Bowden Kelly, [@bowdenk7](https://twitter.com/bowdenk7)
 
 When developing containerized applications, it is common to try to debug build and runtime issues by attaching a shell to the running container using `docker exec --it {containerID} /bin/sh`.
 

--- a/blogs/2020/02/18/optimizing-ci.md
+++ b/blogs/2020/02/18/optimizing-ci.md
@@ -1,16 +1,17 @@
 ---
 Order: 
-TOCTitle: Improving CI Build Times
-PageTitle: How Visual Studio Code leverages Azure Pipelines Artifact Caching Tasks to improve CI
+TOCTitle: Improving CI build times
+PageTitle: Improving CI build times
 MetaDescription: How Visual Studio Code leverages Azure Pipelines Artifact Caching Tasks to improve CI
 MetaSocialImage: /assets/blogs/2020/02/18/hero.png
 Date: 2020-02-18
 ShortDescription: How Visual Studio Code leverages Azure Pipelines Artifact Caching Tasks to improve CI
-Author: Ethan Dennis, João Moreno
+Authors:
+  - name: Ethan Dennis
+    social: https://twitter.com/erdennis13
+  - name: João Moreno
+    social: https://twitter.com/joaomoreno
 ---
-# Improving CI Build Times
-
-February 18, 2020 by Ethan Dennis, [@erdennis13](https://twitter.com/erdennis13) and João Moreno, [@joaomoreno](https://twitter.com/joaomoreno)
 
 Visual Studio Code is a large project with lots of moving parts and an active participant list. We have [shown](https://code.visualstudio.com/blogs/2018/09/12/engineering-with-azure-pipelines) how we actively use Azure Pipelines to keep up with good engineering practices by maintaining our build and continuous integration infrastructure. In this blog post, we’ll talk about how we used the [Azure Pipelines Artifact Caching Tasks](https://github.com/microsoft/azure-pipelines-artifact-caching-tasks) to dramatically reduce our CI build times.
 

--- a/blogs/2020/02/24/custom-data-format.md
+++ b/blogs/2020/02/24/custom-data-format.md
@@ -1,16 +1,14 @@
 ---
 Order: 
-TOCTitle: Custom Data Format
-PageTitle: "Custom Data Format: Evolving HTML and CSS language features"
-MetaDescription: "Custom Data Format: Evolving HTML and CSS language features"
+TOCTitle: Custom data format
+PageTitle: "Custom data format: Evolving HTML and CSS language features"
+MetaDescription: Evolving HTML and CSS language features.
 Date: 2020-02-24
-Author: Pine Wu
+Authors:
+  - name: Pine Wu
+    social: https://github.com/octref
 MetaSocialImage:
 ---
-
-# Custom Data Format: Evolving HTML and CSS language features
-
-February 24, 2020 by Pine Wu, [@octref](https://github.com/octref)
 
 The web evolves and so do its languages. New entities continue to land in HTML and CSS specifications. [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) and [Houdini](https://developer.mozilla.org/en-US/docs/Web/Houdini) allow users to extend HTML and CSS semantics. Many developers today use programming languages that embed HTML and CSS. Although HTML and CSS see increasingly flexible usage, editor support for new features often lags behind.
 

--- a/blogs/2020/03/02/docker-in-wsl2.md
+++ b/blogs/2020/03/02/docker-in-wsl2.md
@@ -1,15 +1,14 @@
 ---
 Order: 
 TOCTitle: Docker in WSL 2
-PageTitle: Using Docker in Windows for Linux Subsystem (WSL) 2
-MetaDescription: Using Docker in Windows for Linux Subsystem (WSL) 2
+PageTitle: Using Docker in WSL 2
+MetaDescription: Using Docker in Windows Subsystem for Linux
 Date: 2020-03-02
-Author: Matt Hernandez
+Authors:
+  - name: Matt Hernandez
+    social: https://twitter.com/fiveisprime
 MetaSocialImage:
 ---
-# Using Docker in WSL 2
-
-March 2, 2020 by Matt Hernandez, [@fiveisprime](https://twitter.com/fiveisprime)
 
 Last June, the Docker team [announced](https://engineering.docker.com/2019/06/docker-hearts-wsl-2/) that they will be investing in getting Docker running with the Windows Subsystem for Linux (WSL). All of this is made possible with the recent changes to the architecture of WSL to run within a lightweight virtual machine (VM), which we talked about in an earlier [blog post about WSL 2](https://code.visualstudio.com/blogs/2019/09/03/wsl2). Since this announcement, the Docker team has released a [Technical Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/) of Docker that includes support for running with WSL 2.
 

--- a/blogs/2020/05/06/github-issues-integration.md
+++ b/blogs/2020/05/06/github-issues-integration.md
@@ -1,15 +1,14 @@
 ---
 Order: 
-TOCTitle: GitHub Issues Integration
-PageTitle: Working with GitHub Issues in Visual Studio Code
+TOCTitle: GitHub Issues integration
+PageTitle: Introducing GitHub Issues intregration
 MetaDescription: Working with GitHub Issues in Visual Studio Code
 Date: 2020-05-06
-Author: Alex Ross
+Authors:
+  - name: Alex Ross
+    social: https://github.com/alexr00/
 MetaSocialImage:
 ---
-# Introducing GitHub Issues Integration
-
-May 6, 2020 by Alex Ross, [@alexr00](https://github.com/alexr00/)
 
 On the Visual Studio Code team, we use GitHub [issues](https://github.com/microsoft/vscode/issues) to track all of our work. From our detailed [iteration plans](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Aiteration-plan) to individual bugs, we track everything as GitHub issues. Given how important issues are to our team and other GitHub projects, we wanted to add GitHub issues integration to VS Code. This addition complemented the GitHub Pull Request work we [announced](https://code.visualstudio.com/blogs/2018/09/10/introducing-github-pullrequests) over a year ago. Starting with VS Code version 1.45, this new support to move the issues and source code closer together will be available in the [GitHub Pull Requests and Issues](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension (formerly named GitHub Pull Requests).
 

--- a/blogs/2020/05/14/vscode-build-2020.md
+++ b/blogs/2020/05/14/vscode-build-2020.md
@@ -1,15 +1,14 @@
 ---
 Order: 
 TOCTitle: VS Code at Build
-PageTitle: Visual Studio Code at Microsoft Build 2020
+PageTitle: VS Code at Build 2020
 MetaDescription: Visual Studio Code at Microsoft Build 2020
 Date: 2020-05-14
-Author: Alessandro Segala
+Authors:
+  - name: Alessandro Segala
+    social: https://twitter.com/ItalyPaleAle
 MetaSocialImage: /assets/blogs/2020/05/14/vscode-build-social.png
 ---
-# Visual Studio Code at Build 2020
-
-May 14, 2020 by Alessandro Segala, [@ItalyPaleAle](https://twitter.com/ItalyPaleAle)
 
 The [Microsoft Build 2020](https://mybuild.microsoft.com) conference is starting next Tuesday, May 19, and will be running for 48 continuous hours. For the first time, Build is a fully digital event, open to everyone for free.
 

--- a/blogs/2020/06/09/go-extension.md
+++ b/blogs/2020/06/09/go-extension.md
@@ -1,14 +1,13 @@
 ---
 Order: 
 TOCTitle: The Go experience
-PageTitle: Visual Studio Code Go extension joins the Go project
+PageTitle: The Go extension joins the Go project
 MetaDescription: Visual Studio Code Go extension joins the Go project
 Date: 2020-06-09
-Author: Alessandro Segala
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-# The next phase of the Go experience
-
-June 9, 2020 by The VS Code Team, [@code](https://twitter.com/code)
 
 From the beginning, we have worked with developer communities to build Visual Studio Code as a powerful, extensible editor. Five years into this journey, individuals and organizations in our community have helped us create an editor that is really for all developers, using any language.
 

--- a/blogs/2020/07/01/containers-wsl.md
+++ b/blogs/2020/07/01/containers-wsl.md
@@ -4,11 +4,10 @@ TOCTitle: Dev Containers in WSL 2
 PageTitle: Using Dev Containers in WSL 2
 MetaDescription: Using Dev Containers in WSL 2
 Date: 2020-07-01
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-# Using Dev Containers in WSL 2
-
-July 1, 2020 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 Leveraging the power of Docker containers and the Windows Subsystem for Linux 2 (WSL 2), you can preserve your Windows environment by developing your applications in the sandboxed familiarity of a container in a deeply integrated Linux kernel.
 

--- a/blogs/2020/07/27/containers-edu.md
+++ b/blogs/2020/07/27/containers-edu.md
@@ -1,14 +1,13 @@
 ---
 Order: 
-TOCTitle: Development Containers in Education
-PageTitle: Development Containers in Education with Visual Studio Code
-MetaDescription: Development Containers in Education with Visual Studio Code
+TOCTitle: Development containers in education
+PageTitle: "Development containers in education: A guide for instructors"
+MetaDescription: Development containers in education with Visual Studio Code.
 Date: 2020-07-27
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-# Development Containers in Education: A Guide for Instructors
-
-July 27, 2020 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 We've heard from many educators that the first days or weeks of the semester can be lost to configuring the correct environment for students. Even so, students may still end up with a low-quality development experience or insufficient grading of their assignments:
 

--- a/blogs/2020/12/03/chromebook-get-started.md
+++ b/blogs/2020/12/03/chromebook-get-started.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: VS Code on Chromebook
-PageTitle: Coding and learning with VS Code on Chromebooks
+PageTitle: Learning with VS Code on Chromebooks
 MetaDescription: Installing Visual Studio Code on Chromebooks with Crostini and getting started with coding and learning
 Date: 2020-12-03
-Author: Alessandro Segala
+Authors:
+  - name: Alessandro Segala
+    social: https://twitter.com/ItalyPaleAle
 ---
-
-# Learning with VS Code on Chromebooks
-
-December 3, 2020 by Alessandro Segala, [@ItalyPaleAle](https://twitter.com/ItalyPaleAle)
 
 For the last few years, Chromebooks running Google Chrome OS have been providing an alternative to "traditional" laptops. Thanks to lots of choices, from very affordable models to high-end ones, Chromebooks are especially popular among students, who can use them for learning, completing assignments, and attending classes virtually.
 

--- a/blogs/2021/02/16/extension-bisect.md
+++ b/blogs/2021/02/16/extension-bisect.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: Extension bisect
-PageTitle: Visual Studio Code extension bisect utility
+PageTitle: Resolving extension issues with bisect
 MetaDescription: Find problematic extensions quickly with the Visual Studio Code extension bisect utility
 Date: 2021-02-16
-Author: Johannes Rieken
+Authors:
+  - name: Johannes Rieken
+    social: https://twitter.com/johannesrieken
 ---
-
-# Resolving extension issues with bisect
-
-February 16, 2021 by Johannes Rieken, [@johannesrieken](https://twitter.com/johannesrieken)
 
 > "Just like git-bisect, but for VS Code extensions."
 

--- a/blogs/2021/06/02/build-2021.md
+++ b/blogs/2021/06/02/build-2021.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: Build 2021
-PageTitle: Visual Studio Code at Microsoft Build 2021
+PageTitle: VS Code at Build 2021
 MetaDescription: A hand-picked collection of Visual Studio Code content from Build 2021.
 Date: 2021-06-02
-Author: Alessandro Segala
+Authors:
+  - name: Alessandro Segala
+    social: https://twitter.com/ItalyPaleAle
 ---
-
-# Visual Studio Code at Build 2021
-
-June 2, 2021 by Alessandro Segala, [@ItalyPaleAle](https://twitter.com/ItalyPaleAle)
 
 > "That's a wrap! Now catch up with content on-demand."
 

--- a/blogs/2021/06/10/remote-repositories.md
+++ b/blogs/2021/06/10/remote-repositories.md
@@ -1,14 +1,15 @@
 ---
 Order: 
-TOCTitle: Remote Repositories
-PageTitle: Remote Repositories extension for Visual Studio Code
+TOCTitle: Remote repositories
+PageTitle: Remote repositories
 MetaDescription: Remotely browse and edit a source control repository from within Visual Studio Code.
 Date: 2021-06-10
-Author: Brigit Murtaugh, Eric Amodio
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
+  - name: Eric Amodio
+    social: https://twitter.com/eamodio
 ---
-# Remote Repositories
-
-June 10, 2021 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh), Eric Amodio, [@eamodio](https://twitter.com/eamodio)
 
 >**Note**: The Remote Repositories extension has been renamed to [GitHub Repositories](https://marketplace.visualstudio.com/items?itemName=github.remotehub) since this blog post was published. You can also check out the [latest documentation](/docs/sourcecontrol/github.md#github-repositories-extension), which will have the most updated information on the extension.
 

--- a/blogs/2021/07/06/workspace-trust.md
+++ b/blogs/2021/07/06/workspace-trust.md
@@ -1,14 +1,13 @@
 ---
 Order: 
-TOCTitle: Workspace Trust
-PageTitle: Workspace Trust in Visual Studio Code
+TOCTitle: Workspace trust
+PageTitle: Workspace trust
 MetaDescription: The rationale and development of the Workspace Trust feature in Visual Studio Code.
 Date: 2021-07-06
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-# Workspace Trust
-
-July 6, 2021 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 Can I trust myself? This is the existential question facing many Visual Studio Code users since the [1.57 update](https://code.visualstudio.com/updates/v1_57).
 

--- a/blogs/2021/08/05/notebooks.md
+++ b/blogs/2021/08/05/notebooks.md
@@ -1,14 +1,13 @@
 ---
 Order: 
 TOCTitle: Notebooks
-PageTitle: The Coming of Age of Notebooks
+PageTitle: The coming of age of notebooks
 MetaDescription: Challenges with the rollout of the new native notebook experience in Visual Studio Code.
 Date: 2021-08-05
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-# The Coming of Age of Notebooks
-
-August 05, 2021 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 **A (not so) new way of doing development**
 

--- a/blogs/2021/09/29/bracket-pair-colorization.md
+++ b/blogs/2021/09/29/bracket-pair-colorization.md
@@ -1,15 +1,14 @@
 ---
 Order: 
 TOCTitle: Bracket Pair Colorization
-PageTitle: How We Made Bracket Pair Colorization 10,000x Faster In Visual Studio Code
+PageTitle: Bracket pair colorization 10,000x faster
 MetaDescription: How we made bracket pair colorization in Visual Studio Code up to 10,000 times faster.
 Date: 2021-09-29
-Author: Henning Dieterichs
+Authors:
+  - name: Henning Dieterichs
+    social: https://twitter.com/hediet_dev
 HasLaTeX: true
 ---
-# Bracket pair colorization 10,000x faster
-
-September 29, 2021 by Henning Dieterichs, [@hediet_dev](https://twitter.com/hediet_dev)
 
 When dealing with deeply nested brackets in Visual Studio Code, it can be hard to figure out which brackets match and which do not.
 

--- a/blogs/2021/10/11/webview-ui-toolkit.md
+++ b/blogs/2021/10/11/webview-ui-toolkit.md
@@ -1,15 +1,15 @@
 ---
 Order: 
 TOCTitle: Webview UI Toolkit
-PageTitle: Webview UI Toolkit for Visual Studio Code
+PageTitle: Introducing the Webview UI Toolkit for VS Code
 MetaDescription: Announcing the public preview of the Webview UI Toolkit for Visual Studio Code
 Date: 2021-10-11
-Author: David Dossett
+Authors:
+  - name: David Dossett
+    social: https://twitter.com/david_dossett
+  - name: Hawk Ticehurst
+    social: https://bsky.app/profile/hawkticehurst.com
 ---
-
-# Webview UI Toolkit for Visual Studio Code
-
-October 11, 2021 by David Dossett, [@david_dossett](https://twitter.com/david_dossett) and Hawk Ticehurst, [@hawkticehurst](https://bsky.app/profile/hawkticehurst.com)
 
 We're so excited to announce the public preview of the [Webview UI Toolkit for Visual Studio Code](https://github.com/microsoft/vscode-webview-ui-toolkit). With this toolkit, extensions developers can quickly and easily create [webview-based extensions](https://code.visualstudio.com/api/extension-guides/webview) in Visual Studio Code that look, feel, and act like the editor itself.
 

--- a/blogs/2021/10/20/vscode-dev.md
+++ b/blogs/2021/10/20/vscode-dev.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: vscode.dev
-PageTitle: vscode.dev Visual Studio Code for the Web
+PageTitle: vscode.dev(!)
 MetaDescription: Announcing vscode.dev Visual Studio Code for the Web
 Date: 2021-10-20
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-
-# vscode.dev(!)
-
-October 20, 2021 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 Back in 2019, when the `.dev` top-level domain opened, we picked up `vscode.dev` and quickly parked it, pointing at our website `code.visualstudio.com` (or, if you are from the Boston area like me, we "pahked it"). Like a lot of people who buy a `.dev` domain, we had no idea what we were going to do with it. And we certainly didn't anticipate that it would end up being the fulfillment of a mission over a decade in the making.
 

--- a/blogs/2021/11/08/custom-notebooks.md
+++ b/blogs/2021/11/08/custom-notebooks.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: Custom Notebooks
-PageTitle: Notebooks, Visual Studio Code style
+PageTitle: Notebooks, VS Code style
 MetaDescription: Bringing custom notebook experiences to the Visual Studio Code extension Marketplace.
 Date: 2021-11-08
-Author: Tanha Kabir
+Authors:
+  - name: Tanha Kabir
+    social: https://twitter.com/_tanhakabir
 ---
-
-# Notebooks, Visual Studio Code style
-
-November 8, 2021 by Tanha Kabir, [@_tanhakabir](https://twitter.com/_tanhakabir)
 
 Notebooks are documents that contain a mix of rich Markdown, executable code snippets, and accompanying rich output. These are all separated into distinct cells and can be interleaved in any order.
 

--- a/blogs/2022/03/08/the-tutorial-problem.md
+++ b/blogs/2022/03/08/the-tutorial-problem.md
@@ -4,12 +4,10 @@ TOCTitle: The problem with tutorials
 PageTitle: The problem with tutorials
 MetaDescription: How Laravel uses containerized dev environments to make a better tutorial
 Date: 2022-03-08
-Author: Burke Holland
+Authors:
+  - name: Burke Holland
+    social: https://twitter.com/burkeholland
 ---
-
-# The problem with tutorials
-
-March 8, 2022 by Burke Holland, [@burkeholland](https://twitter.com/burkeholland)
 
 Writing a great tutorial isn't easy. I should know - I've written a lot of them, and not every one was a smashing success.
 

--- a/blogs/2022/04/04/increase-productivity-with-containers.md
+++ b/blogs/2022/04/04/increase-productivity-with-containers.md
@@ -1,15 +1,13 @@
 ---
 Order: 
-TOCTitle: Moving from Local to Remote Development
-PageTitle: Using Containers to move from local to Remote Development
+TOCTitle: Moving from local to remote development
+PageTitle: Using containers to move from local to remote development
 MetaDescription: Increase productivity by moving your development environment from local, to containers, to the cloud.
 Date: 2022-04-04
-Author: Olivia Guzzardo
+Authors:
+  - name: Olivia Guzzardo
+    social: https://twitter.com/OliviaGuzzardo
 ---
-
-# Using Containers to move from Local to Remote Development
-
-April 4, 2022 by Olivia Guzzardo, [@OliviaGuzzardo](https://twitter.com/OliviaGuzzardo)
 
 One of my favorite things that industry professionals like to ask aspiring developers is, "How many lines of code does the average developer write per day?" Most guess in the hundreds or thousands – they're always shocked to hear that the actual average figure lies in the tens.
 

--- a/blogs/2022/05/18/dev-container-cli.md
+++ b/blogs/2022/05/18/dev-container-cli.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: Dev container CLI
-PageTitle: Development Container CLI
+PageTitle: The dev container CLI
 MetaDescription: Provide a consistent development environment anywhere using the development container CLI.
 Date: 2022-05-18
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-
-# The dev container CLI
-
-May 18, 2022 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 ## TL;DR
 

--- a/blogs/2022/07/07/vscode-server.md
+++ b/blogs/2022/07/07/vscode-server.md
@@ -4,12 +4,10 @@ TOCTitle: The VS Code Server
 PageTitle: The VS Code Server
 MetaDescription: Securely connect to and develop on any remote machine with the VS Code Server private preview.
 Date: 2022-07-07
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-
-# The Visual Studio Code Server
-
-July 7, 2022 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 ## A remote present and future
 

--- a/blogs/2022/08/16/markdown-language-server.md
+++ b/blogs/2022/08/16/markdown-language-server.md
@@ -1,15 +1,13 @@
 ---
 Order: 
-TOCTitle: Markdown Language Server
-PageTitle: Introducing the Markdown Language Server
+TOCTitle: Markdown language server
+PageTitle: Introducing the Markdown language server
 MetaDescription: Why we decided to build a language server for working with Markdown
 Date: 2022-08-16
-Author: Matt Bierner
+Authors:
+  - name: Matt Bierner
+    social: https://hachyderm.io/@mattbierner
 ---
-
-# Introducing the Markdown Language Server
-
-August 16, 2022 by Matt Bierner, [@MattBierner](https://hachyderm.io/@mattbierner)
 
 Markdown support was the first feature I took ownership of when I joined Visual Studio Code back in 2016. Wow, has it really been six years? It was a great match though. I've worked with Markdown long enough that I often find myself hopefully typing backticks and asterisks into Twitter, Outlook, and just about every textbox my cursor lands in. It's been incredibly rewarding to grow VS Code's built-in Markdown support over the years and see how our Markdown extension has directly and indirectly shaped core features like webviews and notebooks.
 

--- a/blogs/2022/09/15/dev-container-features.md
+++ b/blogs/2022/09/15/dev-container-features.md
@@ -1,15 +1,13 @@
 ---
 Order: 
-TOCTitle: Dev Container Features
-PageTitle: Dev Container Features
-MetaDescription: What are dev container Features and what's new
+TOCTitle: Dev container features
+PageTitle: Custom dev container features
+MetaDescription: What are dev container features and what's new
 Date: 2022-09-15
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-
-# Custom Dev Container Features
-
-September 15, 2022 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 We've all had that moment when setting up our development environment – "Oh, I just need one more thing!" – that "thing" being one more language or toolset (or maybe a few more 😊) to work on your project.
 

--- a/blogs/2022/10/04/vscode-community-discussions.md
+++ b/blogs/2022/10/04/vscode-community-discussions.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: VS Code Community Discussions
-PageTitle: VS Code Community Discussions for Extension Authors
+PageTitle: VS Code Community Discussions for extension authors
 MetaDescription: Announcing the official launch of VS Code Community Discussions, a place for extension authors to connect.
 Date: 2022-10-04
-Author: Olivia Guzzardo
+Authors:
+  - name: Olivia Guzzardo
+    social: https://twitter.com/OliviaGuzzardo
 ---
-
-# VS Code Community Discussions for Extension Authors
-
-October 4, 2022 by Olivia Guzzardo, [@OliviaGuzzardo](https://twitter.com/OliviaGuzzardo)
 
 The true power of VS Code comes from its vast extension ecosystem, which only exists because of our incredible community of extension authors. Whether creating a new language extension to make it possible to program in virtually any language, developing a new theme to help with productivity, or extending the workbench to help with a unique developer workflow, extension authors help millions of people by sharing their creation.
 

--- a/blogs/2022/11/28/vscode-sandbox.md
+++ b/blogs/2022/11/28/vscode-sandbox.md
@@ -1,17 +1,15 @@
 ---
 Order: 
-TOCTitle: VS Code Sandboxing
-PageTitle: VS Code Sandboxing
+TOCTitle: VS Code sandboxing
+PageTitle: Migrating VS Code to process sandboxing
 MetaDescription: Migrating Visual Studio Code to Electron process sandboxing
 Date: 2022-11-28
-Author: Benjamin Pasero
+Authors:
+  - name: Benjamin Pasero
+    social: https://twitter.com/BenjaminPasero
 ---
 
-# Migrating VS Code to Process Sandboxing
-
 **A win-win for security and the VS Code architecture**
-
-November 28, 2022 by Benjamin Pasero, [@BenjaminPasero](https://twitter.com/BenjaminPasero)
 
 Enabling the [sandbox](https://www.electronjs.org/docs/latest/tutorial/sandbox) in [Electron](https://www.electronjs.org/) renderer processes is a critical requirement for secure and reliable Electron applications such as Visual Studio Code. The sandbox reduces the harm that malicious code can cause by limiting access to most system resources. In this blog post, we provide a detailed overview into how we managed to enable process sandboxing in VS Code, a journey that we [started in early 2020](https://github.com/microsoft/vscode/issues/92164) and plan to finish at the beginning of 2023. To help understand the challenge of process sandboxing, this blog post also describes details of the VS Code process model and how it evolved during this journey.
 

--- a/blogs/2022/12/07/remote-even-better.md
+++ b/blogs/2022/12/07/remote-even-better.md
@@ -1,15 +1,13 @@
 ---
 Order: 
-TOCTitle: Remote Development Even Better
-PageTitle: Making Remote Development Even Better
+TOCTitle: Remote development even better
+PageTitle: Making remote development even better
 MetaDescription: Announcing the release of the unified Visual Studio Code command-line interface and the latest improvements to remote development.
 Date: 2022-12-07
-Author: Brigit Murtaugh
+Authors:
+  - name: Brigit Murtaugh
+    social: https://twitter.com/BrigitMurtaugh
 ---
-
-# Remote Development Even Better
-
-December 07, 2022 by Brigit Murtaugh, [@BrigitMurtaugh](https://twitter.com/BrigitMurtaugh)
 
 At its core, Visual Studio Code is a code editor, and it integrates with other environments through our [remote development experiences](https://code.visualstudio.com/docs/remote/remote-overview) to become even more powerful and flexible:
 

--- a/blogs/2023/03/30/vscode-copilot.md
+++ b/blogs/2023/03/30/vscode-copilot.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: VS Code and Copilot
-PageTitle: Visual Studio Code and GitHub Copilot AI
+PageTitle: VS Code and GitHub Copilot
 MetaDescription: Learn about the Visual Studio Code team's experience and future with GitHub Copilot artificial intelligence
 Date: 2023-03-30
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-
-# Visual Studio Code and GitHub Copilot
-
-March 30, 2023 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 **AI did not write this blog post, but it will make your development experiences incredible.**
 

--- a/blogs/2023/04/13/vscode-day.md
+++ b/blogs/2023/04/13/vscode-day.md
@@ -1,15 +1,13 @@
 ---
 Order: 
 TOCTitle: VS Code Day
-PageTitle: Visual Studio Code Day 2023
+PageTitle: "VS Code Day: An event for an editor?"
 MetaDescription: Learn about the latest Visual Studio Code features and extensions during VS Code Day 2023 on April 26, 2023
 Date: 2023-04-13
-Author: Burke Holland
+Authors:
+  - name: Burke Holland
+    social: https://twitter.com/burkeholland
 ---
-
-# VS Code Day: An event for an editor?
-
-April 13, 2023 by Burke Holland, [@burkeholland](https://twitter.com/burkeholland)
 
 VS Code Day is a one-day "Virtually Live" event starting at 10:00 AM PST on April 26. Naming things is hard, but we feel like this title says it all – a full day of community, learning, and all things Visual Studio Code. Registration is now open, and you can grab your spot today: [https://aka.ms/vscodeday](https://aka.ms/vscodeday).
 

--- a/blogs/2023/06/05/vscode-wasm-wasi.md
+++ b/blogs/2023/06/05/vscode-wasm-wasi.md
@@ -1,14 +1,12 @@
 ---
 Order: 
 TOCTitle: VS Code and WebAssemblies
-PageTitle: VS Code and WebAssemblies
+PageTitle: Run WebAssemblies in VS Code for the Web
 MetaDescription: Running WebAssemblies in VS Code for the Web.
 Date: 2023-06-05
-Author: Dirk Bäumer
+Authors:
+  - name: Dirk Bäumer
 ---
-# Run WebAssemblies in VS Code for the Web
-
-June 5, 2023 by Dirk Bäumer
 
 VS Code for the Web ([https://vscode.dev](https://vscode.dev)) has been available for some time now and it has always been our goal to support the full edit / compile / debug cycle in the browser. This is relatively easy for languages like JavaScript and TypeScript since browsers ship with a JavaScript execution engine. It is harder for other languages since we must be able to execute (and therefore debug) the code. For example, to run Python source code in a browser, there needs to be an execution engine that can run the [Python](https://www.python.org/) interpreter. These language runtimes are usually written in C/C++.
 

--- a/blogs/2023/07/20/mangling-vscode.md
+++ b/blogs/2023/07/20/mangling-vscode.md
@@ -4,11 +4,10 @@ TOCTitle: Shrinking VS Code with name mangling
 PageTitle: Shrinking VS Code with name mangling
 MetaDescription: A look at how we cut 20% off the size of VS Code's JavaScript with name mangling.
 Date: 2023-07-20
-Author: Matt Bierner
+Authors:
+  - name: Matt Bierner
+    social: https://hachyderm.io/@mattbierner
 ---
-# Shrinking VS Code with name mangling
-
-July 20, 2023 by Matt Bierner, [@mattbierner](https://hachyderm.io/@mattbierner)
 
 We recently reduced the size of Visual Studio Code's shipped JavaScript by 20%. That works out to a little over 3.9 MB saved. Sure that's less than some of the individual gifs from our release notes, but that's still nothing to sniff at! Not only does this reduction mean less code you need to download and store on disk, it also improves startup time because less source code has to be scanned before the JavaScript is run. Not too shabby considering we got this reduction without deleting any code and without any major refactorings in our codebase. Instead all it took was a new build step: name mangling.
 

--- a/blogs/2023/11/13/vscode-copilot-smarter.md
+++ b/blogs/2023/11/13/vscode-copilot-smarter.md
@@ -4,11 +4,10 @@ TOCTitle: Pursuit of wicked smartness in VS Code
 PageTitle: Pursuit of wicked smartness in VS Code
 MetaDescription: Smart artificial intelligence features in Visual Studio Code with GitHub Copilot
 Date: 2023-11-13
-Author: Chris Dias
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-# Pursuit of wicked smartness in VS Code
-
-November 13, 2023 by Chris Dias, [@chrisdias](https://twitter.com/chrisdias)
 
 If you tuned into [GitHub Universe](https://githubuniverse.com) last week, you saw a tremendous amount of progress, innovation, and vision for artificial intelligence across the entire developer workflow. What we want to do in this blog post is focus in on the advancements around Visual Studio Code over the past few months helping to realize this broader vision.
 

--- a/blogs/2024/04/15/vscode-day.md
+++ b/blogs/2024/04/15/vscode-day.md
@@ -1,16 +1,14 @@
 ---
 Order: 85
 TOCTitle: VS Code Day 2024
-PageTitle: Visual Studio Code Day 2024
+PageTitle: Your ultimate guide to VS Code Day 2024
 MetaDescription: Learn about the latest Visual Studio Code features and extensions during VS Code Day 2024 on April 24, 2024
 MetaSocialImage: vscodeday-promo.png
 Date: 2024-04-15
-Author: Reynald Adolphe
+Authors:
+  - name: Reynald Adolphe
+    social: https://twitter.com/ReynaldAdolphe
 ---
-
-# Your Ultimate Guide to VS Code Day 2024
-
-April 15, 2024 by Reynald Adolphe, [@ReynaldAdolphe](https://twitter.com/ReynaldAdolphe)
 
 > **Watch [all content from VS Code Day 2024](https://youtube.com/live/iCDfAC4f25w) now.**
 

--- a/blogs/2024/05/08/wasm.md
+++ b/blogs/2024/05/08/wasm.md
@@ -1,16 +1,13 @@
 ---
 Order: 86
-TOCTitle: VS Code Extensions and WebAssembly
-PageTitle: VS Code Extensions and WebAssembly
-MetaDescription: Using WebAssembly for Extension Development.
+TOCTitle: VS Code extensions and WebAssembly
+PageTitle: Using WebAssembly for extension development
+MetaDescription: Using WebAssembly for extension development.
 MetaSocialImage: resource-memory.png
 Date: 2024-05-08
-Author: Dirk Bäumer
+Authors:
+  - name: Dirk Bäumer
 ---
-
-# Using WebAssembly for Extension Development
-
-May 8, 2024 by Dirk Bäumer
 
 Visual Studio Code supports the execution of WASM binaries through the [WebAssembly Execution Engine](https://marketplace.visualstudio.com/items?itemName=ms-vscode.wasm-wasi-core) extension. The primary use case is to compile programs written in C/C++ or Rust into WebAssembly, and then run these programs directly in VS Code. A notable example is [Visual Studio Code for Education](https://vscodeedu.com/), which utilizes this support to run the Python interpreter in VS Code for the Web. This [blog post](https://code.visualstudio.com/blogs/2023/06/05/vscode-wasm-wasi) provides detailed insights into how this is implemented.
 

--- a/blogs/2024/06/07/wasm-part2.md
+++ b/blogs/2024/06/07/wasm-part2.md
@@ -1,16 +1,13 @@
 ---
 Order: 87
-TOCTitle: VS Code Extensions and WebAssembly - Part Two
-PageTitle: VS Code Extensions and WebAssembly - Part Two
+TOCTitle: VS Code extensions and WebAssembly, part two
+PageTitle: Using WebAssembly for extension development, part two
 MetaDescription: Use WebAssembly in VS Code extensions to run in a separate worker, or write a language server with a language that compiles to WebAssembly.
 MetaSocialImage: goto-definition.png
 Date: 2024-06-07
-Author: Dirk Bäumer
+Authors:
+  - name: Dirk Bäumer
 ---
-
-# Using WebAssembly for Extension Development - Part Two
-
-June 7, 2024 by Dirk Bäumer
 
 In the previous blog post about using [WebAssembly for Extension Development](/blogs/2024/05/08/wasm.md), we demonstrated how the component model can be used to integrate WebAssembly code into your Visual Studio Code extension. In this blog post, we focus on two additional independent use cases: (a) running the WebAssembly code in a [worker](#executing-webassembly-code-in-a-worker) to avoid blocking the extension host's main thread, and (b) creating a [language server](#a-webassembly-based-language-server) using a language that compiles to WebAssembly.
 

--- a/blogs/2024/06/24/extensions-are-all-you-need.md
+++ b/blogs/2024/06/24/extensions-are-all-you-need.md
@@ -1,16 +1,14 @@
 ---
 Order: 88
 TOCTitle: Copilot extensions are all you need
-PageTitle: GitHub Copilot Extensions are all you need
+PageTitle: GitHub Copilot extensions are all you need
 MetaDescription: Learn how to extend GitHub Copilot by using the Chat and Language Model APIs in your Visual Studio Code extension. Get inspired by early adopters and their extensions.
 MetaSocialImage: chat-extension-sample.png
 Date: 2024-06-24
-Author: Isidor Nikolic
+Authors:
+  - name: Isidor Nikolic
+    social: https://x.com/isidorn
 ---
-
-# GitHub Copilot Extensions are all you need
-
-June 24, 2024 by Isidor Nikolic, [@isidorn](https://x.com/isidorn)
 
 In 2017, Google researchers introduced the concept of *transformers* in their seminal paper, ["Attention is All You Need"](https://proceedings.neurips.cc/paper_files/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf). These types of models, which prioritize information similarly to human focus, are the foundation of today’s modern language models, such as the ones that power GitHub Copilot.
 

--- a/blogs/2024/11/12/introducing-copilot-edits.md
+++ b/blogs/2024/11/12/introducing-copilot-edits.md
@@ -1,16 +1,14 @@
 ---
 Order: 89
 TOCTitle: Introducing Copilot Edits
-PageTitle: Introducing Copilot Edits
+PageTitle: Introducing Copilot Edits (preview)
 MetaDescription: Copilot Edits allows you to get to the changes you need in your workspace, across multiple files, using a UI designed for fast iteration. You can specify a set of files to be edited, and then use natural language to simply ask Copilot what you need. You stay in the flow of your code while reviewing the suggested changes, accepting what works, and iterating with follow-up asks.
 MetaSocialImage: copilot-edits.png
 Date: 2024-11-12
-Author: Isidor Nikolic
+Authors:
+  - name: Isidor Nikolic
+    social: https://x.com/isidorn
 ---
-
-# Introducing Copilot Edits (preview)
-
-November 12th, 2024 by [Isidor Nikolic](https://x.com/isidorn)
 
 Until recently, you could use GitHub Copilot in VS Code in two separate ways. You could modify code inside the editor using completions or Inline Chat. Or you could use Copilot to ask questions about your code in the Chat view. Copilot Edits, a preview feature, is a brand new way of using Copilot in VS Code. It combines the best of Chat and Inline Chat: the conversational flow and the ability to make inline changes across of set of files that you manage. And it just works.
 

--- a/blogs/2024/11/15/introducing-github-copilot-for-azure.md
+++ b/blogs/2024/11/15/introducing-github-copilot-for-azure.md
@@ -1,16 +1,14 @@
 ---
 Order: 90
 TOCTitle: GitHub Copilot for Azure
-PageTitle: Introducing GitHub Copilot for Azure
+PageTitle: Introducing GitHub Copilot for Azure (preview)
 MetaDescription: Introducing GitHub Copilot for Azure, a chat participant to ask about Azure and help you manage and troubleshoot your Azure resources.
 MetaSocialImage: quickstart-create.png
 Date: 2024-11-15
-Author: Chris Harris
+Authors:
+  - name: Chris Dias
+    social: https://twitter.com/chrisdias
 ---
-
-# Introducing GitHub Copilot for Azure (preview)
-
-November 15, 2024 by Chris Harris, Product Manager
 
 I'm thrilled to introduce the preview of **GitHub Copilot for Azure** - a new tool that integrates effortlessly with GitHub Copilot Chat in VS Code. Imagine it as your personal guide for navigating the Azure cloud. No more toggling between your IDE and the Azure portal to manage infrastructure or look up commands and arguments. Now, you can concentrate on your core task - coding. Whether you're setting up services or deploying applications, simply prompt `@azure` in the Chat view and manage everything directly within your editor.
 

--- a/blogs/2024/12/18/free-github-copilot.md
+++ b/blogs/2024/12/18/free-github-copilot.md
@@ -5,12 +5,10 @@ PageTitle: Announcing a free GitHub Copilot for VS Code
 MetaDescription: Announcing a free plan for GitHub Copilot in Visual Studio Code.
 MetaSocialImage: copilot-free.jpg
 Date: 2024-12-18
-Author: Burke Holland
+Authors:
+  - name: Burke Holland
+    social: https://twitter.com/burkeholland
 ---
-
-# Announcing a free GitHub Copilot for VS Code
-
-December 18, 2024 by Burke Holland, @burkeholland
 
 We're excited to announce an all new **free plan for GitHub Copilot**, available for everyone today in VS Code. All you need is a GitHub account. No trial. No subscription. No credit card required.
 

--- a/blogs/2025/02/12/next-edit-suggestions.md
+++ b/blogs/2025/02/12/next-edit-suggestions.md
@@ -1,17 +1,17 @@
 ---
 Order: 92
-TOCTitle: Copilot Next Edit Suggestions (preview)
-PageTitle: Copilot Next Edit Suggestions (preview)
+TOCTitle: Copilot next edit suggestions (preview)
+PageTitle: Copilot next edit suggestions (preview)
 MetaDescription: Announcing the Next Edit Suggestions and Agent Mode for GitHub Copilot in Visual Studio Code.
 MetaSocialImage: nes-gutter-cover.png
 Date: 2025-02-12
-Author: Brigit Murtaugh, Burke Holland
+Authors:
+  - name: Brigit Murtaugh
+    social: https://github.com/bamurtaugh
+  - name: Burke Holland
+    social: https://github.com/burkeholland
 Keywords: [nes]
 ---
-
-# Copilot Next Edit Suggestions (preview)
-
-February 12, 2025 by [Brigit Murtaugh](https://github.com/bamurtaugh), [Burke Holland](https://github.com/burkeholland)
 
 We're excited to announce not one, not two, but _three_ previews for GitHub Copilot in this release of Visual Studio Code:
 

--- a/blogs/2025/02/24/introducing-copilot-agent-mode.md
+++ b/blogs/2025/02/24/introducing-copilot-agent-mode.md
@@ -1,16 +1,14 @@
 ---
 Order: 93
 TOCTitle: Copilot Agent Mode (preview)
-PageTitle: Copilot Agent Mode (preview)
+PageTitle: Introducing GitHub Copilot agent mode (preview)
 MetaDescription: Announcing the GitHub Copilot agent mode in Visual Studio Code.
 MetaSocialImage: agent-mode.png
 Date: 2025-02-24
-Author: Isidor Nikolic
+Authors:
+  - name: Isidor Nikolic
+    social: https://github.com/isidorn
 ---
-
-# Introducing GitHub Copilot agent mode (preview)
-
-February 24, 2025 by [Isidor Nikolic](https://github.com/isidorn)
 
 > [!TIP]
 > Agent mode is now available in VS Code Stable and has support for MCP servers. Read more about the [updates to agent mode in our blog post](/blogs/2025/04/07/agentMode.md).

--- a/blogs/2025/03/26/custom-instructions.md
+++ b/blogs/2025/03/26/custom-instructions.md
@@ -1,16 +1,16 @@
 ---
 Order: 94
 TOCTitle: Better AI results with custom instructions
-PageTitle: "Context is all you need - Better AI results with custom instructions"
+PageTitle: "Context is all you need: Better AI results with custom instructions"
 MetaDescription: Announcing the general availability of custom instructions for VS Code.
 MetaSocialImage: tail-recursion.jpg
 Date: 2025-03-26
-Author: Rob Conery, Harald Kirschner
+Authors:
+  - name: Rob Conery
+    social: https://bsky.app/profile/robconery.com
+  - name: Harald Kirschner
+    social: https://twitter.com/burkeholland
 ---
-
-# Context is all you need: Better AI results with custom instructions
-
-March 26, 2025 by Rob Conery, [@robconery.com](https://bsky.app/profile/robconery.com), Burke Holland, [@burkeholland](https://twitter.com/burkeholland)
 
 Earlier this month, we announced the general availability of [custom instructions in Visual Studio Code](https://code.visualstudio.com/docs/copilot/copilot-customization). Custom instructions are how you give Copilot specific context about your team's workflow, your particular style preferences, libraries the model may not know about, etc.
 

--- a/blogs/2025/04/07/agentMode.md
+++ b/blogs/2025/04/07/agentMode.md
@@ -1,16 +1,14 @@
 ---
 Order: 97
 TOCTitle: Agent mode available to all users
-PageTitle: "Agent mode: available to all users and supports MCP"
+PageTitle: "Agent mode: Available to all users and supports MCP"
 MetaDescription: Agent mode is now available to all users and supports MCP.
 MetaSocialImage: agent_full.png
 Date: 2025-04-07
-Author: Isidor Nikolic
+Authors:
+  - name: Isidor Nikolic
+    social: https://github.com/isidorn
 ---
-
-# Agent mode: available to all users and supports MCP
-
-April 7th, 2025 by [Isidor Nikolic](https://github.com/isidorn)
 
 Agent mode is rolling out to all VS Code users! The agent acts as an autonomous pair programmer that performs multi-step coding tasks at your command, such as analyzing your codebase, proposing file edits, and running terminal commands. It responds to compile and lint errors, monitors terminal output, and auto-corrects in a loop until the task is completed. The agent can also use contributed tools, allowing it to interact with external MCP servers or VS Code extensions to perform a wide variety of tasks.
 

--- a/blogs/2025/05/12/agent-mode-meets-mcp.md
+++ b/blogs/2025/05/12/agent-mode-meets-mcp.md
@@ -1,16 +1,14 @@
 ---
 Order: 98
 TOCTitle: Adding MCP in VS Code
-PageTitle: "Beyond the tools, adding MCP in VS Code"
+PageTitle: Beyond the tools, adding MCP in VS Code
 MetaDescription: Bring your own tools to VS Code's agent mode with MCP.
 MetaSocialImage: agent-mcp-tools.png
 Date: 2025-05-14
-Author: Harald Kirschner
+Authors:
+  - name: Harald Kirschner
+    social: https://github.com/digitarald
 ---
-
-# Beyond the tools, adding MCP in VS Code
-
-May 14th, 2025 by [Harald Kirschner](https://github.com/digitarald)
 
 When we first introduced [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) in VS Code, it opened new ways of interacting with your code and workspace through chat. You could ask the agent to inspect files, run builds, and even [debug tests](https://code.visualstudio.com/docs/copilot/guides/test-with-copilot). But you were limited by what the model was trained on and the contents of your workspace. So, the next step was clear: we needed a way for agents to reach beyond those boundaries and interact with real, external services in a secure, user-controlled way.
 

--- a/blogs/2025/05/19/openSourceAIEditor.md
+++ b/blogs/2025/05/19/openSourceAIEditor.md
@@ -1,18 +1,16 @@
 ---
 Order: 99
 TOCTitle: Open Source AI Editor
-PageTitle: "VS Code: Open Source AI Editor"
+PageTitle: "VS Code: Open source AI editor"
 MetaDescription: We will open source the GitHub Copilot Chat extension. It’s the next step towards making VS Code an open source AI editor.
 MetaSocialImage: open_source_ai_editor.png
 Date: 2025-05-19
-Author: The VS Code team
+Authors:
+  - name: VS Code Team
+    social: https://x.com/code
 ---
 
-# VS Code: Open Source AI Editor
-
 **Update (June 30th, 2025): the [GitHub Copilot Chat extension is now open source](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone).**
-
-May 19th, 2025 by the VS Code team
 
 We believe that the future of code editors should be open and powered by AI. For the last decade, VS Code has been one of the [most successful OSS projects on GitHub](https://github.blog/news-insights/octoverse/octoverse-2024/#the-state-of-open-source). We are grateful for our vibrant community of contributors and users who choose VS Code because it is open source. As AI becomes core to the developer experience in VS Code, we intend to stay true to our founding development principles: open, collaborative, and community-driven.
 

--- a/blogs/2025/05/27/ai-and-remote.md
+++ b/blogs/2025/05/27/ai-and-remote.md
@@ -1,16 +1,20 @@
 ---
 Order: 100
 TOCTitle: Enhance productivity with AI + Remote Dev
-PageTitle: "Enhance productivity with AI + Remote Dev"
+PageTitle: Enhance productivity with AI + Remote Dev
 MetaDescription: Enhance your developer productivity with AI and Remote Development.
 MetaSocialImage: ai-remote-development-social.png
 Date: 2025-05-27
-Author: Brigit Murtaugh, Christof Marti, Josh Spicer, Olivia Guzzardo McVicker
+Authors:
+  - name: Brigit Murtaugh
+    social: https://github.com/bamurtaugh
+  - name: Christof Marti
+    social: https://github.com/chrmarti
+  - name: Josh Spicer
+    social: https://github.com/joshspicer
+  - name: Olivia Guzzardo McVicker
+    social: https://github.com/olguzzar
 ---
-
-# Enhance productivity with AI + Remote Dev
-
-May 27th, 2025 by [Brigit Murtaugh](https://github.com/bamurtaugh), [Christof Marti](https://github.com/chrmarti), [Josh Spicer](https://github.com/joshspicer), [Olivia Guzzardo McVicker](https://github.com/olguzzar)
 
 One of the features that makes VS Code so flexible and powerful is [Remote Development](/docs/remote/remote-overview.md). Whether you're connecting to a secure VM from your local desktop, a hugely powerful computer from your tablet, or a containerized environment with all the dependencies your project needs – VS Code's ability to develop _anything from anywhere_ can help in just about any setup.
 

--- a/blogs/2025/06/12/full-mcp-spec-support.md
+++ b/blogs/2025/06/12/full-mcp-spec-support.md
@@ -1,16 +1,16 @@
 ---
 Order: 101
-TOCTitle: Full MCP Spec Support
-PageTitle: "The Complete MCP Experience: Full Specification Support in VS Code"
+TOCTitle: Full MCP spec support
+PageTitle: "The complete MCP experience: Full specification support in VS Code"
 MetaDescription: VS Code now supports the complete Model Context Protocol specification, including authorization, prompts, resources, and sampling.
 MetaSocialImage: mcp-resources-context.png
 Date: 2025-06-12
-Author: Harald Kirschner
+Authors:
+  - name: Harald Kirschner
+    social: https://github.com/digitarald
+  - name: Tyler Leonhardt
+    social: https://github.com/tylerleonhardt
 ---
-
-# The Complete MCP Experience: Full Specification Support in VS Code
-
-June 12, 2025 by [Harald Kirschner](https://github.com/digitarald), [Connor Peet](https://github.com/connor4312), and [Tyler Leonhardt](https://github.com/tylerleonhardt)
 
 VS Code now supports the complete [Model Context Protocol specification](https://modelcontextprotocol.io/).
 

--- a/blogs/2025/06/30/openSourceAIEditorFirstMilestone.md
+++ b/blogs/2025/06/30/openSourceAIEditorFirstMilestone.md
@@ -1,16 +1,14 @@
 ---
 Order: 102
-TOCTitle: "Open Source AI Editor: First Milestone"
-PageTitle: "Open Source AI Editor: First Milestone"
+TOCTitle: Open source AI editor milestone
+PageTitle: "Open source AI editor: First milestone"
 MetaDescription: We are open sourcing the GitHub Copilot Chat extension. It’s the first milestone in making VS Code an open source AI editor.
 MetaSocialImage: open_source_ai_editor.png
 Date: 2025-06-30
-Author: The VS Code team
+Authors:
+  - name: VS Code Team
+    social: https://x.com/code
 ---
-
-# Open Source AI Editor: First Milestone
-
-June 30th, 2025 by the VS Code Team
 
 Last month we shared our plan to make [**VS Code an open source AI editor**]( https://code.visualstudio.com/blogs/2025/05/19/openSourceAIEditor). Today we reached the first milestone: the GitHub Copilot Chat extension is now [open source on GitHub](http://github.com/microsoft/vscode-copilot-chat) under the MIT license.
 

--- a/blogs/2025/07/17/copilot-coding-agent.md
+++ b/blogs/2025/07/17/copilot-coding-agent.md
@@ -1,16 +1,14 @@
 ---
 Order: 103
-TOCTitle: "Command GitHub's Coding Agent from VS Code"
-PageTitle: "Command GitHub's Coding Agent from VS Code"
+TOCTitle: Command GitHub's coding agent from VS Code
+PageTitle: Command GitHub's coding agent from VS Code
 MetaDescription: VS Code's integration with GitHub Copilot Coding Agent allows you to delegate tasks to the agent and let it handle them in the background.
 MetaSocialImage: copilot-wip.png
 Date: 2025-07-17
-Author: Burke Holland
+Authors:
+  - name: Burke Holland
+    social: https://twitter.com/burkeholland
 ---
-
-# Command GitHub's Coding Agent from VS Code
-
-July 17, 2025 by Burke Holland, [@burkeholland](https://twitter.com/burkeholland)
 
 Today, we’re excited to give you a first look at the Copilot Coding Agent in Visual Studio Code.
 

--- a/blogs/2025/08/27/vscode-dev-days.md
+++ b/blogs/2025/08/27/vscode-dev-days.md
@@ -1,16 +1,16 @@
 ---
 Order: 104
-TOCTitle: "VS Code Dev Days 2025"
-PageTitle: "VS Code Dev Days – Join an event near you to learn about AI-assisted development"
+TOCTitle: VS Code Dev Days 2025
+PageTitle: VS Code Dev Days 2025
 MetaDescription: Join a VS Code Dev Days event to learn about GitHub Copilot in VS Code
 MetaSocialImage: VSCode-Dev-Days-banner.jpg
 Date: 2025-08-26
-Author: Katie Savage, Cynthia Zanoni
+Authors:
+  - name: Katie Savage
+    social: https://github.com/katiesavage
+  - name: Cynthia Zanoni
+    social: https://x.com/cynthiazanoni
 ---
-
-# VS Code Dev Days – Join an event near you to learn about AI-assisted development
-
-August 26th, 2025 by [Katie Savage](https://github.com/katiesavage) and [Cynthia Zanoni](https://x.com/cynthiazanoni)
 
 > *VS Code Dev Days is over, but you can view our [virtual event on demand](https://www.youtube.com/live/ujSgVqC94TQ?si=oe1QOjpU3RRqq0Ez) or check out the [free training and workshop content](https://github.com/microsoft/VS-Code-Dev-Days/tree/main).*
 

--- a/blogs/2025/09/15/autoModelSelection.md
+++ b/blogs/2025/09/15/autoModelSelection.md
@@ -1,16 +1,14 @@
 ---
 Order: 106
-TOCTitle: "Introducing auto model selection (preview)"
-PageTitle: "Introducing auto model selection (preview)"
+TOCTitle: Introducing auto model selection (preview)
+PageTitle: Introducing auto model selection (preview)
 MetaDescription: Use auto model selection in VS Code to get faster responses, reduced rate limiting, and a 10% discount on premium requests for paid users.
 MetaSocialImage: autoDropdown.png
 Date: 2025-09-15
-Author: Isidor Nikolic
+Authors:
+  - name: Isidor Nikolic
+    social: https://github.com/isidorn
 ---
-
-# Introducing auto model selection (preview)
-
-September 15th, 2025 by [Isidor Nikolic](https://github.com/isidorn), [@isidorn]( https://x.com/isidorn)
 
 Faster responses, a lower chance of rate limiting, and 10% off premium requests for paid users - auto picks the best available model for each request based on current capacity and performance. With auto you can’t choose a specific model, auto handles that for you. Auto model selection in Chat is being rolled out in preview to all GitHub Copilot users in VS Code, starting with the individual plans.
 

--- a/blogs/2025/10/22/bring-your-own-key.md
+++ b/blogs/2025/10/22/bring-your-own-key.md
@@ -1,16 +1,16 @@
 ---
 Order: 107
-TOCTitle: Expanding Model Choice
-PageTitle: Expanding Model Choice in VS Code with Bring Your Own Key
+TOCTitle: Expanding model choice
+PageTitle: Expanding model choice in VS Code with bring your own key
 MetaDescription: Learn how the new Language Model Chat Provider API in VS Code is enabling more model choice and extensibility for chat experiences via the Bring Your Own Key experience.
 MetaSocialImage: expanding-model-choice.png
 Date: 2025-10-22
-Author: Olivia Guzzardo McVicker, Pierce Boggan
+Authors:
+  - name: Olivia Guzzardo McVicker
+    social: https://github.com/olguzzar
+  - name: Pierce Boggan
+    social: https://github.com/pierceboggan
 ---
-
-# Expanding Model Choice in VS Code with Bring Your Own Key
-
-October 22, 2025 by [Olivia Guzzardo McVicker](https://github.com/olguzzar), [Pierce Boggan](https://github.com/pierceboggan)
 
 We know that model choice is important to you. Our team has been hard at work making the latest models like [Claude Haiku 4.5](https://github.blog/changelog/2025-10-15-anthropics-claude-haiku-4-5-is-in-public-preview-for-github-copilot/) and [GPT 5 available](https://github.blog/changelog/2025-08-07-openai-gpt-5-is-now-in-public-preview-for-github-copilot/) to you on the same day they were announced. But we've also heard your feedback that you want support for even more models in VS Code, be it locally or in the cloud.
 

--- a/blogs/2025/11/03/unified-agent-experience.md
+++ b/blogs/2025/11/03/unified-agent-experience.md
@@ -1,15 +1,14 @@
 ---
 Order: 108
-TOCTitle: A Unified Agent Experience
-PageTitle: A Unified Experience for all Coding Agents
+TOCTitle: A unified agent experience
+PageTitle: A unified experience for all coding agents
 MetaDescription: "Agents took over VS Code in 2025. We released agent mode for VS Code, integration for the Copilot coding agent, and the new GitHub Copilot CLI. But Copilot is not the only agent game in town. There are now more coding agents than ever, including options from OpenAI and Anthropic."
 MetaSocialImage: unified-agent-experience.png
 Date: 2025-11-05
-Author: VS Code Team
+Authors:
+  - name: VS Code Team
+    social: https://twitter.com/code
 ---
-# A Unified Experience for all Coding Agents
-
-November 5, 2025 by VS Code Team, [@code](https://twitter.com/code)
 
 _Special thanks to Rob Lourens, Bhavya U, Matt Bierner, Peng Lyu, Osvaldo Ortega, Josh Spicer, Brigit Murtaugh, Martin Aeschlimann, Alex Britez and Harald Kirschner for their work on these features._
 

--- a/blogs/2025/11/04/openSourceAIEditorSecondMilestone.md
+++ b/blogs/2025/11/04/openSourceAIEditorSecondMilestone.md
@@ -1,16 +1,14 @@
 ---
 Order: 109
-TOCTitle: "Open Source AI Editor: Second Milestone"
-PageTitle: "Open Source AI Editor: Second Milestone"
+TOCTitle: "Open source AI editor: Second milestone"
+PageTitle: "Open source AI editor: Second milestone"
 MetaDescription: Ghost text suggestions are now open source as part of the Copilot Chat extension - the second milestone in making VS Code an open source AI editor.
 MetaSocialImage: copilot-oct-pr.png
 Date: 2025-11-06
-Author: The VS Code team
+Authors:
+  - name: VS Code Team
+    social: https://x.com/code
 ---
-
-# Open Source AI Editor: Second Milestone
-
-November 6th, 2025 by the VS Code Team
 
 In [May](https://code.visualstudio.com/blogs/2025/05/19/openSourceAIEditor), we announced our initial plan to make VS Code an open source AI editor, and in [June](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone), we reached our first milestone by open sourcing the GitHub Copilot Chat extension.
 

--- a/blogs/2025/11/18/PrivateMarketplace.md
+++ b/blogs/2025/11/18/PrivateMarketplace.md
@@ -1,16 +1,14 @@
 ---
 Order: 120
-TOCTitle: "Announcing Private Marketplace for VS Code"
-PageTitle: "Announcing Private Marketplace for VS Code"
+TOCTitle: Announcing Private Marketplace for VS Code
+PageTitle: Announcing Private Marketplace for VS Code
 MetaDescription: Private Marketplace for VS Code extensions now generally available.
 MetaSocialImage: PrivateMarketplaceHero.png
 Date: 2025-11-18
-Author: Sean Iyer
+Authors:
+  - name: Sean Iyer
+    social: https://x.com/nuget
 ---
-
-# Introducing the Visual Studio Code Private Marketplace: Your Team's Secure, Curated Extension Hub 🎉
-
-November 18, 2025 by [Sean Iyer](https://x.com/nuget)
 
 Developers shouldn't have to juggle manual installs, worry about unverified extensions, or chase compliance exceptions just to get their favorite tools. Today, we're excited to announce Private Marketplace for VS Code—a dedicated, enterprise-ready hub that puts you in full control of how extensions are sourced, reviewed, and distributed to your dev teams. 🔐✨
 

--- a/blogs/2025/12/03/introducing-vs-code-insiders-podcast.md
+++ b/blogs/2025/12/03/introducing-vs-code-insiders-podcast.md
@@ -1,16 +1,14 @@
 ---
 Order: 121
-TOCTitle: "Introducing the VS Code Insiders Podcast"
-PageTitle: "Introducing the VS Code Insiders Podcast"
+TOCTitle: Introducing the VS Code Insiders Podcast
+PageTitle: Introducing the VS Code Insiders Podcast
 MetaDescription: The VS Code Insiders Podcast is your insider's guide to the features, decisions, and people shaping the future of Visual Studio Code.
 MetaSocialImage: hero-vscode-podcast.webp
-Date: 2025-12-03
-Author: James Montemagno
+Date: 2025-12-01
+Authors:
+  - name: James Montemagno
+    social: https://x.com/jamesmontemagno
 ---
-
-# Introducing the VS Code Insiders Podcast
-
-December 1, 2025 by James Montemagno, [@jamesmontemagno](https://x.com/jamesmontemagno).
 
 ![VS Code Podcast Hero Banner - A modern podcast studio with VS Code logo, microphones, and code flowing in the background](hero-vscode-podcast.jpg)
 

--- a/blogs/2026/01/15/docfind.md
+++ b/blogs/2026/01/15/docfind.md
@@ -1,16 +1,14 @@
 ---
 Order: 122
-TOCTitle: "Building docfind"
-PageTitle: "Building docfind: Fast Client-Side Search with Rust and WebAssembly"
+TOCTitle: Building docfind
+PageTitle: "Building docfind: Fast client-side search with Rust and WebAssembly"
 MetaDescription: How we built docfind, a high-performance client-side search engine using Rust and WebAssembly, and how GitHub Copilot accelerated development.
 MetaSocialImage: docfind-social.png
 Date: 2026-01-15
-Author: João Moreno
+Authors:
+  - name: João Moreno
+    social: https://github.com/joaomoreno
 ---
-
-# Building docfind: Fast Client-Side Search with Rust and WebAssembly
-
-January 15, 2026 by [João Moreno](https://github.com/joaomoreno)
 
 If you've visited the [VS Code website](https://code.visualstudio.com/) recently, you might have noticed something new: a fast, responsive search experience that feels almost instant.
 

--- a/blogs/2026/01/26/mcp-apps-support.md
+++ b/blogs/2026/01/26/mcp-apps-support.md
@@ -1,16 +1,16 @@
 ---
 Order: 125
-TOCTitle: MCP Apps Support
-PageTitle: "Giving Agents a Visual Voice: MCP Apps Support in VS Code"
+TOCTitle: MCP Apps support
+PageTitle: "Giving agents a visual voice: MCP Apps support in VS Code"
 MetaDescription: VS Code now supports MCP Apps, enabling AI agents to display interactive UIs for richer developer workflows.
 MetaSocialImage: mcp-apps-list-sort.png
 Date: 2026-01-26
-Author: Harald Kirschner, Connor Peet
+Authors:
+  - name: Harald Kirschner
+    social: https://github.com/digitarald
+  - name: Connor Peet
+    social: https://github.com/connor4312
 ---
-
-# Giving Agents a Visual Voice: MCP Apps Support in VS Code
-
-January 26, 2026 by [Harald Kirschner](https://github.com/digitarald) and [Connor Peet](https://github.com/connor4312)
 
 AI coding agents have become remarkably capable. Out of the box, they search your codebase, edit files, run terminal commands, and respond to compile errors. Add [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers), and they can query databases, browse the web with Playwright, summarize GitHub issues, and connect to your cloud platforms. Models can even process images—you can paste a screenshot to debug a layout issue, or have Playwright capture browser state for verification.
 

--- a/blogs/2026/02/05/multi-agent-development.md
+++ b/blogs/2026/02/05/multi-agent-development.md
@@ -1,16 +1,14 @@
 ---
 Order: 126
-TOCTitle: Multi-Agent Development
-PageTitle: "Your Home for Multi-Agent Development"
+TOCTitle: Multi-agent development
+PageTitle: Your home for multi-agent development
 MetaDescription: VS Code has become the unified interface for all your coding agents. Manage local, background, and cloud agents in one place, use Claude and Codex agents alongside Copilot, and benefit from open standards like MCP and Agent Skills.
 MetaSocialImage: your-agent-ux.png
 Date: 2026-02-05
-Author: VS Code Team
+Authors:
+  - name: VS Code Team
+    social: https://x.com/code
 ---
-
-# Your Home for Multi-Agent Development
-
-February 5, 2026 by VS Code Team, [@code](https://x.com/code)
 
 Agents are everywhere. We've been working to make VS Code the home for multi-agent development. One place to run your agents, manage your sessions, and pick the right tool for each task, without switching editors or juggling subscriptions.
 

--- a/blogs/2026/02/26/long-distance-nes.md
+++ b/blogs/2026/02/26/long-distance-nes.md
@@ -1,16 +1,18 @@
 ---
 Order: 127
-TOCTitle: Long Distance NES
-PageTitle: "Building Long-Distance Next Edit Suggestions"
+TOCTitle: Long distance NES
+PageTitle: Building long-distance next edit suggestions
 MetaDescription: Learn how we extended next edit suggestions to work across your entire file, reducing friction and improving productivity in GitHub Copilot.
 MetaSocialImage: long-distance-nes-hero.png
 Date: 2026-02-26
-Author: Vikram Duvvur, Gaurav Mittal, Benjamin Simmonds
+Authors:
+  - name: Vikram Duvvur
+    social: https://github.com/vkrd
+  - name: Gaurav Mittal
+    social: https://github.com/g1910
+  - name: Benjamin Simmonds
+    social: https://github.com/benibenj
 ---
-
-# Building Long-Distance Next Edit Suggestions
-
-February 26, 2026 by [Vikram Duvvur](https://github.com/vkrd), [Gaurav Mittal](https://github.com/g1910), [Benjamin Simmonds](https://github.com/benibenj)
 
 Last February, we released [next edit suggestions (NES)](/docs/copilot/ai-powered-suggestions.md#next-edit-suggestions) in GitHub Copilot. NES extends ghost text by not just inserting code at your cursor, but suggesting edits nearby, anticipating what you'd change next. This was a powerful step forward, but it only worked within a small window around your cursor. In real editing workflows, the next change you need to make is often several screens away.
 


### PR DESCRIPTION
This is a companion PR to the website redesign that is nearly finished. Update every blog post to adhere to the new YAML / authoring conventions for blog posts, plus some misc content changes.

Updates include:

- Remove embedded markdown H1 and author byline from every blog post
- Update `Author` YAML field to follow the new `Authors` + `name` + `social` convention
- Update all titles so they use sentence casing
- Ensure markdown H1 title (now removed) and YAML `PageTitle` are the same