### PR TITLE
Add enterprise-managed OTel section to the agent monitoring guide

### DIFF
--- a/docs/agents/guides/monitoring-agents.md
+++ b/docs/agents/guides/monitoring-agents.md
@@ -11,6 +11,8 @@ Keywords:
 - traces
 - metrics
 - agents
+- enterprise
+- managed settings
 ---
 
 # Monitor agent usage with OpenTelemetry
@@ -245,7 +247,7 @@ Open **Settings** (`kb(workbench.action.openSettings)`) and search for `copilot 
 
 ### Environment variables
 
-Environment variables always take precedence over VS Code settings.
+Environment variables always take precedence over VS Code settings. When your organization mandates OTel configuration through [Copilot managed settings](#manage-otel-configuration-for-your-organization), those managed values take precedence over both environment variables and user settings.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -270,6 +272,15 @@ When `setting(github.copilot.chat.otel.dbSpanExporter.enabled)` is `true`, Copil
 | Command | Description |
 |---|---|
 | **Chat: Export Agent Traces DB** (`github.copilot.chat.otel.exportAgentTracesDB`) | Export the local SQLite span database to a `.db` file. Only available when the `dbSpanExporter.enabled` setting is `true`. |
+
+## Manage OTel configuration for your organization
+
+Enterprises can mandate OTel export configuration centrally through Copilot managed settings, so that telemetry flows to an approved collector without each developer setting `OTEL_*` environment variables. Managed telemetry configuration applies to both the Copilot Chat extension and the agent host process.
+
+Administrators deliver these settings through the `telemetry` block in Copilot managed settings, using native MDM, a server-managed GitHub account policy, or a `managed-settings.json` file on disk. For the full list of managed telemetry keys, the delivery channels, and important caveats such as secure header handling and reload-to-apply behavior, see [Configure telemetry export with OpenTelemetry](/docs/enterprise/ai-settings.md#configure-telemetry-export-with-opentelemetry).
+
+> [!NOTE]
+> When a managed telemetry value is configured, it takes precedence over both environment variables and user settings. The resolved value follows the order: policy, then environment variable, then user setting, then default.
 
 ## Trace structure for background and Claude agents
 
@@ -441,6 +452,7 @@ OTel monitoring is off by default and emits no data until you explicitly enable 
 ## Related content
 
 * [AI settings reference](/docs/agents/reference/ai-settings.md)
+* [Manage AI settings in enterprise environments](/docs/enterprise/ai-settings.md)
 * [Troubleshoot AI in VS Code](/docs/agents/agent-troubleshooting/troubleshooting.md)
 * [OTel GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/)
 * [Inside the LLM Call: GenAI Observability with OpenTelemetry](https://opentelemetry.io/blog/2026/genai-observability/)


### PR DESCRIPTION
## Summary

Adds an enterprise-managed OpenTelemetry (OTel) section to the agent monitoring guide and cross-links it to the managed-settings documentation, ahead of the wider public announcement of the OTel enterprise policy.

Follows up on:
- microsoft/vscode-docs#9998 (documented the `telemetry.*` managed settings in `enterprise/ai-settings.md`)
- microsoft/vscode#323227 (the shipped extension + agent-host OTel managed-settings policy)

## Changes to `docs/agents/guides/monitoring-agents.md`

- Adds a **"Manage OTel configuration for your organization"** section explaining that enterprises can mandate OTel export centrally via Copilot managed settings, that it applies to both the Copilot Chat extension and the agent host process, and that it is delivered through native MDM, a server-managed GitHub account policy, or a `managed-settings.json` file. Links to [Configure telemetry export with OpenTelemetry](/docs/enterprise/ai-settings.md#configure-telemetry-export-with-opentelemetry) for the full key list, delivery channels, and the secure-headers / reload-to-apply caveats.
- Clarifies precedence in the **Environment variables** section — managed telemetry policy overrides both environment variables and user settings — with an in-page cross-link.
- Adds `enterprise` / `managed settings` keywords and a **Related content** link to the enterprise AI settings doc.

## Notes

- Verified the referenced `enterprise/ai-settings.md` telemetry section against the VS Code source (`copilotManagedSettings.ts` file-based paths + native MDM keys, `CopilotOtel*` policies) and microsoft/vscode#323227; the critical behaviors (precedence, extension-only/out-of-env headers, reload-to-apply) are accurate.
- Targets `vnext` to align with the managed-settings docs already on that branch.