### PR TITLE
docs: fix callout formatting in codebasics.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ You can then navigate to `http://localhost:3000` in your browser to see the docu
 
 ## Publishing
 
-Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com> but the intent is that they will usually be live within 24 hours.
+Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com>, but the intent is that they will usually be live within 24 hours.

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ You can then navigate to `http://localhost:3000` in your browser to see the docu
 
 ## Publishing
 
-Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com>, but the intent is that they will usually be live within 24 hours.
+Publishing merged pull requests is not automatic and is initiated manually after changes have been reviewed on an internal staging server. There is no specific time guarantee for when PR updates will be available on <https://code.visualstudio.com> but the intent is that they will usually be live within 24 hours.

--- a/docs/editing/codebasics.md
+++ b/docs/editing/codebasics.md
@@ -27,7 +27,7 @@ VS Code supports multiple cursors for fast, simultaneous edits. You can add seco
 
 `kb(editor.action.addSelectionToNextFindMatch)` selects the word at the cursor, or the next occurrence of the current selection.
 
->[!TIP]
+> [!TIP]
 > You can skip the next matching occurrence while using multi-cursor find by running
 > `kb(editor.action.moveSelectionToNextFindMatch)`. This helps you avoid adding unwanted
 > selections when editing repeated text.


### PR DESCRIPTION
## Description

This PR fixes a minor formatting inconsistency in the docs/editing/codebasics.md file.

## Changes
- Fixed callout formatting by adding missing space after > in [!TIP] callout (line 30)
- This makes the formatting consistent with other callouts in the same document

## Testing
- Verified the formatting matches other callouts in the file
- No functional changes, only formatting improvement

## Related
- Improves documentation consistency