### PR TITLE
Fix missing comma in documentation

### DIFF
--- a/docs/editor/whyvscode.md
+++ b/docs/editor/whyvscode.md
@@ -23,7 +23,7 @@ For serious coding, you'll often benefit from tools with more code understanding
 
 And when the coding gets tough, the tough get debugging. Debugging is often the one feature that developers miss most in a leaner coding experience, so we made it happen. Visual Studio Code includes an interactive debugger, so you can step through source code, inspect variables, view call stacks, and execute commands in the console.
 
-VS Code also integrates with build and scripting tools to perform common tasks making everyday workflows faster. VS Code has support for Git so you can work with source control without leaving the editor including viewing pending changes diffs.
+VS Code also integrates with build and scripting tools to perform common tasks, making everyday workflows faster. VS Code has support for Git so you can work with source control without leaving the editor including viewing pending changes diffs.
 
 ## Make it your own
 


### PR DESCRIPTION
## What
Added a missing comma in a sentence for improved readability.

## Why
The sentence was missing a comma before a participial phrase, which affected clarity.

## Changes
- Added comma after "tasks"

## Notes
This is a documentation-only change. Verified manually.

