### PR TITLE
Update Edit mode removal version from 1.125 to 1.126

### DIFF
--- a/release-notes/v1_110.md
+++ b/release-notes/v1_110.md
@@ -736,7 +736,7 @@ This migration has both simplified and sped up our builds. There are only a hand
 
 ### New deprecations in this release
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ### Upcoming deprecations
 

--- a/release-notes/v1_111.md
+++ b/release-notes/v1_111.md
@@ -170,7 +170,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Notable fixes
 

--- a/release-notes/v1_112.md
+++ b/release-notes/v1_112.md
@@ -268,7 +268,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Notable fixes
 

--- a/release-notes/v1_113.md
+++ b/release-notes/v1_113.md
@@ -240,7 +240,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Thank you
 

--- a/release-notes/v1_114.md
+++ b/release-notes/v1_114.md
@@ -199,7 +199,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Notable fixes
 

--- a/release-notes/v1_115.md
+++ b/release-notes/v1_115.md
@@ -133,7 +133,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Notable fixes
 

--- a/release-notes/v1_116.md
+++ b/release-notes/v1_116.md
@@ -272,7 +272,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Thank you
 

--- a/release-notes/v1_118.md
+++ b/release-notes/v1_118.md
@@ -337,7 +337,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Thank you
 

--- a/release-notes/v1_119.md
+++ b/release-notes/v1_119.md
@@ -244,7 +244,7 @@ None
 
 ### Upcoming deprecations
 
-* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.125. Beginning with version 1.125, Edit Mode will be fully removed and can no longer be enabled via settings.
+* **Edit Mode** is officially deprecated as of VS Code version 1.110. Users can temporarily re-enable Edit Mode via VS Code setting `setting(chat.editMode.hidden)`. This setting will remain supported through version 1.126. Beginning with version 1.126, Edit Mode will be fully removed and can no longer be enabled via settings.
 
 ## Thank you
 


### PR DESCRIPTION
## Why

The release notes previously stated that Edit mode would be fully removed beginning with version 1.125. That timeline has shifted to 1.126, so the deprecation notes need to reflect the corrected version.

## What changed

Updated the recurring Edit mode deprecation note across the release notes where it appeared, changing both references (the "remain supported through version" and "Beginning with version" sentences) from 1.125 to 1.126.

Affected files:

* `release-notes/v1_110.md`
* `release-notes/v1_111.md`
* `release-notes/v1_112.md`
* `release-notes/v1_113.md`
* `release-notes/v1_114.md`
* `release-notes/v1_115.md`
* `release-notes/v1_116.md`
* `release-notes/v1_118.md`
* `release-notes/v1_119.md`

## Notes

The `docs/`, `api/`, `blogs/`, and `learn/` content folders and the 1.120+ release notes were checked and contained no Edit mode deprecation references tied to 1.125, so no changes were needed there.

cc/ @benibenj 