### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/blogs/2017/08/07/emmet.md
+++ b/blogs/2017/08/07/emmet.md
@@ -31,7 +31,7 @@ Read on to learn about the Emmet 2.0 changes in Visual Studio Code.
 
 ## New modular approach to Emmet
 
-Previously, the [Emmet library](https://github.com/emmetio/emmet) was a single monolithic codebase that was used for every [Emmet action](https://docs.emmet.io/actions/). The author of Emmet, [Sergey Chikuyonok](https://github.com/sergeche), envisioned a new world for Emmet 2.0 with smaller, re-usable modules.
+Previously, the [Emmet library](https://github.com/emmetio/emmet) was a single monolithic codebase that was used for every [Emmet action](https://docs.emmet.io/actions/). The author of Emmet, [Sergey Chikuyonok](https://github.com/sergeche), envisioned a new world for Emmet 2.0 with smaller, reusable modules.
 
 There are now separate npm modules from [@emmetio](https://github.com/emmetio) for the different parts of the pipeline required to expand an Emmet abbreviation. These include steps such as:
 

--- a/docs/configure/profiles.md
+++ b/docs/configure/profiles.md
@@ -161,7 +161,7 @@ You can import an existing profile from the **Profiles editor** by selecting the
 
 ![Import profile from the Profiles editor](images/profiles/profiles-editor-import-profile.png)
 
-When you select **Import Profile...**, you are prompted for the URL of a GitHub gist or the file location of a profile via an **Import Profile** dialog. Once you have selected the profile, the [Profile creation form](#create-a-profile) opens with the profile to import pre-selected. You can continue to modify the profile and select **Create** to import the profile.
+When you select **Import Profile...**, you are prompted for the URL of a GitHub gist or the file location of a profile via an **Import Profile** dialog. Once you have selected the profile, the [Profile creation form](#create-a-profile) opens with the profile to import preselected. You can continue to modify the profile and select **Create** to import the profile.
 
 ## Uses for profiles
 


### PR DESCRIPTION
Fixes two spelling errors:\n- 're-usable' → 'reusable' in emmet blog post\n- 'pre-selected' → 'preselected' in profiles documentation