### PR TITLE
docs: fix cloud conversion section typo

### DIFF
--- a/docs/intelligentapps/modelconversion.md
+++ b/docs/intelligentapps/modelconversion.md
@@ -153,7 +153,7 @@ Running a workflow in model conversion is the core step that transform the pre-b
     Cloud Conversion enables you to run model conversion and quantization in the cloud, when your local machine doesn’t have enough compute or storage capacity. You need an Azure subscription to use Cloud Conversion.
 
     1. Select **Run with Cloud** from the dropdown in the top right.
-        Note that the **Evalution** section is disabled because the cloud environment doesn't have target processors for inference.
+        Note that the **Evaluation** section is disabled because the cloud environment doesn't have target processors for inference.
 
         ![Screenshot that shows Run with Cloud button.](./images/modelconversion/cloud-conversion-run.png)
 


### PR DESCRIPTION
## Summary
- Fixes a typo in the cloud conversion section so the disabled section name matches the UI wording.

## Related issue
- N/A

## Guideline alignment
- Single-file docs wording fix
- No behavior changes

## Validation
- `git diff --check`
