### PR TITLE
fix: apply color-scheme to match VS Code theme for native scrollbar

### DIFF
--- a/release-notes/css/inproduct_releasenotes.css
+++ b/release-notes/css/inproduct_releasenotes.css
@@ -11,6 +11,15 @@ body {
 	overscroll-behavior: none;
 }
 
+body.vscode-dark,
+body.vscode-high-contrast {
+  color-scheme: dark;
+}
+
+body.vscode-light {
+  color-scheme: light;
+}
+
 #scroll-to-top {
 	position: fixed;
 	width: 40px;

--- a/remote-release-notes/css/inproduct_releasenotes.css
+++ b/remote-release-notes/css/inproduct_releasenotes.css
@@ -8,6 +8,15 @@ body {
     max-width: 980px;
 }
 
+body.vscode-dark,
+body.vscode-high-contrast {
+    color-scheme: dark;
+}
+
+body.vscode-light {
+    color-scheme: light;
+}
+
 #scroll-to-top {
     position: fixed;
     width: 40px;


### PR DESCRIPTION
## Summary

- The main scrollbar in release notes webviews was always rendering in light mode, even when VS Code uses a dark or high-contrast theme.
- Added `color-scheme` CSS rules keyed to the existing `body.vscode-dark`, `body.vscode-high-contrast`, and `body.vscode-light` class selectors in both `release-notes/css/inproduct_releasenotes.css` and `remote-release-notes/css/inproduct_releasenotes.css`.
- The browser engine reads `color-scheme` to decide which OS-native scrollbar style to render, so this makes the scrollbar automatically follow the active VS Code theme with no JavaScript required.

Fixes: #9176
Refs: microsoft/vscode#282421

## Changes

- `release-notes/css/inproduct_releasenotes.css`: add `color-scheme` rules after the `body {}` block
- `remote-release-notes/css/inproduct_releasenotes.css`: add `color-scheme` rules after the `body {}` block

## Test plan

- [ ] Open any release notes page in VS Code with a **dark** theme — scrollbar should appear dark
- [ ] Open any release notes page in VS Code with a **light** theme — scrollbar should appear light
- [ ] Open any release notes page in VS Code with a **high-contrast** theme — scrollbar should appear dark/high-contrast

Made with [Cursor](https://cursor.com)