### PR TITLE
docs: fix WSL known-issues wording

### DIFF
--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -167,7 +167,7 @@ See the [Dev Containers documentation](/docs/devcontainers/containers.md) for mo
 
 ## Known limitations
 
-This section contains a list of common know issues with WSL. The intent is not to provide a complete list of issues but to highlight some of the common problems seen with WSL.
+This section contains a list of common known issues with WSL. The intent is not to provide a complete list of issues but to highlight some of the common problems seen with WSL.
 
 See [here for a list of active issues](https://aka.ms/vscode-remote/wsl/issues) related to WSL.
 

--- a/docs/remote/wsl.md
+++ b/docs/remote/wsl.md
@@ -167,7 +167,7 @@ See the [Dev Containers documentation](/docs/devcontainers/containers.md) for mo
 
 ## Known limitations
 
-This section contains a list of common known issues with WSL. The intent is not to provide a complete list of issues but to highlight some of the common problems seen with WSL.
+This section contains a list of common issues with WSL. The intent is not to provide a complete list of issues but to highlight some of the common problems seen with WSL.
 
 See [here for a list of active issues](https://aka.ms/vscode-remote/wsl/issues) related to WSL.
 


### PR DESCRIPTION
## Summary
- fix `know` to `known` in the WSL known-issues section

## Related issue
- N/A (minor docs wording fix)

## Guideline alignment
- Followed https://github.com/microsoft/vscode-docs/blob/main/CONTRIBUTING.md
- This stays within one markdown file and follows the docs-only workflow.

## Validation
- `git diff --check`