### PR TITLE
Enhance accessibility documentation on zoom levels

### DIFF
--- a/docs/configure/accessibility/accessibility.md
+++ b/docs/configure/accessibility/accessibility.md
@@ -9,7 +9,7 @@ Visual Studio Code has many features to help make the editor accessible to all u
 
 ## Zoom
 
-You can adjust the zoom level in VS Code with the **View** > **Appearance** > **Zoom** commands.  Each **Zoom** command  increases or decreases the zoom level by 20 percent.
+You can adjust the zoom level in VS Code with the **View** > **Appearance** > **Zoom** commands.  Each **Zoom** command increases or decreases the zoom level by 20 percent.
 
 * **View** > **Appearance** > **Zoom In** (`kb(workbench.action.zoomIn)`) - increase the zoom level.
 * **View** > **Appearance** > **Zoom Out** (`kb(workbench.action.zoomOut)`) - decrease the zoom level.
@@ -21,7 +21,7 @@ You can adjust the zoom level in VS Code with the **View** > **Appearance** > **
 
 ### Persisted zoom level
 
-When you adjust the zoom level with the **View** > **Appearance** > **Zoom In / Out** commands, the zoom level is persisted in the `setting(window.zoomLevel)` [setting](/docs/configure/settings.md). The default value is 0 and each increment/decrement changes the zoom level by 20 percent.
+When you adjust the zoom level with the **View** > **Appearance** > **Zoom In / Out** commands, the zoom level is persisted in the `setting(window.zoomLevel)` [setting](/docs/configure/settings.md). The default value is 0. Each increment above or below 0 represents zooming 20% in or out. You can also enter decimals to adjust the zoom level with a finer granularity.
 
 ## Accessibility help
 


### PR DESCRIPTION
Clarify the explanation of persisted zoom levels and added details about using decimal values for finer adjustments using the window.zoomLevel setting markdown description found in [desktop.contribution.ts in vscode repo](https://github.com/microsoft/vscode/blob/5886d8601a2fce479d0330bd6e18616662821dac/src/vs/workbench/electron-browser/desktop.contribution.ts#L207).

The original description wasn't clear to me. I wasn't sure what an increment/decrement meant nor it wasn't explained that decimals could be used. This clarifies that increment/decrement means increase or decrease by 1 and shows the setting explicitly allows decimals for finer grain zoom granularity.

Note: this is a duplicate of [9709](https://github.com/microsoft/vscode-docs/pull/9709) because I accidentally deleted the fork before the changes were merged.