### PR TITLE
default value for chat.experimental.incrementalRendering.buffering is word

### DIFF
--- a/release-notes/v1_117.md
+++ b/release-notes/v1_117.md
@@ -76,7 +76,7 @@ Configure incremental response rendering with the following settings:
 
 * `setting(chat.experimental.incrementalRendering.enabled)`: Enable or disable incremental response rendering with optional block-level animation when streaming chat responses. Default: `true`.
 * `setting(chat.experimental.incrementalRendering.animationStyle)`: Configure the animation style for incremental response rendering. Options: `none`, `fade`, `rise`, `blur`, `scale`, `slide`, `reveal`. Default: `fade`.
-* `setting(chat.experimental.incrementalRendering.buffering)`: Configure how content is buffered before rendering during incremental response rendering. Lower buffering levels render faster but may show incomplete sentences or partially-formed Markdown. Options: `off`, `word`, `paragraph`. Default: `off`.
+* `setting(chat.experimental.incrementalRendering.buffering)`: Configure how content is buffered before rendering during incremental response rendering. Lower buffering levels render faster but may show incomplete sentences or partially-formed Markdown. Options: `off`, `word`, `paragraph`. Default: `word`.
 
 ### Sort agent sessions by recent activity
 


### PR DESCRIPTION
For 1.117 release notes, in "Chat experience" section, setting `chat.experimental.incrementalRendering.buffering` states default value is `off`. When I view that in settings, the default is `word`.

<img width="1329" height="549" alt="image" src="https://github.com/user-attachments/assets/da98c61b-c323-45c8-acd1-fe50418754a7" />