### PR TITLE
Add session insights and session sync documentation

### DIFF
--- a/docs/copilot/chat/chat-sessions.md
+++ b/docs/copilot/chat/chat-sessions.md
@@ -25,6 +25,7 @@ Key things to know about chat sessions:
 * **Checkpoints**: at any time, you can roll back to a previous state or edit a previous prompt to change direction. Learn more about [checkpoints](/docs/copilot/chat/chat-checkpoints.md).
 * **Agent types**: sessions can run locally, in the background, or in the cloud. Learn more about [agent types](/docs/copilot/agents/overview.md#types-of-agents).
 * **Multiple sessions**: you can run multiple sessions in parallel, each focused on a different task. Use the [sessions list](#sessions-list) to monitor ongoing sessions and switch between them.
+* **Session insights**: query your session history to generate standup reports, get tips, and search past work. Learn more about [session insights](/docs/copilot/chat/session-insights.md).
 
 > [!TIP]
 > Start a new chat session when you want to change topics to help the AI provide more relevant responses.

--- a/docs/copilot/chat/session-insights.md
+++ b/docs/copilot/chat/session-insights.md
@@ -1,0 +1,100 @@
+---
+ContentId: a3f7d8e2-5c4b-49a1-b6d3-7e8f9a2c1d4b
+DateApproved:
+MetaDescription: Use session insights in VS Code to generate standup reports, get personalized tips, and query your Copilot chat history with natural language.
+MetaSocialImage: ../images/shared/github-copilot-social.png
+---
+# Session insights
+
+Your GitHub Copilot sessions build a searchable history of everything you work on. Ask natural language questions about past sessions, generate standup reports, get personalized tips, and search your coding history. With [session sync](/docs/copilot/chat/session-sync.md) active by default, queries draw from sessions across Copilot CLI, coding agent, code review, and VS Code.
+
+## Available commands
+
+Use these commands in the Copilot Chat input to query your session history:
+
+| Command | Description |
+|---------|-------------|
+| `/chronicle:standup` | Generate a standup report from recent sessions, grouped by branch and repo |
+| `/chronicle:tips` | Get personalized tips based on your usage patterns over the past 7 days |
+| `/chronicle:cost-tips` | Get tips to reduce token usage and Copilot cost |
+| `/chronicle:search <query>` | Search sessions by keyword, file path, or PR or issue reference |
+| `/chronicle:reindex` | Rebuild the local session index |
+
+You can also ask free-form questions about your session history directly in chat. For example, type "What files did I edit yesterday?" or "Have I worked on anything related to the payments API?" and Copilot searches your synced session history to answer. Unlike `/chronicle:search` which performs a direct content search, free-form questions use semantic understanding to find relevant sessions.
+
+## Generate standup reports
+
+The `/chronicle:standup` command summarizes your recent coding sessions into a standup-style report. It groups work by feature branch and repository, including:
+
+* What you worked on, derived from conversation turns
+* Key files you edited
+* PRs, issues, and commits you referenced
+* Whether work is done or in progress
+
+```prompt
+/chronicle:standup
+```
+
+By default, the report covers the last 24 hours of sessions.
+
+## Get personalized tips
+
+The `/chronicle:tips` command analyzes 7 days of your session history to suggest ways to use Copilot more effectively. Tips are grounded in your actual usage patterns, not generic advice.
+
+```prompt
+/chronicle:tips
+```
+
+Tips include suggestions about tools you rarely use, prompting patterns that lead to better results, or workflow improvements based on how you interact with Copilot.
+
+## Reduce cost with usage tips
+
+The `/chronicle:cost-tips` command analyzes your recent sessions to identify opportunities to reduce token usage and Copilot cost.
+
+```prompt
+/chronicle:cost-tips
+```
+
+## Search your session history
+
+Use `/chronicle:search` followed by a query to find past sessions by keyword, file path, or reference:
+
+```prompt
+/chronicle:search authentication middleware
+```
+
+The search uses full-text indexing across session summaries, conversation turns, file paths, and checkpoint notes. Results include session IDs and timestamps so you can resume relevant sessions.
+
+## What gets tracked
+
+For each chat session, the local session store records:
+
+* **Session metadata**: repository, branch, working directory, timestamps, and the agent or participant used.
+* **Conversation turns**: user messages (up to 1,000 characters) and assistant responses (up to 5,000 characters).
+* **Files touched**: file paths from tool calls such as `replace_string_in_file`, `create_file`, `read_file`, and `apply_patch`.
+* **External references**: PR numbers, issue numbers, and commit SHAs extracted from GitHub MCP tool calls and terminal commands.
+
+Data is stored in a local SQLite database. Secrets such as tokens, API keys, passwords, and connection strings are automatically filtered before anything is written to the store.
+
+## Reindex the session store
+
+If sessions appear missing or the database becomes corrupted, rebuild the index. Reindexing also syncs your session data to your account.
+
+```prompt
+/chronicle:reindex
+```
+
+You can also run the **Reindex Sessions** command (`github.copilot.chronicle.reindex`) from the Command Palette.
+
+Situations where reindexing helps:
+
+* After restoring session files from a backup
+* After an unexpected crash that prevented data from flushing to the store
+* After manually deleting session directories
+* After opting back into session sync
+
+## Related content
+
+* [Session sync](/docs/copilot/chat/session-sync.md) - Sync sessions to your GitHub account for cross-device access
+* [Manage chat sessions](/docs/copilot/chat/chat-sessions.md) - Create and organize chat sessions
+* [Settings reference](/docs/copilot/reference/copilot-settings.md) - All Copilot settings

--- a/docs/copilot/chat/session-sync.md
+++ b/docs/copilot/chat/session-sync.md
@@ -1,0 +1,82 @@
+---
+ContentId: b4e8c9f3-6d5a-4b2e-c7a4-8f9e1b3d2c5a
+DateApproved:
+MetaDescription: Sync your Copilot chat sessions to GitHub for cross-device access, enterprise policy controls, and sharing with teammates.
+MetaSocialImage: ../images/shared/github-copilot-social.png
+---
+# Session sync
+
+By default, VS Code syncs your GitHub Copilot chat sessions to your GitHub account. Synced sessions appear on github.com alongside other agent sessions in the **Agents** tab of your repository. This enables [session insights](/docs/copilot/chat/session-insights.md) to query across all your sessions, including those from Copilot CLI, coding agent, code review, and the GitHub Copilot Desktop app.
+
+## Opt out of session sync
+
+To keep session data local only, set `setting(chat.sessionSync.enabled)` to `false`. When you opt out, session data stays on your machine and you can only query it locally.
+
+## Exclude repositories from sync
+
+Use `setting(chat.sessionSync.excludeRepositories)` to prevent sessions in specific repositories from syncing to the cloud. The setting accepts exact `owner/repo` names or glob patterns:
+
+```json
+"chat.sessionSync.excludeRepositories": [
+    "my-org/private-repo",
+    "my-org/secret-*"
+]
+```
+
+Sessions from matching repositories are stored locally only.
+
+## Enterprise policy
+
+For Copilot Business and Copilot Enterprise users, the "Store local sessions in the Cloud" policy controls whether session sync is available.
+
+* **Organization-level policy** (unconfigured by default): organization owners can set this to "View from cloud" (sync only) or "View and control" (sync plus remote control). If the policy is disabled or unconfigured, sessions are stored locally only for the organization's users.
+* **Enterprise-level policy**: enterprise owners can enforce a setting across all organizations, or select "Let organizations decide" to allow each organization to choose its own level. If the enterprise enforces "View and control," all organizations under it receive that setting.
+
+> [!IMPORTANT]
+> Enabling the policy does not give administrators access to your session data. Synced sessions are tied to your personal account and are accessible only to you by default.
+
+When disabled by policy, the session sync status shows **Disabled by policy** and users cannot override the setting.
+
+## Share a session
+
+Sessions are unshared by default. You can share a synced session for view-only access to anyone who has access to the repository:
+
+1. Open the **Agents** tab on github.com.
+2. Select a session and open **Sharing settings** from the `...` menu.
+3. Enable sharing to give repository collaborators view-only access.
+
+Recipients can view the session's prompts, responses, and file changes, but cannot steer or modify the session. Shared sessions are not indexed for other users' session queries.
+
+## Session sync status
+
+The session sync status appears in the Copilot status bar in the Chat view. It shows the current state of cloud sync:
+
+| State | Description |
+|-------|-------------|
+| **Not enabled** | Session sync is off. Data stays local to this device. |
+| **Enabled** | Sessions are syncing to your GitHub account. |
+| **N sessions synced** | Shows how many sessions have been uploaded. Select to view sessions on github.com. |
+| **Syncing N session(s)** | Upload is in progress. |
+| **Disabled by policy** | Your organization's policy prevents session sync. |
+| **Sync error** | Something went wrong during the last sync. Try again later. |
+
+## Privacy and data control
+
+* Sessions are private to you by default. Synced sessions are tied to your personal GitHub account and are accessible only to you unless you explicitly share them.
+* Secrets such as tokens, API keys, and credentials are automatically stripped before data leaves your machine.
+* You can opt out at any time by setting `setting(chat.sessionSync.enabled)` to `false`. Existing synced sessions remain on github.com until you delete them.
+* **Managing synced data**: you can delete or hide synced sessions from github.com. Hiding a session removes it from your session index so it no longer appears in query results. Deleting local session files does not affect synced data.
+
+## Settings reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `setting(github.copilot.chat.localIndex.enabled)` | `true` | Enable local session tracking (prerequisite for sync) |
+| `setting(chat.sessionSync.enabled)` | `true` | Sync sessions to your GitHub account |
+| `setting(chat.sessionSync.excludeRepositories)` | `[]` | Repository patterns to exclude from sync |
+
+## Related content
+
+* [Session insights](/docs/copilot/chat/session-insights.md) - Query your session history for standup reports, tips, and search
+* [Manage chat sessions](/docs/copilot/chat/chat-sessions.md) - Create and organize chat sessions
+* [Security](/docs/copilot/security.md) - Copilot security and privacy

--- a/docs/copilot/customization/language-models.md
+++ b/docs/copilot/customization/language-models.md
@@ -309,6 +309,13 @@ Each model in the `models` array supports the following properties:
 | `vision` | Set to `true` if the model supports image inputs. |
 | `maxInputTokens` | Maximum number of input tokens the model accepts. |
 | `maxOutputTokens` | Maximum number of output tokens the model generates. |
+| `editTools` | _(Optional)_ An array of edit tools the model supports. If not configured, the editor tries multiple edit tools and picks the best one. Possible values: `find-replace`, `multi-find-replace`, `apply-patch`, `code-rewrite`. |
+| `thinking` | _(Optional)_ Set to `true` if the model supports thinking capabilities. Defaults to `false`. |
+| `streaming` | _(Optional)_ Set to `true` if the model supports streaming responses. Defaults to `true`. |
+| `zeroDataRetentionEnabled` | _(Optional)_ Set to `true` if Zero Data Retention (ZDR) is enabled for this endpoint. When enabled, `previous_response_id` is not sent in requests via the Responses API. Defaults to `false`. |
+| `supportsReasoningEffort` | _(Optional)_ An array of reasoning effort levels the model accepts (for example, `["low", "medium", "high"]`). When set, a **Thinking Effort** picker is shown in the model picker. Common levels are `minimal`, `low`, `medium`, `high`. |
+| `reasoningEffortFormat` | _(Optional)_ Body shape used to forward reasoning effort to the model. `chat-completions` sends a top-level `reasoning_effort` string. `responses` sends a nested `reasoning.effort` object. When unset, the format follows the URL. |
+| `requestHeaders` | _(Optional)_ An object of additional HTTP headers to include with requests to this model. Certain reserved headers (forbidden, forwarding, and internal headers) are not allowed and are ignored if present. |
 
 ## Frequently asked questions
 

--- a/docs/copilot/reference/copilot-settings.md
+++ b/docs/copilot/reference/copilot-settings.md
@@ -93,6 +93,9 @@ The team is continuously working on improving Copilot in VS Code and adding new 
 | `setting(chat.utilityModel)`<br/>Override the language model used for built-in [utility flows](/docs/copilot/customization/language-models.md#change-the-model-for-utility-tasks), such as generating titles, summaries, and fallback responses. | `"Default"` |
 | `setting(chat.utilitySmallModel)`<br/>Override the language model used for fast, lightweight [utility flows](/docs/copilot/customization/language-models.md#change-the-model-for-utility-tasks), such as commit messages, rename suggestions, and intent detection. A fast, inexpensive model is recommended. | `"Default"` |
 | `setting(github.copilot.chat.edits.suggestRelatedFilesFromGitHistory)` _(Experimental)_<br/>Suggest related files from git history in chat context. | `true` |
+| `setting(github.copilot.chat.localIndex.enabled)`<br/>Enable local session tracking for [session insights](/docs/copilot/chat/session-insights.md) and `/chronicle` commands. | `true` |
+| `setting(chat.sessionSync.enabled)`<br/>Enable [session sync](/docs/copilot/chat/session-sync.md) to GitHub.com. When enabled, Copilot session data syncs to your GitHub account for cross-device access. Requires `github.copilot.chat.localIndex.enabled` to also be enabled. | `true` |
+| `setting(chat.sessionSync.excludeRepositories)`<br/>Repository patterns to exclude from [session sync](/docs/copilot/chat/session-sync.md). Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories are stored locally only. | `[]` |
 
 ## Agent settings
 

--- a/docs/redirection.json
+++ b/docs/redirection.json
@@ -1,4 +1,5 @@
 [
+    { "from": "/docs/copilot/guides/chronicle-session-insights", "to": "/docs/copilot/chat/session-insights", "status": 301 },
     { "from": "/docs/copilot/core-concepts", "to": "/docs/copilot/concepts/overview", "status": 301 },
     { "from": "/docs/copilot/agents/background-agents", "to": "/docs/copilot/agents/copilot-cli", "status": 301 },
     { "from": "/docs/copilot/setup-simplified", "to": "/docs/copilot/setup", "status": 301 },

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -75,6 +75,8 @@
         "topics": [
           ["Overview", "/docs/copilot/chat/copilot-chat"],
           ["Chat Sessions", "/docs/copilot/chat/chat-sessions"],
+          ["Session Insights", "/docs/copilot/chat/session-insights"],
+          ["Session Sync", "/docs/copilot/chat/session-sync"],
           ["Add Context", "/docs/copilot/chat/copilot-chat-context"],
           ["Inline Chat", "/docs/copilot/chat/inline-chat"],
           ["Review Edits", "/docs/copilot/chat/review-code-edits"],

--- a/release-notes/v1_109.md
+++ b/release-notes/v1_109.md
@@ -172,7 +172,7 @@ We have revamped our Plan agent to also take advantage of the `askQuestions` too
 
 ### Plan agent
 
-The built-in [Plan agent](https://code.visualstudio.com/docs/copilot/chat/chat-planning) lets you create a structured implementation plan before starting to code. This helps ensure that the AI understands the task requirements and produces high-quality code that meets your expectations.
+The built-in [Plan agent](https://code.visualstudio.com/docs/copilot/agents/planning) lets you create a structured implementation plan before starting to code. This helps ensure that the AI understands the task requirements and produces high-quality code that meets your expectations.
 
 * The Plan agent now follows a structured 4-phase iterative workflow that produces higher-quality implementation plans:
 

--- a/release-notes/v1_122.md
+++ b/release-notes/v1_122.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: May 21, 2026_
+_Last updated: May 23, 2026_
 
 Welcome to the 1.122 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,6 +40,8 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#may-23-2026">May 23, 2026</a></li>
+      <li><a href="#may-22-2026">May 22, 2026</a></li>
       <li><a href="#may-21-2026">May 21, 2026</a></li>
       <li><a href="#may-20-2026">May 20, 2026</a></li>
       <li><a href="#may-19-2026">May 19, 2026</a></li>
@@ -47,6 +49,18 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## May 23, 2026
+
+* Add "Add Screenshot to Chat" action in the integrated browser to capture and attach a screenshot of the current page to a chat message. _[#318065](https://github.com/microsoft/vscode/issues/318065)_
+
+## May 22, 2026
+
+* Hover tooltips in the Agents window sessions list show the full session title and folder path. _[#317858](https://github.com/microsoft/vscode/issues/317858)_
+
+* Preserve the `gallery` field when installing an MCP server via the `vscode:mcp/install` protocol URL, ensuring servers from registries retain their metadata for update checks and enablement. _[#293481](https://github.com/microsoft/vscode/issues/293481)_
+
+* MCP OAuth supports specifying a custom `clientId` in the `oauth` section of `mcp.json`, enabling servers that don't support Dynamic Client Registration. Client secrets are stored securely in the OS secret store. _[#257415](https://github.com/microsoft/vscode/issues/257415)_
 
 ## May 21, 2026
 


### PR DESCRIPTION
Adds two new documentation pages for Copilot session tracking:

## New pages
- **docs/copilot/chat/session-insights.md** — Chronicle commands, free-form querying, what gets tracked
- **docs/copilot/chat/session-sync.md** — Cloud sync (on by default), opt-out, exclude repos, enterprise policy, session sharing, privacy controls

## Updates to existing pages
- **docs/toc.json** — Added entries under Chat section
- **docs/copilot/reference/copilot-settings.md** — Added three settings with true defaults
- **docs/copilot/chat/chat-sessions.md** — Cross-link to session insights
- **docs/redirection.json** — Redirect from old path

## Aligned with
- GitHub docs-internal PR #60985
- VS Code source: extensions/copilot/src/extension/chronicle and extensions/copilot/src/platform/chronicle

Both github.copilot.chat.localIndex.enabled and chat.sessionSync.enabled default to true for the stable release.