### PR TITLE
docs: clarify terminal line wrapping for multiline problem matchers

### DIFF
--- a/docs/debugtest/tasks.md
+++ b/docs/debugtest/tasks.md
@@ -727,7 +727,10 @@ test.js
 Our problem matcher is line-based so we need to capture the file name (test.js) with a different regular expression than the actual problem location and message (1:0   error  Missing "use strict" statement).
 
 To do this, use an array of problem patterns for the `pattern` property. This way you define a pattern per each line you want to match.
+
 > **Note:** In a multi-line problem matcher, each line in the output must be matched sequentially by the pattern array. Intermediate lines cannot be skipped, even if they are not needed for capturing values.
+
+> **Note:** Terminal line wrapping can break multi-line problem matchers. If a line of output is too long and the terminal wraps it into two lines, VS Code processes it as two separate lines. Your problem matcher will fail unless your pattern array accounts for the extra wrapped line. To avoid this, ensure your terminal is wide enough or configure your build tool to disable line wrapping if possible.
 
 The following problem pattern matches the output from ESLint in stylish mode - but still has one small issue that we need to resolve next. The code below has a first regular expression to capture the file name and the second to capture the line, column, severity, message, and error code:
 

--- a/docs/debugtest/tasks.md
+++ b/docs/debugtest/tasks.md
@@ -379,7 +379,7 @@ You can specify a task's run behaviors using the `runOptions` property:
   * `terminateNewest` - Terminate the newest running instance.
   * `terminateOldest` - Terminate the oldest running instance.
   * `warn` - Don't start a new instance (show warning).
-  
+
 ## Customizing auto-detected tasks
 
 As mentioned above, you can customize auto-detected tasks in the `tasks.json` file. You usually do so to modify presentation properties or to attach a problem matcher to scan the task's output for errors and warnings. You can customize a task directly from the **Run Task** list by pressing the gear icon to the right to insert the corresponding task reference into the `tasks.json` file. Assume you have the following Gulp file to lint JavaScript files using ESLint (the file is taken from [https://github.com/adametry/gulp-eslint](https://github.com/adametry/gulp-eslint)):
@@ -728,9 +728,17 @@ Our problem matcher is line-based so we need to capture the file name (test.js) 
 
 To do this, use an array of problem patterns for the `pattern` property. This way you define a pattern per each line you want to match.
 
-> **Note:** In a multi-line problem matcher, each line in the output must be matched sequentially by the pattern array. Intermediate lines cannot be skipped, even if they are not needed for capturing values.
+> **Note:** In a multi-line problem matcher, the pattern array must match every consecutive line of output, starting from the first pattern. You cannot skip intermediate lines, even if they contain no useful information.
 
-> **Note:** Terminal line wrapping can break multi-line problem matchers. If a line of output is too long and the terminal wraps it into two lines, VS Code processes it as two separate lines. Your problem matcher will fail unless your pattern array accounts for the extra wrapped line. To avoid this, ensure your terminal is wide enough or configure your build tool to disable line wrapping if possible.
+If your tool outputs three lines and you only need data from the first and third, your pattern array still needs three entries. Use `{"regexp": "^.*$"}` with no capture group assignments for lines you don't need data from:
+
+```json
+"pattern": [
+    { "regexp": "^Error:\\s+(.*)$", "message": 1 },
+    { "regexp": "^.*$" },
+    { "regexp": "^\\s+at\\s+(.*):(\\d+)$", "file": 1, "line": 2 }
+]
+```
 
 The following problem pattern matches the output from ESLint in stylish mode - but still has one small issue that we need to resolve next. The code below has a first regular expression to capture the file name and the second to capture the line, column, severity, message, and error code:
 


### PR DESCRIPTION
Fixes #6851. Adds a note about terminal line wrapping breaking multi-line problem matchers, which was a point of confusion for users trying to write custom problem matchers that match across lines wrapped by the terminal window.