### PR TITLE
release-notes(1.121): add Grafana dashboard for Copilot agent telemetry

### DIFF
--- a/release-notes/images/1_121/grafana-copilot-dashboard.png
+++ b/release-notes/images/1_121/grafana-copilot-dashboard.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cdc0e760bad4d2ca1ef35711a9452048102c09ad59c9e198a9f916a6464c1e8
+size 784801

--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -80,6 +80,16 @@ Your feedback continues to be a great help in shaping Agents. If you've already 
 
 We're also continuing to work on the broader extension story in the Agents window, including what extension enablement unlocks and how various extensions should behave in this environment. Whether you'd like to ideate on new scenarios that take advantage of running agents across projects, or share feedback on how your existing extension behaves in the Agents window, we'd love to collaborate with you through [GitHub issues](https://github.com/microsoft/vscode/issues?q=state%3Aopen%20label%3A%22agents-window%22).
 
+### Grafana dashboard for Copilot agent telemetry
+
+In VS Code [1.119](https://code.visualstudio.com/updates/v1_119#_opentelemetry-tracing-for-agent-sessions), Copilot Chat agent sessions started emitting OpenTelemetry traces, metrics, and events that follow the [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/). Standing up the pipeline still required wiring up your own collector and dashboard.
+
+In collaboration with the Grafana team, there is now a prebuilt Grafana dashboard for Copilot OpenTelemetry signals. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the dashboard to visualize Copilot operations, input and output tokens, chat sessions, tool calls, and per-model response time and TTFT, without building any panels yourself.
+
+The end-to-end setup is documented in the Azure Managed Grafana guide [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot). To enable OpenTelemetry export from VS Code, see [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents).
+
+![Screenshot showing the GitHub Copilot Grafana dashboard with panels for operations, tokens, chat sessions, tool calls, and per-model latency.](images/1_121/grafana-copilot-dashboard.png)
+
 ## Chat
 
 

--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -80,9 +80,9 @@ Your feedback continues to be a great help in shaping Agents. If you've already 
 
 We're also continuing to work on the broader extension story in the Agents window, including what extension enablement unlocks and how various extensions should behave in this environment. Whether you'd like to ideate on new scenarios that take advantage of running agents across projects, or share feedback on how your existing extension behaves in the Agents window, we'd love to collaborate with you through [GitHub issues](https://github.com/microsoft/vscode/issues?q=state%3Aopen%20label%3A%22agents-window%22).
 
-### Grafana dashboard for Copilot agent telemetry
+### Agent Observability with Grafana
 
-In collaboration with the Grafana team, there is now a prebuilt Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
+In collaboration with the Grafana team, there is now a prebuilt Azure Managed Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the Azure Managed Grafana dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
 
 See [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot) for the end-to-end setup, and [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents) for enabling export from VS Code.
 

--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -80,7 +80,7 @@ Your feedback continues to be a great help in shaping Agents. If you've already 
 
 We're also continuing to work on the broader extension story in the Agents window, including what extension enablement unlocks and how various extensions should behave in this environment. Whether you'd like to ideate on new scenarios that take advantage of running agents across projects, or share feedback on how your existing extension behaves in the Agents window, we'd love to collaborate with you through [GitHub issues](https://github.com/microsoft/vscode/issues?q=state%3Aopen%20label%3A%22agents-window%22).
 
-### Agent Observability with Grafana
+### Agent observability with OpenTelemetry and Grafana
 
 In collaboration with the Grafana team, there is now a prebuilt Azure Managed Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the Azure Managed Grafana dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
 

--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -82,7 +82,7 @@ We're also continuing to work on the broader extension story in the Agents windo
 
 ### Agent observability with OpenTelemetry and Grafana
 
-In collaboration with the Grafana team, there is now a prebuilt Azure Managed Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the Azure Managed Grafana dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
+In collaboration with the Azure Managed Grafana team, there is now a prebuilt Azure Managed Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the Azure Managed Grafana dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
 
 See [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot) for the end-to-end setup, and [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents) for enabling export from VS Code.
 

--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -82,11 +82,9 @@ We're also continuing to work on the broader extension story in the Agents windo
 
 ### Grafana dashboard for Copilot agent telemetry
 
-In VS Code [1.119](https://code.visualstudio.com/updates/v1_119#_opentelemetry-tracing-for-agent-sessions), Copilot Chat agent sessions started emitting OpenTelemetry traces, metrics, and events that follow the [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/). Standing up the pipeline still required wiring up your own collector and dashboard.
+In collaboration with the Grafana team, there is now a prebuilt Grafana dashboard for the OpenTelemetry signals that Copilot Chat emits. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the dashboard to visualize Copilot operations, token usage, chat sessions, tool calls, and per-model response time and TTFT.
 
-In collaboration with the Grafana team, there is now a prebuilt Grafana dashboard for Copilot OpenTelemetry signals. Point Copilot Chat at an OTel Collector that forwards to Azure Application Insights, then import the dashboard to visualize Copilot operations, input and output tokens, chat sessions, tool calls, and per-model response time and TTFT, without building any panels yourself.
-
-The end-to-end setup is documented in the Azure Managed Grafana guide [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot). To enable OpenTelemetry export from VS Code, see [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents).
+See [Monitor AI coding agents with Grafana](https://learn.microsoft.com/azure/managed-grafana/grafana-opentelemetry-app-insights#github-copilot) for the end-to-end setup, and [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents) for enabling export from VS Code.
 
 ![Screenshot showing the GitHub Copilot Grafana dashboard with panels for operations, tokens, chat sessions, tool calls, and per-model latency.](images/1_121/grafana-copilot-dashboard.png)
 


### PR DESCRIPTION
Adds a new entry to the 1.121 release notes highlighting the prebuilt Grafana dashboard for Copilot OpenTelemetry signals (published with the Grafana team in the Azure Managed Grafana docs).

### What

New `### Grafana dashboard for Copilot agent telemetry` entry under `## Agents` in [release-notes/v1_121.md](https://github.com/microsoft/vscode-docs/blob/docs/release-notes-grafana-dashboard/release-notes/v1_121.md), immediately after the existing "Agents Window (Preview)" item.

### Why this placement

* The dashboard is a usage scenario for the OTel telemetry feature shipped in [VS Code 1.119](https://code.visualstudio.com/updates/v1_119#_opentelemetry-tracing-for-agent-sessions), which lived under `## Agent experience`. In 1.121's section structure, that maps to `## Agents`.
* Modern release notes (v1_100+) no longer use a standalone `## Documentation` section. Ecosystem and partner items are placed inline under the relevant feature's H2 — see [`### Chronicle (Experimental)`](https://github.com/microsoft/vscode-docs/blob/main/release-notes/v1_118.md) under Chat performance and history, and [`### Ghostty support for external terminal`](https://github.com/microsoft/vscode-docs/blob/main/release-notes/v1_110.md) under Terminal.
* Telemetry items have never had a dedicated H2 in release notes history — they have always been nested under the relevant audience or feature section.

### Companion PR

Doc-level addition that pairs with this entry: [#9796](https://github.com/microsoft/vscode-docs/pull/9796) (links the same Grafana guide from the Azure Application Insights section of `monitoring-agents.md` on `main`).

### TODO before release

* Add the screenshot at `release-notes/images/1_121/grafana-copilot-dashboard.png` (referenced but not yet committed). Source: the Copilot dashboard preview on the Azure Managed Grafana doc page, or a fresh capture from `aka.ms/amg/dash/gh-copilot`. Remember Git LFS.