### PR TITLE
Add Edit mode deprecation note to v1.126 release notes

### DIFF
--- a/release-notes/v1_126.md
+++ b/release-notes/v1_126.md
@@ -153,14 +153,9 @@ Let us know what you think of the new structure by [submitting feedback](https:/
 
 ### Edit mode
 
-We've deprecated the `chat.editMode.hidden` setting, so the built-in Edit mode is no longer supported in most scenarios. We recommend using [Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) instead, which covers the same editing scenarios while also being able to run tasks and tools on your behalf.
+We have deprecated the built-in Edit mode, and removed the `chat.editMode.hidden` setting. We recommend using [Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) instead, which covers the same editing scenarios while also being able to run tasks and tools on your behalf. Alternatively, you can create a [custom agent](https://code.visualstudio.com/docs/agent-customization/custom-agents) to mimic the Edit mode experience.
 
-You will still encounter Edit mode in some scenarios, because it remains in the codebase for compatibility and fallback purposes:
-
-* The built-in Edit mode (`ChatMode.Edit`) is still registered for backward compatibility.
-* It is intentionally shown when `chat.agent.enabled` is disabled by policy. When Agent mode is disabled by policy, the mode picker falls back to the built-in Edit mode.
-* Old or restored sessions and certain command paths can still select it. For example, `setChatMode('edit')` still resolves, and `workbench.action.chat.newEditSession` remains as an alias path.
-
+Users who have Agent mode disabled (`chat.agent.enabled`) by policy will still see the legacy Edit mode.
 
 ## Thank you
 

--- a/release-notes/v1_126.md
+++ b/release-notes/v1_126.md
@@ -155,7 +155,7 @@ Let us know what you think of the new structure by [submitting feedback](https:/
 
 We've deprecated the `chat.editMode.hidden` setting, so the built-in Edit mode is no longer supported in most scenarios. We recommend using [Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) instead, which covers the same editing scenarios while also being able to run tasks and tools on your behalf.
 
-You might still encounter Edit mode in some scenarios, because it remains in the codebase for compatibility and fallback purposes:
+You will still encounter Edit mode in some scenarios, because it remains in the codebase for compatibility and fallback purposes:
 
 * The built-in Edit mode (`ChatMode.Edit`) is still registered for backward compatibility.
 * It is intentionally shown when `chat.agent.enabled` is disabled by policy. When Agent mode is disabled by policy, the mode picker falls back to the built-in Edit mode.

--- a/release-notes/v1_126.md
+++ b/release-notes/v1_126.md
@@ -151,7 +151,15 @@ Let us know what you think of the new structure by [submitting feedback](https:/
 
 ## Deprecated features and settings
 
-None.
+### Edit mode
+
+We've deprecated the `chat.editMode.hidden` setting, so the built-in Edit mode is no longer supported in most scenarios. We recommend using [Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) instead, which covers the same editing scenarios while also being able to run tasks and tools on your behalf.
+
+You might still encounter Edit mode in some scenarios, because it remains in the codebase for compatibility and fallback purposes:
+
+* The built-in Edit mode (`ChatMode.Edit`) is still registered for backward compatibility.
+* It is intentionally shown when `chat.agent.enabled` is disabled by policy. When Agent mode is disabled by policy, the mode picker falls back to the built-in Edit mode.
+* Old or restored sessions and certain command paths can still select it. For example, `setChatMode('edit')` still resolves, and `workbench.action.chat.newEditSession` remains as an alias path.
 
 
 ## Thank you


### PR DESCRIPTION
## Why

The 1.126 release deprecates the `chat.editMode.hidden` setting, so the built-in Edit chat mode is no longer surfaced in most scenarios. The release notes' "Deprecated features and settings" section was empty ("None."), leaving users without guidance, especially those who may still encounter Edit mode in fallback paths.

## What

Replaces the empty deprecation section in `release-notes/v1_126.md` with an "Edit mode" entry that:

- Leads with the `chat.editMode.hidden` setting deprecation and recommends Agent mode as the replacement.
- Documents the caveats explaining why users might still see Edit mode, since it remains in the codebase for compatibility and fallback:
  - `ChatMode.Edit` is still registered for backward compatibility.
  - It is intentionally shown when `chat.agent.enabled` is policy-disabled (the mode picker falls back to built-in Edit).
  - Old/restored sessions and command paths (`setChatMode('edit')`, `workbench.action.chat.newEditSession`) can still select it.

Docs-only change.