### PR TITLE
Document plugin formats and environment variables

### DIFF
--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -64,10 +64,13 @@ VS Code auto-detects the plugin format by checking for format-specific manifest 
 | OpenPlugin | `.plugin/plugin.json` |
 
 ### Plugin environment variables
+
+Some plugin formats provide a root token that you can use in hook commands and MCP server configurations to reference files within the plugin directory. VS Code expands the token at runtime and also sets it as an environment variable in the hook or server process.
+
 | Plugin format | Plugin root |
 |---------------|------------------|
 | Claude | `${CLAUDE_PLUGIN_ROOT}` |
-| Copilot | (Not Defined) |
+| Copilot | (Not defined) |
 | OpenPlugin | `${PLUGIN_ROOT}` |
 
 ## Hooks in plugins

--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -57,7 +57,7 @@ Once installed, plugin-provided customizations appear alongside your locally def
 > Plugins can include hooks and MCP servers that run code on your machine. Review the plugin contents and publisher before installing, especially for plugins from community marketplaces.
 
 ## Plugin formats
-The plugin format is auto-selected based on the plugin file path (relative to the plugin root).
+VS Code auto-detects the plugin format by checking for format-specific manifest paths. Copilot format is used as the default when no other format markers are found.
 | Plugin format | Plugin file path(s) |
 |---------------|------------------|
 | Claude | `.claude-plugin/plugin.json` |

--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -61,7 +61,6 @@ VS Code auto-detects the plugin format by checking for format-specific manifest 
 | Plugin format | Plugin file path(s) |
 |---------------|------------------|
 | Claude | `.claude-plugin/plugin.json` |
-| Copilot | `plugin.json`, `.github/plugin/plugin.json` |
 | OpenPlugin | `.plugin/plugin.json` |
 
 ### Plugin environment variables

--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -64,7 +64,7 @@ The plugin format is auto-selected based on the plugin file path (relative to th
 | Copilot | `plugin.json`, `.github/plugin/plugin.json` |
 | OpenPlugin | `.plugin/plugin.json` |
 
-### Plugin Environment Variables
+### Plugin environment variables
 | Plugin format | Plugin root |
 |---------------|------------------|
 | Claude | `${CLAUDE_PLUGIN_ROOT}` |

--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -56,7 +56,7 @@ Once installed, plugin-provided customizations appear alongside your locally def
 > [!CAUTION]
 > Plugins can include hooks and MCP servers that run code on your machine. Review the plugin contents and publisher before installing, especially for plugins from community marketplaces.
 
-## Plugin Formats
+## Plugin formats
 The plugin format is auto-selected based on the plugin file path (relative to the plugin root).
 | Plugin format | Plugin file path(s) |
 |---------------|------------------|

--- a/docs/copilot/customization/agent-plugins.md
+++ b/docs/copilot/customization/agent-plugins.md
@@ -56,6 +56,21 @@ Once installed, plugin-provided customizations appear alongside your locally def
 > [!CAUTION]
 > Plugins can include hooks and MCP servers that run code on your machine. Review the plugin contents and publisher before installing, especially for plugins from community marketplaces.
 
+## Plugin Formats
+The plugin format is auto-selected based on the plugin file path (relative to the plugin root).
+| Plugin format | Plugin file path(s) |
+|---------------|------------------|
+| Claude | `.claude-plugin/plugin.json` |
+| Copilot | `plugin.json`, `.github/plugin/plugin.json` |
+| OpenPlugin | `.plugin/plugin.json` |
+
+### Plugin Environment Variables
+| Plugin format | Plugin root |
+|---------------|------------------|
+| Claude | `${CLAUDE_PLUGIN_ROOT}` |
+| Copilot | (Not Defined) |
+| OpenPlugin | `${PLUGIN_ROOT}` |
+
 ## Hooks in plugins
 
 Plugins can include [hooks](/docs/copilot/customization/hooks.md) that run shell commands at agent lifecycle points. Plugin hooks work alongside your workspace and user-level hooks. When a plugin is enabled, its hooks fire in addition to any other hooks configured for the same event.


### PR DESCRIPTION
Added sections on plugin formats and environment variables. I had to dig through the vscode source to figure out why plugin hooks weren't working properly. Turns out that the plugin root is not provided to hooks when using Copilot format plugins. OpenPlugin and Claude format plugins get different plugin root environment variables. These changes should help clear up when each plugin format type is used and what root environment variable is provided (if any).

[Plugin file path selection](https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20plugin.json&type=code)

[Environment variables for plugin type](https://github.com/microsoft/vscode/blob/ef1473ae7bff35241d10ba60779afed154e54b00/src/vs/platform/agentPlugins/common/pluginParsers.ts#L93)