### PR TITLE
Fact-check and refine agent course tutorials

### DIFF
--- a/learn/agents/1-using-tools-with-agents.md
+++ b/learn/agents/1-using-tools-with-agents.md
@@ -18,7 +18,7 @@ Tools are how agents act on your request. They search your workspace, read files
 
 ## Prerequisites
 
-Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. You also need access to any extra tools you want to try, such as MCP servers or extensions that contribute tools.
+Before you start, install VS Code, enable AI features, and sign in to GitHub Copilot. You also need access to any extra tools you want to try, such as MCP servers or extensions that contribute tools.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)

--- a/learn/agents/1-using-tools-with-agents.md
+++ b/learn/agents/1-using-tools-with-agents.md
@@ -1,7 +1,7 @@
 ---
 ContentId: 5d7a2a1e-9f1c-4d2a-8c6a-1c2a8f7d4a01
 DateApproved: 05/21/2026
-MetaDescription: Learn how to use built-in tools, MCP tools, extension tools, approvals, and sandboxing with agents in VS Code.
+MetaDescription: Practice choosing agent tools, tool sets, approvals, and sandboxing settings for focused AI workflows in VS Code.
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 Keywords:
   - copilot
@@ -14,55 +14,107 @@ Keywords:
 
 # Using tools with agents
 
-Tools give agents in VS Code access to the workspace, the web, APIs, and other capabilities they need to finish real tasks. This course shows how to choose tools, group them into tool sets, and keep agent work safe with approvals and sandboxing.
+Tools are how agents act on your request. They search your workspace, read files, edit code, run terminal commands, fetch web content, and call external services. In this guide, you will start with a small task, choose only the tools the task needs, and decide when to use a tool set, approvals, or sandboxing.
 
 ## Prerequisites
 
-Before you start: you'll need VS Code Insiders installed and the GitHub Copilot and GitHub Copilot Chat extensions set up and signed in. You also need access to the tools you want to use, such as MCP servers or extensions that contribute tools.
+Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. You also need access to any extra tools you want to try, such as MCP servers or extensions that contribute tools.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)
 
-## What tools do
+## Start with a task
 
-Agents use tools to search code, read files, run commands, fetch content, and call services. VS Code supports three kinds of tools:
+Imagine you want the agent to explain how authentication works in a repository and then suggest one small test to add. That task needs repository context, but it probably does not need terminal access, web access, or external services at the start.
+
+Use this prompt in an agent session:
+
+```prompt
+Explain the authentication flow in this project. Find the main files involved, then suggest one focused test I should add next.
+```
+
+Before you send it, decide which tools the agent should have. VS Code supports three kinds of tools:
 
 * Built-in tools, such as read, edit, search, execute, and web.
 * MCP tools from installed Model Context Protocol servers.
 * Extension tools contributed by VS Code extensions.
 
-The agent selects tools from the enabled set based on your prompt and context. If you want to force a specific tool, type `#` and the tool name in chat.
+The agent selects from the enabled tools based on your prompt and context. Your job is to give it enough capability to finish the task without giving it a noisy list of unrelated options.
 
-For example, use `#codebase` in a prompt when you want the agent to focus on your repository context.
+## Choose tools for the first pass
 
-To install more tools, open the Extensions view and search with the `@mcp` filter for MCP servers, or search normally for extensions that contribute tools.
+1. Open the Chat view.
 
-## Choose the right tools
+1. Select **Agent** from the agent picker.
 
-Open the Chat view, switch to **Agent**, and use the **Configure Tools** button in the chat input to choose the tools for the current session.
+1. Select **Configure Tools** in the chat input.
+
+1. Keep repository search and file-reading tools enabled.
+
+1. Leave terminal, web, and external service tools off for this first pass.
+
+1. Send the prompt.
 
 ![Screenshot showing the Chat view with the Configure Tools button in the chat input.](../../docs/copilot/images/chat-tools/agent-mode-select-tools.png)
 
-Select only the tools you need. A smaller tool set gives the model less to sort through and usually leads to better results. Every enabled tool also consumes part of the model's context window.
+Starting small helps the agent stay focused. It also reduces tool definitions in the model context window. VS Code can expose some groups as virtual tools to keep tool counts manageable, but a smaller active set still makes the task easier for the model to reason about.
 
-A chat request can have a maximum of 128 tools enabled at a time, so keeping the active set focused also helps avoid tool count issues.
+> [!TIP]
+> If the agent says it needs to run tests or inspect generated output, add the terminal tool for the next request instead of restarting with every tool enabled.
+
+## Add a specific tool when needed
+
+Sometimes you know exactly which tool should ground the answer. Type `#` in the chat input to see available tools, context sources, and tool sets.
+
+For example, revise the previous prompt like this:
+
+```prompt
+Explain the authentication flow in this project. Focus on repository context. #codebase
+```
+
+Use explicit tool references when the task has a clear source of truth:
+
+* Use `#codebase` when the answer should come from your repository.
+* Use `#problems` when you want the agent to fix current diagnostics.
+* Use `#web` when the answer needs current external documentation.
 
 ![Screenshot showing the tool picker drop-down with built-in tools, MCP servers, and user-defined tool sets.](../../docs/copilot/images/chat-tools/chat-tools-picker.png)
 
