### PR TITLE
Document Copilot enterprise-managed settings delivery channels

### DIFF
--- a/docs/enterprise/ai-settings.md
+++ b/docs/enterprise/ai-settings.md
@@ -30,6 +30,9 @@ All three channels use the same managed setting keys and values. For the list of
 
 ### Precedence across channels
 
+> [!NOTE]
+> Precedence is enforced starting in VS Code version 1.128.
+
 When the same setting is available from more than one channel, VS Code uses a single authoritative channel rather than merging the channels. The channel with the highest precedence that provides any managed settings wins outright, and the other channels are ignored.
 
 The precedence order is:

--- a/docs/enterprise/ai-settings.md
+++ b/docs/enterprise/ai-settings.md
@@ -89,9 +89,11 @@ The following managed settings are available. Each key maps to a VS Code policy 
 | Managed setting key | VS Code policy | Setting | Description |
 |---------------------|----------------|---------|-------------|
 | `permissions.disableBypassPermissionsMode` | `ChatToolsAutoApprove` | `setting(chat.tools.global.autoApprove)` | Set to `disable` to turn off global auto-approval ("YOLO mode") and hide the bypass and Autopilot options. |
+| `model` | `ChatDefaultModel` | `setting(chat.defaultModel)` | Default chat model for new conversations. See [Set a default chat model](#set-a-default-chat-model). |
 | `enabledPlugins` | `ChatEnabledPlugins` | `setting(chat.plugins.enabledPlugins)` | Allowlist of plugin IDs, with each plugin explicitly enabled or disabled. |
 | `extraKnownMarketplaces` | `ChatExtraMarketplaces` | `setting(chat.plugins.extraMarketplaces)` | Additional plugin marketplaces to make available. |
 | `strictKnownMarketplaces` | `ChatStrictMarketplaces` | `setting(chat.plugins.strictMarketplaces)` | Trust only the marketplaces supplied through managed settings. |
+| `telemetry.*` | `CopilotOtel*` | `setting(chat.agentHost.otel.*)` | OpenTelemetry export configuration. See [Configure telemetry export with OpenTelemetry](#configure-telemetry-export-with-opentelemetry). |
 
 ### Verify applied managed settings
 
@@ -113,6 +115,20 @@ When the policy is not set, AI features are not restricted by this gate.
 This policy is fail-closed: if the user is not signed in, is signed in with a non-GitHub account, or is signed in to a GitHub account that does not belong to an approved organization, AI features remain disabled.
 
 IT admins can verify the gate state at any time with the **Developer: Policy Diagnostics** command, which includes an **Account Policy Gate** section. For more information, see [Verify policy enforcement](/docs/enterprise/policies.md#verify-policy-enforcement).
+
+## Set a default chat model
+
+Organizations can set a default model that applies to every new conversation, so developers start from an approved model without configuring it themselves.
+
+To set the default model, set the `ChatDefaultModel` policy. This configures the `setting(chat.defaultModel)` setting in VS Code. You can also deliver it through Copilot managed settings with the `model` key.
+
+The value accepts one of the following:
+
+* `auto` - let Copilot pick the model.
+* A model family name, such as `opus` or `gemini` - resolves to the latest available version in that family.
+* A full model ID.
+
+New conversations start at the configured model across the chat panel and the Agents window, including Copilot CLI sessions. Developers can still switch models within a conversation, and an explicit choice is never overridden by the configured default. Reopened conversations keep their own saved model. When the setting is not configured, model selection behavior is unchanged.
 
 ## Enable or disable the use of agents
 
@@ -297,6 +313,30 @@ Learn how to [create custom agents for your organization](https://docs.github.co
 
 > [!NOTE]
 > Organization-level customizations are managed through GitHub organization settings, not VS Code enterprise policies. Individual developers control whether to use these customizations through their VS Code settings.
+
+## Configure telemetry export with OpenTelemetry
+
+Organizations can mandate where Copilot sends [OpenTelemetry](https://opentelemetry.io/) (OTel) data, so that telemetry flows to an approved collector without each developer setting `OTEL_*` environment variables. Managed telemetry configuration applies to both the Copilot Chat extension and the agent host process.
+
+Deliver these settings through the `telemetry` block in [Copilot managed settings](#deploy-copilot-managed-settings). Each field maps to a VS Code policy and a `chat.agentHost.otel.*` setting:
+
+| Managed setting key | Setting | Description |
+|---------------------|---------|-------------|
+| `telemetry.enabled` | `setting(chat.agentHost.otel.enabled)` | Enable or disable Copilot OpenTelemetry export. When managed, users cannot override the value. |
+| `telemetry.endpoint` | `setting(chat.agentHost.otel.otlpEndpoint)` | OTLP collector endpoint that receives the telemetry. |
+| `telemetry.protocol` | `setting(chat.agentHost.otel.exporterType)` | OTLP transport, such as `otlp-http` or `otlp-grpc`. The managed wire protocol (protobuf or JSON) is applied to both surfaces. |
+| `telemetry.captureContent` | `setting(chat.agentHost.otel.captureContent)` | Whether export captures prompt, response, and tool content. |
+| `telemetry.lockCaptureContent` | — | Prevents developers from overriding the managed `captureContent` value. |
+| `telemetry.serviceName` | `setting(chat.agentHost.otel.serviceName)` | The OTel `service.name` resource attribute. |
+| `telemetry.resourceAttributes` | `setting(chat.agentHost.otel.resourceAttributes)` | Additional OTel resource attributes, provided as a JSON object. |
+| `telemetry.headers` | `setting(chat.agentHost.otel.headers)` | OTLP exporter headers, such as an authentication token, provided as a JSON object. |
+
+For each field, the resolved value is determined by the precedence order: policy, then environment variable, then user setting, then default. A managed value always wins.
+
+> [!NOTE]
+> Managed `telemetry.headers` are applied only to the Copilot Chat extension's OTLP exporter and are never passed through environment variables, so that a header value such as an authentication token can't leak into the tool subprocesses that the agent host spawns. As a result, managed headers are not delivered to the agent host process in this release.
+
+The agent host computes its telemetry configuration when it starts. If a managed telemetry value changes after the agent host has started, reload VS Code to apply it.
 
 ## Security considerations
 

--- a/docs/enterprise/ai-settings.md
+++ b/docs/enterprise/ai-settings.md
@@ -14,11 +14,51 @@ Users can control the functionality and behavior of AI features through VS Code 
 
 Learn how to [deploy policies for VS Code](/docs/enterprise/policies.md) to your organization's devices.
 
-## Deploy managed settings from a file
+## Deploy Copilot managed settings
 
-VS Code can read Copilot managed settings from a `managed-settings.json` file on disk. Use this option when your organization manages devices with configuration-management tools, such as Chef, Puppet, or Ansible, and does not use Mobile Device Management (MDM). VS Code applies these file-based managed settings the same way as MDM-delivered managed settings, and they override user settings on managed devices.
+Copilot managed settings are a centrally-managed governance layer that applies the same configuration across VS Code and GitHub Copilot CLI. When you set a managed setting, it maps to a VS Code enterprise policy and overrides the corresponding user setting on managed devices.
 
-Place `managed-settings.json` in the well-known VS Code managed settings location for each operating system:
+Managed settings differ from the [VS Code enterprise policies](/docs/enterprise/policies.md) that you deploy with ADMX templates or configuration profiles. Managed settings use Copilot-specific delivery channels and a Copilot-specific configuration shape, so a single definition governs both VS Code and Copilot CLI.
+
+VS Code reads managed settings from three delivery channels. Choose the channel that fits how you manage devices:
+
+* **Native MDM** - deliver settings through the Windows Registry or macOS managed preferences with an MDM solution such as Microsoft Intune.
+* **Server-managed** - resolve settings from the developer's signed-in GitHub account, configured by your GitHub enterprise or organization admin.
+* **File-based** - place a `managed-settings.json` file on disk, for use with configuration-management tools such as Chef, Puppet, or Ansible.
+
+All three channels use the same managed setting keys and values. For the list of available keys and the VS Code settings they map to, see [Available managed settings](#available-managed-settings).
+
+### Precedence across channels
+
+When the same setting is available from more than one channel, VS Code uses a single authoritative channel rather than merging the channels. The channel with the highest precedence that provides any managed settings wins outright, and the other channels are ignored.
+
+The precedence order is:
+
+1. Native MDM
+1. Server-managed
+1. File-based
+
+For example, if native MDM delivers any managed settings, VS Code uses the native MDM channel and ignores the server-managed and file-based channels entirely.
+
+### Deliver managed settings through native MDM
+
+On Windows and macOS, VS Code reads Copilot managed settings from OS-level managed preferences. Deliver them through your MDM solution, the same way you deliver other device policies.
+
+| Operating system | Location |
+|------------------|----------|
+| Windows | Registry key `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\GitHubCopilot` |
+| macOS | Managed preferences for the `com.github.copilot` preference domain |
+
+> [!IMPORTANT]
+> These keys are specific to Copilot managed settings and are separate from the VS Code enterprise policy keys under `Software\Policies\Microsoft\VSCode`. Native MDM delivery of Copilot managed settings is available on Windows and macOS only. On Linux, use the file-based channel.
+
+Scalar settings use their dot-separated key directly (for example, `permissions.disableBypassPermissionsMode`). Structured settings (for example, `enabledPlugins`) are provided as a JSON string value.
+
+### Deliver managed settings from a file
+
+VS Code can read Copilot managed settings from a `managed-settings.json` file on disk. Use this option when your organization manages devices with configuration-management tools, such as Chef, Puppet, or Ansible, and does not use Mobile Device Management (MDM).
+
+Place `managed-settings.json` in the well-known location for each operating system:
 
 | Operating system | Path |
 |------------------|------|
@@ -26,9 +66,36 @@ Place `managed-settings.json` in the well-known VS Code managed settings locatio
 | Windows | `%ProgramFiles%\GitHubCopilot\managed-settings.json` |
 | Linux | `/etc/github-copilot/managed-settings.json` |
 
-When the same setting is delivered through multiple channels, a server-provided value takes precedence over a native MDM value, which takes precedence over the file. The channels are not merged.
+The file uses the Copilot managed settings shape. The following example disables bypass permissions mode:
 
-Use the same managed setting names and JSON values that you use for MDM-delivered managed settings. You can verify the applied values with the **Developer: Policy Diagnostics** command, which reports the policy state currently enforced on the device. For more information, see [Verify policy enforcement](/docs/enterprise/policies.md#verify-policy-enforcement).
+```json
+{
+    "permissions": {
+        "disableBypassPermissionsMode": "disable"
+    }
+}
+```
+
+### Deliver managed settings from the server
+
+When developers sign in with a GitHub account, VS Code resolves managed settings that your GitHub enterprise or organization admin configures in `copilot/managed-settings.json`. Because these settings travel with the account, they apply across the developer's devices without local device management.
+
+Server-managed settings are configured on the GitHub side. For more information, see [Manage Copilot for your enterprise](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise) in the GitHub documentation.
+
+### Available managed settings
+
+The following managed settings are available. Each key maps to a VS Code policy and the setting it controls. For full details on each policy's accepted values and behavior, see the [enterprise policy reference](/docs/enterprise/policies.md#vs-code-enterprise-policy-reference).
+
+| Managed setting key | VS Code policy | Setting | Description |
+|---------------------|----------------|---------|-------------|
+| `permissions.disableBypassPermissionsMode` | `ChatToolsAutoApprove` | `setting(chat.tools.global.autoApprove)` | Set to `disable` to turn off global auto-approval ("YOLO mode") and hide the bypass and Autopilot options. |
+| `enabledPlugins` | `ChatEnabledPlugins` | `setting(chat.plugins.enabledPlugins)` | Allowlist of plugin IDs, with each plugin explicitly enabled or disabled. |
+| `extraKnownMarketplaces` | `ChatExtraMarketplaces` | `setting(chat.plugins.extraMarketplaces)` | Additional plugin marketplaces to make available. |
+| `strictKnownMarketplaces` | `ChatStrictMarketplaces` | `setting(chat.plugins.strictMarketplaces)` | Trust only the marketplaces supplied through managed settings. |
+
+### Verify applied managed settings
+
+You can verify the applied values with the **Developer: Policy Diagnostics** command, which reports the policy state currently enforced on the device, including which managed settings channel is active. For more information, see [Verify policy enforcement](/docs/enterprise/policies.md#verify-policy-enforcement).
 
 ## Restrict AI features to approved GitHub organizations
 
@@ -79,10 +146,7 @@ To disable agent plugin integration in chat, set the `ChatPluginsEnabled` policy
 
 [Agent plugins](/docs/agent-customization/agent-plugins.md) are prepackaged bundles of agent customizations that developers discover and install from plugin marketplaces. Organizations can centrally control which plugins and marketplaces are available, instead of having each developer configure them locally.
 
-VS Code reads these policies from the same Copilot enterprise settings file that drives [enterprise plugin standards for Copilot CLI](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/configure-enterprise-plugin-standards), so a single policy definition applies to both clients. You can also configure them through your existing device management solution.
-
-> [!NOTE]
-> These plugin policies are experimental.
+VS Code reads these policies from the same Copilot managed settings that drive [enterprise plugin standards for Copilot CLI](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/configure-enterprise-plugin-standards), so a single definition applies to both clients. You can deliver them through any of the [Copilot managed settings channels](#deploy-copilot-managed-settings).
 
 The following policies are available:
 


### PR DESCRIPTION
## Summary

Documents how IT admins deploy Copilot enterprise-managed settings in VS Code, covering all three delivery channels and the available managed settings. Researched against the VS Code source (`copilotManagedSettings.ts`, `policyData.jsonc`, and the in-repo `github-managed-settings.md` skill doc) and the merged feature PRs.

Targets `vnext` so it aligns with the file-based managed settings release note already on that branch.

/cc @joshspicer for review (policy watcher / managed-settings owner).

## Changes to `docs/enterprise/ai-settings.md`

**Delivery channels**
* Restructures into **"Deploy Copilot managed settings"**, framing it as the cross-client (VS Code + Copilot CLI) governance layer distinct from VS Code's own ADMX/profile policies.
* Adds the **native MDM** channel (Windows `HKLM\SOFTWARE\Policies\GitHubCopilot`, macOS `com.github.copilot`), with a callout that these are separate from `Software\Policies\Microsoft\VSCode` and Windows/macOS only.
* Adds the **server-managed** channel (`copilot/managed-settings.json`).
* Keeps the **file-based** channel with a JSON example.
* **Corrects the precedence** to native MDM > server-managed > file-based (was reversed); channels are not merged.

**Available managed settings**
* Adds a reference table mapping each key to its VS Code policy and setting.
* Adds **`model`** (`ChatDefaultModel` → `chat.defaultModel`) and a **"Set a default chat model"** section — accepts `auto`, a model family, or a full model ID (microsoft/vscode#322669).
* Adds the **`telemetry.*` / OpenTelemetry** block (`CopilotOtel*` → `chat.agentHost.otel.*`) and a **"Configure telemetry export with OpenTelemetry"** section, including the secure-headers and reload-to-apply notes (microsoft/vscode#323227).
* Removes the experimental label from the managed plugin policies.

## Notes

* `docs/enterprise/policies.md` reference table is auto-generated and pinned to 1.122, so the new 1.127 policies are intentionally not hand-added there — the tooling will sync them.
* Public managed settings schema is not yet published, so no schema link is included.

## Review focus

* **Precedence** — confirm native MDM > server-managed > file-based is correct (the prior docs text had it reversed).
* **Native MDM keys** — confirm `HKLM\SOFTWARE\Policies\GitHubCopilot` (Windows) and the `com.github.copilot` preference domain (macOS) are what admins author against.
* **Server path** — confirm `copilot/managed-settings.json` is the canonical name to reference.
* **OTel headers** — confirm the agent-host-headers-deferred and reload-to-apply caveats are accurate to ship.