### PR TITLE
Add docs for Copilot remote control

### DIFF
--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -65,7 +65,7 @@ Copilot CLI sessions support the same [permission levels](/docs/copilot/agents/a
 
 ### Use `/remote` to continue a Copilot CLI session on GitHub (Experimental)
 
-Use `/remote` when you want to keep moving on work that you started in VS Code after you step away from it. For example, you might start a Copilot CLI session in VS Code, leave your desk, and then continue following along from github.com or the GitHub Mobile app.
+Use `/remote` to keep a Copilot CLI session going after you leave VS Code. Pick it up from github.com or the GitHub Mobile app without losing context.
 
 To use `/remote`:
 

--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -65,7 +65,7 @@ Copilot CLI sessions support the same [permission levels](/docs/copilot/agents/a
 
 ### Use `/remote` to open a Copilot CLI session on GitHub (Experimental)
 
-You can mirror an active Copilot CLI session to a GitHub task page by using the `/remote` command in chat. This is useful when you want to monitor or steer the same background session from another device or browser while it continues running locally in VS Code.
+Copilot CLI sessions are not limited to VS Code. Use `/remote` to monitor and steer a running Copilot CLI session from GitHub on the web or on mobile while the session continues running in VS Code.
 
 To use `/remote`:
 
@@ -74,7 +74,7 @@ To use `/remote`:
 1. Run `/remote` in the chat input.
 1. Select **Open on GitHub** to open the linked task page.
 
-The GitHub task page mirrors the current session history, tool activity, and status updates. If the session requires approval for a tool call, the approval is shown in both VS Code and on GitHub. You can approve the request from either location, and the other prompt closes automatically.
+When remote control is enabled, VS Code streams the session history, tool activity, and status updates to the linked GitHub task page in real time. Activity stays in sync across VS Code and GitHub, so actions you take in one place are reflected in the other. If the session requires approval for a tool call or input for a question, the prompt is shown in both places and you can respond from either location.
 
 To stop mirroring the session to GitHub, run `/remote off`.
 

--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -63,6 +63,24 @@ Copilot CLI sessions support the same [permission levels](/docs/copilot/agents/a
 * **Worktree isolation**: the permission level is automatically set to **Bypass Approvals** and can't be changed. Because the agent operates on an isolated copy of your codebase (Git worktree), all tool calls are auto-approved without confirmation dialogs.
 * **Workspace isolation**: all three permission levels are available (**Default Approvals**, **Bypass Approvals**, and **Autopilot**), just like local agent sessions. Select a level from the permissions picker in the chat input area.
 
+### Use `/remote` to open a Copilot CLI session on GitHub (Experimental)
+
+You can mirror an active Copilot CLI session to a GitHub task page by using the `/remote` command in chat. This is useful when you want to monitor or steer the same background session from another device or browser while it continues running locally in VS Code.
+
+To use `/remote`:
+
+1. Enable the `setting(github.copilot.chat.cli.remote.enabled)` setting.
+1. Start or resume a Copilot CLI session from the Chat view.
+1. Run `/remote` in the chat input.
+1. Select **Open on GitHub** to open the linked task page.
+
+The GitHub task page mirrors the current session history, tool activity, and status updates. If the session requires approval for a tool call, the approval is shown in both VS Code and on GitHub. You can approve the request from either location, and the other prompt closes automatically.
+
+To stop mirroring the session to GitHub, run `/remote off`.
+
+> [!NOTE]
+> `/remote` requires GitHub authentication in VS Code and a workspace that maps to a GitHub repository. If additional GitHub permissions are needed, VS Code prompts you to grant them before remote control is enabled.
+
 ### Limitations of Copilot CLI sessions
 
 * Copilot CLI sessions can't access all VS Code built-in tools. You can explicitly [add context](/docs/copilot/chat/copilot-chat-context.md) in the chat input.

--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -63,9 +63,9 @@ Copilot CLI sessions support the same [permission levels](/docs/copilot/agents/a
 * **Worktree isolation**: the permission level is automatically set to **Bypass Approvals** and can't be changed. Because the agent operates on an isolated copy of your codebase (Git worktree), all tool calls are auto-approved without confirmation dialogs.
 * **Workspace isolation**: all three permission levels are available (**Default Approvals**, **Bypass Approvals**, and **Autopilot**), just like local agent sessions. Select a level from the permissions picker in the chat input area.
 
-### Use `/remote` to open a Copilot CLI session on GitHub (Experimental)
+### Use `/remote` to continue a Copilot CLI session on GitHub (Experimental)
 
-Copilot CLI sessions are not limited to VS Code. Use `/remote` to monitor and steer a running Copilot CLI session from GitHub on the web or on mobile while the session continues running in VS Code.
+Use `/remote` when you want to keep moving on work that you started in VS Code after you step away from it. For example, you might start a Copilot CLI session in VS Code, leave your desk, and then continue following along from github.com or the GitHub Mobile app.
 
 To use `/remote`:
 
@@ -74,7 +74,7 @@ To use `/remote`:
 1. Run `/remote` in the chat input.
 1. Select **Open on GitHub** to open the linked task page.
 
-When remote control is enabled, VS Code streams the session history, tool activity, and status updates to the linked GitHub task page in real time. Activity stays in sync across VS Code and GitHub, so actions you take in one place are reflected in the other. If the session requires approval for a tool call or input for a question, the prompt is shown in both places and you can respond from either location.
+When remote control is enabled, VS Code streams the session history, tool activity, and status updates to the linked GitHub task page in real time. This lets you pick up the same session from GitHub without losing context. Activity stays in sync across VS Code and GitHub, so actions you take in one place are reflected in the other. If the session requires approval for a tool call or input for a question, the prompt is shown in both places and you can respond from either location.
 
 To stop mirroring the session to GitHub, run `/remote off`.
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: April 23, 2026_
+_Last updated: April 21, 2026_
 
 Welcome to the 1.118 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,16 +40,11 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
-      <li><a href="#april-23-2026">April 23, 2026</a></li>
       <li><a href="#april-21-2026">April 21, 2026</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
-
-## April 23, 2026
-
-* Copilot CLI sessions support the experimental `/remote` command to mirror a background session to a GitHub task page, including approvals from either VS Code or GitHub while keeping tool activity and running state in sync. [#312240](https://github.com/microsoft/vscode/pull/312240)
 
 ## April 21, 2026
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: April 21, 2026_
+_Last updated: April 23, 2026_
 
 Welcome to the 1.118 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,11 +40,16 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#april-23-2026">April 23, 2026</a></li>
       <li><a href="#april-21-2026">April 21, 2026</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## April 23, 2026
+
+* Copilot CLI sessions support the experimental `/remote` command to mirror a background session to a GitHub task page, including approvals from either VS Code or GitHub while keeping tool activity and running state in sync. [#312240](https://github.com/microsoft/vscode/pull/312240)
 
 ## April 21, 2026
 


### PR DESCRIPTION
## Why
The Copilot CLI /remote flow now has real user-facing behavior in VS Code and on GitHub, so the docs should explain how to enable it, what prerequisites it has, and how approvals work across both surfaces.

## What changed
- add a /remote section to the Copilot CLI sessions docs

## Notes
- this PR targets the `vnext` branch
- release notes for this feature will be handled separately from the daily Insiders notes