-> [!TIP]
-> Start with the fewest tools that can complete the task, then add more only when the agent needs them.
+## Decide between individual tools and tool sets
 
-## Group related tools with tool sets
+Individual tools work well for one-off requests. Tool sets work better when you repeat the same setup.
 
-Tool sets let you save related tools as a single reusable group. You can use them in chat prompts, prompt files, and custom agents.
+| Use | Good fit | Example |
+| --- | --- | --- |
+| Individual tools | A short task with one clear source of context. | Explain a file with `#codebase` and no terminal access. |
+| Tool set | A repeated workflow that needs the same group of tools. | A Python maintenance workflow with search, edit, testing, and Python language tools. |
+| Custom agent tools | A role that should always run with the same boundaries. | A planning agent with search and web tools, but no edit or terminal tools. |
 
-Create a tool set from the Command Palette with **Chat: Configure Tool Sets**, or from the cog in the tool picker with **Create a new tool set file**. Then add the tools you want in the generated `.jsonc` file.
+## Create a tool set for repeat work
 
-Use tool sets when you want a repeatable setup for a task such as Python work, web research, or repository changes. Tool sets you create show up under **User defined tool sets** in the tool picker.
+In this step, create a reusable tool set for repository cleanup work.
+
+1. Open the Command Palette.
+
+1. Run **Chat: Configure Tool Sets** and select **Create new tool sets file**.
+
+1. In the `.jsonc` file that opens, add the tools you use for the cleanup workflow, such as search, edit, and test tools, plus a `description` and `icon`.
+
+1. Save the file.
+
+1. Return to Chat and select the tool set from **Configure Tools**, or reference it in a prompt by typing `#` followed by the tool set name.
+
+Now try a prompt that uses the saved setup:
+
+```prompt
+Find one small cleanup opportunity in this repository, make the change, and run the focused validation for it.
+```
+
+Tool sets solve the problem of repeatedly rebuilding the same tool selection. They also make reviews easier because the saved file shows which tools are expected for a workflow.
 
 ## Limit tools for a custom agent
 
