### PR TITLE
Document search exclusion settings for agent text search and grep

### DIFF
--- a/docs/agents/best-practices.md
+++ b/docs/agents/best-practices.md
@@ -33,6 +33,7 @@ Tips for effective project configuration:
 * **Keep instruction files concise.** They load on every chat interaction. Focus on information the AI can't infer from code, such as non-default conventions, architectural decisions, or environment setup.
 * **Scope instructions with `applyTo` patterns.** Enter `/instructions` to create language-specific or folder-specific instruction files instead of putting everything in one file.
 * **Limit enabled tools.** Fewer active tools means faster, more relevant responses. Enable tools only when the task needs them.
+* **Exclude generated and noisy files from search.** Configure `setting(search.exclude)` and `setting(files.exclude)` so agent text search and grep stay focused on source code. See [improve agent search with exclusion settings](/docs/agents/reference/workspace-context.md#improve-agent-search-with-exclusion-settings).
 
 For full setup details, see the [customization overview](/docs/agent-customization/overview.md).
 

--- a/docs/agents/guides/optimize-usage.md
+++ b/docs/agents/guides/optimize-usage.md
@@ -65,12 +65,15 @@ For more information, see [Use tools in chat](/docs/chat/chat-tools.md).
 
 ## Exclude files from Copilot context
 
-Large generated files, build outputs, or irrelevant directories can be included in the AI context, increasing token usage without adding value. Exclude these files to reduce unnecessary context:
+Large generated files, build outputs, or irrelevant directories can increase token usage without adding value. Exclude these files to keep agent context focused:
 
-* Use a `.gitignore` file to exclude files from the [workspace index](/docs/agents/reference/workspace-context.md#what-content-is-included-in-the-semantic-index). The workspace index respects `.gitignore` rules.
-* Use the `setting(files.exclude)` setting to hide files from VS Code entirely, which also excludes them from the index.
+* Use a `.gitignore` file to exclude files from the [workspace index](/docs/agents/reference/workspace-context.md#what-content-is-included-in-the-semantic-index) and from agent text search and grep.
+* Use the `setting(files.exclude)` setting to hide files from VS Code entirely, which also excludes them from the index and agent search tools.
+* Use the `setting(search.exclude)` setting to exclude files from agent text search and grep while keeping them visible in the Explorer, for example log files you want to open manually but not include in search results.
 
-For more information, see [workspace context](/docs/agents/reference/workspace-context.md).
+Search match snippets count toward the context window even when the agent doesn't open the matched file. Excluding noisy paths reduces irrelevant tokens in search results.
+
+For more information and example configurations, see [improve agent search with exclusion settings](/docs/agents/reference/workspace-context.md#improve-agent-search-with-exclusion-settings).
 
 ## Manage context with compaction
 

--- a/docs/agents/reference/workspace-context.md
+++ b/docs/agents/reference/workspace-context.md
@@ -17,8 +17,6 @@ Keywords:
 - grep
 - text search
 - agentic search
-- files.exclude
-- search.exclude
 ---
 
 # How Copilot understands your workspace
@@ -81,7 +79,7 @@ Agents search through the same sources a developer would use when navigating a c
 
 ### Improve agent search with exclusion settings
 
-When an agent searches your workspace with **text search** or **grep**, every match returned becomes part of the conversation context, even if the agent never opens the file. Generated files, build artifacts, logs, and large datasets can produce many irrelevant matches that bury useful results and fill the context window with noise.
+When an agent searches your workspace with text search or grep, every match returned becomes part of the conversation context, even if the agent never opens the file. Generated files, build artifacts, logs, and large datasets can produce many irrelevant matches that fill the context window with noise.
 
 Configure exclusion settings to keep agent searches focused on source code you care about:
 
@@ -93,38 +91,8 @@ Strict exclusions improve search relevance, speed up searches over large workspa
 
 Add exclusion patterns to your [workspace settings](/docs/configure/settings.md). Patterns use [glob syntax](/docs/editor/glob-patterns.md).
 
-**Node.js**
-
-```json
-"search.exclude": {
-  "**/node_modules": true,
-  "**/dist": true,
-  "**/coverage": true
-}
-```
-
-**Python**
-
-```json
-"search.exclude": {
-  "**/__pycache__": true,
-  "**/.venv": true,
-  "**/.pytest_cache": true
-}
-```
-
-**AI and data projects**
-
-```json
-"search.exclude": {
-  "**/*.jsonl": true,
-  "**/*.parquet": true,
-  "**/datasets/**": true
-}
-```
-
 > [!TIP]
-> When a text search returns no results because of exclusion settings, the agent receives a hint and can search ignored paths if needed, for example when investigating a dependency in `node_modules`.
+> When a text search returns no results, the agent receives a hint that the pattern may be excluded, for example when investigating a dependency in `node_modules`.
 
 ## Semantic search
 

--- a/docs/agents/reference/workspace-context.md
+++ b/docs/agents/reference/workspace-context.md
@@ -17,6 +17,8 @@ Keywords:
 - grep
 - text search
 - agentic search
+- files.exclude
+- search.exclude
 ---
 
 # How Copilot understands your workspace
@@ -76,6 +78,53 @@ Agents search through the same sources a developer would use when navigating a c
 
 > [!IMPORTANT]
 > `.gitignore` is bypassed if you have a file open or have text selected within an ignored file.
+
+### Improve agent search with exclusion settings
+
+When an agent searches your workspace with **text search** or **grep**, every match returned becomes part of the conversation context, even if the agent never opens the file. Generated files, build artifacts, logs, and large datasets can produce many irrelevant matches that bury useful results and fill the context window with noise.
+
+Configure exclusion settings to keep agent searches focused on source code you care about:
+
+* **`.gitignore`**: excludes files from text search, grep, and the [semantic index](#what-content-is-included-in-the-semantic-index).
+* **`setting(files.exclude)`**: hides files from the Explorer and excludes them from text search, grep, and the semantic index.
+* **`setting(search.exclude)`**: excludes files from text search and grep while keeping them visible in the Explorer.
+
+Strict exclusions improve search relevance, speed up searches over large workspaces, and reduce the tokens consumed by search results. This also helps [manage AI credit usage](/docs/agents/guides/optimize-usage.md#exclude-files-from-copilot-context).
+
+Add exclusion patterns to your [workspace settings](/docs/configure/settings.md). Patterns use [glob syntax](/docs/editor/glob-patterns.md).
+
+**Node.js**
+
+```json
+"search.exclude": {
+  "**/node_modules": true,
+  "**/dist": true,
+  "**/coverage": true
+}
+```
+
+**Python**
+
+```json
+"search.exclude": {
+  "**/__pycache__": true,
+  "**/.venv": true,
+  "**/.pytest_cache": true
+}
+```
+
+**AI and data projects**
+
+```json
+"search.exclude": {
+  "**/*.jsonl": true,
+  "**/*.parquet": true,
+  "**/datasets/**": true
+}
+```
+
+> [!TIP]
+> When a text search returns no results because of exclusion settings, the agent receives a hint and can search ignored paths if needed, for example when investigating a dependency in `node_modules`.
 
 ## Semantic search
 


### PR DESCRIPTION
## Summary
- Add guidance on how `files.exclude`, `search.exclude`, and `.gitignore` affect agent text search and grep
- Explain that search match snippets consume agent context, not just opened files
- Include example exclusion configs for Node.js, Python, and AI/data projects
- Cross-link from optimize-usage and best-practices guides

Fixes #9898

## Test plan
- [ ] Verify links resolve correctly on the docs site
- [ ] Review wording with docs team for accuracy of text search/grep exclusion behavior


Made with [Cursor](https://cursor.com)