### PR TITLE
Fix Integrated Browser shortcut reference

### DIFF
--- a/docs/debugtest/integrated-browser.md
+++ b/docs/debugtest/integrated-browser.md
@@ -18,7 +18,7 @@ The integrated browser enables you to open and interact with web pages directly 
 There are several ways to open the integrated browser:
 
 * Run the **Browser: Open Integrated Browser** command from the Command Palette (`kb(workbench.action.showCommands)`).
-* Select **View** > **Browser** from the menu bar, or use the `kb(workbench.action.browser.openFromViewMenu)` keyboard shortcut.
+* Select **View** > **Browser** from the menu bar, or use the `kb(workbench.action.browser.openOrList)` keyboard shortcut.
 * Select the globe button in the VS Code title bar. Use the `setting(workbench.browser.showInTitleBar)` setting to control whether the globe button appears.
 * Select a `localhost` link anywhere in VS Code, like the terminal or chat. Enable this behavior with the `setting(workbench.browser.openLocalhostLinks)` setting.
 * Ask an agent to open or interact with a web page. See [Browser tools for agents](#browser-tools-for-agents).

--- a/release-notes/v1_116.md
+++ b/release-notes/v1_116.md
@@ -206,7 +206,7 @@ When searching in the Keyboard Shortcuts editor, the screen reader now announces
 The [integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) is now easier to access thanks to two new entry points:
 
 * The **View** menu, under **View** > **Browser**
-* The keyboard shortcut `kb(workbench.action.browser.openFromViewMenu)`
+* The keyboard shortcut `kb(workbench.action.browser.openOrList)`
 <!-- shortcut `Ctrl+Alt+/` (`⌥⌘/` on macOS) -->
 
 These actions open the integrated browser if no tabs are open, or let you quickly see and jump to existing tabs.


### PR DESCRIPTION
It was showing `unassigned`:
<img width="310" height="41" alt="image" src="https://github.com/user-attachments/assets/92b1b828-05af-4c63-96a4-9071d472b99e" />

The command id changed with this PR:
* https://github.com/microsoft/vscode/pull/312440
