### PR TITLE
docs: Fix comma placement in publishing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ You can then navigate to `http://localhost:3000` in your browser to see the docu
 
 ## Publishing
 
-Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com> but the intent is that they will usually be live within 24 hours.
+Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com>, but the intent is that they will usually be live within 24 hours.


### PR DESCRIPTION
## Summary\n\nFixed grammar in the Publishing section by adding a comma after the link.\n\n## Changes\n\n- Added comma after the URL for proper sentence structure\n- Improves readability of the publishing timeline information\n\n## Type\n\n- [x] Documentation\n- [x] Grammar fix\n\nSmall grammar fix for better readability.