### PR TITLE
docs/remote: Add step (create devcontainer.json file) for SSH to a remote container

### DIFF
--- a/remote/advancedcontainers/develop-remote-host.md
+++ b/remote/advancedcontainers/develop-remote-host.md
@@ -19,6 +19,7 @@ If you are using a Linux or macOS SSH host, you can use the [Remote - SSH](/docs
 1. **Optional:** Set up SSH [key based authentication](/docs/remote/troubleshooting.md#configuring-key-based-authentication) to the server so you do not need to enter your password multiple times.
 1. [Install Docker](/docs/devcontainers/containers#installation) on your SSH host. You do not need to install Docker locally.
 1. Follow the [quick start](/docs/remote/ssh.md#connect-to-a-remote-host) for the Remote - SSH extension to connect to a host and open a folder there.
+1. Create a [devcontainer.json](/docs/devcontainers/containers#_create-a-devcontainerjson-file) file.
 1. Use the **Dev Containers: Reopen in Container** command from the Command Palette (`kbstyle(F1)`, `kb(workbench.action.showCommands)`).
 
 The rest of the Dev Containers quick start applies as-is. You can learn more about the [Remote - SSH extension in its documentation](/docs/remote/ssh.md).


### PR DESCRIPTION
The existing steps might [fail](https://github.com/microsoft/vscode-remote-release/issues/9870#issuecomment-2655444563) due to [the lack of](https://github.com/microsoft/vscode-remote-release/issues/9870#issuecomment-2527644186) `devcontainer.json` file when running **Dev Containers: Reopen in Container**.
Some users fixed it by [uninstalling Copilot on the remote server](https://github.com/microsoft/vscode-remote-release/issues/9870#issuecomment-2974761129), as `devcontainer.json` was not created [with Copilot extension installed](https://github.com/microsoft/vscode-remote-release/issues/9870#issuecomment-2655444563). 
For another solution, I can reproduce the issue and mitigate it by manually creating `devcontainer.json`.