### PR TITLE
Document date-based VS Code Insiders targeting

### DIFF
--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -402,7 +402,7 @@ You can use the `engines.vscode` property to ensure the extension only gets inst
 
 For example, imagine that the latest Stable version of VS Code is `1.8.0`. During the development of version `1.9.0`, a new API was introduced and made available in the Insider release through the version `1.9.0-insider`. If you want to publish an extension version that benefits from this API, you should indicate a version dependency of `^1.9.0`. In this way, your new extension version will only be available on VS Code `>=1.9.0` (in other words, users with the current Insiders release). Users with the VS Code Stable will only get the update when the Stable release reaches version `1.9.0`.
 
-To target an Insiders build by date, append a date tag in `YYYYMMDD` format to the version. For example, `^1.56.0-20210428` targets VS Code 1.56 or later builds created on or after 0:00 UTC on April 28, 2021.
+To target an Insiders build by date, append a date tag in `YYYYMMDD` format to the version. VS Code 1.57 and later enforce the date tag. Earlier versions evaluate only the numeric portion of the version. For example, `^1.56.0-20210428` targets VS Code 1.56 or later builds created on or after 0:00 UTC on April 28, 2021.
 
 ## Advanced usage
 

--- a/api/working-with-extensions/publishing-extension.md
+++ b/api/working-with-extensions/publishing-extension.md
@@ -402,6 +402,8 @@ You can use the `engines.vscode` property to ensure the extension only gets inst
 
 For example, imagine that the latest Stable version of VS Code is `1.8.0`. During the development of version `1.9.0`, a new API was introduced and made available in the Insider release through the version `1.9.0-insider`. If you want to publish an extension version that benefits from this API, you should indicate a version dependency of `^1.9.0`. In this way, your new extension version will only be available on VS Code `>=1.9.0` (in other words, users with the current Insiders release). Users with the VS Code Stable will only get the update when the Stable release reaches version `1.9.0`.
 
+To target an Insiders build by date, append a date tag in `YYYYMMDD` format to the version. For example, `^1.56.0-20210428` targets VS Code 1.56 or later builds created on or after 0:00 UTC on April 28, 2021.
+
 ## Advanced usage
 
 ### Marketplace integration

--- a/release-notes/v1_57.md
+++ b/release-notes/v1_57.md
@@ -641,7 +641,7 @@ export interface DebugSession {
 
 ### Improved VS Code Insiders version targeting
 
-When working on extensions that use proposed APIs, it's possible that a new Insiders build is released with breaking changes. In order to provide a more seamless transition for users, you can now target Insiders versions precisely with a date tag. For example, setting `engines.vscode` to `^1.56.0-20210428` will target any VS Code 1.56 (or newer) build that was created on or after 0:00 UTC, April 28, 2020. This allows you to safely release post-dated extension updates before an upcoming Insiders version is released.
+When working on extensions that use proposed APIs, it's possible that a new Insiders build is released with breaking changes. In order to provide a more seamless transition for users, you can now target Insiders versions precisely with a date tag. For example, setting `engines.vscode` to `^1.56.0-20210428` will target any VS Code 1.56 (or newer) build that was created on or after 0:00 UTC, April 28, 2021. This allows you to safely release post-dated extension updates before an upcoming Insiders version is released.
 
 ```json
 "engines": {


### PR DESCRIPTION
## Summary

Document how extension authors can append a date tag in `YYYYMMDD` format to `engines.vscode` when targeting an Insiders build.

The new example explains that `^1.56.0-20210428` targets VS Code 1.56 or later builds created on or after April 28, 2021.

Also correct the corresponding VS Code 1.57 release note, which incorrectly identifies April 28, 2021 as April 28, 2020.

Closes #5815

## Validation

- Ran `git diff --check`.
- Compared the documented syntax and behavior with the VS Code 1.57 release notes.