### PR TITLE
docs(copilot): link Grafana dashboard and OTel GenAI blog from monitoring guide

### DIFF
--- a/docs/copilot/guides/monitoring-agents.md
+++ b/docs/copilot/guides/monitoring-agents.md
@@ -275,6 +275,8 @@ Open `http://localhost:16686`, select service `copilot-chat`, and select **Find 
 
 Use an [OTel Collector](https://opentelemetry.io/docs/collector/) with the [Azure Monitor exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter) to forward Copilot Chat telemetry to Application Insights. Point the VS Code `setting(github.copilot.chat.otel.otlpEndpoint)` setting at the collector's OTLP endpoint, and configure the collector to export to your Application Insights connection string.
 
+For an end-to-end setup with a ready-made dashboard, see [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot). The guide walks through running the OTel Collector, pointing VS Code at it, and importing a prebuilt [Azure Managed Grafana](https://learn.microsoft.com/azure/managed-grafana/) dashboard. The dashboard visualizes Copilot operations, input and output tokens, chat sessions, tool calls, and per-model response time and TTFT from Application Insights.
+
 ### Langfuse
 
 [Langfuse](https://langfuse.com/) is an open-source LLM observability platform with native OTLP ingestion and support for OTel GenAI Semantic Conventions.

--- a/docs/copilot/guides/monitoring-agents.md
+++ b/docs/copilot/guides/monitoring-agents.md
@@ -348,4 +348,5 @@ OTel monitoring is off by default and emits no data until you explicitly enable 
 - [Copilot settings reference](/docs/copilot/reference/copilot-settings.md)
 - [Troubleshoot AI in VS Code](/docs/copilot/troubleshooting.md)
 - [OTel GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/)
+- [Inside the LLM Call: GenAI Observability with OpenTelemetry](https://opentelemetry.io/blog/2026/genai-observability/)
 - [Aspire Dashboard standalone docs](https://aspire.dev/dashboard/standalone/)


### PR DESCRIPTION
Two small additions to [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents):

### 1. Azure Application Insights subsection

Adds a pointer from the [Azure Application Insights subsection](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents#_azure-application-insights) to the new Learn guide [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot).

The guide walks readers through running an OTel Collector, pointing VS Code at it, and importing a prebuilt Azure Managed Grafana dashboard that visualizes Copilot operations, input and output tokens, chat sessions, tool calls, and per-model response time and TTFT from Application Insights.

### 2. Related content

Adds a link to the OpenTelemetry blog post [Inside the LLM Call: GenAI Observability with OpenTelemetry](https://opentelemetry.io/blog/2026/genai-observability/), which features VS Code Copilot as the example OTel emitter and walks through exploring GenAI traces and metrics in the Aspire Dashboard.