### PR TITLE
Remove preview/experimental labels from agent plugin docs

### DIFF
--- a/docs/agent-customization/agent-plugins.md
+++ b/docs/agent-customization/agent-plugins.md
@@ -21,7 +21,7 @@ Agent plugins are prepackaged bundles of agent customizations that you can disco
 Plugins work alongside your locally defined customizations. When you install a plugin, its commands, skills, agents, hooks, and MCP servers appear in chat.
 
 > [!NOTE]
-> Agent plugins are currently in preview. Enable or disable support for agent plugins with the `setting(chat.plugins.enabled)` setting.
+> Enable or disable support for agent plugins with the `setting(chat.plugins.enabled)` setting.
 
 ## What plugins provide
 

--- a/docs/agents/reference/ai-settings.md
+++ b/docs/agents/reference/ai-settings.md
@@ -236,9 +236,9 @@ The [Agents view](/docs/agents/overview.md) provides a centralized location for 
 
 | Setting and Description | Default |
 |------------------------|---------------|
-| `setting(chat.plugins.enabled)` _(Preview)_<br/>Enable or disable support for [agent plugins](/docs/agent-customization/agent-plugins.md). | `false` |
+| `setting(chat.plugins.enabled)`<br/>Enable or disable support for [agent plugins](/docs/agent-customization/agent-plugins.md). | `false` |
 | `setting(chat.plugins.marketplaces)` _(Experimental)_<br/>Configure additional plugin marketplace Git repositories for discovering agent plugins. | `["github/copilot-plugins", "github/awesome-copilot"]` |
-| `setting(chat.plugins.enabledPlugins)` _(Experimental)_<br/>Allowlist of plugin IDs to enable or disable. Can be [centrally managed through enterprise policy](/docs/enterprise/ai-settings.md#manage-agent-plugins-and-marketplaces). | `{}` |
+| `setting(chat.plugins.enabledPlugins)`<br/>Allowlist of plugin IDs to enable or disable. Can be [centrally managed through enterprise policy](/docs/enterprise/ai-settings.md#manage-agent-plugins-and-marketplaces). | `{}` |
 | `setting(chat.plugins.strictMarketplaces)` _(Experimental)_<br/>Trust only marketplaces supplied by [enterprise policy](/docs/enterprise/ai-settings.md#manage-agent-plugins-and-marketplaces). | `false` |
 | `setting(chat.pluginLocations)` _(Experimental)_<br/>Register locally cloned or downloaded agent plugins by mapping directory paths to an enabled or disabled state. | `{}` |
 

--- a/learn/agents/3-agent-plugins.md
+++ b/learn/agents/3-agent-plugins.md
@@ -51,7 +51,7 @@ Use plugins when the value comes from the pieces working together. Use individua
 
 ## Browse and inspect a plugin
 
-Agent plugins are currently in preview. After you enable `setting(chat.plugins.enabled)`, VS Code discovers plugins from the [copilot-plugins](https://github.com/github/copilot-plugins) and [awesome-copilot](https://github.com/github/awesome-copilot/) marketplaces by default. You can add more with `setting(chat.plugins.marketplaces)`.
+After you enable `setting(chat.plugins.enabled)`, VS Code discovers plugins from the [copilot-plugins](https://github.com/github/copilot-plugins) and [awesome-copilot](https://github.com/github/awesome-copilot/) marketplaces by default. You can add more with `setting(chat.plugins.marketplaces)`.
 
 1. Open the Chat view.
 


### PR DESCRIPTION
Agent plugins are no longer in preview. This updates the documentation to reflect [microsoft/vscode#321495](https://github.com/microsoft/vscode/pull/321495), which removed the `preview` and `experimental` tags from the `chat.plugins.enabled`, `chat.plugins.enabledPlugins`, and `chat.plugins.extraMarketplaces` settings.

Changes:

* Removed `_(Preview)_` and `_(Experimental)_` annotations from the settings table in `docs/agents/reference/ai-settings.md`
* Removed the "currently in preview" NOTE blockquote from `docs/agent-customization/agent-plugins.md`
* Removed "currently in preview" phrasing from `learn/agents/3-agent-plugins.md`