### PR TITLE
Add blog post: Solving MCP Tool Overload

### DIFF
--- a/blogs/2026/04/24/embedding-cache.excalidraw
+++ b/blogs/2026/04/24/embedding-cache.excalidraw
@@ -1,0 +1,35 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {"type":"text","id":"title","x":100,"y":0,"width":400,"height":30,"text":"tool_search(\"open browser page\")","fontSize":24,"strokeColor":"#1e1e1e","fontFamily":3},
+    {"type":"arrow","id":"a0","x":310,"y":32,"width":0,"height":28,"points":[[0,0],[0,28]],"strokeColor":"#1e1e1e","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"rectangle","id":"eq","x":160,"y":65,"width":300,"height":65,"backgroundColor":"#d0bfff","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#8b5cf6","strokeWidth":2},
+    {"type":"text","id":"eqt","x":230,"y":83,"width":160,"height":30,"text":"Embed query","fontSize":22,"strokeColor":"#1e1e1e","containerId":"eq","textAlign":"center"},
+    {"type":"arrow","id":"a1","x":310,"y":130,"width":0,"height":50,"points":[[0,0],[0,50]],"strokeColor":"#8b5cf6","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"a1l","x":320,"y":140,"width":110,"height":20,"text":"query vector","fontSize":16,"strokeColor":"#757575"},
+    {"type":"rectangle","id":"cs","x":110,"y":185,"width":400,"height":80,"backgroundColor":"#fff3bf","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#f59e0b","strokeWidth":2},
+    {"type":"text","id":"cst","x":190,"y":200,"width":240,"height":50,"text":"Cosine similarity\ntop-k matches","fontSize":20,"strokeColor":"#1e1e1e","containerId":"cs","textAlign":"center"},
+    {"type":"arrow","id":"a2","x":310,"y":265,"width":0,"height":50,"points":[[0,0],[0,50]],"strokeColor":"#1e1e1e","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"rectangle","id":"res","x":130,"y":320,"width":360,"height":75,"backgroundColor":"#b2f2bb","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#22c55e","strokeWidth":2},
+    {"type":"text","id":"rest","x":147,"y":327,"width":326,"height":60,"text":"tool_reference[]\nopen_browser, click_element, ...","fontSize":18,"strokeColor":"#1e1e1e","containerId":"res","textAlign":"center"},
+    {"type":"text","id":"ct","x":640,"y":0,"width":290,"height":28,"text":"Tool Embedding Cache","fontSize":22,"strokeColor":"#1e1e1e","fontFamily":3},
+    {"type":"rectangle","id":"c1","x":600,"y":45,"width":360,"height":95,"backgroundColor":"#a5d8ff","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#4a9eed","strokeWidth":2},
+    {"type":"text","id":"c1t","x":640,"y":58,"width":280,"height":69,"text":"Layer 1: Pre-computed\nBuilt-in tools\nShipped with VS Code","fontSize":16,"strokeColor":"#1e1e1e","containerId":"c1","textAlign":"center"},
+    {"type":"arrow","id":"ca1","x":600,"y":95,"width":-90,"height":115,"points":[[0,0],[-90,115]],"strokeColor":"#4a9eed","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"rectangle","id":"c2","x":600,"y":170,"width":360,"height":95,"backgroundColor":"#c3fae8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#06b6d4","strokeWidth":2},
+    {"type":"text","id":"c2t","x":640,"y":183,"width":280,"height":69,"text":"Layer 2: Local persistent cache\nMCP & extension tools\nLRU, 1000 entries","fontSize":16,"strokeColor":"#1e1e1e","containerId":"c2","textAlign":"center"},
+    {"type":"arrow","id":"ca2","x":600,"y":225,"width":-90,"height":5,"points":[[0,0],[-90,5]],"strokeColor":"#06b6d4","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"el","x":525,"y":125,"width":70,"height":40,"text":"tool\nembeddings","fontSize":16,"strokeColor":"#757575"},
+    {"type":"rectangle","id":"miss","x":650,"y":310,"width":260,"height":65,"backgroundColor":"#ffd8a8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#f59e0b","strokeWidth":2},
+    {"type":"text","id":"misst","x":670,"y":323,"width":220,"height":40,"text":"Compute embedding\nStore in local cache","fontSize":16,"strokeColor":"#1e1e1e","containerId":"miss","textAlign":"center"},
+    {"type":"arrow","id":"am","x":780,"y":265,"width":0,"height":45,"points":[[0,0],[0,45]],"strokeColor":"#757575","strokeWidth":1,"endArrowhead":"arrow"},
+    {"type":"text","id":"aml","x":790,"y":278,"width":40,"height":20,"text":"miss","fontSize":14,"strokeColor":"#757575"},
+    {"type":"rectangle","id":"fast","x":180,"y":430,"width":260,"height":50,"backgroundColor":"#d3f9d8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#22c55e","strokeWidth":2},
+    {"type":"text","id":"fastt","x":198,"y":442,"width":224,"height":26,"text":"sub-millisecond lookup","fontSize":20,"strokeColor":"#15803d","containerId":"fast","textAlign":"center"}
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff"
+  }
+}

--- a/blogs/2026/04/24/embedding-cache.png
+++ b/blogs/2026/04/24/embedding-cache.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b3f65af955a8bf17a528fc1855d85120bdf4f349f13098e1bdc08602e942191
+size 128212

--- a/blogs/2026/04/24/solving-mcp-tool-overload.md
+++ b/blogs/2026/04/24/solving-mcp-tool-overload.md
@@ -1,0 +1,217 @@
+---
+Order: 130
+TOCTitle: MCP Tool Overload
+PageTitle: "Solving MCP Tool Overload: How VS Code Manages 200+ Agent Tools"
+MetaDescription: AI agents in VS Code access 200+ tools but only send 30 per turn. Progressive tool discovery uses embeddings and caching to make the rest instantly available.
+MetaSocialImage: tool-discovery-hero.png
+Date: 2026-04-24
+Author: Bhavya U, Connor Peet, Harald Kirschner
+---
+
+# Solving MCP Tool Overload: How VS Code Manages 200+ Agent Tools
+
+April 24, 2026 by [Bhavya U](https://github.com/bhavyaus), [Connor Peet](https://github.com/connor4312), [Harald Kirschner](https://github.com/digitarald)
+
+We just got back from [MCP Dev Summit](https://events.linuxfoundation.org/mcp-dev-summit-north-america/) in New York City, where we presented on [MCP Apps support in VS Code](https://code.visualstudio.com/blogs/2026/01/26/mcp-apps-support). One theme came up in nearly every session: too many tools. As the MCP ecosystem grows, servers and extensions each bring their own capabilities, and it adds up fast. Install a few [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers), enable some extensions, and your agent session suddenly has access to over 200 tools. Including all of their schemas in every request adds over 12,000 tokens on top of the base prompt, pushing a single turn past 18,000 tokens before you've even said "hello."
+
+That creates real problems. The model gets slower. It picks the wrong tool more often. And because the tool list changes between sessions (different MCP servers, different extensions), [prompt caching](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching), one of the biggest performance wins in production LLM systems, becomes unreliable.
+
+We believe strongly that **the client should handle this**, not the user. Developers shouldn't have to think about which tools to enable, worry about token budgets, or pay penalties in performance and cost just because their ecosystem is rich. The hard parts of agentic optimization, including how tools are provided to the model, should be invisible. This post walks through how we built that in VS Code: progressive tool discovery.
+
+<!-- TODO: Replace ASCII art with designed diagram -->
+
+```text
+  ALL TOOLS LOADED                    CORE + DEFERRED
+  (before)                            (after)
+
+  +---------------------------+       +---------------------------+
+  | System prompt   ~6K tok   |       | System prompt   ~6K tok   |
+  +---------------------------+       +---------------------------+
+  | read_file        { ... }  |       | read_file        { ... }  |
+  | grep_search      { ... }  |       | grep_search      { ... }  |
+  | run_in_terminal  { ... }  |       | run_in_terminal  { ... }  |
+  | replace_string   { ... }  |       | replace_string   { ... }  |
+  | ...28 more full schemas   |       | ...28 more full schemas   |
+  +---------------------------+       +------ stable prefix ------+
+  | open_browser     { ... }  |       | open_browser  (deferred)  |
+  | click_element    { ... }  |       | click_element (deferred)  |
+  | run_notebook     { ... }  |       | run_notebook  (deferred)  |
+  | create_pr        { ... }  |       | create_pr     (deferred)  |
+  | ...170 more full schemas  |       | ...170 more (deferred)    |
+  +---------------------------+       +---------------------------+
+
+  Total: ~18,800 tokens                Total: ~6,400 tokens
+         (12K+ just for tools)                (schemas hidden for deferred)
+```
+
+## A core toolkit and a search index
+
+When we looked at telemetry, a clear pattern emerged. On any given turn, the agent uses two to five tools. The same ~30 tools cover nearly 88% of all invocations: reading files, editing code, searching the codebase, running terminal commands. The remaining 170+ tools are specialized: open a browser page, run a notebook cell, create a GitHub pull request, drag an element on a page. Important, but not on every turn.
+
+This suggested a natural split. Keep a **core set** of tools always available, and make everything else **discoverable on demand**.
+
+When VS Code sends a request to the model, it partitions all available tools into two groups:
+
+- **Always-available tools** (~30) are sent with their full schemas. Think `read_file`, `replace_string_in_file`, `run_in_terminal`, `grep_search`. They're always ready to call.
+- **Deferred tools** (everything else) are also included, but marked with a `defer_loading` flag. The full definition is sent in the API request so the provider can resolve it later, but the model only sees the tool name. It knows the capability is there but needs to unlock it first.
+
+In the API request, the difference looks like this:
+
+```json
+// Always-available: full schema sent, visible to the model
+{
+  "name": "read_file",
+  "description": "Read the contents of a file...",
+  "input_schema": { "type": "object", "properties": { ... } }
+}
+
+// Deferred: full schema sent, but hidden from the model until unlocked
+{
+  "name": "open_browser_page",
+  "description": "Open a browser page...",
+  "input_schema": { "type": "object", "properties": { ... } },
+  "defer_loading": true
+}
+```
+
+To unlock a deferred tool, the agent calls `tool_search`, a [built-in capability](https://code.visualstudio.com/docs/copilot/agents/agent-tools) that takes a natural language query and returns the three to five most relevant matches. Once returned, those tools become immediately callable for the rest of the conversation.
+
+From the model's perspective, the flow is simple:
+
+1. "I need to open a browser."
+2. Calls `tool_search` with query "open browser page"
+3. Gets back `open_browser_page`, `click_element`, `screenshot_page`
+4. Calls `open_browser_page` with the URL
+
+One extra tool call, and the agent has exactly what it needs.
+
+<!-- TODO: Replace ASCII art with designed diagram -->
+
+```text
+  User                     Model                  VS Code               Anthropic API
+   |                        |                       |                       |
+   |-- "open this URL" ---->|                       |                       |
+   |                        |                       |                       |
+   |                        |-- tool_search -------->|                       |
+   |                        |   "open browser page"  |                       |
+   |                        |                        |                       |
+   |                        |                    [embed query]               |
+   |                        |                    [cosine sim vs cache]       |
+   |                        |                    [top-k matches]             |
+   |                        |                        |                       |
+   |                        |<-- tool_reference[] ---|                       |
+   |                        |    open_browser_page   |                       |
+   |                        |    click_element       |                       |
+   |                        |    screenshot_page     |                       |
+   |                        |                        |                       |
+   |                        |                        |-- expand schemas ---->|
+   |                        |                        |   (API resolves refs) |
+   |                        |                        |                       |
+   |                        |-- open_browser_page -->|                       |
+   |                        |   { url: "..." }       |                       |
+   |                        |                        |                       |
+```
+
+> [!NOTE]
+> Progressive discovery with `defer_loading` is currently enabled for Claude Sonnet 4.5+ and Opus 4.5+ (Haiku does not support `tool_search`). OpenAI's GPT 5.4 and newer models also support `tool_search`. For Gemini models, VS Code uses a separate tool grouping system that consolidates related tools into virtual groups. Subagents get curated, small tool sets and skip `tool_search` entirely.
+
+## Why we built our own search
+
+Here's where our approach diverges from what you might expect. Anthropic's API offers a built-in server-side tool search. You can include `tool_search_tool_regex` or `tool_search_tool_bm25` in your tools array, and the server handles search automatically using regex pattern matching or BM25 text search.
+
+We actually shipped that first. In late 2025, we rolled out Anthropic's server-side search behind a feature flag, tested it via A/B experiment, and enabled it for Opus 4.5. It worked, but we ran into three issues:
+
+1. **Keyword matching had limits.** A query like "look up this URL" should match `fetch_webpage` even though none of those words appear in the tool name. Regex and BM25 struggle with this kind of semantic gap. We could see it in the data: the server-side approach needed more search invocations to find the right tools.
+2. **Dynamic tool discovery.** MCP servers support [dynamic tool discovery](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-discovery), where the set of available tools can change mid-session. Server-side search has no awareness of these changes, but a client-side implementation can re-index tools as they appear.
+3. **Enterprise compliance.** Anthropic's server-side tool search was not Zero Data Retention compliant, a blocker for enterprise customers.
+
+So we pivoted. We replaced server-side search with a **client-side implementation** running entirely within VS Code, using **embedding-based semantic similarity**. When the model calls `tool_search`, VS Code computes an embedding of the query, compares it against pre-computed embeddings of every tool's name and description, and returns the closest matches by cosine similarity.
+
+We didn't choose embeddings on a hunch. Back in mid-2025, we ran a controlled experiment comparing three approaches to tool selection on a benchmark of 200 tool-use scenarios:
+
+| Method | Correct tool in results | Hit rate |
+|--------|------------------------|----------|
+| Embedding-based (top 10 by cosine similarity) | **93.0%** | 186/200 |
+| GPT-4.1-based (LLM picks top 10 tools) | 87.5% | 175/200 |
+| Default tools only (no selection) | 69.0% | 138/200 |
+
+Embeddings beat an LLM at its own game, with a 24 percentage point improvement over defaults. And the client-side implementation needed fewer search invocations than the server-side regex approach to find the right tools in our evals.
+
+The key insight: Anthropic's API doesn't care *who* does the search. It supports a "custom tool search" pattern where the client implements its own search tool and returns `tool_reference` content blocks, the same format the server-side search would produce. The API handles the rest, expanding those references into full tool schemas for the model. We get the best of both worlds: Anthropic's native deferred-tool infrastructure with our own search quality.
+
+OpenAI's GPT 5.4+ models also support [tool search](https://developers.openai.com/api/docs/guides/tools-tool-search) with a similar client-executed mode. When the model emits a `tool_search_call`, VS Code performs the embedding-based lookup and returns a `tool_search_output` containing the matched deferred tools (full definitions with `defer_loading: true`). The deferred tools must be included as part of the tool output for the model to call them on subsequent turns.
+
+## Making discovery instant
+
+The agent shouldn't have to wait for a network round-trip every time it needs to discover a tool. We built a two-layer caching system to make search a sub-millisecond local operation.
+
+**Layer 1: Pre-computed cache.** For every VS Code release, we pre-compute embeddings for all known built-in tools and ship them as a versioned cache. When the agent searches, the lookup is a pure in-memory dot-product.
+
+**Layer 2: Local persistent cache.** For tools from MCP servers or [extensions](https://code.visualstudio.com/api/extension-guides/ai/tools), tools we can't know about at release time, VS Code computes embeddings on first encounter and stores them in a compact binary file in your global storage. The cache uses an LRU policy with 1,000 entries, keyed by a hash of the tool's name and description. If a tool's description changes (say, an MCP server updates), the hash changes and a fresh embedding is computed automatically.
+
+The result: the first time you use an MCP server's tools, there's a brief computation. Every subsequent search is instant.
+
+<!-- TODO: Replace ASCII art with designed diagram -->
+
+```text
+  tool_search("open browser page")
+       |
+       v
+  +------------------+    tool embs   +------------------------+
+  | Embed query      |--- hit? ------>| Layer 1: Pre-computed  |
+  | (API call or     |                | (built-in tools,       |
+  | local model)     |                |  shipped with VS Code) |
+  +------------------+                +------------------------+
+       |                                    miss |
+       v                                         v
+  +------------------+    tool embs   +------------------------+
+  | Cosine similarity|--- hit? ------>| Layer 2: Local binary  |
+  | top-k results    |                | (MCP/ext tools, LRU,   |
+  +------------------+                |  1000 entries, hashed)  |
+       |                              +------------------------+
+       v                                         |
+  [tool_reference]                           miss |
+  open_browser_page                               v
+  click_element                          [compute embedding]
+  screenshot_page                        [write to cache]
+```
+
+## Teaching the model the protocol
+
+Progressive discovery only works if the model knows the rules. We invest significant prompt engineering in making this seamless:
+
+- The system prompt explains that deferred tools must be discovered via `tool_search` before they can be called.
+- A full list of deferred tool names is included, so the model knows *what's available* to search for. It just can't call them directly.
+- We encourage broad queries: "search for 'github' to find all GitHub tools at once, rather than separate searches for issues and pull requests."
+- We explicitly warn against anti-patterns: don't call a deferred tool without searching first, don't re-search for tools already found.
+- A reminder at the end of the prompt reinforces the protocol. Models follow instructions well, but critical behaviors deserve repetition.
+
+We also learned the hard way that some tools can't be deferred. Early on, we deferred `view_image`. The model saw the name in a flat list but never its description, and it simply didn't think to search for an image-viewing tool when encountering `.png` files. Benchmark failures led us to a simple rule: tools that represent core capabilities the model might not think to look for need to stay always-available. Telemetry, not guesswork, drives which tools make the cut.
+
+## The prompt caching bonus
+
+There's a subtle but important performance benefit to this architecture that goes beyond token savings.
+
+We deliberately put always-available tools **first** in the request. Because these tools are the same across turns and often across sessions, they form a **stable prefix** that the API can cache. Deferred tools, which vary by session, come after and don't invalidate the cached prefix.
+
+We also discovered that our initial implementation wasn't placing `cache_control` breakpoints on tools or the system prompt, causing ~13,000 tokens of stable content to be reprocessed every turn. After reordering the request and adding breakpoints in the right places, the first ~15,000 tokens of every request hit the prompt cache on every turn after the first. Less latency, lower cost, and the model gets its context faster.
+
+## What we learned
+
+Building progressive tool discovery taught us lessons that apply broadly to anyone building agentic systems:
+
+1. **You don't have to send every tool in every request.** Split your tools into a core set and a discoverable set. The model is perfectly capable of searching when it needs something specialized.
+
+2. **Semantic search beats keyword matching for tool discovery.** Models describe what they need in natural language. Your search should understand natural language too. In our benchmarks, embeddings outperformed both LLM-based selection and regex/BM25 search.
+
+3. **Cache aggressively, at multiple layers.** Pre-compute what you can. Persist what you compute. Make the common case instant.
+
+4. **Teach the protocol explicitly, and then remind.** Models follow instructions well, but critical behaviors deserve repetition in the prompt. And watch for tools that become invisible when deferred.
+
+5. **Use the platform's native primitives.** Anthropic's `defer_loading` and `tool_reference` blocks and OpenAI's `tool_search` with client-executed mode gave us the right abstractions. We just brought our own search quality.
+
+The result: VS Code's agent can access 200+ tools while paying the token cost of ~30 on most turns, with sub-millisecond discovery when it needs more. The model barely notices the difference, but your prompt cache and your latency certainly do.
+
+Looking ahead, we're exploring **personalized deferral**: instead of a static list of always-available tools, use each developer's actual usage patterns to decide what stays loaded. A data scientist would keep notebook tools always available. A web developer would keep browser tools. The core set adapts to you.
+
+Happy coding! 💙

--- a/blogs/2026/04/24/solving-mcp-tool-overload.md
+++ b/blogs/2026/04/24/solving-mcp-tool-overload.md
@@ -18,31 +18,7 @@ That creates real problems: the **model gets slower and it picks the wrong tool 
 
 We strongly believe that **the client should handle tool management**, not the user. Developers shouldn't have to think about which tools to enable, worry about token budgets, or pay penalties in performance and cost just because their ecosystem is rich. The hard parts of agentic optimization, including how tools are provided to the model, should be invisible. This post walks through how we built that into VS Code: **progressive tool discovery**.
 
-<!-- TODO: Replace ASCII art with designed diagram -->
-
-```text
-  ALL TOOLS LOADED                    CORE + DEFERRED
-  (before)                            (after)
-
-  +---------------------------+       +---------------------------+
-  | System prompt   ~6K tok   |       | System prompt   ~6K tok   |
-  +---------------------------+       +---------------------------+
-  | read_file        { ... }  |       | read_file        { ... }  |
-  | grep_search      { ... }  |       | grep_search      { ... }  |
-  | run_in_terminal  { ... }  |       | run_in_terminal  { ... }  |
-  | replace_string   { ... }  |       | replace_string   { ... }  |
-  | ...28 more full schemas   |       | ...28 more full schemas   |
-  +---------------------------+       +------ stable prefix ------+
-  | open_browser     { ... }  |       | open_browser  (deferred)  |
-  | click_element    { ... }  |       | click_element (deferred)  |
-  | run_notebook     { ... }  |       | run_notebook  (deferred)  |
-  | create_pr        { ... }  |       | create_pr     (deferred)  |
-  | ...170 more full schemas  |       | ...170 more (deferred)    |
-  +---------------------------+       +---------------------------+
-
-  Total: ~18,800 tokens                Total: ~6,400 tokens
-         (12K+ just for tools)                (schemas hidden for deferred)
-```
+![Diagram showing before and after comparison of tool token usage, from 18,800 tokens with all tools loaded to 6,400 tokens with core plus deferred tools, a 65% reduction.](tool-token-comparison.png)
 
 ## A core toolkit and a search index
 
@@ -85,32 +61,7 @@ From the model's perspective, the flow is simple:
 
 One extra tool call, and the agent has exactly what it needs.
 
-<!-- TODO: Replace ASCII art with designed diagram -->
-
-```text
-  User                     Model                  VS Code               Anthropic API
-   |                        |                       |                       |
-   |-- "open this URL" ---->|                       |                       |
-   |                        |                       |                       |
-   |                        |-- tool_search -------->|                       |
-   |                        |   "open browser page"  |                       |
-   |                        |                        |                       |
-   |                        |                    [embed query]               |
-   |                        |                    [cosine sim vs cache]       |
-   |                        |                    [top-k matches]             |
-   |                        |                        |                       |
-   |                        |<-- tool_reference[] ---|                       |
-   |                        |    open_browser_page   |                       |
-   |                        |    click_element       |                       |
-   |                        |    screenshot_page     |                       |
-   |                        |                        |                       |
-   |                        |                        |-- expand schemas ---->|
-   |                        |                        |   (API resolves refs) |
-   |                        |                        |                       |
-   |                        |-- open_browser_page -->|                       |
-   |                        |   { url: "..." }       |                       |
-   |                        |                        |                       |
-```
+![Sequence diagram showing the tool search flow between User, Model, VS Code, and API Provider, with six steps from user request through tool discovery and execution.](tool-search-sequence.png)
 
 > Progressive discovery with `defer_loading` is currently enabled for Claude Sonnet 4.5+ and Opus 4.5+ (Haiku does not support `tool_search`). OpenAI's GPT 5.4 and newer models also support `tool_search`. For Gemini models, VS Code uses a separate tool grouping system that consolidates related tools into virtual groups. Subagents only get curated, small tool sets and they skip `tool_search` entirely.
 
@@ -150,30 +101,7 @@ The agent shouldn't have to wait for a network round-trip every time it needs to
 
 The result: the first time you use an MCP server's tools, there's a brief computation. Every subsequent search is instant.
 
-<!-- TODO: Replace ASCII art with designed diagram -->
-
-```text
-  tool_search("open browser page")
-       |
-       v
-  +------------------+    tool embs   +------------------------+
-  | Embed query      |--- hit? ------>| Layer 1: Pre-computed  |
-  | (API call or     |                | (built-in tools,       |
-  | local model)     |                |  shipped with VS Code) |
-  +------------------+                +------------------------+
-       |                                    miss |
-       v                                         v
-  +------------------+    tool embs   +------------------------+
-  | Cosine similarity|--- hit? ------>| Layer 2: Local binary  |
-  | top-k results    |                | (MCP/ext tools, LRU,   |
-  +------------------+                |  1000 entries, hashed)  |
-       |                              +------------------------+
-       v                                         |
-  [tool_reference]                           miss |
-  open_browser_page                               v
-  click_element                          [compute embedding]
-  screenshot_page                        [write to cache]
-```
+![Diagram showing the two-layer embedding cache architecture, with a pre-computed cache for built-in tools and a local persistent cache for MCP and extension tools, feeding into cosine similarity for sub-millisecond tool lookup.](embedding-cache.png)
 
 ## Teaching the model the protocol
 

--- a/blogs/2026/04/24/solving-mcp-tool-overload.md
+++ b/blogs/2026/04/24/solving-mcp-tool-overload.md
@@ -12,11 +12,11 @@ Author: Bhavya U, Connor Peet, Harald Kirschner
 
 April 24, 2026 by [Bhavya U](https://github.com/bhavyaus), [Connor Peet](https://github.com/connor4312), [Harald Kirschner](https://github.com/digitarald)
 
-We just got back from [MCP Dev Summit](https://events.linuxfoundation.org/mcp-dev-summit-north-america/) in New York City, where we presented on [MCP Apps support in VS Code](https://code.visualstudio.com/blogs/2026/01/26/mcp-apps-support). One theme came up in nearly every session: too many tools. As the MCP ecosystem grows, servers and extensions each bring their own capabilities, and it adds up fast. Install a few [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers), enable some extensions, and your agent session suddenly has access to over 200 tools. Including all of their schemas in every request adds over 12,000 tokens on top of the base prompt, pushing a single turn past 18,000 tokens before you've even said "hello."
+We just got back from [MCP Dev Summit](https://events.linuxfoundation.org/mcp-dev-summit-north-america/) in New York City, where we presented on [MCP Apps support in VS Code](https://code.visualstudio.com/blogs/2026/01/26/mcp-apps-support). One theme that consistently came up was that **there are too many tools**. As the MCP ecosystem grows, servers and extensions each bring their own capabilities, which adds up quickly. Install a few [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers), enable some extensions, and your agent session suddenly has access to over 200 tools. Including all of their schemas in every request adds over 12,000 tokens on top of the base prompt, pushing a single turn past 18,000 tokens before you've even said "hello."
 
-That creates real problems. The model gets slower. It picks the wrong tool more often. And because the tool list changes between sessions (different MCP servers, different extensions), [prompt caching](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching), one of the biggest performance wins in production LLM systems, becomes unreliable.
+That creates real problems: the **model gets slower and it picks the wrong tool more often**. And because the tool list changes between sessions (different MCP servers, different extensions), [prompt caching](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching), one of the biggest performance wins in production LLM systems, becomes unreliable.
 
-We believe strongly that **the client should handle this**, not the user. Developers shouldn't have to think about which tools to enable, worry about token budgets, or pay penalties in performance and cost just because their ecosystem is rich. The hard parts of agentic optimization, including how tools are provided to the model, should be invisible. This post walks through how we built that in VS Code: progressive tool discovery.
+We strongly believe that **the client should handle tool management**, not the user. Developers shouldn't have to think about which tools to enable, worry about token budgets, or pay penalties in performance and cost just because their ecosystem is rich. The hard parts of agentic optimization, including how tools are provided to the model, should be invisible. This post walks through how we built that into VS Code: **progressive tool discovery**.
 
 <!-- TODO: Replace ASCII art with designed diagram -->
 
@@ -46,18 +46,18 @@ We believe strongly that **the client should handle this**, not the user. Develo
 
 ## A core toolkit and a search index
 
-When we looked at telemetry, a clear pattern emerged. On any given turn, the agent uses two to five tools. The same ~30 tools cover nearly 88% of all invocations: reading files, editing code, searching the codebase, running terminal commands. The remaining 170+ tools are specialized: open a browser page, run a notebook cell, create a GitHub pull request, drag an element on a page. Important, but not on every turn.
+When we looked at telemetry, a clear pattern emerged. On any given turn, the agent typically uses two to five tools. And the same ~30 tools cover nearly 88% of all invocations: reading files, editing code, searching the codebase, running terminal commands. The remaining 170+ tools are only used for specialized scenarios: open a browser page, run a notebook cell, create a GitHub pull request, drag an element on a page. These tools are important, but not on every turn.
 
-This suggested a natural split. Keep a **core set** of tools always available, and make everything else **discoverable on demand**.
+The pattern pointed to a natural split. Keep a **core set** of tools always available, and make everything else **discoverable on demand**.
 
 When VS Code sends a request to the model, it partitions all available tools into two groups:
 
 - **Always-available tools** (~30) are sent with their full schemas. Think `read_file`, `replace_string_in_file`, `run_in_terminal`, `grep_search`. They're always ready to call.
-- **Deferred tools** (everything else) are also included, but marked with a `defer_loading` flag. The full definition is sent in the API request so the provider can resolve it later, but the model only sees the tool name. It knows the capability is there but needs to unlock it first.
+- **Deferred tools** (everything else) are also included, but marked with a `defer_loading` flag. The full definition is sent in the API request, so the provider can resolve the tool later. However, the model only sees the tool name: it knows the capability is there but needs to unlock it first.
 
 In the API request, the difference looks like this:
 
-```json
+```jsonc
 // Always-available: full schema sent, visible to the model
 {
   "name": "read_file",
@@ -112,20 +112,19 @@ One extra tool call, and the agent has exactly what it needs.
    |                        |                        |                       |
 ```
 
-> [!NOTE]
-> Progressive discovery with `defer_loading` is currently enabled for Claude Sonnet 4.5+ and Opus 4.5+ (Haiku does not support `tool_search`). OpenAI's GPT 5.4 and newer models also support `tool_search`. For Gemini models, VS Code uses a separate tool grouping system that consolidates related tools into virtual groups. Subagents get curated, small tool sets and skip `tool_search` entirely.
+> Progressive discovery with `defer_loading` is currently enabled for Claude Sonnet 4.5+ and Opus 4.5+ (Haiku does not support `tool_search`). OpenAI's GPT 5.4 and newer models also support `tool_search`. For Gemini models, VS Code uses a separate tool grouping system that consolidates related tools into virtual groups. Subagents only get curated, small tool sets and they skip `tool_search` entirely.
 
 ## Why we built our own search
 
-Here's where our approach diverges from what you might expect. Anthropic's API offers a built-in server-side tool search. You can include `tool_search_tool_regex` or `tool_search_tool_bm25` in your tools array, and the server handles search automatically using regex pattern matching or BM25 text search.
+Tool search and deferred loading is not a new concept. Anthropic's API offers a built-in server-side tool search. You can include `tool_search_tool_regex` or `tool_search_tool_bm25` in your tools array, and the server handles search automatically using regex pattern matching or BM25 text search.
 
-We actually shipped that first. In late 2025, we rolled out Anthropic's server-side search behind a feature flag, tested it via A/B experiment, and enabled it for Opus 4.5. It worked, but we ran into three issues:
+Initially, we used this approach. In late 2025, we rolled out Anthropic's server-side search behind a feature flag, tested it via A/B experiment, and enabled it for Opus 4.5. It worked, but we ran into three issues:
 
 1. **Keyword matching had limits.** A query like "look up this URL" should match `fetch_webpage` even though none of those words appear in the tool name. Regex and BM25 struggle with this kind of semantic gap. We could see it in the data: the server-side approach needed more search invocations to find the right tools.
 2. **Dynamic tool discovery.** MCP servers support [dynamic tool discovery](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-discovery), where the set of available tools can change mid-session. Server-side search has no awareness of these changes, but a client-side implementation can re-index tools as they appear.
 3. **Enterprise compliance.** Anthropic's server-side tool search was not Zero Data Retention compliant, a blocker for enterprise customers.
 
-So we pivoted. We replaced server-side search with a **client-side implementation** running entirely within VS Code, using **embedding-based semantic similarity**. When the model calls `tool_search`, VS Code computes an embedding of the query, compares it against pre-computed embeddings of every tool's name and description, and returns the closest matches by cosine similarity.
+So we pivoted. We replaced server-side search with a **client-side implementation** that runs entirely within VS Code and that uses **embedding-based semantic similarity**. When the model calls `tool_search`, VS Code computes an embedding of the query, compares it against pre-computed embeddings of every tool's name and description, and returns the closest matches by cosine similarity.
 
 We didn't choose embeddings on a hunch. Back in mid-2025, we ran a controlled experiment comparing three approaches to tool selection on a benchmark of 200 tool-use scenarios:
 
@@ -137,7 +136,7 @@ We didn't choose embeddings on a hunch. Back in mid-2025, we ran a controlled ex
 
 Embeddings beat an LLM at its own game, with a 24 percentage point improvement over defaults. And the client-side implementation needed fewer search invocations than the server-side regex approach to find the right tools in our evals.
 
-The key insight: Anthropic's API doesn't care *who* does the search. It supports a "custom tool search" pattern where the client implements its own search tool and returns `tool_reference` content blocks, the same format the server-side search would produce. The API handles the rest, expanding those references into full tool schemas for the model. We get the best of both worlds: Anthropic's native deferred-tool infrastructure with our own search quality.
+The key insight was that Anthropic's API doesn't care *who* does the search. It supports a "custom tool search" pattern where the client implements its own search tool and returns `tool_reference` content blocks, the same format the server-side search would produce. The API handles the rest, expanding those references into full tool schemas for the model. As a result, we get the best of both worlds: Anthropic's native deferred-tool infrastructure with our own search quality.
 
 OpenAI's GPT 5.4+ models also support [tool search](https://developers.openai.com/api/docs/guides/tools-tool-search) with a similar client-executed mode. When the model emits a `tool_search_call`, VS Code performs the embedding-based lookup and returns a `tool_search_output` containing the matched deferred tools (full definitions with `defer_loading: true`). The deferred tools must be included as part of the tool output for the model to call them on subsequent turns.
 
@@ -178,7 +177,7 @@ The result: the first time you use an MCP server's tools, there's a brief comput
 
 ## Teaching the model the protocol
 
-Progressive discovery only works if the model knows the rules. We invest significant prompt engineering in making this seamless:
+Progressive discovery only works if the model knows the rules. We invest significantly in prompt engineering to make this seamless for you:
 
 - The system prompt explains that deferred tools must be discovered via `tool_search` before they can be called.
 - A full list of deferred tool names is included, so the model knows *what's available* to search for. It just can't call them directly.
@@ -186,7 +185,7 @@ Progressive discovery only works if the model knows the rules. We invest signifi
 - We explicitly warn against anti-patterns: don't call a deferred tool without searching first, don't re-search for tools already found.
 - A reminder at the end of the prompt reinforces the protocol. Models follow instructions well, but critical behaviors deserve repetition.
 
-We also learned the hard way that some tools can't be deferred. Early on, we deferred `view_image`. The model saw the name in a flat list but never its description, and it simply didn't think to search for an image-viewing tool when encountering `.png` files. Benchmark failures led us to a simple rule: tools that represent core capabilities the model might not think to look for need to stay always-available. Telemetry, not guesswork, drives which tools make the cut.
+We also learned the hard way that some tools can't be deferred. Early on, we deferred `view_image` and the model only saw the name in a flat list but never its description. So the model simply didn't think to search for an image-viewing tool when it encountered `.png` files. Benchmark failures led us to a simple rule: tools that represent core capabilities and that the model might not think to look for, need to stay always-available. Telemetry, not guesswork, drives which tools make the cut.
 
 ## The prompt caching bonus
 

--- a/blogs/2026/04/24/tool-search-sequence.excalidraw
+++ b/blogs/2026/04/24/tool-search-sequence.excalidraw
@@ -1,0 +1,41 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {"type":"rectangle","id":"a1","x":20,"y":10,"width":130,"height":50,"backgroundColor":"#a5d8ff","fillStyle":"solid","roundness":{"type":3},"strokeWidth":2},
+    {"type":"text","id":"a1t","x":60,"y":22,"width":50,"height":26,"text":"User","fontSize":20,"strokeColor":"#1e1e1e","containerId":"a1","textAlign":"center"},
+    {"type":"rectangle","id":"a2","x":270,"y":10,"width":130,"height":50,"backgroundColor":"#d0bfff","fillStyle":"solid","roundness":{"type":3},"strokeWidth":2},
+    {"type":"text","id":"a2t","x":302,"y":22,"width":66,"height":26,"text":"Model","fontSize":20,"strokeColor":"#1e1e1e","containerId":"a2","textAlign":"center"},
+    {"type":"rectangle","id":"a3","x":520,"y":10,"width":140,"height":50,"backgroundColor":"#b2f2bb","fillStyle":"solid","roundness":{"type":3},"strokeWidth":2},
+    {"type":"text","id":"a3t","x":546,"y":22,"width":88,"height":26,"text":"VS Code","fontSize":20,"strokeColor":"#1e1e1e","containerId":"a3","textAlign":"center"},
+    {"type":"rectangle","id":"a4","x":790,"y":10,"width":160,"height":50,"backgroundColor":"#ffd8a8","fillStyle":"solid","roundness":{"type":3},"strokeWidth":2},
+    {"type":"text","id":"a4t","x":809,"y":22,"width":122,"height":26,"text":"API Provider","fontSize":20,"strokeColor":"#1e1e1e","containerId":"a4","textAlign":"center"},
+    {"type":"arrow","id":"l1","x":85,"y":60,"width":0,"height":640,"points":[[0,0],[0,640]],"strokeColor":"#d0d0d0","strokeWidth":1,"endArrowhead":null},
+    {"type":"arrow","id":"l2","x":335,"y":60,"width":0,"height":640,"points":[[0,0],[0,640]],"strokeColor":"#d0d0d0","strokeWidth":1,"endArrowhead":null},
+    {"type":"arrow","id":"l3","x":590,"y":60,"width":0,"height":640,"points":[[0,0],[0,640]],"strokeColor":"#d0d0d0","strokeWidth":1,"endArrowhead":null},
+    {"type":"arrow","id":"l4","x":870,"y":60,"width":0,"height":640,"points":[[0,0],[0,640]],"strokeColor":"#d0d0d0","strokeWidth":1,"endArrowhead":null},
+    {"type":"text","id":"s1","x":30,"y":115,"width":20,"height":24,"text":"1","fontSize":18,"strokeColor":"#757575"},
+    {"type":"arrow","id":"m1","x":85,"y":130,"width":250,"height":0,"points":[[0,0],[250,0]],"strokeColor":"#4a9eed","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"m1l","x":130,"y":108,"width":160,"height":20,"text":"\"open this URL\"","fontSize":16,"strokeColor":"#4a9eed"},
+    {"type":"text","id":"s2","x":30,"y":215,"width":20,"height":24,"text":"2","fontSize":18,"strokeColor":"#757575"},
+    {"type":"arrow","id":"m2","x":335,"y":230,"width":255,"height":0,"points":[[0,0],[255,0]],"strokeColor":"#8b5cf6","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"m2l","x":355,"y":208,"width":210,"height":20,"text":"tool_search(\"open browser\")","fontSize":16,"strokeColor":"#8b5cf6"},
+    {"type":"text","id":"s3","x":30,"y":295,"width":20,"height":24,"text":"3","fontSize":18,"strokeColor":"#757575"},
+    {"type":"rectangle","id":"proc","x":548,"y":290,"width":85,"height":85,"backgroundColor":"#d3f9d8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#22c55e","strokeWidth":1},
+    {"type":"text","id":"proct","x":553,"y":300,"width":80,"height":66,"text":"embed\nquery\ncosine\nsim","fontSize":14,"strokeColor":"#15803d","containerId":"proc","textAlign":"center"},
+    {"type":"text","id":"s4","x":30,"y":415,"width":20,"height":24,"text":"4","fontSize":18,"strokeColor":"#757575"},
+    {"type":"arrow","id":"m3","x":548,"y":430,"width":-213,"height":0,"points":[[0,0],[-213,0]],"strokeColor":"#22c55e","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"m3l","x":380,"y":408,"width":130,"height":20,"text":"tool_reference[]","fontSize":16,"strokeColor":"#22c55e"},
+    {"type":"text","id":"tools","x":345,"y":448,"width":220,"height":40,"text":"open_browser_page,\nclick_element, screenshot_page","fontSize":14,"strokeColor":"#757575"},
+    {"type":"text","id":"s5","x":30,"y":525,"width":20,"height":24,"text":"5","fontSize":18,"strokeColor":"#757575"},
+    {"type":"arrow","id":"m4","x":590,"y":540,"width":280,"height":0,"points":[[0,0],[280,0]],"strokeColor":"#f59e0b","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"m4l","x":630,"y":518,"width":200,"height":20,"text":"expand deferred schemas","fontSize":16,"strokeColor":"#f59e0b"},
+    {"type":"text","id":"s6","x":30,"y":625,"width":20,"height":24,"text":"6","fontSize":18,"strokeColor":"#757575"},
+    {"type":"arrow","id":"m5","x":335,"y":640,"width":255,"height":0,"points":[[0,0],[255,0]],"strokeColor":"#8b5cf6","strokeWidth":2,"endArrowhead":"arrow"},
+    {"type":"text","id":"m5l","x":355,"y":618,"width":225,"height":20,"text":"open_browser_page({ url })","fontSize":16,"strokeColor":"#8b5cf6"}
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff"
+  }
+}

--- a/blogs/2026/04/24/tool-search-sequence.png
+++ b/blogs/2026/04/24/tool-search-sequence.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:667ed3c6db7f1aaef330e5b5b5dd81ae2e79113b001ebeef940f7dbd45c4314f
+size 98687

--- a/blogs/2026/04/24/tool-token-comparison.excalidraw
+++ b/blogs/2026/04/24/tool-token-comparison.excalidraw
@@ -1,0 +1,30 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {"type":"text","id":"lt","x":170,"y":-10,"width":130,"height":35,"text":"Before","fontSize":28,"strokeColor":"#ef4444","fontFamily":3},
+    {"type":"rectangle","id":"lsp","x":50,"y":40,"width":350,"height":60,"backgroundColor":"#a5d8ff","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#4a9eed","strokeWidth":2},
+    {"type":"text","id":"lspt","x":97,"y":53,"width":256,"height":34,"text":"System prompt  ~6K tok","fontSize":18,"strokeColor":"#1e1e1e","containerId":"lsp","textAlign":"center"},
+    {"type":"rectangle","id":"lct","x":50,"y":108,"width":350,"height":100,"backgroundColor":"#ffd8a8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#f59e0b","strokeWidth":2},
+    {"type":"text","id":"lctt","x":143,"y":133,"width":164,"height":50,"text":"32 core tools\nfull schemas","fontSize":18,"strokeColor":"#1e1e1e","containerId":"lct","textAlign":"center"},
+    {"type":"rectangle","id":"lst","x":50,"y":216,"width":350,"height":200,"backgroundColor":"#ffc9c9","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#ef4444","strokeWidth":2},
+    {"type":"text","id":"lstt","x":77,"y":265,"width":296,"height":102,"text":"170+ more tools\nfull schemas\n\nevery tool in every request","fontSize":18,"strokeColor":"#1e1e1e","containerId":"lst","textAlign":"center"},
+    {"type":"text","id":"ltt","x":115,"y":430,"width":220,"height":30,"text":"~18,800 tokens","fontSize":22,"strokeColor":"#ef4444","fontFamily":3},
+    {"type":"arrow","id":"ma","x":430,"y":260,"width":130,"height":0,"points":[[0,0],[130,0]],"strokeColor":"#1e1e1e","strokeWidth":3,"endArrowhead":"triangle"},
+    {"type":"text","id":"rt","x":725,"y":-10,"width":100,"height":35,"text":"After","fontSize":28,"strokeColor":"#22c55e","fontFamily":3},
+    {"type":"rectangle","id":"rsp","x":600,"y":40,"width":350,"height":60,"backgroundColor":"#a5d8ff","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#4a9eed","strokeWidth":2},
+    {"type":"text","id":"rspt","x":647,"y":53,"width":256,"height":34,"text":"System prompt  ~6K tok","fontSize":18,"strokeColor":"#1e1e1e","containerId":"rsp","textAlign":"center"},
+    {"type":"rectangle","id":"rct","x":600,"y":108,"width":350,"height":100,"backgroundColor":"#b2f2bb","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#22c55e","strokeWidth":2},
+    {"type":"text","id":"rctt","x":693,"y":133,"width":164,"height":50,"text":"32 core tools\nfull schemas","fontSize":18,"strokeColor":"#1e1e1e","containerId":"rct","textAlign":"center"},
+    {"type":"text","id":"spl","x":648,"y":215,"width":254,"height":22,"text":"------ stable prefix ------","fontSize":16,"strokeColor":"#15803d"},
+    {"type":"rectangle","id":"rdt","x":600,"y":240,"width":350,"height":80,"backgroundColor":"#c3fae8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#06b6d4","strokeWidth":2},
+    {"type":"text","id":"rdtt","x":638,"y":255,"width":274,"height":50,"text":"170+ deferred tools\nname only, no schemas","fontSize":18,"strokeColor":"#1e1e1e","containerId":"rdt","textAlign":"center"},
+    {"type":"text","id":"rtt","x":680,"y":430,"width":190,"height":30,"text":"~6,400 tokens","fontSize":22,"strokeColor":"#22c55e","fontFamily":3},
+    {"type":"rectangle","id":"sav","x":640,"y":350,"width":270,"height":55,"backgroundColor":"#d3f9d8","fillStyle":"solid","roundness":{"type":3},"strokeColor":"#22c55e","strokeWidth":2},
+    {"type":"text","id":"savt","x":667,"y":363,"width":216,"height":30,"text":"65% fewer tokens","fontSize":22,"strokeColor":"#15803d","containerId":"sav","textAlign":"center"}
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff"
+  }
+}

--- a/blogs/2026/04/24/tool-token-comparison.png
+++ b/blogs/2026/04/24/tool-token-comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:420e634774f9a977762a276f55b957aeea33ab5e486b2c875f78aeada898e959
+size 93479


### PR DESCRIPTION
Engineering blog post on how VS Code handles MCP tool overload with progressive tool discovery.

- Explains the core/deferred tool split (~30 always-available, 170+ deferred with `defer_loading`)
- Client-side embedding search replacing Anthropic server-side regex/BM25
- Two-layer embedding cache (pre-computed + local persistent LRU)
- Prompt caching optimization via stable tool prefix
- Covers Anthropic `tool_reference` and OpenAI `tool_search` integration
- Co-authored by Bhavya U, Connor Peet, Harald Kirschner

TODOs before publish:
- [ ] Replace ASCII art diagrams with designed visuals
- [ ] Create `tool-discovery-hero.png` social image
- [ ] Verify MCP spec URL anchor