### PR TITLE
docs: fix Flask tutorial step wording

### DIFF
--- a/docs/python/tutorial-flask.md
+++ b/docs/python/tutorial-flask.md
@@ -515,7 +515,7 @@ For more information on code snippets in general, refer to [Creating snippets](/
 
 With the code snippet in place, you can quickly create templates for the Home, About, and Contact pages.
 
-1. In the `templates` folder, create a new file named `home.html`, Then start typing `flext` to see the snippet appear as a completion:
+1. In the `templates` folder, create a new file named `home.html`. Then start typing `flext` to see the snippet appear as a completion:
 
     ![Flask tutorial: autocompletion for the flextlayout code snippet](images/flask-tutorial/autocomplete-for-code-snippet.png)
 


### PR DESCRIPTION
## Summary
- Fixes the sentence casing in the Flask tutorial so the step reads cleanly.

## Related issue
- N/A

## Guideline alignment
- Single-file docs wording fix
- No behavior changes

## Validation
- `git diff --check`