-When you build a [custom agent](https://code.visualstudio.com/docs/copilot/customization/custom-agents), you can list the tools and tool sets it has access to in the `tools` field of the agent's markdown frontmatter:
+When you build a [custom agent](https://code.visualstudio.com/docs/copilot/customization/custom-agents), you can list the tools and tool sets it has access to in the `tools` field of the agent's Markdown frontmatter:
 
 ```yaml
 ---
@@ -71,15 +123,23 @@ tools: ['search', 'edit', 'pylance', 'runTests']
 ---
 ```
 
-You can also select **Configure Tools** in the agent file to pick tools from a quick pick and have VS Code update the list for you.
+You can also edit the `tools` field directly, or open the tools picker with the **Configure Tools** button in the Chat view and let VS Code update the agent's list for you.
 
-## Manage approvals
+Use a custom agent when the tool boundary is part of the role. For example, a planning agent should not edit files by accident, so give it search and web tools but leave out edit and terminal tools. An implementation agent needs a broader set because its job is to modify code and validate the change.
 
-The permissions picker controls how much autonomy the agent has during a session.
+## Pick a permission level
+
+Next, decide how much review you want before tools run. The permissions picker controls how much autonomy the agent has during a session.
 
 * **Default Approvals** asks before sensitive actions.
 * **Bypass Approvals** auto-approves tool calls.
 * **Autopilot** (Preview) auto-approves tool calls and continues working until the task is done.
+
+Use the mode that matches the risk of the task:
+
+* Use **Default Approvals** while exploring unfamiliar code or when the agent can run commands you want to review.
+* Use **Bypass Approvals** for routine workflows in a trusted workspace after you know which tools will run.
+* Use **Autopilot** for contained tasks where the agent can keep iterating until it reaches a result you can review.
 
 You can keep your preferred mode across sessions with `setting(chat.permissions.default)`. Autopilot is available when `setting(chat.autopilot.enabled)` is on.
 
@@ -88,17 +148,29 @@ You can keep your preferred mode across sessions with `setting(chat.permissions.
 
 ![Screenshot of approval options.](../../docs/copilot/chat/images/copilot-chat/chat-approval-options.png)
 
-## Use sandboxing for risky commands
+## Add sandboxing for terminal work
 
 Agent sandboxing adds OS-level isolation for terminal commands run by the agent. It limits file system and network access, and sandboxed commands are auto-approved because they already run in a controlled environment.
 
 Enable it with `setting(chat.agent.sandbox.enabled)`. On macOS and Linux, you can choose full isolation or file system isolation with network access.
 
-Sandboxing is a good fit for tasks that need terminal access but should not reach beyond the workspace or approved domains.
+Sandboxing is a good fit when the agent needs terminal access but should not reach beyond the workspace or approved domains. For example, use sandboxing before asking the agent to run a generated script, start a local tool, or inspect a project with unfamiliar package scripts.
+
+## Your turn
+
+Try the same repository task three ways:
+
+1. Run it with only repository search and file-reading tools.
+
+1. Add the terminal tool and ask the agent to run one focused validation.
+
+1. Save the tool selection as a tool set and reuse it in a new chat.
+
+After each run, compare what changed. Notice whether the agent stayed focused, asked for missing permissions, or used tools you did not expect.
 
 ## Why this matters
 
-The right tool mix keeps agents focused. A smaller set reduces noise, while approvals and sandboxing help you keep control when the agent can make changes or reach outside the workspace.
+The right tool mix keeps agents focused. Tool sets make good workflows repeatable. Custom agents make tool boundaries part of a role. Approvals and sandboxing help you stay in control when the agent can make changes or reach outside the workspace.
 
 ## What's next
 

--- a/learn/agents/2-extending-agents-with-mcp-servers.md
+++ b/learn/agents/2-extending-agents-with-mcp-servers.md
@@ -1,7 +1,7 @@
 ---
 ContentId: 7a2e1d9c-4b8f-4a3d-8e0c-2f5d6b7c8a02
 DateApproved: 05/21/2026
-MetaDescription: Learn how MCP servers extend agents in VS Code with tools, resources, prompts, and apps.
+MetaDescription: Install, use, configure, and sandbox an MCP server to give VS Code agents focused external capabilities.
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 Keywords:
   - mcp
@@ -14,72 +14,122 @@ Keywords:
 
 # Extending agents with MCP servers
 
-MCP servers connect agents to external tools and data sources. In VS Code, they extend an agent with capabilities such as file operations, database access, API calls, resources, and prompts.
-
-This course shows how to install an MCP server, configure it in your workspace or user profile, secure it with sandboxing, and manage it from VS Code.
+MCP servers connect agents to external tools and data sources. In this guide, you will install an MCP server, use one of its tools in chat, choose the right configuration scope, and decide when to sandbox the server.
 
 ## Prerequisites
 
-Before you start: you'll need VS Code Insiders installed and the GitHub Copilot and GitHub Copilot Chat extensions set up and signed in. You also need access to an MCP server or the ability to add one from the marketplace.
+Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. You also need access to an MCP server or the ability to add one from the marketplace.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)
 
-## What MCP adds
+## Start with a concrete server
 
-[Model Context Protocol](https://modelcontextprotocol.io/) is an open standard maintained by the Linux Foundation, and VS Code has full spec support. Think of MCP as the connector between agents and the external tools, data, and prompts they need.
+For this lesson, use the Playwright MCP server as the example. It gives the agent browser tools so it can open pages, interact with them, and capture screenshots.
 
-MCP is built around three primitives:
+1. Open the Extensions view.
 
-* **Tools**: actions the agent can invoke.
-* **Resources**: context the agent can read.
-* **Prompts**: reusable prompt templates that standardize interactions.
+1. Search for `@mcp playwright`.
 
-Servers can also expose interactive UI through MCP Apps, which render forms or visualizations inline in chat.
+1. Select **Install** to install the Playwright MCP server in your user profile.
 
-## Install an MCP server
+1. When VS Code asks whether you trust the server, review the publisher and server details, then confirm if you trust it.
 
-Use the Extensions view and search for `@mcp` to browse the MCP server gallery. From there, you can install a server in your user profile or in your workspace.
-
-When you install a server, VS Code writes the configuration into `mcp.json` and discovers the server's tools for use in chat.
+When the server starts, VS Code discovers its tools and makes them available in chat.
 
 ![Screenshot showing the MCP servers in the Extensions view.](../../docs/copilot/images/mcp-servers/extensions-view-mcp-servers.png)
 
-## Configure MCP servers
+## Use the server in chat
 
-There are two common configuration scopes:
+Now give the agent a task that actually needs browser access.
 
-* **Workspace**: `.vscode/mcp.json`
-* **User profile**: the user-level `mcp.json` file
+1. Open the Chat view.
 
-Use workspace configuration when you want a server tied to a project. Use user profile configuration when you want the server available across workspaces.
+1. Select **Agent**.
 
-You can also add a server through **MCP: Add Server** or open the user configuration with **MCP: Open User Configuration**. For servers that need credentials, store them in inputs in the user `mcp.json` so secrets are not committed to the workspace.
+1. Select **Configure Tools**.
+
+1. Enable the Playwright tools.
+
+1. Send this prompt:
+
+    ```prompt
+    Go to code.visualstudio.com, decline the cookie banner if it appears, and describe the main navigation items on the homepage.
+    ```
+
+The agent should call the Playwright MCP tools because the task requires browser interaction. If it asks for approval before a tool call, review the action and approve it when it matches the task.
+
+![Screenshot showing an MCP tool invocation in chat with the input and output shown.](../../docs/copilot/images/mcp-servers/chat-agent-mode-tool-invocation.png)
+
+## Decide where the configuration belongs
+
+Installing a server writes configuration to an `mcp.json` file. Choose the scope based on who should use the server.
+
+| Scope | Use it when | Example |
+| --- | --- | --- |
+| User profile | The server is useful across your own workspaces. | A browser automation server or documentation lookup server. |
+| Workspace | The server is part of how the project works. | A project-specific API server or database inspection tool. |
+| Remote user profile | The server must run on a remote machine. | A server that needs access to tools installed in a dev container or remote environment. |
+
+Use **MCP: Open User Configuration** to inspect your user profile configuration. Use **MCP: Open Workspace Folder Configuration** when you want a `.vscode/mcp.json` file for the current project.
+
+For servers that need credentials, do not hardcode secrets in a workspace file. Store sensitive values with input variables or environment files.
 
 > [!TIP]
 > VS Code provides IntelliSense and inline actions for `mcp.json`, which makes it easier to start, stop, and inspect servers.
 
 ![MCP server configuration with lenses to manage server.](../../docs/copilot/images/mcp-servers/mcp-server-config-lenses.png)
 
-## Use an MCP server in chat
+## Learn what MCP can provide
 
-Once a server is installed and enabled, open Chat, switch to **Agent**, and select the server's tools in the tools picker.
+MCP is built around a few capabilities. Each one solves a different problem.
 
-The agent can then call the server's tools when your prompt needs external context or actions. For example, with the Microsoft Learn MCP server enabled, a prompt like "What are the Microsoft Python best practices?" grounds the answer in official documentation by calling the server's tools.
+* **Tools** let the agent take actions, such as opening a browser or querying an API.
+* **Resources** provide read-only context that you attach to a request, such as a database schema or document.
+* **Prompts** provide reusable templates from the server, such as a standard research prompt.
+* **MCP Apps** render interactive UI in chat when a server supports richer input or output.
 
-![Screenshot showing an MCP tool invocation in chat with the input and output shown.](../../docs/copilot/images/mcp-servers/chat-agent-mode-tool-invocation.png)
+Use tools when the agent needs to do something. Use resources when it needs to read something. Use prompts when your team wants a repeatable interaction pattern.
 
-## Secure MCP servers
+## Sandbox a local server
 
 Treat local MCP servers as code that can run on your machine. Review the publisher and configuration before you install one.
 
-By default, MCP tool calls prompt for approval before running, which keeps a human in the loop. For local stdio servers on macOS and Linux, you can enable sandboxing to restrict file system and network access. Sandboxed servers are auto-approved because they already run in a controlled environment.
+By default, MCP tool calls prompt for approval before running, which keeps a human in the loop. For local stdio servers on macOS and Linux, you can enable sandboxing to restrict file system and network access.
 
-For example, with the Playwright MCP server, enabling sandboxing lets the agent navigate pages and run browser tasks without prompting on every step, because the work is isolated from your host.
+Add sandboxing when a server needs useful powers but should stay inside clear boundaries. For example, with the Playwright MCP server, sandboxing lets the agent navigate pages and run browser tasks without prompting on every step because the work is isolated from your host.
 
-If a server needs more access, update the sandbox rules instead of widening access for the whole machine.
+To enable sandboxing for a local stdio server, set `sandboxEnabled` to `true` in the server configuration. If the server needs more access, update the sandbox rules for that server instead of widening access for the whole machine.
+
+```json
+{
+  "servers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/mcp-server-playwright"],
+      "sandboxEnabled": true
+    }
+  }
+}
+```
 
 ![Screenshot showing the MCP server trust prompt.](../../docs/copilot/images/mcp-servers/mcp-server-trust-dialog.png)
+
+## Practice with a second server
+
+After you try Playwright, install a documentation or API-focused MCP server and compare the workflow.
+
+1. Search for `@mcp` in the Extensions view.
+
+1. Pick a server that connects to documentation, issue tracking, or another system you use.
+
+1. Install it in your user profile if it is personal tooling, or in the workspace if the project should share it.
+
+1. Enable its tools in Chat.
+
+1. Ask a prompt that requires that external source.
+
+For example, with a documentation MCP server enabled, ask a question that should be grounded in that documentation instead of the model's general knowledge.
 
 ## Manage MCP servers
 

--- a/learn/agents/2-extending-agents-with-mcp-servers.md
+++ b/learn/agents/2-extending-agents-with-mcp-servers.md
@@ -18,7 +18,7 @@ MCP servers connect agents to external tools and data sources. In this guide, yo
 
 ## Prerequisites
 
-Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. You also need access to an MCP server or the ability to add one from the marketplace.
+Before you start, install VS Code, enable AI features, and sign in to GitHub Copilot. You also need access to an MCP server or the ability to add one from the marketplace.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)

--- a/learn/agents/3-agent-plugins.md
+++ b/learn/agents/3-agent-plugins.md
@@ -18,7 +18,7 @@ Agent plugins bundle multiple customizations into one installable package. In th
 
 ## Prerequisites
 
-Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. Then enable support for agent plugins with `setting(chat.plugins.enabled)`.
+Before you start, install VS Code, enable AI features, and sign in to GitHub Copilot. Then enable support for agent plugins with `setting(chat.plugins.enabled)`.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)

--- a/learn/agents/3-agent-plugins.md
+++ b/learn/agents/3-agent-plugins.md
@@ -1,7 +1,7 @@
 ---
 ContentId: 9c8b7a6d-5e4f-4c3b-9a2d-1f0e2d3c4b05
 DateApproved: 05/21/2026
-MetaDescription: Learn how agent plugins bundle commands, skills, agents, hooks, and MCP servers in VS Code.
+MetaDescription: Practice installing, reviewing, using, and recommending agent plugins for repeatable AI workflows in VS Code.
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 Keywords:
   - plugins
@@ -14,20 +14,26 @@ Keywords:
 
 # Agent plugins
 
-Agent plugins bundle multiple customizations into one installable package. Instead of setting up each capability separately, you can install a plugin that brings commands, skills, custom agents, hooks, and MCP servers into VS Code together.
-
-This course shows how to install plugins, browse available collections, use plugin-provided tools, and share recommended plugins with your team.
+Agent plugins bundle multiple customizations into one installable package. In this guide, you will inspect a plugin before installing it, use a plugin-provided command, and decide when a plugin is a better fit than separate local customizations.
 
 ## Prerequisites
 
-Before you start: you'll need VS Code Insiders installed and the GitHub Copilot and GitHub Copilot Chat extensions set up and signed in. Then enable support for agent plugins in your settings.
+Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. Then enable support for agent plugins with `setting(chat.plugins.enabled)`.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)
 
-## What plugins provide
+## Start with the problem plugins solve
 
-A plugin can include any combination of:
+Imagine your team has a review workflow that uses three pieces:
+
+* A skill that explains how to review changes in your repository.
+* A custom agent that only has read-only tools.
+* An MCP server that looks up issue metadata.
+
+You could ask every teammate to configure those pieces one by one. A plugin packages them together so the workflow can be discovered, installed, updated, and disabled as one unit.
+
+Plugins can include any combination of:
 
 * Slash commands
 * Agent skills
@@ -35,15 +41,29 @@ A plugin can include any combination of:
 * Hooks
 * MCP servers
 
-That makes plugins useful for sharing a team workflow or adopting a prebuilt package of agent behavior.
+Use plugins when the value comes from the pieces working together. Use individual customizations when you only need one small behavior in one workspace.
 
-## Install and manage plugins
+| Use | Good fit | Not a good fit |
+| --- | --- | --- |
+| Plugin | Share a complete workflow across a team. | One personal prompt you rarely reuse. |
+| Skill | Load task-specific instructions, scripts, and resources on demand. | A full workflow that also needs agents, hooks, or MCP servers. |
+| Custom agent | Create a reusable role with its own instructions and tool limits. | A package that should install multiple customization types together. |
 
-Agent plugins are currently in preview. Enable them with `setting(chat.plugins.enabled)` in your user settings before you can install or browse plugins.
+## Browse and inspect a plugin
 
-By default, VS Code discovers plugins from the [copilot-plugins](https://github.com/github/copilot-plugins) and [awesome-copilot](https://github.com/github/awesome-copilot/) marketplaces. You can add more with `setting(chat.plugins.marketplaces)`.
+Agent plugins are currently in preview. After you enable `setting(chat.plugins.enabled)`, VS Code discovers plugins from the [copilot-plugins](https://github.com/github/copilot-plugins) and [awesome-copilot](https://github.com/github/awesome-copilot/) marketplaces by default. You can add more with `setting(chat.plugins.marketplaces)`.
 
-Open the **Agent Customizations** view from the cog in the Chat view, then select **Plugins** in the left menu to browse available plugins.
+1. Open the Chat view.
+
+1. Select the cog, then open **Agent Customizations**.
+
+1. Select **Plugins** in the left menu.
+
+1. Pick a plugin that matches a workflow you recognize, such as testing, code review, or documentation.
+
+1. Before installing, inspect what it includes. Look for skills, agents, hooks, and MCP servers.
+
+1. Install it only if you trust the source and understand what it adds.
 
 From there, you can:
 
@@ -58,22 +78,49 @@ After installation, the plugin's customizations appear alongside your local ones
 
 ![Screenshot of the Agent Plugins - Installed view in the Extensions view.](../../docs/copilot/images/agent-plugins/installed-plugins.png)
 
-## Use plugin-provided customizations
+## Try a plugin command
 
-Plugins can expose custom agents, skills, and MCP servers all in one place. In chat, you can invoke plugin content with slash commands or by selecting the relevant customization from the picker.
+Plugins can expose custom agents, skills, slash commands, and MCP servers all in one place. In chat, you can invoke plugin content with slash commands or by selecting the relevant customization from the picker.
 
 For example, after installing the awesome-copilot plugin, you can run `/awesome-copilot:suggest` to have the plugin look across your project and recommend related collections you can install next.
 
-That makes plugins useful when you want a single install to add a complete workflow, such as a testing package that includes a testing skill, a review agent, and an MCP server for reporting.
+Try this sequence:
+
+1. Open a repository you use for development.
+
+1. Start a new agent chat.
+
+1. Type `/` and find the plugin command.
+
+1. Run the command and review what it recommends.
+
+1. If it recommends more plugins, inspect those plugins before installing them.
+
+The goal is not to install everything. The goal is to see how a plugin can bring a complete workflow into chat with one command.
 
 ![Screenshot of the Agent Customizations editor showing installed plugin content.](../../docs/copilot/images/customization/chat-customizations-editor-plugins.png)
 
 > [!CAUTION]
 > Plugins can run hooks and MCP servers on your machine. Review the contents and publisher before you install one.
 
-## Plugin structure
+## Read the manifest
 
-Plugins are defined by a `plugin.json` manifest and can point to folders for skills, agents, hooks, and MCP server definitions. The plugin format is shared between VS Code, GitHub Copilot CLI, and Claude Code, so a single plugin repository can work across all three tools.
+When you inspect a plugin repository, start with `plugin.json`. The manifest defines the plugin identity and points to the folders that contain skills, agents, hooks, and MCP server definitions.
+
+Look for fields like these:
+
+```json
+{
+    "name": "team-review-tools",
+    "description": "Review workflow for the team repository",
+    "skills": "skills/",
+    "agents": "agents/",
+    "hooks": "hooks.json",
+    "mcpServers": ".mcp.json"
+}
+```
+
+This step matters because plugins can run hooks and MCP servers on your machine. The manifest tells you where to inspect the behavior before you trust it.
 
 ## Share recommended plugins
 
@@ -97,9 +144,21 @@ To share a curated set of plugins with your team, add an `extraKnownMarketplaces
 
 Use this approach when you want consistent tooling across a team without forcing a plugin into every workspace. VS Code shows a notification the first time a chat message is sent, and team members can also view the recommended plugins from the Extensions view with the `@agentPlugins @recommended` filter.
 
