### PR TITLE
Proposal: add a "Changes in settings" table to release notes (#9742)

### DIFF
--- a/release-notes/v1_126.md
+++ b/release-notes/v1_126.md
@@ -46,6 +46,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#changes-in-settings">Changes in settings</a></li>
       <li><a href="#cost-management">Cost management</a></li>
       <li><a href="#language-models">Language models</a></li>
       <li><a href="#agents-window-preview">Agents window</a></li>
@@ -57,6 +58,15 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## Changes in settings
+
+This table summarizes the settings that were added, changed, or deprecated in this release, so you can quickly spot behavioral changes. For details, follow the link to the relevant section or see [Deprecated features and settings](#deprecated-features-and-settings).
+
+| Setting | Change | Description |
+| --- | --- | --- |
+| `setting(security.workspace.trust.startupPrompt)` | Change | The default value changed from `once` to `never`. New folders now open in [Restricted Mode](#open-new-folders-in-restricted-mode) instead of immediately prompting you to trust the folder. To restore the previous behavior, set the value back to `once`. |
+
 
 ## Cost management
 

--- a/templates/template-release-note-endgame.md
+++ b/templates/template-release-note-endgame.md
@@ -42,6 +42,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#changes-in-settings">Changes in settings</a></li>
       <li><a href="#agents">Agents</a></li>
       <li><a href="#chat">Chat</a></li>
       <li><a href="#mcp">MCP</a></li>
@@ -67,6 +68,15 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## Changes in settings
+
+This table summarizes the settings that were added, changed, or deprecated in this release, so you can quickly spot behavioral changes. For details, follow the link to the relevant section or see [Deprecated features and settings](#deprecated-features-and-settings).
+
+| Setting | Change | Description |
+| --- | --- | --- |
+| `setting(example.setting)` | New / Change / Deprecated | TODO: @ntrogh describe the behavioral change and the reasoning behind it. |
+
 
 ## Agents
 


### PR DESCRIPTION
## Proposal — addresses #9742

This is a **draft proposal** (not a merge-ready change) for surfacing setting changes in release notes, as requested in #9742.

### Problem
New, changed, and deprecated settings are currently spread through the prose of each release note. Behavioral changes — especially silent default changes with security/privacy impact — are hard to find for users who don't read every section.

### Proposed change
A `Changes in settings` quick-reference table placed **near the top** of each release note:

| Setting | Change | Description |
| --- | --- | --- |
| `setting(example.setting)` | New / Change / Deprecated | Behavioral change and the reasoning behind it. |

### What's in this PR
1. **`templates/template-release-note-endgame.md`** — adds the section + a TOC entry so every future release note includes it.
2. **`release-notes/v1_126.md`** — a worked example using the **real** default change in that release (`security.workspace.trust.startupPrompt` went `once` → `never`), to show the format on actual content.

### Editorial decisions (for reviewers)
- **Endgame template only.** The insiders template is a daily, date-keyed changelog where a per-release table doesn't fit.
- **Complements, not duplicates, `Deprecated features and settings`.** The new table is a top-of-note quick index; the existing section keeps detailed deprecation guidance.

Happy to adjust placement, columns, or wording — flagging the idea concretely for the team's input.