### PR TITLE
Fix broken video links on Java and Python language pages

### DIFF
--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -122,7 +122,7 @@ For example, Maven, Eclipse, and Gradle Java projects are supported through [Lan
 With [Maven for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven), you can generate projects from [Maven Archetypes](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html), browse through all the Maven projects within your workspace, and execute Maven goals easily from an embedded explorer. Projects can also be created and managed with the [Project Manager for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency) extension.
 
 <video autoplay loop muted playsinline controls title="Using the Java Projects view from the Project Manager for Java extension">
-  <source src="/docs/languages/java/package-viewer.mp4" type="video/mp4">
+  <source src="images/java/package-viewer.mp4" type="video/mp4">
 </video>
 
 Visual Studio Code also supports working with standalone Java files outside of a Java project, described in the [Getting Started with Java](/docs/java/java-tutorial.md) tutorial.
@@ -146,7 +146,7 @@ One of the key advantages of VS Code is speed. When you open your Java source fi
 [IntelliSense](/docs/editing/intellisense.md) is a general term for language features, including intelligent code completion (in-context method and variable suggestions) across all your files and for both built-in and third-party modules. VS Code supports code completion and IntelliSense for Java through [Language Support for Java™ by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java). It also provides AI-assisted IntelliSense called [IntelliCode](https://visualstudio.microsoft.com/services/intellicode/) by putting what you're most likely to use at the top of your completion list.
 
 <video autoplay loop muted playsinline controls title="Java inline code completions and hovers">
-  <source src="/docs/languages/java/intellisense.mp4" type="video/mp4">
+  <source src="images/java/Intellisense.mp4" type="video/mp4">
 </video>
 
 ### Enhance completions with AI
@@ -177,7 +177,7 @@ We support a wide range of code snippet shortcuts and postfix completion feature
 Starting a debugging session is easy: click the **Run|Debug** button available at the CodeLens of your `main()` function, or press `kb(workbench.action.debug.start)`. The debugger will automatically generate the proper configuration for you.
 
 <video autoplay loop muted playsinline controls title="Setting a breakpoint, launching the debugging, and using Hot Code Replace">
-  <source src="/docs/languages/java/resolve-main.mp4" type="video/mp4">
+  <source src="images/java/resolve-main.mp4" type="video/mp4">
 </video>
 
 Although it's lightweight, the Java debugger supports advanced features such as expression evaluation, conditional breakpoints, and [Hot Code Replace](/docs/java/java-debugging.md#hot-code-replace). For more debugging-related information, visit [Java Debugging](/docs/java/java-debugging.md).
@@ -187,7 +187,7 @@ Although it's lightweight, the Java debugger supports advanced features such as 
 With the support from the [Test Runner for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test) extension, you can easily run, debug, and manage your JUnit and TestNG test cases.
 
 <video autoplay loop muted playsinline controls title="Running tests and investigating a failed test">
-  <source src="/docs/languages/java/testng.mp4" type="video/mp4">
+  <source src="images/java/testng.mp4" type="video/mp4">
 </video>
 
 For more about testing, read [Testing Java](/docs/java/java-testing.md).

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -68,7 +68,7 @@ Linting analyzes your Python code for potential errors, making it easy to naviga
 The Python extension can apply a number of different linters including Pylint, pycodestyle, Flake8, mypy, pydocstyle, prospector, and pylama. See [Linting](/docs/python/linting.md).
 
 <video autoplay loop muted playsinline controls title="Python linting video">
-  <source src="/docs/languages/python/python-linting.mp4" type="video/mp4">
+  <source src="images/python/python-linting.mp4" type="video/mp4">
 </video>
 
 ## Debugging
@@ -80,7 +80,7 @@ For more specific information on debugging in Python, such as configuring your `
 Additionally, the [Django](/docs/python/tutorial-django.md) and [Flask](/docs/python/tutorial-flask.md) tutorials provide examples of how to implement debugging in the context of web applications, including debugging Django templates.
 
 <video autoplay loop muted playsinline controls title="Python debugging video">
-  <source src="/docs/languages/python/python-debugging.mp4" type="video/mp4">
+  <source src="images/python/python-debugging.mp4" type="video/mp4">
 </video>
 
 ## Environments


### PR DESCRIPTION
## Problem

The videos on [Languages / Java](https://code.visualstudio.com/docs/languages/java) and [Languages / Python](https://code.visualstudio.com/docs/languages/python) render as blank players. All six `<source>` elements 404 on the live site, e.g.:

- `https://code.visualstudio.com/docs/languages/java/package-viewer.mp4` → **404**

## Root cause

The pages use absolute `src="/docs/languages/<lang>/*.mp4"` paths. The website build only rewrites media paths that start with `images/` (into `/assets/docs/languages/...`); absolute `/docs/...` paths are shipped unchanged and 404. The video files themselves are present and deployed — they live under `docs/languages/images/<lang>/` and are served at `/assets/docs/languages/<lang>/*.mp4` (200).

This is the same issue as #5717, fixed by #5718 for the JavaScript/TypeScript pages. The Java and Python pages were not included in that fix (Java's videos were later relocated into `images/java/`, which broke the old absolute path). A code search shows these are the only two pages still using the absolute form.

## Fix

Switch the six video `src` values to the relative `images/<lang>/` convention (the same convention the images on these pages already use), so the build rewrites them to the correct `/assets/` URLs.

**`docs/languages/java.md`** (4)
- `package-viewer.mp4`, `Intellisense.mp4` (matches the actual filename casing), `resolve-main.mp4`, `testng.mp4`

**`docs/languages/python.md`** (2)
- `python-linting.mp4`, `python-debugging.mp4`

All six target files are confirmed present under `docs/languages/images/<lang>/`.

Refs #5717, #5718.