+## Your turn
+
+Choose one workflow you repeat in your team or personal projects. Then decide how you would package it.
+
+1. If it needs one instruction set, write down the skill you would create.
+
+1. If it needs a role with a fixed tool boundary, write down the custom agent you would create.
+
+1. If it needs several customizations working together, sketch a plugin manifest.
+
+You do not need to publish a plugin for this exercise. The goal is to practice identifying when a bundle is useful.
+
 ## Why this matters
 
-Plugins turn a set of related customizations into one package. That makes it easier to share a workflow, install a collection once, and keep teammates aligned on the same agent behavior.
+Plugins turn a set of related customizations into one package. That makes a workflow easier to discover, install, review, disable, and recommend to teammates.
 
 ## What's next
 

--- a/learn/agents/4-using-third-party-agents-in-vs-code.md
+++ b/learn/agents/4-using-third-party-agents-in-vs-code.md
@@ -1,7 +1,7 @@
 ---
 ContentId: 1e2d3c4b-5a6f-4d7e-8c9b-0a1b2c3d4e06
 DateApproved: 05/21/2026
-MetaDescription: Learn how to use third-party agents like Claude and Codex in VS Code with your GitHub Copilot subscription.
+MetaDescription: Start Claude and Codex agent sessions in VS Code and choose local or cloud workflows for coding tasks.
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 Keywords:
   - third-party agents
