### PR TITLE
Document Agent Plugins as an open standard

### DIFF
--- a/docs/agent-customization/agent-plugins.md
+++ b/docs/agent-customization/agent-plugins.md
@@ -16,9 +16,10 @@ Keywords:
 ---
 # Agent plugins in VS Code
 
-Agent plugins are prepackaged bundles of agent customizations that you can discover and install from plugin marketplaces in Visual Studio Code. Agent Plugins is an [open standard](https://agent-plugins.org/) for packaging [agent skills](/docs/agent-customization/agent-skills.md) and [MCP servers](/docs/agent-customization/mcp-servers.md) that works across multiple AI agents, including GitHub Copilot in VS Code, GitHub Copilot CLI, and the GitHub Copilot app.
+Agent plugins are prepackaged bundles of agent customizations that you can discover and install from plugin marketplaces in Visual Studio Code. Plugins work alongside your locally defined customizations. When you install a plugin, its supported customizations appear in chat.
 
-Through its existing Copilot and Claude plugin formats, VS Code also supports client-specific plugin capabilities, including slash commands, [custom agents](/docs/agent-customization/custom-agents.md), and [hooks](/docs/agent-customization/hooks.md). Plugins work alongside your locally defined customizations. When you install a plugin, its supported commands, skills, agents, hooks, and MCP servers appear in chat.
+Agent Plugins is an [open standard](https://agent-plugins.org/) for packaging [agent skills](/docs/agent-customization/agent-skills.md) and [MCP servers](/docs/agent-customization/mcp-servers.md) that works across multiple AI agents, including GitHub Copilot in VS Code, GitHub Copilot CLI, and the GitHub Copilot app.
+Through its existing Copilot and Claude plugin formats, VS Code also supports client-specific plugin capabilities, including slash commands, [custom agents](/docs/agent-customization/custom-agents.md), and [hooks](/docs/agent-customization/hooks.md).
 
 For how plugins fit into the broader set of customization options, see [Customization concepts](/docs/agents/concepts/customization.md).
 
@@ -27,15 +28,15 @@ For how plugins fit into the broader set of customization options, see [Customiz
 
 ## What plugins provide
 
-An agent plugin can bundle one or more of the following customization types:
-
-* **Slash commands**: additional commands you can invoke with `/` in chat
-* **Skills**: [agent skills](/docs/agent-customization/agent-skills.md) with instructions, scripts, and resources that load on-demand
-* **Agents**: [custom agents](/docs/agent-customization/custom-agents.md) with specialized personas and tool configurations
-* **Hooks**: [hooks](/docs/agent-customization/hooks.md) that execute shell commands at agent lifecycle points
-* **MCP servers**: [MCP servers](/docs/agent-customization/mcp-servers.md) for external tool integrations
-
 Agent Plugins 1.0 defines skills and MCP servers as portable component types. Other capabilities are client-specific and can use the standard's reverse-domain [client extension namespaces](https://agent-plugins.org/plugin-authors/client-extensions). VS Code currently ignores client extension data and directories in Agent Plugins 1.0 packages.
+
+| Capability | Description | Client-specific | Standard |
+|------------|-------------|:--------------:|:--------:|
+| [MCP servers](/docs/agent-customization/mcp-servers.md) | External tool integrations | | ✓ |
+| [Skills](/docs/agent-customization/agent-skills.md) | Instructions, scripts, and resources that load on-demand | | ✓ |
+| [Agents](/docs/agent-customization/custom-agents.md) | Specialized personas and tool configurations | ✓ | |
+| [Hooks](/docs/agent-customization/hooks.md) | Shell commands that execute at agent lifecycle points | ✓ | |
+| Slash commands | Commands you can invoke with `/` in chat | ✓ | |
 
 For example, a Copilot-format testing plugin might include a `test-runner` skill with scripts, a `test-reviewer` agent with read-only tools, and an MCP server for a test reporting dashboard. The plugin directory structure looks like this:
 
@@ -86,7 +87,7 @@ An Agent Plugins 1.0 package has a `plugin.json` file at its root that declares 
 | `keywords` | string[] | No | Search and discovery terms. |
 | `extensions` | object | No | Client-specific data keyed by reverse-domain namespace. |
 
-Skills are discovered from `skills/`, and MCP server configuration is discovered from `mcp.json`. You don't list these component paths in the manifest. Agents, hooks, commands, and MCP server definitions are not portable top-level manifest fields.
+Skills are discovered from the `skills/` folder, and MCP server configuration is discovered from the `mcp.json` file. You don't list these component paths in the manifest. Custom agents, hooks, commands, and MCP server definitions are not portable top-level manifest fields.
 
 For the full field constraints and validation rules, see the [Agent Plugins manifest documentation](https://agent-plugins.org/plugin-authors/manifest).
 
@@ -110,17 +111,107 @@ Some plugin formats provide a root token that you can use in hook commands and M
 
 | Plugin format | Plugin root |
 |---------------|------------------|
+| Agent Plugins 1.0 | `${PLUGIN_ROOT}` |
 | Claude | `${CLAUDE_PLUGIN_ROOT}` |
 | Copilot | `${PLUGIN_ROOT}` or `${CLAUDE_PLUGIN_ROOT}` |
 | Legacy OpenPlugin | `${PLUGIN_ROOT}` |
 
-Agent Plugins 1.0 defines `${PLUGIN_ROOT}` for packaged files and `${PLUGIN_DATA}` for writable state that persists across plugin updates. VS Code preserves these placeholders for the plugin runtime to expand. For details about where placeholders are supported, see the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec/blob/main/spec/1.0.0.md#9-environment-variables-and-placeholder-expansion).
+Agent Plugins 1.0 also defines `${PLUGIN_ROOT}` for packaged files and `${PLUGIN_DATA}` for writable state that persists across plugin updates. VS Code preserves these placeholders for the plugin runtime to expand. For details about where placeholders are supported, see the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec/blob/main/spec/1.0.0.md#9-environment-variables-and-placeholder-expansion).
+
+## MCP servers in plugins
+
+Plugins can bundle [MCP servers](/docs/agent-customization/mcp-servers.md) to provide agents with additional tools and data sources. Plugin MCP servers start automatically when the plugin is enabled and stop when the plugin is disabled.
+
+### MCP configuration file
+
+{% tabs id="mcp-configuration" %}
+{% tab label="Agent Plugins 1.0" %}
+
+Place MCP server definitions in the `mcp.json` file at the plugin root and follow the [portable MCP configuration format](https://agent-plugins.org/plugin-authors/mcp-servers).
+
+```text
+my-plugin/
+  plugin.json             # Plugin metadata and configuration
+  skills/
+  mcp.json              # MCP server definitions
+  servers/
+    db-server             # Server executable
+  config.json             # Server configuration
+```
+
+{% /tab %}
+
+{% tab label="Copilot and Claude" %}
+
+Place MCP server definitions in the `.mcp.json` file at the plugin root. VS Code discovers this file automatically when it loads the plugin.
+
+```text
+my-plugin/
+  plugin.json             # Plugin metadata and configuration
+  skills/
+  .mcp.json              # MCP server definitions
+  servers/
+    db-server             # Server executable
+  config.json             # Server configuration
+```
+
+In the `.mcp.json` file, MCP servers are defined in a top-level `mcpServers` object. Each server entry specifies a command, arguments, and optional environment variables:
+
+```json
+{
+  "mcpServers": {
+    "plugin-database": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/servers/db-server",
+      "args": ["--config", "${CLAUDE_PLUGIN_ROOT}/config.json"],
+      "env": {
+        "DB_PATH": "${CLAUDE_PLUGIN_ROOT}/data"
+      }
+    },
+    "plugin-api": {
+      "command": "npx",
+      "args": ["@company/mcp-server", "--plugin-mode"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+### Reference plugin paths in server configuration
+
+For Claude-format plugins, use the `${CLAUDE_PLUGIN_ROOT}` token in MCP server fields to reference executables and files within the plugin directory. VS Code expands this token in the following fields:
+
+* `command`: the executable path
+* `args`: command-line arguments
+* `cwd`: working directory
+* `env`: environment variable values
+* `envFile`: path to an environment file
+* `url`: for HTTP-based MCP servers
+* `headers`: HTTP header values
+
+VS Code also injects a `CLAUDE_PLUGIN_ROOT` environment variable into the server process, so server code can access the plugin path at runtime.
+
+{% /tab %}
+
+{% /tabs %}
+
+### How plugin MCP servers interact with other servers
+
+Plugin MCP servers appear alongside workspace and user-level MCP servers. You can manage them through the same tools:
+
+* Select **Configure Tools** in the Chat view to see tools from all MCP servers, including plugin servers.
+
+* Run **MCP: List Servers** from the Command Palette to view plugin servers alongside other servers.
+
+Plugin MCP servers are implicitly trusted when you install the plugin. Unlike workspace MCP servers, they do not show a separate trust prompt at startup.
+
+Disabling a plugin stops its MCP servers. Tools provided by the stopped servers are no longer available in chat.
 
 ## Hooks in plugins
 
 Plugins can include [hooks](/docs/agent-customization/hooks.md) that run shell commands at agent lifecycle points. Plugin hooks work alongside your workspace and user-level hooks. When a plugin is enabled, its hooks fire in addition to any other hooks configured for the same event.
 
-Hooks are client-specific and are not a portable Agent Plugins 1.0 component type.
+> [!NOTE]
+> Hooks are client-specific and are not a portable Agent Plugins 1.0 component type.
 
 ### Hook file location
 
@@ -211,99 +302,49 @@ Plugin hooks run alongside workspace-level and user-level hooks. When multiple h
 
 Disabling a plugin also disables its hooks. You can enable or disable plugins globally or for a specific workspace from the Extensions view.
 
-## MCP servers in plugins
-
-Plugins can bundle [MCP servers](/docs/agent-customization/mcp-servers.md) to provide agents with additional tools and data sources. Plugin MCP servers start automatically when the plugin is enabled and stop when the plugin is disabled.
-
-### MCP configuration file
-
-For Agent Plugins 1.0, place MCP server definitions in `mcp.json` at the plugin root and follow the [portable MCP configuration format](https://agent-plugins.org/plugin-authors/mcp-servers).
-
-For Copilot and Claude plugin formats, place MCP server definitions in `.mcp.json` at the plugin root. VS Code discovers this file automatically when it loads the plugin.
-
-```text
-my-plugin/
-  .mcp.json              # MCP server definitions
-  servers/
-    db-server             # Server executable
-  config.json             # Server configuration
-```
-
-### Copilot and Claude MCP configuration format
-
-For Copilot and Claude plugin formats, MCP servers are defined in a top-level `mcpServers` object. Each server entry specifies a command, arguments, and optional environment variables:
-
-```json
-{
-  "mcpServers": {
-    "plugin-database": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/servers/db-server",
-      "args": ["--config", "${CLAUDE_PLUGIN_ROOT}/config.json"],
-      "env": {
-        "DB_PATH": "${CLAUDE_PLUGIN_ROOT}/data"
-      }
-    },
-    "plugin-api": {
-      "command": "npx",
-      "args": ["@company/mcp-server", "--plugin-mode"],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}"
-    }
-  }
-}
-```
-
-> [!NOTE]
-> This example is not the Agent Plugins 1.0 `mcp.json` format. For the portable format, see [MCP servers in Agent Plugins](https://agent-plugins.org/plugin-authors/mcp-servers).
-
-### Reference plugin paths in server configuration
-
-For Claude-format plugins, use the `${CLAUDE_PLUGIN_ROOT}` token in MCP server fields to reference executables and files within the plugin directory. VS Code expands this token in the following fields:
-
-* `command`: the executable path
-* `args`: command-line arguments
-* `cwd`: working directory
-* `env`: environment variable values
-* `envFile`: path to an environment file
-* `url`: for HTTP-based MCP servers
-* `headers`: HTTP header values
-
-VS Code also injects a `CLAUDE_PLUGIN_ROOT` environment variable into the server process, so server code can access the plugin path at runtime.
-
-### How plugin MCP servers interact with other servers
-
-Plugin MCP servers appear alongside workspace and user-level MCP servers. You can manage them through the same tools:
-
-* Select **Configure Tools** in the Chat view to see tools from all MCP servers, including plugin servers.
-* Run **MCP: List Servers** from the Command Palette to view plugin servers alongside other servers.
-
-Plugin MCP servers are implicitly trusted when you install the plugin. Unlike workspace MCP servers, they do not show a separate trust prompt at startup.
-
-Disabling a plugin stops its MCP servers. Tools provided by the stopped servers are no longer available in chat.
-
 ## Discover and install plugins
 
-VS Code provides a dedicated view in the Extensions sidebar to browse and manage agent plugins.
+You can browse and install plugins from marketplaces or directly from a Git repository.
 
-### Browse available plugins
+### Install a plugin from a marketplace
+
+{% tabs id="plugin-marketplace" %}
+{% tab label="Extensions view" %}
 
 1. Open the Extensions view (`kb(workbench.view.extensions)`) and enter `@agentPlugins` in the search field.
 
     Alternatively, select the **More Actions** (three dots) icon in the Extensions sidebar and choose **Views** > **Agent Plugins**.
 
-1. Browse the list of available plugins from your configured marketplaces.
+1. Browse the list of available plugins from your [configured marketplaces](#configure-plugin-marketplaces).
 
     ![Screenshot of browsing agent plugins in the Extensions sidebar.](images/agent-plugins/extensions-view.png)
 
-1. Select **Install** to install a plugin in your user profile.
+1. Select **Install** to install a plugin.
 
     The first time you install a plugin from a new marketplace, VS Code shows a trust prompt. Review the marketplace source before confirming.
 
+{% /tab %}
+
+{% tab label="Agent Customizations" %}
+
+1. Open the Agent Customizations editor by running **Chat: Open Customizations** from the Command Palette, selecting the gear icon in the Chat view, or selecting **Plugins** in the Agents window.
+
+1. Select the **Plugins** tab and select **Browse Marketplace** to browse available plugins from your [configured marketplaces](#configure-plugin-marketplaces).
+
+1. Select **Install** to install a plugin.
+
+  The first time you install a plugin from a new marketplace, VS Code shows a trust prompt. Review the marketplace source before confirming.
+
+{% /tab %}
+{% /tabs %}
+
 ### Install a plugin from source
 
-You can install a plugin directly from a Git repository URL, without adding a full marketplace first.
+You can install a plugin directly from a Git repository URL without adding a full marketplace first.
 
 * Run **Chat: Install Plugin From Source** from the Command Palette.
-* Alternatively, select the **+** button on the **Plugins** page of the Agent Customizations editor.
+
+* Alternatively, select **Install Plugin from Source** on the **Plugins** page of the Agent Customizations editor.
 
 Enter a Git repository URL (for example, `https://github.com/rwoll/markdown-review`) and VS Code clones and installs the plugin.
 
@@ -326,6 +367,7 @@ You can also manage installed plugins from the Chat view by selecting the **gear
 You can enable or disable a plugin globally or for a specific workspace:
 
 * Use the context menu on a plugin in the **Agent Plugins - Installed** section of the Extensions view.
+
 * Use the [Agent Customizations editor](/docs/agent-customization/overview.md#use-the-agent-customizations-editor) to toggle a plugin's enabled state.
 
 The enable/disable state is stored separately from the plugin configuration, so it does not affect shared workspace settings.
@@ -363,7 +405,7 @@ Marketplace plugins can also reference external package sources such as npm or P
 
 ## Use local plugins
 
-If you manually clone or download a plugin, you can register it with the `setting(chat.pluginLocations)` setting. This setting maps local plugin directory paths to an enabled or disabled state.
+If you manually clone or download a plugin, you can register it with the `setting(chat.pluginLocations)` setting. This setting maps local plugin directory paths to an enabled or disabled state. Set the value to `true` to enable the plugin, or `false` to keep it registered but disabled.
 
 ```json
 // settings.json
@@ -372,8 +414,6 @@ If you manually clone or download a plugin, you can register it with the `settin
     "/path/to/another-plugin": false
 }
 ```
-
-Set the value to `true` to enable the plugin, or `false` to keep it registered but disabled.
 
 ## Update plugins
 
@@ -461,7 +501,3 @@ This can happen when a previous install left cached data. Delete the cached plug
 
 * [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing)
 * [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
-* [Use Agent Skills](/docs/agent-customization/agent-skills.md)
-* [Add and manage MCP servers](/docs/agent-customization/mcp-servers.md)
-* [Use hooks for lifecycle automation](/docs/agent-customization/hooks.md)
-* [Create custom agents](/docs/agent-customization/custom-agents.md)

--- a/docs/agent-customization/agent-plugins.md
+++ b/docs/agent-customization/agent-plugins.md
@@ -18,7 +18,7 @@ Keywords:
 
 Agent plugins are prepackaged bundles of agent customizations that you can discover and install from plugin marketplaces in Visual Studio Code. Agent Plugins is an [open standard](https://agent-plugins.org/) for packaging [agent skills](/docs/agent-customization/agent-skills.md) and [MCP servers](/docs/agent-customization/mcp-servers.md) that works across multiple AI agents, including GitHub Copilot in VS Code, GitHub Copilot CLI, and the GitHub Copilot app.
 
-VS Code also supports client-specific plugin capabilities, including slash commands, [custom agents](/docs/agent-customization/custom-agents.md), and [hooks](/docs/agent-customization/hooks.md). Plugins work alongside your locally defined customizations. When you install a plugin, its supported commands, skills, agents, hooks, and MCP servers appear in chat.
+Through its existing Copilot and Claude plugin formats, VS Code also supports client-specific plugin capabilities, including slash commands, [custom agents](/docs/agent-customization/custom-agents.md), and [hooks](/docs/agent-customization/hooks.md). Plugins work alongside your locally defined customizations. When you install a plugin, its supported commands, skills, agents, hooks, and MCP servers appear in chat.
 
 For how plugins fit into the broader set of customization options, see [Customization concepts](/docs/agents/concepts/customization.md).
 
@@ -35,7 +35,7 @@ An agent plugin can bundle one or more of the following customization types:
 * **Hooks**: [hooks](/docs/agent-customization/hooks.md) that execute shell commands at agent lifecycle points
 * **MCP servers**: [MCP servers](/docs/agent-customization/mcp-servers.md) for external tool integrations
 
-Agent Plugins 1.0 defines skills and MCP servers as portable component types. Other capabilities are client-specific and can use the standard's reverse-domain [client extension namespaces](https://agent-plugins.org/plugin-authors/client-extensions).
+Agent Plugins 1.0 defines skills and MCP servers as portable component types. Other capabilities are client-specific and can use the standard's reverse-domain [client extension namespaces](https://agent-plugins.org/plugin-authors/client-extensions). VS Code currently ignores client extension data and directories in Agent Plugins 1.0 packages.
 
 For example, a Copilot-format testing plugin might include a `test-runner` skill with scripts, a `test-reviewer` agent with read-only tools, and an MCP server for a test reporting dashboard. The plugin directory structure looks like this:
 
@@ -415,7 +415,7 @@ Specify the following fields in the settings file to configure workspace plugin 
 
 Agent Plugins 1.0 is an open standard designed for cross-tool compatibility. A conformant plugin uses a root `plugin.json`, puts skills in `skills/`, and puts MCP server configuration in `mcp.json`. Compatible clients can discover the portable component types they support from the same package.
 
-Agent Plugins can also include client-specific manifest data and files under a stable reverse-domain namespace. Clients ignore namespaces they don't implement, so client-specific capabilities don't prevent other clients from loading the portable components.
+Agent Plugins can also include client-specific manifest data and files under a stable reverse-domain namespace. Clients ignore namespaces they don't implement, so client-specific capabilities don't prevent other clients from loading the portable components. VS Code currently ignores these namespaces and loads only the portable skills and MCP server configuration.
 
 For example:
 

--- a/docs/agent-customization/agent-plugins.md
+++ b/docs/agent-customization/agent-plugins.md
@@ -1,7 +1,7 @@
 ---
 ContentId: f9b2c4e3-8a7d-4e1f-b5c3-2d9a6f8e4b71
 DateApproved: 8/5/2026
-MetaDescription: Learn how to discover, install, and manage agent plugins in VS Code to extend GitHub Copilot with pre-packaged commands, skills, agents, hooks, and MCP servers.
+MetaDescription: Learn how to discover, install, and manage agent plugins in VS Code, including plugins that follow the open Agent Plugins standard.
 MetaSocialImage: ../images/shared/github-copilot-social.png
 Keywords:
 - copilot
@@ -14,11 +14,11 @@ Keywords:
 - hooks
 - mcp
 ---
-# Agent plugins in VS Code (Preview)
+# Agent plugins in VS Code
 
-Agent plugins are prepackaged bundles of agent customizations that you can discover and install from plugin marketplaces in Visual Studio Code. A single plugin can provide any combination of slash commands, [agent skills](/docs/agent-customization/agent-skills.md), [custom agents](/docs/agent-customization/custom-agents.md), [hooks](/docs/agent-customization/hooks.md), and [MCP servers](/docs/agent-customization/mcp-servers.md).
+Agent plugins are prepackaged bundles of agent customizations that you can discover and install from plugin marketplaces in Visual Studio Code. Agent Plugins is an [open standard](https://agent-plugins.org/) for packaging [agent skills](/docs/agent-customization/agent-skills.md) and [MCP servers](/docs/agent-customization/mcp-servers.md) that works across multiple AI agents, including GitHub Copilot in VS Code, GitHub Copilot CLI, and the GitHub Copilot app.
 
-Plugins work alongside your locally defined customizations. When you install a plugin, its commands, skills, agents, hooks, and MCP servers appear in chat.
+VS Code also supports client-specific plugin capabilities, including slash commands, [custom agents](/docs/agent-customization/custom-agents.md), and [hooks](/docs/agent-customization/hooks.md). Plugins work alongside your locally defined customizations. When you install a plugin, its supported commands, skills, agents, hooks, and MCP servers appear in chat.
 
 For how plugins fit into the broader set of customization options, see [Customization concepts](/docs/agents/concepts/customization.md).
 
@@ -35,7 +35,9 @@ An agent plugin can bundle one or more of the following customization types:
 * **Hooks**: [hooks](/docs/agent-customization/hooks.md) that execute shell commands at agent lifecycle points
 * **MCP servers**: [MCP servers](/docs/agent-customization/mcp-servers.md) for external tool integrations
 
-For example, a testing plugin might include a `test-runner` skill with scripts, a `test-reviewer` agent with read-only tools, and an MCP server for a test reporting dashboard. The plugin directory structure looks like this:
+Agent Plugins 1.0 defines skills and MCP servers as portable component types. Other capabilities are client-specific and can use the standard's reverse-domain [client extension namespaces](https://agent-plugins.org/plugin-authors/client-extensions).
+
+For example, a Copilot-format testing plugin might include a `test-runner` skill with scripts, a `test-reviewer` agent with read-only tools, and an MCP server for a test reporting dashboard. The plugin directory structure looks like this:
 
 ```text
 my-testing-plugin/
@@ -58,54 +60,49 @@ Once installed, plugin-provided customizations appear alongside your locally def
 > [!CAUTION]
 > Plugins can include hooks and MCP servers that run code on your machine. Review the plugin contents and publisher before installing, especially for plugins from community marketplaces.
 
-## Plugin metadata (plugin.json)
+## Plugin manifest (plugin.json)
 
-Every plugin requires a `plugin.json` manifest file at its root. This file defines the plugin's identity and tells VS Code where to find its components.
-
-### Required field
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Kebab-case plugin name. Only lowercase letters, numbers, and hyphens are allowed. Maximum 64 characters. Do not use slashes, colons, or namespace prefixes (for example, `my-plugin` is valid but `myorg/my-plugin` is not). Invalid names cause the plugin to silently fail to load. |
-
-### Optional fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `description` | string | Brief description of the plugin. Maximum 1024 characters. |
-| `version` | string | Semantic version (for example, `1.0.0`). When a plugin is listed in a marketplace, version can appear in both `plugin.json` and the `marketplace.json` plugin entry. Bump the version in `plugin.json` when you publish changes. |
-| `author` | object | Author information with `name` (required), `email`, and `url` fields. |
-| `skills` | string or string[] | Path(s) to skill directories. Defaults to `skills/`. |
-| `agents` | string or string[] | Path(s) to agent directories. Defaults to `agents/`. |
-| `hooks` | string or object | Path to a hooks config file or an inline hooks object. |
-| `mcpServers` | string or object | Path to an MCP config file (for example, `.mcp.json`) or inline server definitions. |
-
-For the full field reference, see the [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference#pluginjson).
-
-### Example plugin.json
+An Agent Plugins 1.0 package has a `plugin.json` file at its root that declares the standard's schema:
 
 ```json
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "my-dev-tools",
   "description": "React development utilities",
-  "version": "1.2.0",
-  "author": {
-    "name": "Jane Doe"
-  },
-  "skills": "skills/",
-  "agents": "agents/",
-  "hooks": "hooks.json",
-  "mcpServers": ".mcp.json"
+  "version": "1.2.0"
 }
 ```
 
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `$schema` | string | Yes | Canonical Agent Plugins schema identifier. |
+| `name` | string | Yes | Plugin name and package identifier. |
+| `version` | string | No | Plugin version. Semantic Versioning is recommended. |
+| `description` | string | No | Brief description of the plugin. |
+| `author` | object | No | Author information with optional `name`, `email`, and `url` fields. |
+| `homepage` | string | No | Documentation or homepage. |
+| `repository` | string | No | Source repository. |
+| `license` | string | No | License identifier. An SPDX identifier is recommended. |
+| `keywords` | string[] | No | Search and discovery terms. |
+| `extensions` | object | No | Client-specific data keyed by reverse-domain namespace. |
+
+Skills are discovered from `skills/`, and MCP server configuration is discovered from `mcp.json`. You don't list these component paths in the manifest. Agents, hooks, commands, and MCP server definitions are not portable top-level manifest fields.
+
+For the full field constraints and validation rules, see the [Agent Plugins manifest documentation](https://agent-plugins.org/plugin-authors/manifest).
+
+> [!NOTE]
+> Existing Copilot-format plugins that don't declare the Agent Plugins schema remain supported. For their manifest fields, see the [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference#pluginjson).
+
 ## Plugin formats
 
-VS Code auto-detects the plugin format by checking for format-specific manifest paths. Copilot format is used as the default when no other format markers are found.
-| Plugin format | Plugin file path(s) |
-|---------------|------------------|
+VS Code auto-detects the plugin format by checking the root manifest and format-specific manifest paths. A root `plugin.json` that declares the canonical Agent Plugins `$schema` uses Agent Plugins semantics. The Copilot format is used as the default when no other format marker is found.
+
+| Plugin format | Plugin manifest |
+|---------------|-----------------|
+| Agent Plugins 1.0 | `plugin.json` with `$schema` set to `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json` |
+| Copilot | `plugin.json` |
 | Claude | `.claude-plugin/plugin.json` |
-| OpenPlugin | `.plugin/plugin.json` |
+| Legacy OpenPlugin | `.plugin/plugin.json` |
 
 ### Plugin environment variables
 
@@ -114,12 +111,16 @@ Some plugin formats provide a root token that you can use in hook commands and M
 | Plugin format | Plugin root |
 |---------------|------------------|
 | Claude | `${CLAUDE_PLUGIN_ROOT}` |
-| Copilot | (Not defined) |
-| OpenPlugin | `${PLUGIN_ROOT}` |
+| Copilot | `${PLUGIN_ROOT}` or `${CLAUDE_PLUGIN_ROOT}` |
+| Legacy OpenPlugin | `${PLUGIN_ROOT}` |
+
+Agent Plugins 1.0 defines `${PLUGIN_ROOT}` for packaged files and `${PLUGIN_DATA}` for writable state that persists across plugin updates. VS Code preserves these placeholders for the plugin runtime to expand. For details about where placeholders are supported, see the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec/blob/main/spec/1.0.0.md#9-environment-variables-and-placeholder-expansion).
 
 ## Hooks in plugins
 
 Plugins can include [hooks](/docs/agent-customization/hooks.md) that run shell commands at agent lifecycle points. Plugin hooks work alongside your workspace and user-level hooks. When a plugin is enabled, its hooks fire in addition to any other hooks configured for the same event.
+
+Hooks are client-specific and are not a portable Agent Plugins 1.0 component type.
 
 ### Hook file location
 
@@ -216,7 +217,9 @@ Plugins can bundle [MCP servers](/docs/agent-customization/mcp-servers.md) to pr
 
 ### MCP configuration file
 
-Place MCP server definitions in `.mcp.json` at the plugin root. VS Code discovers this file automatically when it loads the plugin.
+For Agent Plugins 1.0, place MCP server definitions in `mcp.json` at the plugin root and follow the [portable MCP configuration format](https://agent-plugins.org/plugin-authors/mcp-servers).
+
+For Copilot and Claude plugin formats, place MCP server definitions in `.mcp.json` at the plugin root. VS Code discovers this file automatically when it loads the plugin.
 
 ```text
 my-plugin/
@@ -226,9 +229,9 @@ my-plugin/
   config.json             # Server configuration
 ```
 
-### MCP configuration format
+### Copilot and Claude MCP configuration format
 
-Plugin MCP servers are defined in a top-level `mcpServers` object. Each server entry specifies a command, arguments, and optional environment variables:
+For Copilot and Claude plugin formats, MCP servers are defined in a top-level `mcpServers` object. Each server entry specifies a command, arguments, and optional environment variables:
 
 ```json
 {
@@ -250,7 +253,7 @@ Plugin MCP servers are defined in a top-level `mcpServers` object. Each server e
 ```
 
 > [!NOTE]
-> The top-level key is `mcpServers` (not `servers` as in the workspace `mcp.json`).
+> This example is not the Agent Plugins 1.0 `mcp.json` format. For the portable format, see [MCP servers in Agent Plugins](https://agent-plugins.org/plugin-authors/mcp-servers).
 
 ### Reference plugin paths in server configuration
 
@@ -410,31 +413,30 @@ Specify the following fields in the settings file to configure workspace plugin 
 
 ## Cross-tool compatibility
 
-The plugin format is shared between VS Code, GitHub Copilot CLI, and Claude Code. A single plugin repository can work across all three tools.
+Agent Plugins 1.0 is an open standard designed for cross-tool compatibility. A conformant plugin uses a root `plugin.json`, puts skills in `skills/`, and puts MCP server configuration in `mcp.json`. Compatible clients can discover the portable component types they support from the same package.
 
-VS Code auto-detects the plugin format by looking for `plugin.json` in multiple locations, checked in this order:
+Agent Plugins can also include client-specific manifest data and files under a stable reverse-domain namespace. Clients ignore namespaces they don't implement, so client-specific capabilities don't prevent other clients from loading the portable components.
 
-1. `.plugin/plugin.json`
-1. `plugin.json` (at the plugin root)
-1. `.github/plugin/plugin.json`
-1. `.claude-plugin/plugin.json`
+For example:
 
-If you author plugins for multiple tools, you can place `plugin.json` at the root and use symlinks or copies in the format-specific directories. Keep the `name` field identical across all copies to avoid conflicts.
+```text
+my-plugin/
+  plugin.json
+  skills/
+  mcp.json
+  com.example.client/
+```
 
-Key differences to be aware of across tools:
+VS Code continues to support existing Copilot, Claude, and legacy OpenPlugin formats. Plugins that don't declare the Agent Plugins schema continue to use their existing format-specific discovery rules.
 
-* **Hook file location**: Claude-format plugins expect hooks in `hooks/hooks.json`, while Copilot-format plugins use `hooks.json` at the root. VS Code detects the format automatically.
-* **Plugin root token**: Claude-format plugins use `${CLAUDE_PLUGIN_ROOT}` to reference files within the plugin directory. This token is not available in Copilot-format plugins.
-* **Skill naming**: all tools require plain kebab-case names in `SKILL.md`. Namespace prefixes (like `myorg/skillname`) cause silent load failures.
-
-For tool-specific details, see the [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) and the [Claude Code plugin marketplace documentation](https://code.claude.com/docs/en/plugin-marketplaces).
+For details about the portable format, see the [Agent Plugins specification](https://github.com/agentplugins/agent-plugins-spec/blob/main/spec/1.0.0.md). For other formats, see the [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) and the [Claude Code plugin marketplace documentation](https://code.claude.com/docs/en/plugin-marketplaces).
 
 ## Troubleshooting
 
 ### Plugin does not appear after installation
 
 * Confirm that agent plugins are enabled: check that `setting(chat.plugins.enabled)` is set to `true`.
-* Verify the plugin's `name` field in `plugin.json` uses only lowercase letters, numbers, and hyphens. Slashes, colons, or other special characters cause the plugin to silently fail to load.
+* Verify the plugin's `name` field follows the naming rules for its format. Agent Plugins 1.0 names use lowercase letters, numbers, hyphens, and periods. Legacy Copilot plugin names use lowercase letters, numbers, and hyphens. Slashes and colons aren't supported.
 * Check that `plugin.json` is in a recognized location (see [Cross-tool compatibility](#cross-tool-compatibility)).
 
 ### Skills from a plugin do not load

--- a/docs/agent-customization/overview.md
+++ b/docs/agent-customization/overview.md
@@ -45,7 +45,7 @@ Customization pays off in concrete ways: you stop repeating context, get consist
 * **[Custom agents](/docs/agent-customization/custom-agents.md)**: Give the AI a focused role with its own instructions, allowed tools, and model, such as a read-only planner or a security reviewer. Switch roles in one step instead of re-explaining them each time.
 * **[MCP servers](/docs/agent-customization/mcp-servers.md)**: Connect the AI to your own tools, databases, and services to work with real project data, not just code. For example, query your database or file an issue.
 * **[Hooks](/docs/agent-customization/hooks.md)**: Run your own commands automatically at key points in the agent's loop, such as formatting after every edit or blocking risky commands. You get deterministic guardrails that don't rely on the model remembering.
-* **[Agent plugins](/docs/agent-customization/agent-plugins.md)** (preview): Install a ready-made bundle of the customizations above from a marketplace, and adopt a proven workflow without building it yourself.
+* **[Agent plugins](/docs/agent-customization/agent-plugins.md)**: Install a ready-made bundle of the customizations above from a marketplace, and adopt a proven workflow without building it yourself.
 * **[Prompt files](/docs/agent-customization/prompt-files.md)**: Save a reusable prompt that you invoke as a slash command, such as `/scaffold-component` or `/prep-pr`. Turn a paragraph of instructions into one command.
 
 To compare these options and decide which one fits a given goal, see [Customization concepts](/docs/agents/concepts/customization.md). The rest of this article focuses on how to set up and manage customizations.


### PR DESCRIPTION
## Summary

- present Agent Plugins 1.0 as an open, cross-client standard, consistent with the Agent Skills documentation
- document the canonical manifest fields, fixed component locations, path variables, and client extension namespaces
- distinguish the portable v1 core from VS Code-specific agents, hooks, commands, and legacy plugin formats
- remove current Preview labels while preserving the historical Experimental label in the v1.110 release notes

## Validation

- `git diff --check`
- verified new Agent Plugins documentation links return HTTP 200
- cross-checked manifest fields against the canonical v1 JSON schema and VS Code parser
- cross-checked format detection and fixed component paths against `microsoft/vscode`
