### PR TITLE
Fix broken in-page anchor links across API reference docs

### DIFF
--- a/api/extension-capabilities/extending-workbench.md
+++ b/api/extension-capabilities/extending-workbench.md
@@ -22,10 +22,10 @@ VS Code provides various APIs that allow you to add your own components to the W
 
 ![workbench-contribution](images/extending-workbench/workbench-contribution.png)
 
-- Activity Bar: The [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) adds a [View Container](#views-container)
-- Side Bar: The built-in [NPM extension](https://github.com/microsoft/vscode/tree/main/extensions/npm) adds a [Tree View](#tree-view) to the Explorer View
-- Editor Group: The built-in [Markdown extension](https://github.com/microsoft/vscode/tree/main/extensions/markdown-language-features) adds a [Webview](#webview) next to other editors in the Editor Group
-- Status Bar: The [VSCodeVim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) adds a [Status Bar Item](#status-bar-item) in the Status Bar
+- Activity Bar: The [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) adds a [View Container](/api/extension-capabilities/extending-workbench#views-container)
+- Side Bar: The built-in [NPM extension](https://github.com/microsoft/vscode/tree/main/extensions/npm) adds a [Tree View](/api/extension-capabilities/extending-workbench#tree-view) to the Explorer View
+- Editor Group: The built-in [Markdown extension](https://github.com/microsoft/vscode/tree/main/extensions/markdown-language-features) adds a [Webview](/api/extension-capabilities/extending-workbench#webview) next to other editors in the Editor Group
+- Status Bar: The [VSCodeVim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) adds a [Status Bar Item](/api/extension-capabilities/extending-workbench#status-bar-item) in the Status Bar
 
 ## Views Container
 

--- a/api/get-started/extension-anatomy.md
+++ b/api/get-started/extension-anatomy.md
@@ -21,7 +21,7 @@ The `Hello World` extension does 3 things:
 Understanding these three concepts is crucial to writing extensions in VS Code:
 
 - [**Activation Events**](/api/references/activation-events): events upon which your extension becomes active.
-- [**Contribution Points**](/api/references/contribution-points): static declarations that you make in the `package.json` [Extension Manifest](#extension-manifest) to extend VS Code.
+- [**Contribution Points**](/api/references/contribution-points): static declarations that you make in the `package.json` [Extension Manifest](/api/get-started/extension-anatomy#extension-manifest) to extend VS Code.
 - [**VS Code API**](/api/references/vscode-api): a set of JavaScript APIs that you can invoke in your extension code.
 
 In general, your extension would use a combination of Contribution Points and VS Code API to extend VS Code's functionality. The [Extension Capabilities Overview](/api/extension-capabilities/overview) topic helps you find the right Contribution Point and VS Code API for your extension.

--- a/api/references/contribution-points.md
+++ b/api/references/contribution-points.md
@@ -1514,7 +1514,7 @@ Contribute a view to VS Code. You must specify an identifier and name for the vi
 - `scm`: Source Control Management (SCM) view container in the Activity Bar
 - `debug`: Run and Debug view container in the Activity Bar
 - `test`: Test view container in the Activity Bar
-- [Custom view containers](#contributes.viewsContainers) contributed by Extensions.
+- [Custom view containers](/api/references/contribution-points#contributes.viewsContainers) contributed by Extensions.
 
 When the user opens the view, VS Code will then emit an activationEvent `onView:${viewId}` (`onView:nodeDependencies` for the example below). You can also control the visibility of the view by providing the `when` context value. The `icon` specified will be used when the title cannot be shown (e.g. when the view is dragged to the Activity Bar). The `contextualTitle` is used when the view is moved out of its default view container and needs additional context.
 
@@ -1545,7 +1545,7 @@ The content of a view can be populated in two ways:
 
 ## contributes.viewsContainers
 
-Contribute a view container into which [Custom views](#contributes.views) can be contributed. You must specify an identifier, title, and an icon for the view container. At present, you can contribute them to the Activity Bar (`activitybar`) and Panel (`panel`). Below example shows how the `Package Explorer` view container is contributed to the Activity Bar and how views are contributed to it.
+Contribute a view container into which [Custom views](/api/references/contribution-points#contributes.views) can be contributed. You must specify an identifier, title, and an icon for the view container. At present, you can contribute them to the Activity Bar (`activitybar`) and Panel (`panel`). Below example shows how the `Package Explorer` view container is contributed to the Activity Bar and how views are contributed to it.
 
 ```json
 {
@@ -1592,7 +1592,7 @@ Contribute a view container into which [Custom views](#contributes.views) can be
 
 ## contributes.viewsWelcome
 
-Contribute welcome content to [Custom views](#contributes.views). Welcome content only applies to empty tree views. A view is considered empty if the tree has no children and no `TreeView.message`. By convention, any command links that are on a line by themselves are displayed as a button. You can specify the view that the welcome content should apply to with the `view` property. Visibility of the welcome content can be controlled with the `when` context value. The text to be displayed as the welcome content is set with the `contents` property.
+Contribute welcome content to [Custom views](/api/references/contribution-points#contributes.views). Welcome content only applies to empty tree views. A view is considered empty if the tree has no children and no `TreeView.message`. By convention, any command links that are on a line by themselves are displayed as a button. You can specify the view that the welcome content should apply to with the `view` property. Visibility of the welcome content can be controlled with the `when` context value. The text to be displayed as the welcome content is set with the `contents` property.
 
 ```json
 {

--- a/api/references/when-clause-contexts.md
+++ b/api/references/when-clause-contexts.md
@@ -101,7 +101,7 @@ Operator | Symbol | Example
 In | `in` | `"resourceFilename in supportedFolders"`
 Not in | `not in` | `"resourceFilename not in supportedFolders"`
 
-First, determine which folders should support the command, and add the folder names to an array. Then, use the [`setContext` command](#add-a-custom-when-clause-context) to turn the array into a context key:
+First, determine which folders should support the command, and add the folder names to an array. Then, use the [`setContext` command](/api/references/when-clause-contexts#add-a-custom-when-clause-context) to turn the array into a context key:
 
 ```ts
 vscode.commands.executeCommand('setContext', 'ext.supportedFolders', [ 'test', 'foo', 'bar' ]);
@@ -137,7 +137,7 @@ In that example, we are taking the value of `resourceFilename` (which is the nam
 
 Below are some of the available context keys, which evaluate to Boolean true/false.
 
-The list here isn't exhaustive and you can find other when clause contexts by searching and filtering in the Keyboard Shortcuts editor (**Preferences: Open Keyboard Shortcuts**) or reviewing the Default Keybindings JSON file (**Preferences: Open Default Keyboard Shortcuts (JSON)**). You can also identify context keys you are interested in using the [Inspect Context Keys utility](#inspect-context-keys-utility).
+The list here isn't exhaustive and you can find other when clause contexts by searching and filtering in the Keyboard Shortcuts editor (**Preferences: Open Keyboard Shortcuts**) or reviewing the Default Keybindings JSON file (**Preferences: Open Default Keyboard Shortcuts (JSON)**). You can also identify context keys you are interested in using the [Inspect Context Keys utility](/api/references/when-clause-contexts#inspect-context-keys-utility).
 
 Context name | True when
 ------------ | ------------
@@ -355,6 +355,6 @@ When you run **Developer: Inspect Context Keys**, your cursor will highlight ele
 
 ![Inspect Context Keys output](images/when-clause-contexts/inspect-context-keys.png)
 
-The list of active context keys is extensive and may contain [custom context keys](#add-a-custom-when-clause-context) from extensions you have installed.
+The list of active context keys is extensive and may contain [custom context keys](/api/references/when-clause-contexts#add-a-custom-when-clause-context) from extensions you have installed.
 
 >**Note**: Some context keys are for VS Code internal use and may change in the future.


### PR DESCRIPTION
Hey! Found a few broken in-page anchor links while browsing the reference pages. 

It seems the build pipeline prefixes purely relative hash links (like `#extension-manifest`) with an underscore (resulting in `#_extension-manifest`), whereas the actual generated heading IDs do not have that prefix (e.g. `id="extension-manifest"`). This causes those links to break on the live site.

Adding the absolute page path prefix (like `/api/get-started/extension-anatomy#extension-manifest`) bypasses this issue entirely. I've updated the relative anchors in:
- `api/extension-capabilities/extending-workbench.md`
- `api/get-started/extension-anatomy.md`
- `api/references/contribution-points.md`
- `api/references/when-clause-contexts.md`

Closes #9760