### PR TITLE
docs: fix JavaScript parameter inlay hints setting

### DIFF
--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -301,7 +301,7 @@ Inlay hints add additional inline information to source code to help you underst
 
 This can help you understand the meaning of each argument at a glance, which is especially helpful for functions that take Boolean flags or have parameters that are easy to mix up.
 
-To enable parameter name hints, set `js/ts.inlayHints.parameterNames`. There are three possible values:
+To enable parameter name hints, set `js/ts.inlayHints.parameterNames.enabled`. There are three possible values:
 
 * `none` — Disable parameter inlay hints.
 * `literals` — Only show inlay hints for literals (string, number, Boolean).


### PR DESCRIPTION
Fix the JavaScript docs to use the correct `js/ts.inlayHints.parameterNames.enabled` setting.

The old setting name does not exist in VS Code.