### PR TITLE
Update settings based on changes in microsoft/vscode#299059

### DIFF
--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -99,11 +99,11 @@ Private repositories are also supported. If a public lookup fails, VS Code falls
 
 ## Use local plugins
 
-If you manually clone or download a plugin, you can register it with the `setting(chat.plugins.paths)` setting. This setting maps local plugin directory paths to an enabled or disabled state.
+If you manually clone or download a plugin, you can register it with the `setting(chat.pluginLocations)` setting. This setting maps local plugin directory paths to an enabled or disabled state.
 
 ```json
 // settings.json
-"chat.plugins.paths": {
+"chat.pluginLocations": {
     "/path/to/my-plugin": true,
     "/path/to/another-plugin": false
 }


### PR DESCRIPTION
This pull request updates the documentation for configuring local plugins in Copilot. The main change is to update the setting name to match the current implementation.

**Documentation update:**

* Updated the documentation to reference the correct setting name, changing `chat.plugins.paths` to `chat.pluginLocations` in `docs/copilot/customization/agent-plugins.md`.

microsoft/vscode#299059