### PR TITLE
docs: update the lineComment examples to the current schema

### DIFF
--- a/api/language-extensions/language-configuration-guide.md
+++ b/api/language-extensions/language-configuration-guide.md
@@ -26,7 +26,7 @@ Here is a [Language Configuration sample](https://github.com/microsoft/vscode-ex
 ```json
 {
   "comments": {
-    "lineComment": "//",
+    "lineComment": { "comment": "//" },
     "blockComment": ["/*", "*/"]
   },
   "brackets": [["{", "}"], ["[", "]"], ["(", ")"]],
@@ -64,13 +64,23 @@ Here is a [Language Configuration sample](https://github.com/microsoft/vscode-ex
 
 ## Comment toggling
 
-VS Code offers two commands for comment toggling. **Toggle Line Comment** and **Toggle Block Comment**. You can specify `comments.blockComment` and `comments.lineComment` to control how VS Code should comment out lines / blocks.
+VS Code offers two commands for comment toggling. **Toggle Line Comment** and **Toggle Block Comment**. You can specify `comments.blockComment` and `comments.lineComment` to control how VS Code should comment out lines / blocks. The `lineComment` property uses an object with a required `comment` field and an optional `noIndent` field.
 
 ```json
 {
   "comments": {
-    "lineComment": "//",
+    "lineComment": { "comment": "//" },
     "blockComment": ["/*", "*/"]
+  }
+}
+```
+
+If your language requires line comments to stay in the first column, set `noIndent` to `true`:
+
+```json
+{
+  "comments": {
+    "lineComment": { "comment": "#", "noIndent": true }
   }
 }
 ```


### PR DESCRIPTION
## Summary

- update the `language-configuration.json` examples to use the current object form of `comments.lineComment`
- document the optional `noIndent` property so the warning described in the issue no longer comes from copying the sample

## Related issue

- Addresses #9210

## Guideline alignment

- followed `CONTRIBUTING.md`
- kept the change to one documentation file and one focused issue

## Validation

- not run (docs-only change)
