### PR TITLE
Improve docs for Copilot CLI /remote

### DIFF
--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -69,15 +69,17 @@ The `/remote` command lets you remote control a Copilot CLI session from github.
 
 When remote control is enabled, VS Code streams the session history, tool activity, and status updates to the linked GitHub task page in real time. Actions you take in one place are reflected in the other. If the session requires approval for a tool call or input for a question, the prompt is shown in both places and you can respond from either location.
 
-To use remote control a Copilot CLI session:
+To use remote control for a Copilot CLI session:
 
 1. Enable the `setting(github.copilot.chat.cli.remote.enabled)` setting.
 
 1. Start or resume a Copilot CLI session from the Chat view.
 
-1. Run `/remote` in the chat input.
+1. Run `/remote on` in the chat input to enable remote control and create the linked GitHub task page.
 
 1. Select **Open on GitHub** to open the linked task page.
+
+Run `/remote` at any time to check the current remote-control status. The `/remote` command only shows status and does not enable or disable remote control.
 
 To stop mirroring the session to GitHub, run `/remote off`.
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -84,7 +84,7 @@ Recent feature highlights include:
 
 * **Claude agent**: The Claude Agent is available in the Agents app, so that you can use it alongside other agents for your coding tasks.
 
-* **Web client**: Access the Agents experience from the browser at [insiders.vscode.dev/agents](https://insiders.vscode.dev/agents), bringing the agent-native workflow to any machine where you have a Dev Tunnel running (via `code-insiders tunnel`). To get started, [download VS Code Insiders](https://code.visualstudio.com/insiders) and run `code-insiders tunnel` to set up a [Dev Tunnel](https://code.visualstudio.com/docs/remote/tunnels). You can then connect to it from the web.
+* **Web client**: Access the Agents experience from the browser at [insiders.vscode.dev/agents](https://insiders.vscode.dev/agents), bringing the agent-native workflow to any machine where you have a Dev Tunnel running (via `code-insiders tunnel`).
 
 * **Background browsers**: The integrated browser persists across sessions, so it no longer refreshes when you return to a session. This makes context switching smoother when using the integrated browser to preview changes while the agent works.
 
@@ -112,43 +112,15 @@ context: fork
 
 This feature is experimental and requires the `setting(github.copilot.chat.skillTool.enabled)` setting to be enabled.
 
+### Last used model and multiplier for Copilot CLI in the Chat view
+
+[Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) sessions in the Chat view now show the last used model and the model multiplier on each response, so you can see at a glance which model handled each turn and how it counts against your usage. The model details appear on the first response in a session as well as on subsequent responses.
+
+![Screenshot showing the last used model and multiplier on a Copilot CLI response in the Chat view.](images/1_118/copilot-cli-model-info.png)
 
 ### Synced session titles for Copilot CLI
 
 Renaming a [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) session previously could leave different surfaces showing different titles. The chat sessions list, the chat editor tab and header, and `copilot --resume` in the terminal now all stay in sync when you rename a session, regardless of where the rename originated. Renames performed in the terminal from Copilot CLI in the terminal are also picked up by VS Code the next time the session metadata is read. VS Code adopts the Copilot SDK session title APIs as the source of truth and routes the sessions list and chat editor header through a single title resolver to keep the displayed title consistent across surfaces.
-
-### Semantic indexing of non-Github Repos now enabled for all users
-
-We've rolled out semantic indexing for all workspaces. Previously this was limited to workspaces that use GitHub or Ado repositories.
-
-The semantic index allow Copilot to perform more fuzzy searches for code and concepts in your codebase. For example, if you ask Copilot "where do we handle user authentication?", a normal text search would would try to find text containing the exact words such as "user" and "authentication". Semantic search instead search for *meaning*, so it can also surface files that use related terms like `login`, `signIn`, `verifyCredentials`, or `OAuth token exchange`, even if the word "authentication" never appears in the code.
-
-The semantic index is built and maintained automatically. Workspaces that use a GitHub or ADO repository can typically use semantic search instantly, while other workspaces may require a few minutes to build up the initial index. You can also use the `Build Codebase semantic index` command to explicitly build the index for the current workspace.
-
-Semantic search is just one of the many tools Copilot uses to understand your workspace when answering questions and generating edits. Copilot will pick the best tools for the job, so you generally do not need to try micromanaging how it searches. Check out the [How Copilot understands your workspace](../docs/copilot/reference/workspace-context.md) docs for more details on semantic search and the other tools that Copilot uses.
-
-### Chronicle
-Chronicle is an session search feature that tracks chat interactions in a local SQLite database. Every time you chat, it records session metadata (branch, repo, timestamps), conversation turns, files touched via tool calls, and external references (PRs, issues, commits).
-
-What you can do with it
-
-`/chronicle:standup` — Generates a standup report from the last 24 hours of coding sessions, grouped by feature/branch, with summaries, file lists, and PR links.
-
-`/chronicle:tips` — Analyzes 7 days of usage to give personalized tips on prompting, tool usage, and workflow.
-
-`/chronicle [query]` — Free-form natural language queries against session history (e.g., "what files did I edit yesterday?").
-Settings
-
-This feature is experimental and requires the `setting(github.copilot.chat.localIndex.enabled)` setting to be enabled.
-
-
-### Built-in support for GitHub text search across repos or orgs
-
-<!-- TODO: mjbvz -->
-
-<!-- TODO: mjbvz -->
-
-
 
 ## MCP
 
@@ -162,18 +134,6 @@ When Copilot asks a question via the question carousel triggered by a terminal i
 The button's aria label now includes the keybinding hint, making it discoverable for screen reader users. You can control whether navigation hints appear in the carousel's aria label with the `setting(accessibility.verbosity.chatQuestionCarousel)` setting.
 
 ## Editor Experience
-
-### Optimized loading of large local resource loading in webviews
-
-We've optimized how [webviews](/api/extension-guides/webview.md) load local resources to improved speed and reduce memory usage. This change benefits any extension that uses webviews or custom editors, as well as built-in VS Code features such as notebook rendering.
-
-VS Code's webview use a service worker to load resources from the workspace or host file system. The service worker intercepts the request for the local file and then proxies it through VS Code's file system calls. This allows us to not only load resources from the disk but also from virtual file systems contributed by extensions.
-
-Previously for file system requests, VS Code would read the entire file into a buffer and then send it to the webview's service worker. This is ok for a few small JS and image files, but not so good when you're loading 20 video files that are a 10s to hundreds of MB each.
-
-Now we instead stream the file contents to the service worker in chunks. This improves responsiveness and also reduces the amount of data VS Code has to accumulate before handing it off to the browser engine.
-
-We further optimized the streaming by adopting [transferable streams](https://github.com/whatwg/streams/blob/main/explainers/transferable-streams.md#transferable-streams-explained). This allows us to create a file stream in the main VS Code renderer process that is consumed directly by `new Response(...)` inside the webview's service worker, bypassing what were previously multiple layers of `postMessage` calls.
 
 
 ## Code Editing
@@ -199,9 +159,6 @@ We further optimized the streaming by adopting [transferable streams](https://gi
 
 ## Languages
 
-### TypeScript 7.0 Beta support
-
-<!-- TODO mjbvz -->
 
 ## Remote Development
 
@@ -227,10 +184,6 @@ A new extension has been added with id `ms-vscode.vscode-chat-customizations-eva
 
 
 ## Engineering
-
-### TSGo for watch
-
-<!-- TODO mjbvz -->
 
 ## Deprecated features and settings
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -124,7 +124,7 @@ Renaming a [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copil
 
 ### GitHub entry point for Copilot CLI sessions (Experimental)
 
-If you step away while a long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) task is still working, you can now expose that same session on GitHub and keep monitoring or steering it from another device. Enable `setting(github.copilot.chat.cli.remote.enabled)`, run `/remote on` in a Copilot CLI chat to create the GitHub task page, use `/remote` to check status without changing it, and run `/remote off` to disable remote control.
+Long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) sessions no longer have to stay tied to the VS Code window where they started. You can now create a GitHub entry point for the same session, so you can check progress, respond to approvals, and steer the work from another device while it keeps running in the background. Enable `setting(github.copilot.chat.cli.remote.enabled)` and run `/remote on` in a Copilot CLI chat to get started. The [Copilot CLI documentation](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) has the full command flow, including `/remote` for status and `/remote off` to disable remote control.
 
 ## MCP
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -84,7 +84,7 @@ Recent feature highlights include:
 
 * **Claude agent**: The Claude Agent is available in the Agents app, so that you can use it alongside other agents for your coding tasks.
 
-* **Web client**: Access the Agents experience from the browser at [insiders.vscode.dev/agents](https://insiders.vscode.dev/agents), bringing the agent-native workflow to any machine where you have a Dev Tunnel running (via `code-insiders tunnel`).
+* **Web client**: Access the Agents experience from the browser at [insiders.vscode.dev/agents](https://insiders.vscode.dev/agents), bringing the agent-native workflow to any machine where you have a Dev Tunnel running (via `code-insiders tunnel`). To get started, [download VS Code Insiders](https://code.visualstudio.com/insiders) and run `code-insiders tunnel` to set up a [Dev Tunnel](https://code.visualstudio.com/docs/remote/tunnels). You can then connect to it from the web.
 
 * **Background browsers**: The integrated browser persists across sessions, so it no longer refreshes when you return to a session. This makes context switching smoother when using the integrated browser to preview changes while the agent works.
 
@@ -112,21 +112,43 @@ context: fork
 
 This feature is experimental and requires the `setting(github.copilot.chat.skillTool.enabled)` setting to be enabled.
 
-### Last used model and multiplier for Copilot CLI in the Chat view
-
-[Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) sessions in the Chat view now show the last used model and the model multiplier on each response, so you can see at a glance which model handled each turn and how it counts against your usage. The model details appear on the first response in a session as well as on subsequent responses.
-
-![Screenshot showing the last used model and multiplier on a Copilot CLI response in the Chat view.](images/1_118/copilot-cli-model-info.png)
 
 ### Synced session titles for Copilot CLI
 
 Renaming a [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) session previously could leave different surfaces showing different titles. The chat sessions list, the chat editor tab and header, and `copilot --resume` in the terminal now all stay in sync when you rename a session, regardless of where the rename originated. Renames performed in the terminal from Copilot CLI in the terminal are also picked up by VS Code the next time the session metadata is read. VS Code adopts the Copilot SDK session title APIs as the source of truth and routes the sessions list and chat editor header through a single title resolver to keep the displayed title consistent across surfaces.
 
-### GitHub entry point for Copilot CLI sessions (Experimental)
+### Semantic indexing of non-Github Repos now enabled for all users
 
-Start a long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) task in VS Code and keep the work moving from anywhere. With the new GitHub entry point, the same session continues in the background while you check progress, review tool activity, respond to approvals, and send follow-up instructions from github.com or GitHub Mobile.
+We've rolled out semantic indexing for all workspaces. Previously this was limited to workspaces that use GitHub or Ado repositories.
 
-Enable `setting(github.copilot.chat.cli.remote.enabled)` and run `/remote on` in a Copilot CLI chat to create the linked GitHub task page. For setup details and the full command flow, including `/remote` for status and `/remote off` to stop remote control, see the [Copilot CLI documentation](https://code.visualstudio.com/docs/copilot/agents/copilot-cli).
+The semantic index allow Copilot to perform more fuzzy searches for code and concepts in your codebase. For example, if you ask Copilot "where do we handle user authentication?", a normal text search would would try to find text containing the exact words such as "user" and "authentication". Semantic search instead search for *meaning*, so it can also surface files that use related terms like `login`, `signIn`, `verifyCredentials`, or `OAuth token exchange`, even if the word "authentication" never appears in the code.
+
+The semantic index is built and maintained automatically. Workspaces that use a GitHub or ADO repository can typically use semantic search instantly, while other workspaces may require a few minutes to build up the initial index. You can also use the `Build Codebase semantic index` command to explicitly build the index for the current workspace.
+
+Semantic search is just one of the many tools Copilot uses to understand your workspace when answering questions and generating edits. Copilot will pick the best tools for the job, so you generally do not need to try micromanaging how it searches. Check out the [How Copilot understands your workspace](../docs/copilot/reference/workspace-context.md) docs for more details on semantic search and the other tools that Copilot uses.
+
+### Chronicle
+Chronicle is an session search feature that tracks chat interactions in a local SQLite database. Every time you chat, it records session metadata (branch, repo, timestamps), conversation turns, files touched via tool calls, and external references (PRs, issues, commits).
+
+What you can do with it
+
+`/chronicle:standup` — Generates a standup report from the last 24 hours of coding sessions, grouped by feature/branch, with summaries, file lists, and PR links.
+
+`/chronicle:tips` — Analyzes 7 days of usage to give personalized tips on prompting, tool usage, and workflow.
+
+`/chronicle [query]` — Free-form natural language queries against session history (e.g., "what files did I edit yesterday?").
+Settings
+
+This feature is experimental and requires the `setting(github.copilot.chat.localIndex.enabled)` setting to be enabled.
+
+
+### Built-in support for GitHub text search across repos or orgs
+
+<!-- TODO: mjbvz -->
+
+<!-- TODO: mjbvz -->
+
+
 
 ## MCP
 
@@ -140,6 +162,18 @@ When Copilot asks a question via the question carousel triggered by a terminal i
 The button's aria label now includes the keybinding hint, making it discoverable for screen reader users. You can control whether navigation hints appear in the carousel's aria label with the `setting(accessibility.verbosity.chatQuestionCarousel)` setting.
 
 ## Editor Experience
+
+### Optimized loading of large local resource loading in webviews
+
+We've optimized how [webviews](/api/extension-guides/webview.md) load local resources to improved speed and reduce memory usage. This change benefits any extension that uses webviews or custom editors, as well as built-in VS Code features such as notebook rendering.
+
+VS Code's webview use a service worker to load resources from the workspace or host file system. The service worker intercepts the request for the local file and then proxies it through VS Code's file system calls. This allows us to not only load resources from the disk but also from virtual file systems contributed by extensions.
+
+Previously for file system requests, VS Code would read the entire file into a buffer and then send it to the webview's service worker. This is ok for a few small JS and image files, but not so good when you're loading 20 video files that are a 10s to hundreds of MB each.
+
+Now we instead stream the file contents to the service worker in chunks. This improves responsiveness and also reduces the amount of data VS Code has to accumulate before handing it off to the browser engine.
+
+We further optimized the streaming by adopting [transferable streams](https://github.com/whatwg/streams/blob/main/explainers/transferable-streams.md#transferable-streams-explained). This allows us to create a file stream in the main VS Code renderer process that is consumed directly by `new Response(...)` inside the webview's service worker, bypassing what were previously multiple layers of `postMessage` calls.
 
 
 ## Code Editing
@@ -165,6 +199,9 @@ The button's aria label now includes the keybinding hint, making it discoverable
 
 ## Languages
 
+### TypeScript 7.0 Beta support
+
+<!-- TODO mjbvz -->
 
 ## Remote Development
 
@@ -190,6 +227,10 @@ A new extension has been added with id `ms-vscode.vscode-chat-customizations-eva
 
 
 ## Engineering
+
+### TSGo for watch
+
+<!-- TODO mjbvz -->
 
 ## Deprecated features and settings
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -124,7 +124,9 @@ Renaming a [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copil
 
 ### GitHub entry point for Copilot CLI sessions (Experimental)
 
-Long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) sessions no longer have to stay tied to the VS Code window where they started. You can now create a GitHub entry point for the same session, so you can check progress, respond to approvals, and steer the work from another device while it keeps running in the background. Enable `setting(github.copilot.chat.cli.remote.enabled)` and run `/remote on` in a Copilot CLI chat to get started. The [Copilot CLI documentation](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) has the full command flow, including `/remote` for status and `/remote off` to disable remote control.
+Start a long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) task in VS Code and keep the work moving from anywhere. With the new GitHub entry point, the same session continues in the background while you check progress, review tool activity, respond to approvals, and send follow-up instructions from github.com or GitHub Mobile.
+
+Enable `setting(github.copilot.chat.cli.remote.enabled)` and run `/remote on` in a Copilot CLI chat to create the linked GitHub task page. For setup details and the full command flow, including `/remote` for status and `/remote off` to stop remote control, see the [Copilot CLI documentation](https://code.visualstudio.com/docs/copilot/agents/copilot-cli).
 
 ## MCP
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -122,6 +122,10 @@ This feature is experimental and requires the `setting(github.copilot.chat.skill
 
 Renaming a [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) session previously could leave different surfaces showing different titles. The chat sessions list, the chat editor tab and header, and `copilot --resume` in the terminal now all stay in sync when you rename a session, regardless of where the rename originated. Renames performed in the terminal from Copilot CLI in the terminal are also picked up by VS Code the next time the session metadata is read. VS Code adopts the Copilot SDK session title APIs as the source of truth and routes the sessions list and chat editor header through a single title resolver to keep the displayed title consistent across surfaces.
 
+### GitHub entry point for Copilot CLI sessions (Experimental)
+
+If you step away while a long-running [Copilot CLI](https://code.visualstudio.com/docs/copilot/agents/copilot-cli) task is still working, you can now expose that same session on GitHub and keep monitoring or steering it from another device. Enable `setting(github.copilot.chat.cli.remote.enabled)`, run `/remote on` in a Copilot CLI chat to create the GitHub task page, use `/remote` to check status without changing it, and run `/remote off` to disable remote control.
+
 ## MCP
 
 


### PR DESCRIPTION
## Summary
- clarify in the Copilot CLI docs that `/remote` reports status and `/remote on` or `/remote off` perform the toggle
- add a 1.118 release-notes entry on `vnext` for the GitHub entry point for Copilot CLI sessions
- lead with the user benefit of monitoring or steering a long-running local session from another device

Related to microsoft/vscode#312874.