### PR TITLE
Fix broken links in C++ doc for configuring with windows

### DIFF
--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -436,10 +436,6 @@ pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 
 When adding the MinGW-w64 destination folder to your list of environment variables, the default path will then be: `C:\msys64\mingw64\bin`.
 
-### MinGW 32-bit
-
-If you need a 32-bit version of the MinGW toolset, consult the [Downloading](https://www.msys2.org/wiki/MSYS2-installation/) section on the MSYS2 wiki. It includes links to both 32-bit and 64-bit installation options.
-
 ## Next steps
 
 - Explore the [VS Code User Guide](/docs/editing/codebasics.md).

--- a/docs/cpp/config-mingw.md
+++ b/docs/cpp/config-mingw.md
@@ -144,7 +144,7 @@ hover over `vector` or `string` to see their type information. If you type  `msg
 
 You can press the `kbstyle(Tab)` key to insert a selected member. If you then add open parenthesis, IntelliSense will show information on which arguments are required.
 
-If IntelliSense is not already configured, open the Command Palette (`kb(workbench.action.showCommands)`) and enter **Select IntelliSense Configuration**. From the dropdown of compilers, select `Use gcc.exe` to configure. More information can be found in the [IntelliSense configuration documentation](/docs/languages/cpp.md#intellisense-configuration).
+If IntelliSense is not already configured, open the Command Palette (`kb(workbench.action.showCommands)`) and enter **Select IntelliSense Configuration**. From the dropdown of compilers, select `Use gcc.exe` to configure. More information can be found in the [IntelliSense configuration documentation](/docs/cpp/configure-intellisense.md).
 
 ## Run helloworld.cpp
 

--- a/docs/cpp/configure-intellisense.md
+++ b/docs/cpp/configure-intellisense.md
@@ -199,7 +199,7 @@ You can select the pin icon on the right of any item in the language status bar 
 
 ## Next steps
 
-* For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-default-settings-cpp.md).
+* For more information about IntelliSense configuration, see [Customizing default settings](/docs/cpp/customize-cpp-settings.md).
 * If you have trouble configuring the settings, please start a discussion at [GitHub discussions](https://github.com/microsoft/vscode-cpptools/discussions), or if you find an issue that needs to be fixed, file an issue at [GitHub issues](https://github.com/microsoft/vscode-cpptools/issues).
 * Explore the [c_cpp_properties schema](/docs/cpp/customize-cpp-settings.md).
 * Review the [Overview of the C++ extension](/docs/languages/cpp.md).


### PR DESCRIPTION
Fix 2 broken links: Mingw 32 bit is not supported anymore my msys so removing entire section, other link was broken and lead to wrong file. 