### PR TITLE
docs: fix devcontainer reference wording

### DIFF
--- a/docs/devcontainers/create-dev-container.md
+++ b/docs/devcontainers/create-dev-container.md
@@ -277,7 +277,7 @@ For example:
 }
 ```
 
-See the [devcontainer.json reference](https://containers.dev/implementors/json_reference) for information other available properties such as the `workspaceFolder` and `shutdownAction`.
+See the [devcontainer.json reference](https://containers.dev/implementors/json_reference) for information on other available properties such as the `workspaceFolder` and `shutdownAction`.
 
 Once you have added a `.devcontainer/devcontainer.json` file to your folder, run the **Dev Containers: Reopen in Container** command (or **Dev Containers: Open Folder in Container...** if you are not yet in a container) from the Command Palette (`kbstyle(F1)`).
 


### PR DESCRIPTION
## Summary
- add the missing `on` in the devcontainer reference sentence

## Related issue
- N/A (minor docs grammar fix)

## Guideline alignment
- Followed https://github.com/microsoft/vscode-docs/blob/main/CONTRIBUTING.md
- This stays within one markdown file and follows the docs-only PR guidance.

## Validation
- `git diff --check`