### PR TITLE
Add OTel enterprise policy release note for 1.128

### DIFF
--- a/release-notes/v1_128.md
+++ b/release-notes/v1_128.md
@@ -56,6 +56,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
       <li><a href="#authentication">Authentication</a></li>
       <li><a href="#languages">Languages</a></li>
       <li><a href="#remote-development">Remote Development</a></li>
+      <li><a href="#enterprise">Enterprise</a></li>
       <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
       <li><a href="#extension-authoring">Extension Authoring</a></li>
       <li><a href="#proposed-apis">Proposed APIs</a></li>
@@ -116,6 +117,24 @@ Highlights include:
 * TODO: @ntrogh
 
 You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_128.md).
+
+
+## Enterprise
+
+### Manage Copilot telemetry export with OpenTelemetry
+
+Organizations can now mandate where GitHub Copilot sends [OpenTelemetry](https://opentelemetry.io/) (OTel) data, so that telemetry flows to an approved collector without each developer setting `OTEL_*` environment variables. The managed configuration applies to both the Copilot Chat extension and the agent host process.
+
+Administrators deliver these settings through the `telemetry` block in [Copilot managed settings](https://code.visualstudio.com/docs/enterprise/ai-settings#_deploy-copilot-managed-settings), using any of the supported delivery channels. The block controls:
+
+* The OTLP export endpoint and protocol.
+* The OTel service name and resource attributes.
+* Exporter headers, such as an authentication token for the collector.
+* Whether prompt and response content is captured, and whether developers can change that.
+
+A managed value always wins, taking precedence over environment variables and user settings.
+
+To learn more, see [Configure telemetry export with OpenTelemetry](https://code.visualstudio.com/docs/enterprise/ai-settings#_configure-telemetry-export-with-opentelemetry) and [Monitor agent usage with OpenTelemetry](https://code.visualstudio.com/docs/agents/guides/monitoring-agents).
 
 
 ## Contributions to extensions


### PR DESCRIPTION
## Summary

Adds an **Enterprise** section to the 1.128 release notes covering enterprise-managed OpenTelemetry (OTel) export for GitHub Copilot.

Related: microsoft/vscode#323227 (the shipped extension + agent-host OTel managed-settings policy).