### PR TITLE
docs: fix attached container reference grammar

### DIFF
--- a/docs/devcontainers/attach-container.md
+++ b/docs/devcontainers/attach-container.md
@@ -61,7 +61,7 @@ Finally, if you have extensions you want installed regardless of the container y
 
 ## Attached container configuration reference
 
-Attached container configuration files are similar to [devcontainer.json](https://containers.dev/implementors/json_reference) and supports a subset of its properties.
+Attached container configuration files are similar to [devcontainer.json](https://containers.dev/implementors/json_reference) and support a subset of its properties.
 
 | Property | Type | Description |
 |----------|------|-------------|


### PR DESCRIPTION
## Summary
- change `supports` to `support` in the attached container configuration reference

## Related issue
- N/A (minor docs grammar fix)

## Guideline alignment
- Followed https://github.com/microsoft/vscode-docs/blob/main/CONTRIBUTING.md
- This stays within one markdown file and follows the docs-only PR guidance.

## Validation
- `git diff --check`