### PR TITLE
Update tasks.md

### DIFF
--- a/docs/debugtest/tasks.md
+++ b/docs/debugtest/tasks.md
@@ -483,7 +483,7 @@ Below is an example of a custom task configuration that passes the current opene
 }
 ```
 
-Similarly, you can reference your project's configuration settings by prefixing the name with **${config:**. For example, `${config:python.formatting.autopep8Path}` returns the Python extension setting `formatting.autopep8Path`.
+Similarly, you can reference your project's configuration settings by prefixing the name with **`${config:`**. For example, `${config:python.formatting.autopep8Path}` returns the Python extension setting `formatting.autopep8Path`.
 
 Below is an example of a custom task configuration, which executes autopep8 on the current file using the autopep8 executable defined by the `python.formatting.autopep8Path` setting:
 


### PR DESCRIPTION
Error when rendering in the vscode ( docsmsft.docs-preview  2.0.10 ), but no one in github viewer:

Similarly, you can reference your project's configuration settings by prefixing the name with **

ParseError: KaTeX parse error: Expected '}', got 'EOF' at end of input: … For example, `

{config:python.formatting.autopep8Path}returns the Python extension settingformatting.autopep8Path`.