### PR TITLE
Document agent host leaving preview

### DIFF
--- a/release-notes/v1_132.md
+++ b/release-notes/v1_132.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: July 28, 2026_
+_Last updated: July 31, 2026_
 
 Welcome to the 1.132 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,15 +40,15 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
-      <li><a href="#july-28-2026">July 28, 2026</a></li>
+      <li><a href="#july-31-2026">July 31, 2026</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## July 28, 2026
+## July 31, 2026
 
-* Feature description with link to issue. _[#issue-number](https://github.com/microsoft/vscode/issues/issue-number)_
+* The agent host moves out of preview and becomes a standard part of VS Code. The `ChatAgentHostEnabled` policy is removed, so administrators can no longer disable the agent host through policy. You can continue to use `setting(chat.agentHost.enabled)` to control whether agents run in the separate agent host process.
 
 ---
 

--- a/release-notes/v1_132.md
+++ b/release-notes/v1_132.md
@@ -41,6 +41,7 @@ To try new features as soon as possible, [**download the nightly Insiders build*
     <div>In this update</div>
     <ul>
       <li><a href="#july-31-2026">July 31, 2026</a></li>
+      <li><a href="#deprecated-features-and-settings">Deprecated features and settings</a></li>
     </ul>
   </nav>
   <div class="notes-main">
@@ -48,7 +49,13 @@ Navigation End -->
 
 ## July 31, 2026
 
-* The agent host moves out of preview and becomes a standard part of VS Code. The `ChatAgentHostEnabled` policy is removed, so administrators can no longer disable the agent host through policy. You can continue to use `setting(chat.agentHost.enabled)` to control whether agents run in the separate agent host process.
+* The agent host moves out of preview and becomes a standard part of VS Code.
+
+## Deprecated features and settings
+
+### Agent host policy
+
+The `ChatAgentHostEnabled` policy is removed, so administrators can no longer disable the agent host through policy. You can continue to use `setting(chat.agentHost.enabled)` to control whether agents run in the separate agent host process.
 
 ---
 


### PR DESCRIPTION
The agent host is moving out of preview in VS Code 1.132, and administrators need to know that its associated policy is being removed.

This updates the July 31 Insiders release notes to describe the status change, removal of the `ChatAgentHostEnabled` policy, and continued user control through `chat.agentHost.enabled`.