### PR TITLE
docs: fix release notes wording

### DIFF
--- a/release-notes/v0_5_0.md
+++ b/release-notes/v0_5_0.md
@@ -8,7 +8,7 @@ MetaDescription: See what is new in Visual Studio Code 0.5.0
 
 Thank you again for using Visual Studio Code! With our second update, we have lots to share with you, so much that we'll start with a quick summary for some of the key items:
 
-* Several updates to how we handle files, including file and folder filtering in the explorer, opening files via the command line at a specific line number, re-using an existing instance when you open multiple files, ability to control the size of the working files list.
+* Several updates to how we handle files, including file and folder filtering in the explorer, opening files via the command line at a specific line number, reusing an existing instance when you open multiple files, ability to control the size of the working files list.
 * Improved editor options that include support for removing trailing whitespace, improved search patterns with include/exclude filters.
 * Significant JavaScript updates including ES6 support, jsconfig.json, improved `///` reference management, additional workspace settings
 * Git enhancements, including an integrated credential prompt, multiline commit message support and improved control over auto-fetch


### PR DESCRIPTION
## Summary
- fix `re-using` in an early release note entry

## Related issue
- N/A (minor docs wording fix)

## Guideline alignment
- Followed https://github.com/microsoft/vscode-docs/blob/main/CONTRIBUTING.md
- This stays within one markdown file and follows the docs-only workflow.

## Validation
- `git diff --check`