### PR TITLE
fix: correct setting name for DevContainer lockfile in release notes

### DIFF
--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -303,7 +303,7 @@ The [Remote Development extensions](https://marketplace.visualstudio.com/items?i
 
 ### Dev Container lockfile for Features enabled by default
 
-**Setting**: `setting(dev.containers.lockfile)`
+**Setting**: `setting(dev.containers.experimentalLockfile)`
 
 We are enabling the lockfile `devcontainer-lock.json` by default. The lockfile records the Dev Container Feature version and checksum the first time a Feature is installed and pins the Feature to that particular version and checksum to improve resilience against supply chain attacks.
 


### PR DESCRIPTION
Changed the setting name from `dev.containers.lockfile` to `dev.containers.experimentalLockfile` in the release notes to accurately reflect the current configuration option.