### PR TITLE
Revise React tutorial to reflect new recommendations

### DIFF
--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -11,16 +11,17 @@ MetaDescription: React JavaScript tutorial showing IntelliSense, debugging, and 
 
 ## Welcome to React
 
+> [!IMPORTANT]
+> `create-react-app` [is no longer actively maintained](https://react.dev/blog/2025/02/14/sunsetting-create-react-app). The React team now recommends using a framework like [Vite](https://vite.dev) (`npm create vite@latest my-app -- --template react`) or [Next.js](https://nextjs.org). The steps in this tutorial still apply to any React project setup.
+
 We'll be using the `create-react-app` [generator](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) for this tutorial. To use the generator as well as run the React application server, you'll need [Node.js](https://nodejs.org/) JavaScript runtime and [npm](https://www.npmjs.com/) (Node.js package manager) installed. npm is included with Node.js which you can download and install from [Node.js downloads](https://nodejs.org/en/download/).
 
->**Tip**: To test that you have Node.js and npm correctly installed on your machine, you can type `node --version` and `npm --version` in a terminal or command prompt.
+> **Tip**: To test that you have Node.js and npm correctly installed on your machine, you can type `node --version` and `npm --version` in a terminal or command prompt.
 
 You can now create a new React application by typing:
 
 ```bash
 npx create-react-app my-app
-
->**Note**: `create-react-app` is no longer actively maintained. The React team now recommends using a framework like [Vite](https://vite.dev) (`npm create vite@latest my-app -- --template react`) or [Next.js](https://nextjs.org). The steps in this tutorial still apply to any React project setup.
 ```
 
 where `my-app` is the name of the folder for your application. This may take a few minutes to create the React application and install its dependencies.

--- a/docs/nodejs/reactjs-tutorial.md
+++ b/docs/nodejs/reactjs-tutorial.md
@@ -19,6 +19,8 @@ You can now create a new React application by typing:
 
 ```bash
 npx create-react-app my-app
+
+>**Note**: `create-react-app` is no longer actively maintained. The React team now recommends using a framework like [Vite](https://vite.dev) (`npm create vite@latest my-app -- --template react`) or [Next.js](https://nextjs.org). The steps in this tutorial still apply to any React project setup.
 ```
 
 where `my-app` is the name of the folder for your application. This may take a few minutes to create the React application and install its dependencies.


### PR DESCRIPTION
`create-react-app` has not been actively maintained since 2022 and the React team has officially removed it from their documentation in favor of frameworks like Vite and Next.js.

This PR adds a note after the `npx create-react-app` command to inform users that the tool is deprecated and points them to the currently recommended alternatives, while noting that the rest of the tutorial steps still apply to any React project.