### PR TITLE
Add Aspire CLI alternative for starting the dashboard

### DIFF
--- a/docs/copilot/guides/monitoring-agents.md
+++ b/docs/copilot/guides/monitoring-agents.md
@@ -224,17 +224,19 @@ Copilot Chat's OTel output works with any backend that supports the OTLP protoco
 
 ### Aspire Dashboard
 
-The [Aspire Dashboard](https://aspire.dev/dashboard/standalone/) is the simplest option for local development. It is a single Docker container with a built-in OTLP endpoint and trace viewer, and requires no cloud account.
+The [Aspire Dashboard](https://aspire.dev/dashboard/standalone/) is the simplest option for local development. It is a single app with a built-in OTLP endpoint and trace viewer, and requires no cloud account.
+
+You can start the dashboard using the [Aspire CLI](https://aspire.dev/get-started/install-cli/):
+
+```bash
+aspire dashboard run
+```
+
+Or run the same standalone dashboard from its Docker container image:
 
 ```bash
 docker run --rm -d -p 18888:18888 -p 4318:18890 --name aspire-dashboard \
   mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-Alternatively, you can start the dashboard using the [Aspire CLI](https://aspire.dev/get-started/install-cli/):
-
-```bash
-aspire dashboard run
 ```
 
 VS Code configuration:

--- a/docs/copilot/guides/monitoring-agents.md
+++ b/docs/copilot/guides/monitoring-agents.md
@@ -227,12 +227,17 @@ Copilot Chat's OTel output works with any backend that supports the OTLP protoco
 The [Aspire Dashboard](https://aspire.dev/dashboard/standalone/) is the simplest option for local development. It is a single Docker container with a built-in OTLP endpoint and trace viewer, and requires no cloud account.
 
 ```bash
-docker run --rm -d \
-  -p 18888:18888 \
-  -p 4318:18890 \
-  --name aspire-dashboard \
+docker run --rm -d -p 18888:18888 -p 4318:18890 --name aspire-dashboard \
   mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
+
+Alternatively, you can start the dashboard using the [Aspire CLI](https://aspire.dev/get-started/install-cli/):
+
+```bash
+aspire dashboard run
+```
+
+VS Code configuration:
 
 ```json
 {
@@ -253,6 +258,8 @@ Open `http://localhost:18888` and go to **Traces** to view your agent interactio
 docker run -d --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:latest
 ```
 
+VS Code configuration:
+
 ```json
 {
   "github.copilot.chat.otel.enabled": true,
@@ -269,6 +276,8 @@ Use an [OTel Collector](https://opentelemetry.io/docs/collector/) with the [Azur
 ### Langfuse
 
 [Langfuse](https://langfuse.com/) is an open-source LLM observability platform with native OTLP ingestion and support for OTel GenAI Semantic Conventions.
+
+VS Code configuration:
 
 ```json
 {


### PR DESCRIPTION
Adds `aspire dashboard run` as an alternative to the Docker command for starting the Aspire Dashboard in the monitoring agents guide.

The [Aspire CLI](https://aspire.dev/get-started/install-cli/) provides a simpler way to start the dashboard without needing Docker. The default ports match the existing Docker setup (frontend on `localhost:18888`, OTLP/HTTP on `localhost:4318`), so the existing VS Code configuration works with both approaches.