### PR TITLE
Add sticky scroll for prompts to the 1.133 release notes

### DIFF
--- a/release-notes/images/1_133/chat-sticky-scroll.mp4
+++ b/release-notes/images/1_133/chat-sticky-scroll.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a573edb6f181b4e86d17f9608d817006cdcf1ad812a49f234378a3d8f725cec
+size 2826346

--- a/release-notes/v1_133.md
+++ b/release-notes/v1_133.md
@@ -100,6 +100,16 @@ Claude is the only agent that works this way today. This release put the foundat
 
 ## Chat
 
+### Sticky scroll for prompts
+
+**Setting**: `setting(chat.stickyScroll.enabled)`
+
+When you scroll back through a long conversation, it is easy to lose track of which prompt a response belongs to. The prompt you have scrolled past now stays pinned to the top of the chat, similar to sticky scroll in the editor.
+
+The pinned prompt shows its position in the conversation. Select it to jump back to that prompt, or use the previous and next buttons beside it to step through your prompts.
+
+<video src="images/1_133/chat-sticky-scroll.mp4" title="Video showing the current prompt pinned to the top of the chat while scrolling." autoplay loop controls muted></video>
+
 
 ## MCP
 


### PR DESCRIPTION
Adds a Chat entry for sticky scroll to the 1.133 release notes.

The prompt you have scrolled past is pinned to the top of the chat, with its position in the conversation and previous/next buttons. It is on by default in this release via `chat.stickyScroll.enabled`.

Implementation: microsoft/vscode#329691
Test plan item: microsoft/vscode#329727

Note: the Agents window prompt timeline (`sessions.chatTimeline.display`) is intentionally not covered here, since it stays Insiders-only for this release.