### PR TITLE
Fix: agent hooks usage example for blocking dangerous commands not working

### DIFF
--- a/docs/copilot/customization/hooks.md
+++ b/docs/copilot/customization/hooks.md
@@ -599,12 +599,12 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
 TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input')
 
-if [ "$TOOL_NAME" = "runTerminalCommand" ]; then
+if [ "$TOOL_NAME" = "run_in_terminal" ]; then
   COMMAND=$(echo "$TOOL_INPUT" | jq -r '.command // empty')
 
   if echo "$COMMAND" | grep -qE '(rm\s+-rf|DROP\s+TABLE|DELETE\s+FROM)'; then
     echo '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"Destructive command blocked by security policy"}}'
-    exit 0
+    exit 2
   fi
 fi
 
@@ -717,7 +717,7 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
 
 # Tools that should always require approval
-SENSITIVE_TOOLS="runTerminalCommand|deleteFile|pushToGitHub"
+SENSITIVE_TOOLS="run_in_terminal|deleteFile|pushToGitHub"
 
 if echo "$TOOL_NAME" | grep -qE "^($SENSITIVE_TOOLS)$"; then
   echo '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"This operation requires manual approval"}}'


### PR DESCRIPTION
The block-dangerous-commands usage example doesn't work because the tool_name check in the script doesn't match the actual tool name, which should be "run_in_terminal".

VSCode version: 1.116.0
OS: Darwin arm64 24.6.0

Steps to reproduce:
1. Copy the block-dangerous-commands example code from the Usage Scenarios section
2. Ask the agent to run `rm -rf ${some_test_file}`
3. Agent hook doesn't block the command