### PR TITLE
docs: explain how to show Solution Explorer from Explorer title bar menu

### DIFF
--- a/docs/csharp/project-management.md
+++ b/docs/csharp/project-management.md
@@ -13,6 +13,8 @@ When you create a C# application in Visual Studio Code, you start with a **proje
 
 The new C# Dev Kit extension contains a new view in the Primary Sidebar, the **Solution Explorer**. This view provides a structured view of your application, its solutions, and its projects for effortless, central project management. When you open a Workspace that contains .NET solution files or project files, the Solution Explorer will automatically appear.
 
+> **Tip**: If the Solution Explorer section is not visible in the Explorer pane, you can enable it manually. Open the **Explorer** view, select the **Views and More Actions** (`...`) button in the Explorer title bar, and check **Solution Explorer** to toggle it on. Note that right-clicking the Activity Bar does not control this specific view.
+
 If you have a single solution file (.sln file) in the workspace, the Solution Explorer will detect that file and automatically load it after the workspace is loaded. For example, take a look at the animation below showing the experience of opening a workspace with a single solution file.
 
 ![Open workspace with 1 solution file](images/project-management/open-workspace-1-sln-file.gif)


### PR DESCRIPTION
## Summary

Closes #9799.

The Solution Explorer section in the Explorer pane may not be visible if it was previously hidden. The existing documentation stated that it appears automatically when a workspace with solution files is opened, but did not explain how to restore it when hidden.

Users have been confused because existing web guidance suggests right-clicking the Activity Bar to show or hide views — but that does not work for the C# Solution Explorer section, which is controlled via the Explorer title bar menu instead.

## Changes

### `docs/csharp/project-management.md`
- Added a **Tip** block immediately after the opening description of Solution Explorer.
- Explains that users should open the **Explorer** view, click the **Views and More Actions (`...`)** button in the Explorer title bar, and check **Solution Explorer** to toggle it on.
- Explicitly notes that right-clicking the Activity Bar does not control this specific view, addressing the most common point of confusion.