@@ -14,51 +14,86 @@ Keywords:
 
 # Using third-party agents in VS Code
 
-Third-party agents let you use provider-specific agent experiences inside VS Code while keeping your work in the same editor and session flow. This course introduces the available agent types, how to start a session, and what to watch for when you use them.
+Third-party agents let you use provider-specific agent experiences inside VS Code. In this guide, you will choose between local and cloud sessions, start a Claude or Codex session, and pick a permission mode that matches the task.
 
 ## Prerequisites
 
-Before you start: you'll need VS Code Insiders installed and the GitHub Copilot and GitHub Copilot Chat extensions set up and signed in. For cloud partner agents, make sure they are enabled in your GitHub Copilot settings. For Codex, install the OpenAI Codex extension.
+Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. For cloud partner agents, follow the GitHub documentation to enable third-party coding agents for your account. You do not need the provider's VS Code extension for cloud partner agents. For local Codex sessions, install the OpenAI Codex extension.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)
 
-## What third-party agents are
+## Choose the session type
 
-Third-party agents come from providers such as Anthropic and OpenAI. They use the provider's SDK and agent harness, and they can work locally or in the cloud depending on the provider and your Copilot setup.
+Third-party agents come from providers such as Anthropic and OpenAI. VS Code uses the provider's SDK and agent harness, while keeping the session in the VS Code chat experience.
 
 Cloud-based third-party agents are currently in preview.
 
