### PR TITLE
chore: update docs for esbuild bundler note

### DIFF
--- a/api/get-started/your-first-extension.md
+++ b/api/get-started/your-first-extension.md
@@ -44,6 +44,8 @@ For a TypeScript project, fill out the following fields:
 
 ```
 
+> **Note:** When using esbuild, install the [esbuild Problem Matchers](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) extension.
+
 Inside the editor, open `src/extension.ts` and press `kb(workbench.action.debug.start)` or run the command **Debug: Start Debugging** from the Command Palette (`kb(workbench.action.showCommands)`). This will compile and run the extension in a new **Extension Development Host** window.
 
 Run the **Hello World** command from the Command Palette (`kb(workbench.action.showCommands)`) in the new window:


### PR DESCRIPTION
Add recommendation to install esbuild Problem Matchers when using esbuild bundler in extension generator docs.