### PR TITLE
docs: remove duplicate "Thank You" section in v1_121 release notes

### DIFF
--- a/release-notes/v1_121.md
+++ b/release-notes/v1_121.md
@@ -311,30 +311,6 @@ Contributions to `vscode`:
 * [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Make appearedInsideViewport in InlineCompletionsModel reactive (#289944) [PR #289946](https://github.com/microsoft/vscode/pull/289946)
 
 
-
-## Thank you
-
-Contributions to our issue tracking:
-
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-* [@RedCMD (RedCMD)](https://github.com/RedCMD)
-* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
-* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
-
-Contributions to `vscode`:
-
-* [@ba-work (Brock Alberry)](https://github.com/ba-work): outputMonitor: fix two false-positive families pausing the agent loop [PR #315485](https://github.com/microsoft/vscode/pull/315485)
-* [@guomaggie](https://github.com/guomaggie): Return final answer text when snippet hydration errors [PR #316094](https://github.com/microsoft/vscode/pull/316094)
-* [@kevin-m-kent](https://github.com/kevin-m-kent): Experiment with terminal output deltas for repeated polls [PR #315543](https://github.com/microsoft/vscode/pull/315543)
-* [@NikolaRHristov (Nikola Hristov)](https://github.com/NikolaRHristov): fix: restore protected modifier on relayCreationTimeoutMs in test helper [PR #316049](https://github.com/microsoft/vscode/pull/316049)
-* [@SebTardif (Sebastien Tardif)](https://github.com/SebTardif): Fix listener leak: move onDidChangeConfiguration out of onDidProgressStep callback [PR #314636](https://github.com/microsoft/vscode/pull/314636)
-* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): fix: memory leak in lifeCycleMainService [PR #315891](https://github.com/microsoft/vscode/pull/315891)
-* [@thernstig (Tobias Hernstig)](https://github.com/thernstig): fix: replace typescript.tsdk.desc with new js/ts.tsdk.path [PR #315268](https://github.com/microsoft/vscode/pull/315268)
-* [@thirteenflt (yutingsun)](https://github.com/thirteenflt): change vsc promptD [PR #316733](https://github.com/microsoft/vscode/pull/316733)
-* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Make appearedInsideViewport in InlineCompletionsModel reactive (#289944) [PR #289946](https://github.com/microsoft/vscode/pull/289946)
-
-
-
 ---
 
 We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.


### PR DESCRIPTION
Removed the duplicate 'Thank you' section and contributions list from the release notes.
Fix #9814 