### PR TITLE
Add BYOK support docs for Copilot Business and Enterprise

### DIFF
--- a/api/extension-guides/ai/language-model-chat-provider.md
+++ b/api/extension-guides/ai/language-model-chat-provider.md
@@ -11,8 +11,8 @@ MetaDescription: Learn how to implement a LanguageModelChatProvider to contribut
 
 The Language Model Chat Provider API enables you to contribute your own language models to chat in Visual Studio Code.
 
-> [!IMPORTANT]
-> Models provided through this API are currently only available to users on [individual GitHub Copilot plans](https://docs.github.com/en/copilot/concepts/billing/individual-plans).
+> [!NOTE]
+> If you are a Copilot Business or Enterprise user, your administrator must enable the **Bring Your Own Language Model Key in VS Code** policy in the [Copilot policy settings](https://github.com/settings/copilot/features) on GitHub.com for models provided through this API.
 
 ## Overview
 

--- a/docs/copilot/customization/language-models.md
+++ b/docs/copilot/customization/language-models.md
@@ -116,8 +116,8 @@ Hover over a model in the list and select the eye icon to show or hide the model
 
 ## Bring your own language model key
 
-> [!IMPORTANT]
-> Bring your own model key is not currently available to Copilot Business or Copilot Enterprise users. It is intended for individual experimentation with the newest models. Support for Business and Enterprise plans is planned for later this year.
+> [!NOTE]
+> If you are a Copilot Business or Enterprise user, your administrator must enable the **Bring Your Own Language Model Key in VS Code** policy in the [Copilot policy settings](https://github.com/settings/copilot/features) on GitHub.com.
 
 GitHub Copilot in VS Code comes with a variety of built-in language models that are optimized for different tasks. If you want to use a model that is not available as a built-in model, you can bring your own language model API key (BYOK) to use models from other providers.
 
@@ -201,9 +201,9 @@ To change the language model that is used for generating inline suggestions in t
 
 ## Frequently asked questions
 
-### Why is bring your own model key not available for Copilot Business or Copilot Enterprise?
+### How do I enable bring your own model key for Copilot Business or Copilot Enterprise?
 
-Bringing your own model key is mainly intended for individual experimentation with the newest models, and is not yet available for Business or Enterprise plans. Support for these plans is planned for later this year. Copilot Business and Enterprise users can still use the built-in, managed models.
+If you are a Copilot Business or Enterprise user, your organization administrator must enable the **Bring Your Own Language Model Key in VS Code** policy in the [Copilot policy settings](https://github.com/settings/copilot/features) on GitHub.com. After the policy is enabled, you can use your own API keys to add models, just like individual plan users.
 
 ### Can I use locally hosted models with Copilot in VS Code?
 

--- a/release-notes/v1_115.md
+++ b/release-notes/v1_115.md
@@ -29,6 +29,8 @@ Welcome to the 1.115 release of Visual Studio Code. This release makes your agen
 
 * [Terminal tools](#terminal-tools-improvements): new capabilities for agents to interact with background terminals.
 
+* [BYOK for Business and Enterprise](#bring-your-own-key-for-copilot-business-and-enterprise): bring your own language model key is now available for Copilot Business and Enterprise users.
+
 Happy Coding!
 
 ---
@@ -49,6 +51,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
       <li><a href="#visual-studio-code-agents-preview">Visual Studio Code Agents (Preview)</a></li>
       <li><a href="#integrated-browser">Integrated browser</a></li>
       <li><a href="#terminal-tools-improvements">Terminal tools improvements</a></li>
+      <li><a href="#github-copilot">GitHub Copilot</a></li>
       <li><a href="#deprecated-features-and-settings">Deprecated features and settings</a></li>
       <li><a href="#notable-fixes">Notable fixes</a></li>
       <li><a href="#thank-you">Thank you</a></li>
@@ -124,6 +127,14 @@ With the new `send_to_terminal` tool, the agent can continue interacting with ba
 Previously, when a terminal command was running in the background, the agent had to manually call `get_terminal_output` to check on its status.  There was no way to know when the command completed or needed input.
 
 With the new experimental `setting(chat.tools.terminal.backgroundNotifications)` setting, the agent is automatically notified when a background terminal command finishes or requires user input. This also applies to foreground terminals that time out and are moved to the background. The agent can then take appropriate action, such as reviewing the output or providing input via the `send_to_terminal` tool.
+
+## GitHub Copilot
+
+### Bring your own key for Copilot Business and Enterprise
+
+Bring your own language model key (BYOK) is now available for Copilot Business and Enterprise users. With BYOK, you can use your own API keys to access models from providers like OpenRouter, Ollama, Google, OpenAI, and more in chat.
+
+To enable BYOK for your organization, an administrator must enable the **Bring Your Own Language Model Key in VS Code** policy in the [Copilot policy settings](https://github.com/settings/copilot/features) on GitHub.com. After the policy is enabled, organization members can [add models from built-in providers](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key) or install language model provider extensions.
 
 ## Deprecated features and settings
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect that bring your own language model key (BYOK) is now available for Copilot Business and Enterprise customers when the admin enables the policy.

## Changes

### docs/copilot/customization/language-models.md
- Replaced IMPORTANT block saying BYOK is not available for Business/Enterprise with a NOTE about admin enablement via the **Bring Your Own Language Model Key in VS Code** policy.
- Updated FAQ from "Why is BYOK not available?" to "How do I enable BYOK for Business/Enterprise?"

### api/extension-guides/ai/language-model-chat-provider.md
- Updated the IMPORTANT callout that restricted Language Model Chat Provider API to individual plans.

### release-notes/v1_115.md
- Added GitHub Copilot section with BYOK Business/Enterprise release note entry.
- Updated welcome summary and TOC navigation.