### PR TITLE
Fix table of contents link in release notes

### DIFF
--- a/release-notes/v1_116.md
+++ b/release-notes/v1_116.md
@@ -29,7 +29,7 @@ Welcome to the 1.116 release of Visual Studio Code. This release continues to ma
 
 * [Terminal agent tools](#terminal-tools): interact with any terminal session from your agent sessions.
 
-* [GitHub Copilot built-in](#github-copilot-is-now-built-in): start using AI without having to install the GitHub Copilot Chat extension.
+* [GitHub Copilot built-in](#github-copilot-is-now-builtin): start using AI without having to install the GitHub Copilot Chat extension.
 
 Happy Coding!
 


### PR DESCRIPTION
The correct hash should be `_github-copilot-is-now-builtin`: https://code.visualstudio.com/updates/v1_116#_github-copilot-is-now-builtin