### PR TITLE
Update MCP developer guide redirection and content clarification

### DIFF
--- a/docs/agents/guides/mcp-developer-guide.md
+++ b/docs/agents/guides/mcp-developer-guide.md
@@ -7,4 +7,6 @@ MetaSocialImage: ../images/shared/github-copilot-social.png
 
 # MCP developer guide
 
-This page is redirected to /api/extension-guides/ai/mcp and only exists to keep the "MCP Developer Guide" TOC item.
+The content has moved to [MCP developer guide](/api/extension-guides/ai/mcp.md).
+
+This page only exists to keep the "MCP Developer Guide" TOC item.


### PR DESCRIPTION
This pull request updates the `docs/agents/guides/mcp-developer-guide.md` file to reflect that the MCP developer guide content has moved. The page now contains a link to the new location and clarifies its purpose as a placeholder for the TOC.

Documentation updates:

* Updated `mcp-developer-guide.md` to link to the new MCP developer guide location and clarified that the page is a TOC placeholder.

This PR is related to #10000 