### PR TITLE
Fix verb forms in README cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The two suggested workflows are:
 ### Cloning
 
 1. Install [Git LFS](https://git-lfs.github.com/).
-2. Run `git lfs install` to setup global git hooks. You only need to run this once per machine.
+2. Run `git lfs install` to set up global Git hooks. You only need to run this once per machine.
 3. SSH auth: `git clone git@github.com:microsoft/vscode-docs.git`<br>HTTPS auth: `git clone https://github.com/microsoft/vscode-docs.git`
 4. Now you can `git add` binary files and commit them. They'll be tracked in LFS.
 
@@ -66,7 +66,7 @@ The two suggested workflows are:
 You might want to clone the repo without the 1.6GB images. Here are the steps:
 
 1. Install [Git LFS](https://git-lfs.github.com/).
-2. Run `git lfs install` to setup global git hooks. You only need to run this once per machine.
+2. Run `git lfs install` to set up global Git hooks. You only need to run this once per machine.
 3. Clone the repo without binary files.
     - macOS / Linux:
       - SSH auth: `GIT_LFS_SKIP_SMUDGE=1 git clone git@github.com:microsoft/vscode-docs.git`
@@ -74,7 +74,7 @@ You might want to clone the repo without the 1.6GB images. Here are the steps:
     - Windows:
       - SSH auth: `$env:GIT_LFS_SKIP_SMUDGE="1"; git clone git@github.com:microsoft/vscode-docs.git`
       - HTTPS auth: `$env:GIT_LFS_SKIP_SMUDGE="1"; git clone https://github.com/microsoft/vscode-docs.git`
-4. Now you can selectively checkout some binary files to work with. For example:
+4. Now you can selectively check out some binary files to work with. For example:
     - `git lfs pull -I "docs/nodejs"` to only download images in `docs/nodejs`
     - `git lfs pull -I "release-notes/images/1_4*/*"` to only download images in `release-notes/images/1_4*`
     - `git lfs pull -I "docs,api"` to download all images in `docs` and in `api`


### PR DESCRIPTION
## Summary

Correct grammar and capitalization in the README cloning instructions:

- Change the verb `setup` to `set up`.
- Capitalize `Git` when referring to the product.
- Change the verb `checkout` to `check out`.

## Validation

- Ran `git diff --check`.