### PR TITLE
Add session insights and session sync documentation

### DIFF
--- a/docs/copilot/chat/chat-sessions.md
+++ b/docs/copilot/chat/chat-sessions.md
@@ -25,6 +25,7 @@ Key things to know about chat sessions:
 * **Checkpoints**: at any time, you can roll back to a previous state or edit a previous prompt to change direction. Learn more about [checkpoints](/docs/copilot/chat/chat-checkpoints.md).
 * **Agent types**: sessions can run locally, in the background, or in the cloud. Learn more about [agent types](/docs/copilot/agents/overview.md#types-of-agents).
 * **Multiple sessions**: you can run multiple sessions in parallel, each focused on a different task. Use the [sessions list](#sessions-list) to monitor ongoing sessions and switch between them.
+* **Session insights**: query your session history to generate standup reports, get tips, and search past work. Learn more about [session insights](/docs/copilot/chat/session-insights.md).
 
 > [!TIP]
 > Start a new chat session when you want to change topics to help the AI provide more relevant responses.

--- a/docs/copilot/chat/session-insights.md
+++ b/docs/copilot/chat/session-insights.md
@@ -1,0 +1,59 @@
+---
+ContentId: a3f7d8e2-5c4b-49a1-b6d3-7e8f9a2c1d4b
+DateApproved:
+MetaDescription: Use chronicle commands in VS Code to generate standup reports, get personalized tips, and query your Copilot session history with natural language.
+MetaSocialImage: ../images/shared/github-copilot-social.png
+---
+# Query session history with chronicle
+
+Your GitHub Copilot sessions build a searchable history of everything you work on. Ask natural language questions about past sessions, generate standup reports, get personalized tips, and search your coding history. With [session sync](/docs/copilot/chat/session-sync.md) active by default, queries draw from sessions across Copilot CLI, coding agent, code review, and VS Code.
+
+## Chronicle commands
+
+Use these commands in the chat input to query your session history:
+
+| Command | Description |
+|---------|-------------|
+| `/chronicle:standup` | Summarize recent coding sessions into a standup report, grouped by branch and repository. Covers the last 24 hours by default. Includes files edited, PRs or issues referenced, and whether work is done or in progress. |
+| `/chronicle:tips` | Analyze your recent session history (typically 7 days) and suggest ways to use Copilot more effectively. Tips are grounded in your actual usage patterns: tools you rarely use, prompting patterns that lead to better results, or workflow improvements. |
+| `/chronicle:cost-tips` | Analyze recent sessions to identify opportunities to reduce token usage and Copilot cost. |
+| `/chronicle:search <query>` | Search sessions by keyword, file path, or PR or issue reference. Uses full-text indexing across session summaries, conversation turns, file paths, and checkpoint notes. Results include session IDs and timestamps so you can resume relevant sessions. |
+| `/chronicle:reindex` | Rebuild the local session index and sync session data to your account. |
+
+## Free-form questions
+
+You can also ask free-form questions about your session history directly in chat. For example, type "What files did I edit yesterday?" or "Have I worked on anything related to the payments API?" and Copilot searches your synced session history to answer. Unlike `/chronicle:search` which performs a direct content search, free-form questions use semantic understanding to find relevant sessions.
+
+## What gets tracked
+
+For each chat session, the local session store records:
+
+* **Session metadata**: repository, branch, working directory, timestamps, and the agent or participant used.
+* **Conversation turns**: user messages (up to 1,000 characters) and assistant responses (up to 5,000 characters).
+* **Files touched**: file paths from tool calls such as `replace_string_in_file`, `create_file`, `read_file`, and `apply_patch`.
+* **External references**: PR numbers, issue numbers, and commit SHAs extracted from GitHub MCP tool calls and terminal commands.
+
+Data is stored in a local SQLite database. Secrets such as tokens, API keys, passwords, and connection strings are automatically filtered before data is synced to the cloud.
+
+## Reindex the session store
+
+If sessions appear missing or the database becomes corrupted, rebuild the index. Reindexing also syncs your session data to your account.
+
+```prompt
+/chronicle:reindex
+```
+
+You can also run the **Reindex Sessions** command (`github.copilot.chronicle.reindex`) from the Command Palette.
+
+Situations where reindexing helps:
+
+* After restoring session files from a backup
+* After an unexpected crash that prevented data from flushing to the store
+* After manually deleting session directories
+* After opting back into session sync
+
+## Related content
+
+* [Session sync](/docs/copilot/chat/session-sync.md) - Sync sessions to your GitHub account for cross-device access
+* [Manage chat sessions](/docs/copilot/chat/chat-sessions.md) - Create and organize chat sessions
+* [Settings reference](/docs/copilot/reference/copilot-settings.md) - All Copilot settings

--- a/docs/copilot/chat/session-sync.md
+++ b/docs/copilot/chat/session-sync.md
@@ -6,7 +6,7 @@ MetaSocialImage: ../images/shared/github-copilot-social.png
 ---
 # Sync Copilot sessions to GitHub
 
-By default, VS Code syncs your GitHub Copilot chat sessions to your GitHub account, including all local agent sessions. Synced sessions are private to you and are not visible to anyone else unless you explicitly share them. They appear on github.com in the **Agents** tab of your repository, enabling [session insights](/docs/copilot/chat/session-insights.md) to query across all your sessions, including those from Copilot CLI, coding agent, code review, and the GitHub Copilot Desktop app.
+By default, VS Code syncs your GitHub Copilot chat sessions to your GitHub account, including all local agent sessions. Synced sessions are private to you and are not visible to anyone else unless you explicitly share them. They appear on GitHub.com in the **Agents** tab of your repository, enabling [session insights](/docs/copilot/chat/session-insights.md) to query across all your sessions, including those from Copilot CLI, coding agent, code review, and the GitHub Copilot Desktop app.
 
 ## Opt out of session sync
 
@@ -29,7 +29,7 @@ Sessions from matching repositories are stored locally only.
 
 For Copilot Business and Copilot Enterprise users, two policies control session sync:
 
-* **GitHub.com enterprise policy** ("Store local sessions in the Cloud"): enterprise and organization owners configure this on github.com to enable or disable cloud sync for their users.
+* **GitHub.com enterprise policy** ("Store local sessions in the Cloud"): enterprise and organization owners configure this on GitHub.com to enable or disable cloud sync for their users.
 * **VS Code group policy** (`CopilotSessionSync`): when disabled, the `setting(chat.sessionSync.enabled)` setting is forced to `false` and sessions stay local only.
 
 > [!IMPORTANT]
@@ -39,9 +39,9 @@ When disabled by policy, the session sync status shows **Disabled by policy** an
 
 ## Share a session
 
-Sessions are unshared by default. On github.com, you can share a synced session for view-only access to anyone who has access to the repository:
+Sessions are not shared by default. On GitHub.com, you can share a synced session for view-only access to anyone who has access to the repository:
 
-1. Open the **Agents** tab on github.com.
+1. Open the **Agents** tab on GitHub.com.
 2. Select a session and open **Sharing settings** from the `...` menu.
 3. Enable sharing to give repository collaborators view-only access.
 
@@ -55,8 +55,8 @@ The session sync status appears in the Copilot status bar in the Chat view. It s
 |-------|-------------|
 | **Not enabled** | Session sync is off. Data stays local to this device. |
 | **Enabled** | Sessions are syncing to your GitHub account. |
-| **N sessions synced** | Shows how many sessions have been uploaded. Select to view sessions on github.com. |
-| **Syncing N session(s)** | Upload is in progress. |
+| **N sessions synced** | Shows how many sessions have been uploaded. Select to view sessions on GitHub.com. |
+| **Syncing N sessions** | Upload is in progress. |
 | **Disabled by policy** | Your organization's policy prevents session sync. |
 | **Sync error** | Something went wrong during the last sync. Try again later. |
 
@@ -64,16 +64,16 @@ The session sync status appears in the Copilot status bar in the Chat view. It s
 
 * Sessions are private to you by default. Synced sessions are tied to your personal GitHub account and are accessible only to you unless you explicitly share them.
 * Secrets such as tokens, API keys, and credentials are automatically stripped before data leaves your machine.
-* You can opt out at any time by setting `setting(chat.sessionSync.enabled)` to `false`. Existing synced sessions remain on github.com until you delete them.
+* You can opt out at any time by setting `setting(chat.sessionSync.enabled)` to `false`. Existing synced sessions remain on GitHub.com until you delete them.
 
 ## Delete synced sessions
 
 To delete synced session data, run the **Delete Session Sync Data** command (`github.copilot.sessionSync.deleteSessions`) from the Command Palette. The command shows a picker where you select which sessions to remove. After selecting sessions, you choose the deletion scope:
 
-* **Delete from local and cloud**: removes session data from your machine and from github.com. This action cannot be undone.
-* **Delete from cloud only**: removes session data from github.com but keeps local data intact.
+* **Delete from local and cloud**: removes session data from your machine and from GitHub.com. This action cannot be undone.
+* **Delete from cloud only**: removes session data from GitHub.com but keeps local data intact.
 
-You can also hide or delete individual synced sessions from the **Agents** tab on github.com. Hiding a session removes it from your session index so it no longer appears in query results.
+You can also hide or delete individual synced sessions from the **Agents** tab on GitHub.com. Hiding a session removes it from your session index so it no longer appears in query results.
 
 ## Settings reference
 

--- a/docs/copilot/chat/session-sync.md
+++ b/docs/copilot/chat/session-sync.md
@@ -1,0 +1,90 @@
+---
+ContentId: b4e8c9f3-6d5a-4b2e-c7a4-8f9e1b3d2c5a
+DateApproved:
+MetaDescription: Sync your Copilot chat sessions to GitHub for cross-device access, enterprise policy controls, and sharing with teammates.
+MetaSocialImage: ../images/shared/github-copilot-social.png
+---
+# Sync Copilot sessions to GitHub
+
+By default, VS Code syncs your GitHub Copilot chat sessions to your GitHub account, including all local agent sessions. Synced sessions are private to you and are not visible to anyone else unless you explicitly share them. They appear on github.com in the **Agents** tab of your repository, enabling [session insights](/docs/copilot/chat/session-insights.md) to query across all your sessions, including those from Copilot CLI, coding agent, code review, and the GitHub Copilot Desktop app.
+
+## Opt out of session sync
+
+To keep session data local only, set `setting(chat.sessionSync.enabled)` to `false`. When you opt out, session data stays on your machine and you can only query it locally.
+
+## Exclude repositories from sync
+
+Use `setting(chat.sessionSync.excludeRepositories)` to prevent sessions in specific repositories from syncing to the cloud. The setting accepts exact `owner/repo` names or glob patterns:
+
+```json
+"chat.sessionSync.excludeRepositories": [
+    "my-org/private-repo",
+    "my-org/secret-*"
+]
+```
+
+Sessions from matching repositories are stored locally only.
+
+## Enterprise policy
+
+For Copilot Business and Copilot Enterprise users, two policies control session sync:
+
+* **GitHub.com enterprise policy** ("Store local sessions in the Cloud"): enterprise and organization owners configure this on github.com to enable or disable cloud sync for their users.
+* **VS Code group policy** (`CopilotSessionSync`): when disabled, the `setting(chat.sessionSync.enabled)` setting is forced to `false` and sessions stay local only.
+
+> [!IMPORTANT]
+> Enabling the policy does not give administrators access to your session data. Synced sessions are tied to your personal account and are accessible only to you by default.
+
+When disabled by policy, the session sync status shows **Disabled by policy** and users cannot override the setting.
+
+## Share a session
+
+Sessions are unshared by default. On github.com, you can share a synced session for view-only access to anyone who has access to the repository:
+
+1. Open the **Agents** tab on github.com.
+2. Select a session and open **Sharing settings** from the `...` menu.
+3. Enable sharing to give repository collaborators view-only access.
+
+Recipients can view the session's prompts, responses, and file changes, but cannot steer or modify the session. Shared sessions are not indexed for other users' session queries.
+
+## Session sync status
+
+The session sync status appears in the Copilot status bar in the Chat view. It shows the current state of cloud sync:
+
+| State | Description |
+|-------|-------------|
+| **Not enabled** | Session sync is off. Data stays local to this device. |
+| **Enabled** | Sessions are syncing to your GitHub account. |
+| **N sessions synced** | Shows how many sessions have been uploaded. Select to view sessions on github.com. |
+| **Syncing N session(s)** | Upload is in progress. |
+| **Disabled by policy** | Your organization's policy prevents session sync. |
+| **Sync error** | Something went wrong during the last sync. Try again later. |
+
+## Privacy and data control
+
+* Sessions are private to you by default. Synced sessions are tied to your personal GitHub account and are accessible only to you unless you explicitly share them.
+* Secrets such as tokens, API keys, and credentials are automatically stripped before data leaves your machine.
+* You can opt out at any time by setting `setting(chat.sessionSync.enabled)` to `false`. Existing synced sessions remain on github.com until you delete them.
+
+## Delete synced sessions
+
+To delete synced session data, run the **Delete Session Sync Data** command (`github.copilot.sessionSync.deleteSessions`) from the Command Palette. The command shows a picker where you select which sessions to remove. After selecting sessions, you choose the deletion scope:
+
+* **Delete from local and cloud**: removes session data from your machine and from github.com. This action cannot be undone.
+* **Delete from cloud only**: removes session data from github.com but keeps local data intact.
+
+You can also hide or delete individual synced sessions from the **Agents** tab on github.com. Hiding a session removes it from your session index so it no longer appears in query results.
+
+## Settings reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `setting(github.copilot.chat.localIndex.enabled)` | `true` | Enable local session tracking (prerequisite for sync) |
+| `setting(chat.sessionSync.enabled)` | `true` | Sync sessions to your GitHub account |
+| `setting(chat.sessionSync.excludeRepositories)` | `[]` | Repository patterns to exclude from sync |
+
+## Related content
+
+* [Session insights](/docs/copilot/chat/session-insights.md) - Query your session history for standup reports, tips, and search
+* [Manage chat sessions](/docs/copilot/chat/chat-sessions.md) - Create and organize chat sessions
+* [Security](/docs/copilot/security.md) - Copilot security and privacy

--- a/docs/copilot/reference/copilot-settings.md
+++ b/docs/copilot/reference/copilot-settings.md
@@ -93,6 +93,9 @@ The team is continuously working on improving Copilot in VS Code and adding new 
 | `setting(chat.utilityModel)`<br/>Override the language model used for built-in [utility flows](/docs/copilot/customization/language-models.md#change-the-model-for-utility-tasks), such as generating titles, summaries, and fallback responses. | `"Default"` |
 | `setting(chat.utilitySmallModel)`<br/>Override the language model used for fast, lightweight [utility flows](/docs/copilot/customization/language-models.md#change-the-model-for-utility-tasks), such as commit messages, rename suggestions, and intent detection. A fast, inexpensive model is recommended. | `"Default"` |
 | `setting(github.copilot.chat.edits.suggestRelatedFilesFromGitHistory)` _(Experimental)_<br/>Suggest related files from git history in chat context. | `true` |
+| `setting(github.copilot.chat.localIndex.enabled)`<br/>Enable local session tracking for [session insights](/docs/copilot/chat/session-insights.md) and `/chronicle` commands. | `true` |
+| `setting(chat.sessionSync.enabled)`<br/>Enable [session sync](/docs/copilot/chat/session-sync.md) to GitHub.com. When enabled, Copilot session data syncs to your GitHub account for cross-device access. Requires `github.copilot.chat.localIndex.enabled` to also be enabled. | `true` |
+| `setting(chat.sessionSync.excludeRepositories)`<br/>Repository patterns to exclude from [session sync](/docs/copilot/chat/session-sync.md). Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories are stored locally only. | `[]` |
 
 ## Agent settings
 

--- a/docs/copilot/reference/copilot-settings.md
+++ b/docs/copilot/reference/copilot-settings.md
@@ -94,7 +94,7 @@ The team is continuously working on improving Copilot in VS Code and adding new 
 | `setting(chat.utilitySmallModel)`<br/>Override the language model used for fast, lightweight [utility flows](/docs/copilot/customization/language-models.md#change-the-model-for-utility-tasks), such as commit messages, rename suggestions, and intent detection. A fast, inexpensive model is recommended. | `"Default"` |
 | `setting(github.copilot.chat.edits.suggestRelatedFilesFromGitHistory)` _(Experimental)_<br/>Suggest related files from git history in chat context. | `true` |
 | `setting(github.copilot.chat.localIndex.enabled)`<br/>Enable local session tracking for [session insights](/docs/copilot/chat/session-insights.md) and `/chronicle` commands. | `true` |
-| `setting(chat.sessionSync.enabled)`<br/>Enable [session sync](/docs/copilot/chat/session-sync.md) to GitHub.com. When enabled, Copilot session data syncs to your GitHub account for cross-device access. Requires `github.copilot.chat.localIndex.enabled` to also be enabled. | `true` |
+| `setting(chat.sessionSync.enabled)`<br/>Enable [session sync](/docs/copilot/chat/session-sync.md) to GitHub.com. When enabled, Copilot session data syncs to your GitHub account for cross-device access. Requires `setting(github.copilot.chat.localIndex.enabled)` to also be enabled. | `true` |
 | `setting(chat.sessionSync.excludeRepositories)`<br/>Repository patterns to exclude from [session sync](/docs/copilot/chat/session-sync.md). Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories are stored locally only. | `[]` |
 
 ## Agent settings

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -75,6 +75,8 @@
         "topics": [
           ["Overview", "/docs/copilot/chat/copilot-chat"],
           ["Chat Sessions", "/docs/copilot/chat/chat-sessions"],
+          ["Session Insights", "/docs/copilot/chat/session-insights"],
+          ["Sync Sessions", "/docs/copilot/chat/session-sync"],
           ["Add Context", "/docs/copilot/chat/copilot-chat-context"],
           ["Inline Chat", "/docs/copilot/chat/inline-chat"],
           ["Review Edits", "/docs/copilot/chat/review-code-edits"],


### PR DESCRIPTION
Adds two new documentation pages for Copilot session tracking (chronicle).

## New pages
- **docs/copilot/chat/session-insights.md** — Chronicle commands, free-form querying, what gets tracked
- **docs/copilot/chat/session-sync.md** — Cloud sync (on by default), opt-out, exclude repos, enterprise policy, session sharing, privacy

## Updates to existing pages
- **docs/toc.json** — Added entries under Chat section
- **docs/copilot/reference/copilot-settings.md** — Added three settings (defaults: true)
- **docs/copilot/chat/chat-sessions.md** — Cross-link to session insights
- **docs/redirection.json** — Redirect from old path

Aligned with GitHub docs-internal PR #60985 and VS Code source (extensions/copilot/src/extension/chronicle + platform/chronicle).