-## Why use them
+Before starting, decide which kind of session fits the task.
 
-Third-party agents let you keep your workflow in VS Code while using provider-specific capabilities. That gives you:
+| Session type | Use it when | Example |
+| --- | --- | --- |
+| Local third-party agent | You want the provider agent to work directly in your local workspace. | Ask Claude to refactor a small module and run local tests. |
+| Cloud partner agent | You want a provider agent to work in a cloud session through your Copilot setup. | Hand off a longer coding task that can run away from your editor. |
+| Built-in VS Code agent | You want the standard VS Code agent with your current tool selection and customizations. | Make a focused edit using selected tools and approvals. |
 
-* The provider's agent behavior and SDK.
-* A single chat experience inside the editor.
-* The ability to debug, test, and code without switching tools.
+Use third-party agents when you specifically want the provider's agent behavior or SDK. Use the built-in VS Code agent when the task mainly depends on VS Code tools, custom agents, tool sets, or the approval model you already configured.
 
-## Start a session
+## Start a Claude session
 
-Open the Chat view, select **New Chat**, and choose the agent type from the **Session Type** dropdown.
+Try Claude with a contained task first, such as asking it to inspect a small feature and propose a plan.
 
-For cloud sessions, first select **Cloud**, then choose the partner agent from the **Partner Agent** dropdown.
+1. Open the Chat view.
+
+1. Select **New Chat**.
+
+1. For a local session, choose **Claude** from the **Session Type** dropdown.
+
+1. For a cloud session, choose **Cloud** from the **Session Type** dropdown, then choose **Claude** from the **Partner Agent** dropdown.
+
+1. Send a prompt that defines the desired scope.
+
+```prompt
+Inspect the current branch and propose a plan for one small refactor. Do not edit files yet.
+```
 
 ![Screenshot showing session type dropdown with Claude agent option selected.](../../docs/copilot/images/third-party-agents/claude-agent-new-chat-1.121.png)
 
