### PR TITLE
Correct link to Copilot CLI docs

### DIFF
--- a/docs/copilot/agents/copilot-cli.md
+++ b/docs/copilot/agents/copilot-cli.md
@@ -209,4 +209,4 @@ To use custom agents with Copilot CLI:
 
 * [Agents overview](/docs/copilot/agents/overview.md): Understand different agent types and how to hand off tasks between agents
 * [Custom agents](/docs/copilot/customization/custom-agents.md): Create custom agent roles and personas
-* [GitHub Copilot CLI documentation](https://cli.github.com/manual/gh_copilot)
+* [GitHub Copilot CLI documentation](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)


### PR DESCRIPTION
The current link (https://cli.github.com/manual/gh_copilot) links to the GitHub CLI usage of GitHub Copilot (e.g. `gh copilot`), which is currently in preview, but not what I would refer to as the "GitHub Copilot CLI" itself (e.g. `copilot`).