### PR TITLE
Add MCP OAuth and enterprise-managed auth (XAA) release notes for 1.123

### DIFF
--- a/release-notes/v1_123.md
+++ b/release-notes/v1_123.md
@@ -55,6 +55,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
       <li><a href="#agents">Agents</a></li>
       <li><a href="#language-models">Language Models</a></li>
       <li><a href="#integrated-browser">Integrated Browser</a></li>
+      <li><a href="#mcp">MCP</a></li>
       <li><a href="#editor-experience">Editor Experience</a></li>
       <li><a href="#thank-you">Thank you</a></li>
     </ul>
@@ -159,6 +160,41 @@ This release, we added two related features:
 * **Add Full Page Screenshot to Chat (Experimental)**: Take a screenshot of the entire web page, even beyond what is shown in the current viewport, and add that screenshot as chat context. This experimental feature requires enabling the `setting(workbench.browser.experimentalUserTools.enabled)` setting.
 
 ![Screenshot of the integrated browser's Add to Chat menu showing the "Add Area Screenshot to Chat" and "Add Full Page Screenshot to Chat (Experimental)" options, with the captured screenshots attached as context in the Chat view.](images/1_123/browser-screenshot-area-fullpage.webp)
+
+## MCP
+
+### Configure OAuth client credentials in mcp.json
+
+Some MCP servers expect you to authenticate with a specific, pre-registered OAuth client instead of relying on Dynamic Client Registration. You can now specify a client ID directly in the `oauth` section of an MCP server entry in `mcp.json`:
+
+```json
+"my-mcp-server": {
+  "url": "https://mcp.example.com/mcp",
+  "type": "http",
+  "oauth": {
+    "clientId": "your-client-id"
+  }
+}
+```
+
+When a client ID is set, VS Code uses it during the OAuth flow instead of registering a new client, so you can bring your own pre-registered client configuration.
+
+Some MCP servers also require a client secret alongside the public client ID. You can now store a client secret in VS Code's OS-backed secret storage, where it stays encrypted instead of sitting in plaintext config.
+
+When an MCP server entry in `mcp.json` has an `oauth.clientId`, a **Set Client Secret** CodeLens appears above it. Selecting it lets you enter the secret, which is stored securely and scoped to the server URL and client ID (so two servers with the same name in different configs never collide). Once a secret is stored, the CodeLens flips to **Replace Client Secret**, and you can reveal, replace, or delete it at any time.
+
+### Enterprise-managed MCP authentication (Preview)
+
+If your organization centralizes sign-in at a single identity provider (like Entra, Okta, or Auth0), you probably don't want every MCP server running its own Dynamic Client Registration against its own authorization server. This release adds a cross-app authorization (XAA) flow that lets you authenticate once against your enterprise IdP, and then VS Code mints a per-resource token for each MCP server on your behalf.
+
+Under the hood, VS Code exchanges your IdP identity for a resource-scoped assertion using [ID-JAG](https://www.ietf.org/archive/id/draft-ietf-oauth-identity-assertion-authz-grant-03.txt) (cross-app access), and then redeems that assertion at the MCP server's authorization server for an access token. The result is that users sign in a single time, and there's no per-server client registration to manage.
+
+> **Note**: ID-JAG is still an emerging standard and isn't widely adopted yet, but we believe it's the future of cross-app authorization. To learn more about XAA and try it against a sample IdP, resource authorization server, and MCP server, see [xaa.dev](https://xaa.dev).
+
+There are two pieces to set this up:
+
+* Admins configure the IdP through the policy-managed `mcp.enterpriseManagedAuth.idp` setting. Because it's policy-backed, it's primarily delivered through Windows Group Policy, macOS managed preferences, or Linux `/etc/vscode/policy.json`, and it never syncs.
+* Individual MCP servers opt in to the flow by setting `"enterpriseManaged": true` in their `oauth` block in `mcp.json`. When that flag is present, VS Code routes the server through the XAA provider instead of the standard per-server registration path.
 
 ## Editor Experience
 


### PR DESCRIPTION
Adds a new **MCP** section to the 1.123 release notes covering the MCP authentication work:

- **Configure OAuth client credentials in `mcp.json`** — specify a client ID in the `oauth` section ([microsoft/vscode#308648](https://github.com/microsoft/vscode/pull/308648)) and store a client secret in OS-backed secret storage via a CodeLens ([microsoft/vscode#317950](https://github.com/microsoft/vscode/pull/317950)).
- **Enterprise-managed MCP authentication (Preview)** — cross-app authorization (XAA) flow using ID-JAG so users authenticate once against an enterprise IdP ([microsoft/vscode#318067](https://github.com/microsoft/vscode/pull/318067), [microsoft/vscode#319041](https://github.com/microsoft/vscode/pull/319041)). Includes a note that ID-JAG is still emerging but is the future of cross-app auth, pointing to [xaa.dev](https://xaa.dev).

Also adds the MCP entry to the in-page TOC nav.

> Note: the client ID/secret PRs shipped in earlier milestones (1.116 / 1.122); they're grouped here intentionally to tell the full MCP auth story alongside XAA in 1.123.