### PR TITLE
Remove an erroneous comma from `faq.md`.

### DIFF
--- a/docs/supporting/faq.md
+++ b/docs/supporting/faq.md
@@ -366,7 +366,7 @@ When VS Code is launched from a terminal (for example, via `code .`), it has acc
 
 However, when launching from your platform's user interface (for example, the VS Code icon in the macOS dock), you normally are not running in the context of a shell and you don't have access to those environment settings. This means that depending on how you launch VS Code, you may not have the same environment.
 
-To work around this, when launched via a UI gesture, VS Code will start a small process to run (or "resolve") the shell environment defined in your, `.bashrc`, `.zshrc`, or PowerShell profile files. If, after a configurable timeout (via `application.shellEnvironmentResolutionTimeout`, defaults to 10 seconds), the shell environment has still not been resolved or resolving failed for any other reason, VS Code will abort the "resolve" process, launch without your shell's environment settings, and you will see an error like the following:
+To work around this, when launched via a UI gesture, VS Code will start a small process to run (or "resolve") the shell environment defined in your `.bashrc`, `.zshrc`, or PowerShell profile files. If, after a configurable timeout (via `application.shellEnvironmentResolutionTimeout`, defaults to 10 seconds), the shell environment has still not been resolved or resolving failed for any other reason, VS Code will abort the "resolve" process, launch without your shell's environment settings, and you will see an error like the following:
 
 ![Shell environment startup error](images/faq/shell-env-error.png)
 


### PR DESCRIPTION
Whilst diagnosing [`vscode/issues/320001#issue-4591929188`](https://github.com/microsoft/vscode/issues/320001#issue-4591929188), I noticed:

https://github.com/microsoft/vscode-docs/blob/cbf89afd48c3ab7dde9d335b79fdac39f7bc9ade/docs/supporting/faq.md#L369

It's not an Oxford comma. It's merely incorrect.