### PR TITLE
Revert "Update release notes for v1.134 with execution subagent"

### DIFF
--- a/release-notes/v1_134.md
+++ b/release-notes/v1_134.md
@@ -119,10 +119,6 @@ Search includes the entire conversation, even content that is not currently rend
 
 <video src="images/1_134/chat-find.mp4" title="Video showing searching a chat conversation and stepping through the matches." autoplay loop controls muted></video>
 
-### Execution Subagent
-
-The execution subagent is now enabled by default for Enterprises and Pro subscribers (monthly and yearly). This subagent runs sequences of bash commands in response to a main agent query and summarizes the results concisely. It uses Google's Gemini 3.5 Flash model as the subagent model, and reduces token consumption by ~7% per user on average.
-
 ## Editor Experience
 
 ### Close other editors from a tab


### PR DESCRIPTION
Reverts microsoft/vscode-docs#10146