### PR TITLE
docs: fix Rogue theme name in semantic token examples

### DIFF
--- a/docs/configure/themes.md
+++ b/docs/configure/themes.md
@@ -157,7 +157,7 @@ You can override the theme setting by:
 
 ```json
 "editor.semanticTokenColorCustomizations": {
-    "[Rouge]": {
+    "[Rogue]": {
         "enabled": true
     }
 }
@@ -169,7 +169,7 @@ Additional styling rules can be configured in `editor.semanticTokenColorCustomiz
 
 ```json
 "editor.semanticTokenColorCustomizations": {
-    "[Rouge]": {
+    "[Rogue]": {
         "enabled": true,
         "rules": {
             "*.declaration": { "bold": true }


### PR DESCRIPTION
## Summary
- Correct the example theme name from `Rouge` to `Rogue` in `docs/configure/themes.md`.

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- Followed `CONTRIBUTING.md` workflow.
- Single-file, docs-only correction.

## Validation
- Not run; docs-only wording change.