### PR TITLE
Document Copilot CLI /remote control behavior

### DIFF
--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -45,6 +45,16 @@ Because Copilot CLI sessions run in the background, they are well-suited for tas
 
 Copilot CLI supports slash commands in chat, including [reusable prompts](/docs/copilot/customization/prompt-files.md), [agent skills](/docs/copilot/customization/agent-skills.md), [hooks](/docs/copilot/customization/hooks.md), `/compact` to manage long conversations, and `/yolo` or `/autoApprove` to toggle [auto-approval of tools](/docs/copilot/agents/agent-tools.md#can-i-automatically-approve-all-tools-and-terminal-commands). Type `/` in the chat input of a Copilot CLI session to see available commands.
 
+### Use remote control for Copilot CLI sessions (Experimental)
+
+If you want to keep an eye on a long-running Copilot CLI chat when you are away from VS Code, you can expose the session on GitHub and continue monitoring or steering it from another device.
+
+To use remote control, first enable `setting(github.copilot.chat.cli.remote.enabled)`.
+
+* Run `/remote on` in a Copilot CLI session to enable remote control and create a GitHub task page for that chat.
+* Run `/remote` to check the current remote-control status. The `/remote` command only shows status and does not enable or disable remote control.
+* Run `/remote off` to stop syncing the session to GitHub and disable remote control.
+
 ### Isolation modes
 
 Copilot CLI supports two types of isolation modes to manage how changes from the agent are applied to your codebase: **Worktree** and **Workspace** isolation. You can choose the isolation mode when you create a new Copilot CLI session.

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -40,6 +40,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#april-27-2026">April 27, 2026</a></li>
       <li><a href="#april-26-2026">April 26, 2026</a></li>
       <li><a href="#april-24-2026">April 24, 2026</a></li>
       <li><a href="#april-23-2026">April 23, 2026</a></li>
@@ -49,6 +50,10 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## April 27, 2026
+
+* Copilot CLI chats can now expose a GitHub entry point, so you can monitor progress and steer a long-running local session from another device. Enable `setting(github.copilot.chat.cli.remote.enabled)`, run `/remote on` to create the GitHub task view, use `/remote` to check status, and run `/remote off` to disable remote control. [#312777](https://github.com/microsoft/vscode/issues/312777)
 
 ## April 26, 2026
 


### PR DESCRIPTION
## Summary
- document the Copilot CLI `/remote` command flow in the Copilot CLI agent article
- clarify that `/remote` shows status and `/remote on` or `/remote off` perform the toggle
- add a VS Code 1.118 release-notes entry with the user value proposition for the GitHub entry point

Related to microsoft/vscode#312874.