-For Codex, install the [OpenAI Codex](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt) extension first. You can then open the Codex view from its activity bar icon or switch to the **Codex** tab in the Chat view.
+Starting with a planning prompt gives you a low-risk way to see how the provider agent approaches the repository before it changes files.
+
+## Start a Codex session
+
+Use Codex when you want OpenAI Codex agent behavior for a coding task. Cloud Codex sessions use the cloud partner flow. Local Codex sessions require the [OpenAI Codex](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt) extension and a Copilot Pro+ subscription for authentication.
+
+1. Open the Chat view.
+
+1. Select **New Chat**.
+
+1. For a local session, choose **Codex** from the **Session Type** dropdown.
+
+1. For a cloud session, choose **Cloud** from the **Session Type** dropdown, then choose **Codex** from the **Partner Agent** dropdown.
+
+1. Send a focused coding task.
+
+```prompt
+Find one failing or missing test around the current change, add the smallest useful test, and explain how to validate it.
+```
 
 ## Claude agent slash commands
 
 Inside a Claude session, type `/` in the chat input to see the available commands.
 
 | Slash command | Description |
-|---------------|-------------|
+| --- | --- |
 | `/agents` | Wizard for creating and managing Claude sub-agents. |
 | `/hooks` | Configure lifecycle hooks that run at key points during a session. |
 | `/memory` | Open and edit the `CLAUDE.md` memory file used across sessions. |
 | `/init` | Initialize a new `CLAUDE.md` memory file for the project. |
+| `/pr-comments` | Get comments from a pull request. |
 | `/review` | Review code changes in a pull request. |
 | `/security-review` | Run a security review on pending changes. |
+
+Try one command after you start a Claude session. For example, use `/review` when you want Claude to inspect pending changes, or use `/init` when you want it to create project memory for future Claude sessions.
 
 ## Enable cloud partner agents
 
@@ -74,26 +109,38 @@ Claude agent runs with one of three permission modes that you can pick from the 
 * **Request approval**: Claude asks for your review before making changes.
 * **Plan**: Claude outlines its intended approach before starting work.
 
