### PR TITLE
docs: fix filename casing in TypeScript tutorial

### DIFF
--- a/docs/typescript/typescript-tutorial.md
+++ b/docs/typescript/typescript-tutorial.md
@@ -10,7 +10,7 @@ MetaSocialImage: ../languages/images/typescript/typescript-social.png
 
 ## Install the TypeScript compiler
 
-Visual Studio Code includes TypeScript language support but does not include the TypeScript compiler, `tsc`. You will need to install the TypeScript compiler either globally or in your workspace to transpile TypeScript source code to JavaScript (`tsc HelloWorld.ts`).
+Visual Studio Code includes TypeScript language support but does not include the TypeScript compiler, `tsc`. You will need to install the TypeScript compiler either globally or in your workspace to transpile TypeScript source code to JavaScript (`tsc helloworld.ts`).
 
 The easiest way to install TypeScript is through npm, the [Node.js Package Manager](https://www.npmjs.com/). If you have npm installed, you can install TypeScript globally (`-g`) on your computer by:
 


### PR DESCRIPTION
## Summary

The introductory example references `tsc HelloWorld.ts`, while the rest of the tutorial consistently uses `helloworld.ts`.

This updates the introductory compile command to use the same filename for consistency throughout the tutorial.