### PR TITLE
Update dictation settings and description in release notes

### DIFF
--- a/release-notes/v1_131.md
+++ b/release-notes/v1_131.md
@@ -95,7 +95,7 @@ A new highly experimental pet has been discovered in VS Code! Enter `/vscode-pet
 
 ### Built-in dictation across VS Code (Experimental)
 
-**Setting**: `setting(dictation.enabled)`, `setting(dictation.showTranscript)`, `setting(dictation.experimental.llmCleanup)`
+**Setting**: `setting(dictation.enabled)`, `setting(dictation.showTranscript)` ([VS Code Insiders](https://code.visualstudio.com/insiders?_exp_download=fb315fc982)), `setting(dictation.experimental.llmCleanup)`
 
 To use dictation in VS Code, you no longer need to install the VS Code Speech extension. The built-in transcription service works in chat inputs, text editors, and the integrated terminal, with live text and controls suited to each surface. A single speech session and microphone selection are shared across all three surfaces, which prevents overlapping recordings and keeps dictated text in the intended location.
 
@@ -103,7 +103,7 @@ To use dictation in VS Code, you no longer need to install the VS Code Speech ex
 
 Built-in dictation uses the private, offline Nemotron model. The model downloads on first use and keeps audio on your device.
 
-Use `setting(dictation.showTranscript)` to control whether the live transcript appears while you dictate. With `setting(dictation.experimental.llmCleanup)` enabled, Copilot refines your transcript as you speak by adding formatting and removing filler words. Transcript text is sent to a language model for cleanup. If cleanup is unavailable, VS Code keeps the raw transcript.
+With `setting(dictation.experimental.llmCleanup)` enabled, Copilot refines your transcript as you speak by adding formatting and removing filler words. Transcript text is sent to a language model for cleanup. If cleanup is unavailable, VS Code keeps the raw transcript. In VS Code Insiders, use `setting(dictation.showTranscript)` to control whether the live transcript appears while you dictate.
 
 #### Platform support
 

--- a/release-notes/v1_131.md
+++ b/release-notes/v1_131.md
@@ -95,7 +95,7 @@ A new highly experimental pet has been discovered in VS Code! Enter `/vscode-pet
 
 ### Built-in dictation across VS Code (Experimental)
 
-**Setting**: `setting(dictation.enabled)`, `setting(dictation.showTranscript)` ([VS Code Insiders](https://code.visualstudio.com/insiders?_exp_download=fb315fc982)), `setting(dictation.experimental.llmCleanup)`
+**Setting**: `setting(dictation.enabled)`, `setting(dictation.showTranscript)` ([VS Code Insiders](https://code.visualstudio.com/insiders)), `setting(dictation.experimental.llmCleanup)`
 
 To use dictation in VS Code, you no longer need to install the VS Code Speech extension. The built-in transcription service works in chat inputs, text editors, and the integrated terminal, with live text and controls suited to each surface. A single speech session and microphone selection are shared across all three surfaces, which prevents overlapping recordings and keeps dictated text in the intended location.
 


### PR DESCRIPTION
Adding note that dictation.showTranscript is only available in VS Code Insiders at the moment