-Pick the mode that matches the task and your risk tolerance. For sensitive work, keep approval in the loop and combine the agent with sandboxing when possible.
+Pick the mode that matches the task:
+
+* Use **Plan** when you are exploring an unfamiliar area or want to review the approach first.
+* Use **Request approval** when the agent can edit files, but you want to approve changes before they land.
+* Use **Edit automatically** for contained work where you are comfortable reviewing the final diff after the agent iterates.
+
+For sensitive work, keep approval in the loop and combine the agent with sandboxing when possible.
 
 ![Screenshot showing Claude agent permission mode options.](../../docs/copilot/images/third-party-agents/claude-agent-permission-modes.png)
 
 > [!CAUTION]
 > The `setting(github.copilot.chat.claudeAgent.allowDangerouslySkipPermissions)` setting bypasses all permission checks. Only enable it in isolated sandbox environments with no internet access.
 
-## Learn more about Claude and Codex
+## Compare the result
 
-Claude sessions use Anthropic's Claude Agent SDK and are available through your Copilot subscription. Codex sessions use the OpenAI Codex extension and authenticate with a Copilot Pro+ subscription, with no extra setup required.
+Run the same small planning prompt in two places:
 
-Use either provider when you want to stay in VS Code and still take advantage of a third-party agent's own model and harness.
+1. Start with the built-in VS Code agent.
+
+1. Run the same prompt in Claude or Codex.
+
+1. Compare the plan, tool use, and amount of control you had during the session.
+
+This comparison helps you decide when a provider-specific agent adds value and when the built-in agent is enough.
 
 ## Why this matters
 
-Third-party agents let you keep your coding workflow in one place while still using provider-specific capabilities. That reduces context switching and keeps debugging, testing, and editing inside VS Code.
+Third-party agents let you keep your coding workflow in one place while still using provider-specific capabilities. The practical choice is not "which agent is best," but which session type fits the work, risk, and amount of review you want.
 
 ## What's next
 
-You now have the four course topics covered. The next step is to fill in each page with the final transcript details, screenshots, and video embeds.
+You now have the four course topics covered. Review the tool choices, MCP server setup, plugin packaging, and third-party agent session types, then apply the smallest setup that fits your next real task.
 
 ## Learn more
 

--- a/learn/agents/4-using-third-party-agents-in-vs-code.md
+++ b/learn/agents/4-using-third-party-agents-in-vs-code.md
@@ -18,7 +18,7 @@ Third-party agents let you use provider-specific agent experiences inside VS Cod
 
 ## Prerequisites
 
-Before you start, install VS Code Insiders, enable AI features, and sign in to GitHub Copilot. For cloud partner agents, follow the GitHub documentation to enable third-party coding agents for your account. You do not need the provider's VS Code extension for cloud partner agents. For local Codex sessions, install the OpenAI Codex extension.
+Before you start, install VS Code, enable AI features, and sign in to GitHub Copilot. For cloud partner agents, follow the GitHub documentation to enable third-party coding agents for your account. You do not need the provider's VS Code extension for cloud partner agents. For local Codex sessions, install the OpenAI Codex extension.
 
 * [Download VS Code](https://code.visualstudio.com/)
 * [Set up GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview#_step-1-set-up-copilot)


### PR DESCRIPTION
This PR layers a deep fact-verification and tutorial-polish pass on top of `learn-course-3` so the diff clearly shows the improvements to the four agent course pages.

## What changed

Each page was rewritten from recap-style to a hands-on, tutorial style and verified against the canonical in-repo docs under `docs/copilot/`.

### Fact-check corrections
- **MCP (page 2):** Re-indented the nested prompt code block so it renders inside its numbered step.
- **Tools (page 1):** Matched the exact UI flow — **Chat: Configure Tool Sets** → **Create new tool sets file** (`.jsonc`) — and corrected the **Configure Tools** guidance to the documented behavior (button in the Chat input / editing the `tools` field).
- **Third-party agents (page 4):** Added the **Copilot Pro+** subscription requirement for local Codex sessions.

### Verified accurate against `docs/copilot/`
- Tool types, permission levels, and sandbox values (`off`/`on`/`allowNetwork`) — [agent-tools.md](https://github.com/microsoft/vscode-docs/blob/main/docs/copilot/agents/agent-tools.md)
- Playwright package `@microsoft/mcp-server-playwright` and `sandboxEnabled` schema — mcp-servers.md
- plugin.json fields, marketplaces, `extraKnownMarketplaces`/`enabledPlugins` — agent-plugins.md
- Slash commands, permission modes, Session Type / Partner Agent dropdowns, `openai.chatgpt` extension — third-party-agents.md
- All referenced image paths exist in the repo.

All four files pass markdown lint (editor diagnostics) with no errors.

Base branch is `learn-course-3` so reviewers can see just these refinements.