### PR TITLE
Replace improper feature names

### DIFF
--- a/release-notes/v1_128.md
+++ b/release-notes/v1_128.md
@@ -62,27 +62,27 @@ Navigation End -->
 
 ## Agents
 
-### Multi-chat in the Claude Code agent-host harness
+### Multiple chats in a session now supports Claude harness
 
-Claude Code agent-host sessions in the [Agents window](https://code.visualstudio.com/docs/agents/agents-window) connect VS Code to the Claude Code coding agent. Multi-chat keeps related conversation threads in one session instead of spreading them across separate top-level sessions.
+Claude agent-host sessions in the [Agents window](https://code.visualstudio.com/docs/agents/agents-window) connect VS Code to the Claude coding agent. Multiple chats can keeps related conversation threads in one session instead of spreading them across separate top-level sessions.
 
-Single-chat Claude Code sessions remain a focused way to work with the agent. With multi-chat, a single session can hold several related chats, so you can compare approaches side by side, branch from an earlier turn, and run related work in parallel. You can add chats, fork a chat from an existing turn, switch between peer chats, and send turns concurrently. Each chat keeps its own history, title, and model selection, and restores with the parent session after restart. Peer chats stay grouped under the Claude Code session and don't appear as separate top-level sessions.
+Single-chat Claude sessions remain a focused way to work with the agent. With multiple chats, a session can contain related chats, so you can compare approaches, branch from an earlier turn, and run work in parallel. You can add chats, fork a chat from an existing turn, switch between peer chats, and send turns concurrently. Each chat keeps its own history, title, and model selection, and restores with the parent session after restart. Peer chats stay grouped under the Claude Code session and don't appear as separate top-level sessions.
 
-The following video shows a single Claude Code session with multiple chats: the main chat adds a `/health` endpoint to an Express app, while a peer chat writes tests for it in parallel, and a forked chat explores an alternative implementation. Each chat runs independently and stays grouped under the same session.
+The following video shows a single Claude session with multiple chats: the main chat adds a `/health` endpoint to an Express app, while a peer chat writes tests for it in parallel, and a forked chat explores an alternative implementation. Each chat runs independently and stays grouped under the same session.
 
 <video src="images/1_128/claude-multi-chat-session.mp4" title="Video showing multiple chats running in parallel within a single Claude Code agent-host session." autoplay loop controls muted></video>
 
-### Quick chats without a workspace in the Agents window
+### Chat without a selected workspace in the Agents window
 
 The Agents window gives you a dedicated place to create, resume, and manage agent sessions. For project work, those sessions keep the chat, files, and changes together with the workspace.
 
-For questions that are not tied to a folder, you can start a quick chat directly from the Agents window without opening a workspace first. Quick chats appear in the **Chats** section and open focused and ready for input. Start a quick chat with `kb(sessionsView.newQuickChat)` or the plus button on the **Chats** section header.
+For questions not tied to a folder, you can now start a chat in the Agents window without selecting a workspace. These chats appear in the **Chats** section and open focused and ready for input. Start a quick chat with `kb(sessionsView.newQuickChat)` or the plus button on the **Chats** section header.
 
 <video src="images/1_128/quick-chat.mp4" title="Video showing starting a workspace-less quick chat in the Agents window." autoplay loop controls muted></video>
 
-Because a quick chat is workspace-less, it uses the full chat area and does not show the workspace-specific **Changes** or **Files** side pane. Quick chats are restored with your other sessions after reload and remain separate from workspace sessions.
+Because a quick chat is workspace-less, it does not show the workspace-specific **Changes** or **Files** side pane. Quick chats are restored with your other sessions after reload and remain separate from workspace sessions.
 
-Quick chats are supported only by agent host sessions, so this experience is available when the agent host is enabled with `setting(chat.agentHost.enabled)`.
+Chats without a workspace are supported only by agent host sessions, so this experience is available when the agent host is enabled with `setting(chat.agentHost.enabled)`.
 
 The **Pinned** and **Chats** groups stay visible when empty by default. Use `setting(sessions.list.showEmptyDefaultGroups)` to hide these default groups until they contain sessions.
 


### PR DESCRIPTION
Replace the use of 'Multi-Chat' and 'Quick Chat' as proper feature names with generic descriptions of functionality, as we don't use these in our UI.