### PR TITLE
docs: fix pluralization of 'platforms' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If you are looking for the VS Code product GitHub repository, you can find it [h
 
 ## Visual Studio Code
 
-[VS Code](https://code.visualstudio.com/) is a lightweight AI code editor for multi-agent development and a powerful development environment for building modern web, mobile, and cloud applications. It is free and available on your favorite platform - Linux, macOS, and Windows.
-
+[VS Code](https://code.visualstudio.com/) is a lightweight AI code editor for multi-agent development and a powerful development environment for building modern web, mobile, and cloud applications. It is free and  
+...available on your favorite platforms: Linux, macOS, and Windows.
 If you landed here looking for other information about VS Code, head over to [our website](https://code.visualstudio.com) for additional information.
 
 ## Feedback


### PR DESCRIPTION
Changed "platform" to the plural "platforms" since multiple operating systems (Linux, macOS, and Windows) are listed.