### PR TITLE
docs(tutorial): remove hardcoded gpt-4o family from selectChatModels example

### DIFF
--- a/api/extension-guides/ai/language-model-tutorial.md
+++ b/api/extension-guides/ai/language-model-tutorial.md
@@ -154,11 +154,8 @@ const disposable = vscode.commands.registerTextEditorCommand('code-tutor.annotat
   // Get the code with line numbers from the current editor
   const codeWithLineNumbers = getVisibleCodeWithLineNumbers(textEditor);
 
-  // select the 4o chat model
-  let [model] = await vscode.lm.selectChatModels({
-    vendor: 'copilot',
-    family: 'gpt-4o',
-  });
+  // select a Copilot chat model
+  let [model] = await vscode.lm.selectChatModels({ vendor: 'copilot' });
 });
 ```
 
@@ -181,11 +178,8 @@ const disposable = vscode.commands.registerTextEditorCommand('code-tutor.annotat
   // Get the code with line numbers from the current editor
   const codeWithLineNumbers = getVisibleCodeWithLineNumbers(textEditor);
 
-  // select the 4o chat model
-  let [model] = await vscode.lm.selectChatModels({
-    vendor: 'copilot',
-    family: 'gpt-4o',
-  });
+  // select a Copilot chat model
+  let [model] = await vscode.lm.selectChatModels({ vendor: 'copilot' });
 
   // init the chat message
   const messages = [
@@ -203,11 +197,8 @@ const disposable = vscode.commands.registerTextEditorCommand('code-tutor.annotat
   // Get the code with line numbers from the current editor
   const codeWithLineNumbers = getVisibleCodeWithLineNumbers(textEditor);
 
-  // select the 4o chat model
-  let [model] = await vscode.lm.selectChatModels({
-    vendor: 'copilot',
-    family: 'gpt-4o',
-  });
+  // select a Copilot chat model
+  let [model] = await vscode.lm.selectChatModels({ vendor: 'copilot' });
 
   // init the chat message
   const messages = [


### PR DESCRIPTION
## Summary

Fixes #9312

The Language Model tutorial had three `selectChatModels` calls using a hardcoded `family: "gpt-4o"` selector.

## Why this is a bug

1. **Brittle tutorial code** — if `gpt-4o` is deprecated or renamed, `selectChatModels` silently returns `[]`. Developers following this tutorial may never know why their extension stopped working.
2. **Inconsistent with API guidance** — `language-model.md` already recommends `{ vendor: "copilot" }` to let VS Code pick the best available model automatically.
3. **Stale comment** — `// select the 4o chat model` implied a specific model was being selected.

## Change (3 occurrences fixed)

```diff
- // select the 4o chat model
- let [model] = await vscode.lm.selectChatModels({
-   vendor: 'copilot',
-   family: 'gpt-4o',
- });
+ // select a Copilot chat model
+ let [model] = await vscode.lm.selectChatModels({ vendor: 'copilot' });
```

## Type of change

- [x] Documentation fix (API doc-bug)

Docs-only. Zero code changes.

Signed-off-by: webdevpraveen <pr4veensingh@proton.me>