### PR TITLE
docs: clarify unsaved circle indicator and Hot Exit backups

### DIFF
--- a/docs/editing/codebasics.md
+++ b/docs/editing/codebasics.md
@@ -88,7 +88,7 @@ The user setting **Editor: Column Selection** controls this feature. Once this m
 
 By default, VS Code requires an explicit action to save your changes to disk, `kb(workbench.action.files.save)`.
 
-When an editor has unsaved changes, a circle indicator is displayed in the editor tab, and the Explorer view shows a badge indicating the number of unsaved files. These indicators convey that your changes have not been saved to disk, though they are safely stored in a backup location by the [Hot Exit](#hot-exit) feature.
+When an editor has unsaved changes, a dot indicator is displayed in the editor tab, and the Explorer view shows a badge indicating the number of unsaved files. These changes are not yet saved to disk, but VS Code automatically backs them up so they can be restored if the application closes unexpectedly (see [Hot Exit](#hot-exit)).
 
 However, it's easy to turn on `Auto Save`, which will save your changes after a configured delay or when focus leaves the editor. With this option turned on, there is no need to explicitly save the file. The easiest way to turn on `Auto Save` is with the **File** > **Auto Save** toggle that turns on and off save after a delay.
 

--- a/docs/editing/codebasics.md
+++ b/docs/editing/codebasics.md
@@ -88,6 +88,8 @@ The user setting **Editor: Column Selection** controls this feature. Once this m
 
 By default, VS Code requires an explicit action to save your changes to disk, `kb(workbench.action.files.save)`.
 
+When an editor has unsaved changes, a circle indicator is displayed in the editor tab, and the Explorer view shows a badge indicating the number of unsaved files. These indicators convey that your changes have not been saved to disk, though they are safely stored in a backup location by the [Hot Exit](#hot-exit) feature.
+
 However, it's easy to turn on `Auto Save`, which will save your changes after a configured delay or when focus leaves the editor. With this option turned on, there is no need to explicitly save the file. The easiest way to turn on `Auto Save` is with the **File** > **Auto Save** toggle that turns on and off save after a delay.
 
 For more control over `Auto Save`, open User or Workspace [settings](/docs/configure/settings.md) and find the associated settings:


### PR DESCRIPTION
Fixes #6895

This PR updates the **Save / Auto Save** section in `codebasics.md` to explicitly mention that the circle indicator in an editor tab (and Explorer badge) conveys that changes are unsaved to disk, but are backed up by the Hot Exit feature. This addresses the feedback that the purpose of the circle indicator and its relationship to Hot Exit wasn't obvious enough to new users.

Changes:
- Added a sentence explaining the circle indicator and linking to the Hot Exit section.