### PR TITLE
docs(agent-customization): update prompt debug guidance

### DIFF
--- a/docs/agent-customization/prompt-files.md
+++ b/docs/agent-customization/prompt-files.md
@@ -212,7 +212,7 @@ To identify the source of a prompt file:
 1. Hover over the prompt file in the list. The source location is displayed in a tooltip.
 
 > [!TIP]
-> Use the chat customization diagnostics view to see all loaded prompt files and any errors. Right-click in the Chat view and select **Diagnostics**. Learn more about [troubleshooting AI in VS Code](/docs/agents/agent-troubleshooting/troubleshooting.md).
+> Use the Agent Debug Log panel to inspect prompt file discovery and related errors. In the Chat view, select the ellipsis (**...**) menu, then select **Show Agent Debug Logs**. Learn more about [troubleshooting AI in VS Code](/docs/agents/agent-troubleshooting/troubleshooting.md).
 
 ## Related resources
 

--- a/docs/agents/agent-troubleshooting/chat-debug-view.md
+++ b/docs/agents/agent-troubleshooting/chat-debug-view.md
@@ -187,7 +187,7 @@ If a custom instruction or prompt file doesn't seem to take effect:
 
 1. Open Agent Logs and check the **Discovery** events to see if the file was loaded, skipped, or failed validation.
 1. Verify the file location and `applyTo` pattern match the current context.
-1. Check the [chat customization diagnostics](/docs/agents/agent-troubleshooting/troubleshooting.md#debug-chat-interactions) for error details.
+1. See [Debug chat interactions](/docs/agents/agent-troubleshooting/troubleshooting.md#debug-chat-interactions) for more troubleshooting options.
 
 ## Related resources
 


### PR DESCRIPTION
## Summary

- replace the stale prompt-files tip that still points users to the removed Chat diagnostics action
- rename the remaining "chat customization diagnostics" reference in the chat debug troubleshooting page

Related to microsoft/vscode-docs#9573.

## Verification

- Checked the current troubleshooting docs for the supported Agent Debug Log panel entry point.
- Verified the changed files no longer mention the removed chat customization diagnostics view or **Diagnostics** chat menu action.
- Ran `git diff --check HEAD~1 HEAD`.
