### PR TITLE
Add "Getting Started with Java & Spring Boot in VS Code" course

### DIFF
--- a/learn/java-spring-boot/1-build-and-run.md
+++ b/learn/java-spring-boot/1-build-and-run.md
@@ -5,7 +5,7 @@ MetaDescription: Build and run a Spring Boot application in Visual Studio Code w
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 ---
 
-# Build and Run Your First Spring Boot App in Visual Studio Code
+# Build and run your first Spring Boot app in Visual Studio Code
 
 You know that moment when you clone a Java repository, open it, and nothing happens? No
 run button, no green ticks, no clue which of the two hundred files is the one that

--- a/learn/java-spring-boot/1-build-and-run.md
+++ b/learn/java-spring-boot/1-build-and-run.md
@@ -1,0 +1,228 @@
+---
+ContentId: d2c6da4d-350d-4007-8b28-7277114e3e23
+DateApproved: 08/18/2026
+MetaDescription: Build and run a Spring Boot application in Visual Studio Code with Java extensions, Maven, and the Spring Boot Dashboard.
+MetaSocialImage: ../images/shared/agent-first-development-social.png
+---
+
+# Build and Run Your First Spring Boot App in Visual Studio Code
+
+You know that moment when you clone a Java repository, open it, and nothing happens? No
+run button, no green ticks, no clue which of the two hundred files is the one that
+starts. Just a folder.
+
+That gap is almost never about Java being hard. It is about tooling that has not been
+switched on yet.
+
+In this chapter, we'll switch it on. Two extension packs, one build, one run — and the
+folder turns into an application you can click around in.
+
+By the end, you will have a Spring Boot web app running on your machine, and you will
+know which file does what and how the tooling found it.
+
+No terminal gymnastics required.
+
+## What You Will Learn
+
+Before we install anything, let's set the target. This is not a tour of every Java
+feature in the editor. It is the shortest honest path from a cloned folder to a running
+web page.
+
+In this chapter, you will learn to:
+
+- **Install the right tooling:** Add the two extension packs that turn Visual Studio Code into a Java and Spring Boot environment, and confirm the surfaces they add.
+- **Confirm your JDK:** Check which Java runtime the project resolved to, and know where to get one if it is missing.
+- **Read the project structure:** Follow a request from the HTML page down to the repository and back, so no file is a mystery.
+- **Build and run from the editor:** Package the project with Maven and start it from the Spring Boot Dashboard, without typing a command.
+- **Verify it end to end:** Add, complete, and delete an item in a real browser, then shut the app down cleanly.
+
+Here is the whole chapter on one line, so you always know where you are.
+
+```mermaid
+flowchart LR
+    A["Cloned folder"] --> B["Install 2<br/>extension packs"]
+    B --> C["Confirm the JDK"]
+    C --> D["Read the code<br/>page → controller → service"]
+    D --> E["Maven package<br/>BUILD SUCCESS"]
+    E --> F["Run from the<br/>Spring Boot Dashboard"]
+    F --> G["Verify in the browser"]
+```
+
+Fig 1: Chapter 1 journey, from an unopened folder to a verified running app.
+
+## Problem Framing: Why the Tooling Comes First
+
+A Java project is not self-describing. The `pom.xml` knows the dependencies, the JDK
+knows how to compile, and Spring Boot knows how to start — but none of that is visible
+until an extension reads it and puts it on screen.
+
+Install the tooling first and the project explains itself. Skip it, and you end up
+reading build files by hand to work out what should have been a button.
+
+### Try this
+
+Compare two ways of starting. In the first, you open a terminal, guess at a Maven
+command, and read a wall of log output. In the second, you install two packs, and the
+editor tells you the runtime it picked, the goals it can run, and the app it can start.
+The second one scales to a team, because the next person sees exactly the same surfaces.
+
+## Prerequisites
+
+A quick readiness check. Most first-run friction here comes from a missing runtime, not
+from the framework.
+
+- **A cloned copy of the sample:** Clone [microsoft/github-copilot-java-mcp-demo](https://github.com/microsoft/github-copilot-java-mcp-demo) and open the folder in Visual Studio Code.
+- **Visual Studio Code:** Installed and up to date, so extension installation and commands behave as described.
+- **A Java Development Kit:** JDK 25. If you do not have one, the first exercise covers where to get it without leaving the editor.
+- **No Java extensions yet:** Leave the **Extension Pack for Java** and the **Spring Boot Extension Pack** uninstalled, because this chapter installs them.
+
+Maven does not need to be installed separately. The repository ships the Maven Wrapper,
+and the extension pack drives it for you.
+
+> **Expected warnings:** The Maven build prints a Mockito self-attach notice and
+> dynamic-agent warnings, and startup prints three `BeanPostProcessorChecker` warnings
+> about the MCP annotation scanner. All of them are normal. Wait for **`BUILD SUCCESS`**
+> and the started message instead of reacting to them.
+
+## What Is the Extension Pack for Java?
+
+The **Extension Pack for Java** is a Microsoft-published bundle that gives Visual Studio
+Code full Java support in one install. Instead of picking extensions one at a time and
+hoping they agree with each other, you get one pack that covers the whole loop.
+
+- **Language support:** Completion, navigation, refactoring, and diagnostics from the Java language server.
+- **Debugging:** Breakpoints, stepping, and variable inspection for any Java process the editor launches.
+- **Maven:** A **Maven** view in the Explorer that reads `pom.xml` and exposes the build lifecycle.
+- **Project management:** A **Java Projects** view that shows sources, dependencies, and the resolved JDK.
+- **Testing:** Test discovery and a run surface in the Testing view.
+
+The **Spring Boot Extension Pack** sits on top of that and adds Spring awareness:
+**Spring Boot Tools** for Spring-aware editing of configuration and mapping code, and
+the **Spring Boot Dashboard** for running, stopping, and inspecting the application.
+
+![Extensions view with the Extension Pack for Java and the Spring Boot Extension Pack](images/ch1-extensions-java-pack.png)
+
+Fig 2: Searching the Extensions view surfaces both packs used in this chapter.
+
+## Exercise - install the tooling
+
+Let's get both packs installed and confirm they are working before touching any code.
+
+1. Select the **Extensions** button in the Activity Bar, search for **`Extension Pack for Java`**, open the result, and select **Install**.
+2. Wait for the **Opening Java Projects** notification to appear and finish. The pack finds the project's `pom.xml` and starts importing on its own.
+3. Confirm the import worked: the Status Bar reads **Java: Ready**, and the Explorer has gained **Java Projects** and **Maven** views.
+4. Select **View → Command Palette**, search for **`Java: Configure Java Runtime`**, and run it. On the **Project Settings** page, stay on **Classpath → JDK Runtime** and find **JDK: JavaSE-25** with its install path below.
+5. If you do not have a JDK yet, **Download a new JDK...** on that tab fetches one without leaving the editor. Otherwise close the tab without selecting **Apply Settings**.
+6. Return to the **Extensions** view, search for **`Spring Boot Extension Pack`**, and install it too. A new **Spring Boot Dashboard** icon appears in the Activity Bar.
+
+That is the entire setup. Everything from here on is the project itself.
+
+## Reading the Project: What the Tooling Just Imported
+
+Now that the editor understands the project, the files are worth a look. The order below
+follows a single request through the app, which is a far better map than alphabetical
+order.
+
+### The build file
+
+`pom.xml` is Maven's project definition, and it is the file the Java extension read
+first. The `spring-boot-starter-parent` sets the framework version, the coordinates name
+the project `springboot-mcp-demo`, and the `java.version` property is `25` — matching the
+JDK you just confirmed.
+
+Below that sit four starter dependencies, and between them they decide what the app can
+do:
+
+- **Actuator:** Adds health and monitoring endpoints. Chapter 2 uses these.
+- **WebMVC:** Spring Boot 4's name for the Spring Web starter. It brings the embedded web server and request handling.
+- **Thymeleaf:** Renders HTML pages on the server.
+- **Spring AI MCP server starter:** Publishes the app's operations over the Model Context Protocol. Chapter 3 uses this.
+
+### The source layout
+
+In the Explorer, expand **src → main**, then the compacted `java\com\example\tododemo`
+row, then **resources → templates**. Under the base package the code splits into small
+folders — `model`, `repository`, `service`, `web` — plus an `mcp` folder that Chapter 3
+covers, and a `templates` folder holding the HTML page.
+
+### The classes, in request order
+
+| File | What it does |
+| ------ | -------------- |
+| `SpringbootMcpDemoApplication.java` | One `@SpringBootApplication` annotation and a `main` method. Spring scans this package and everything below it, starts the embedded server, creates one instance of each annotated class, and wires them together. |
+| `model/Todo.java` | The data: an id, a title, a completed flag, and a creation timestamp. |
+| `repository/TodoRepository.java` | Marked `@Repository`. Keeps todos in a concurrent map rather than a database, and its `save` method is what hands out the next id. |
+| `service/TodoService.java` | Marked `@Service`. Spring passes the repository into its constructor — that is dependency injection in practice. Its `add` method validates and trims the title, creates a `Todo` with no id yet, and saves it. |
+| `templates/index.html` | Plain HTML. The add form posts to `/todos` with a single `title` field, and a Thymeleaf loop below it renders one row per todo. |
+| `web/TodoController.java` | `@GetMapping("/")` asks the service for every todo and renders the template. `@PostMapping("/todos")` passes `title` straight to `service.add`, then returns `redirect:/`, which re-renders the list with the new item. |
+
+Browser, controller, service, repository, and back. That is the full round trip, and it
+is the same path Chapter 2 traces with a debugger.
+
+## Exercise - build and run
+
+With the code understood, let's prove it works.
+
+1. In the Explorer, scroll to the **Maven** section below the file tree and expand it. Expand **springboot-mcp-demo → Lifecycle**, hover over **package**, and select its **Run** button.
+2. Wait for **`BUILD SUCCESS`** in the **Maven-springboot-mcp-demo** terminal that opens. The `package` goal compiles the code, runs the tests, and produces the runnable JAR, so it proves the whole project is sound rather than just that it compiles.
+3. Select the **Spring Boot Dashboard** icon in the Activity Bar, find **springboot-mcp-demo**, and select its **Run** action. Startup takes a few seconds.
+4. Check the running state and port in the Dashboard, then select **Open In Browser** to open <http://localhost:8080>.
+5. In the page, enter **`Prepare the demo`** and select **Add**. Select that row's checkbox, then select its **Delete** button.
+6. Return to the Dashboard and select the app's **Stop** action.
+
+![Spring Boot Dashboard showing springboot-mcp-demo running on port 8080](images/ch1-dashboard-running.png)
+
+Fig 3: The Dashboard reports the app as running, alongside the port it bound to.
+
+Each of those three browser actions is a full server round trip: **Add** posts to
+`/todos` and redirects, the checkbox posts to the toggle endpoint, and **Delete** drops
+the item from the map. The page re-renders every time, which is why the list is always in
+step with the server.
+
+![The Todo web app running at localhost:8080](images/ch1-web-app.png)
+
+Fig 4: The running app — `TodoController` rendered this page from `index.html`. This is the moment just after **Add** in step 5, before the row is completed and deleted.
+
+Because this app keeps its todos in memory, stopping the process clears them. That is
+intentional for a sample, and it means every chapter starts from a clean list.
+
+## Quick Question
+
+The Spring Boot Dashboard can start the application on its own. So why does this chapter
+run a Maven `package` build first, and why start the app from the Dashboard rather than
+from a terminal?
+
+## Answer
+
+Those are two separate answers. `package` is the honest build check: it compiles, runs
+the tests, and produces the artifact, so a green result means the project is sound and
+not merely syntactically valid — a `Run` that starts is a much weaker signal. The
+Dashboard matters for a different reason: it launches the process through Visual Studio
+Code, which is what lets the editor attach a debugger and populate live views such as
+**Properties** and **Memory**. An app started from a plain terminal runs perfectly well
+but stays invisible to those views, and that difference shows up as soon as you want to
+inspect a running request.
+
+## What's Next
+
+You now have a working Java and Spring Boot setup, a project you can navigate, and an
+application you can start and stop from the editor. That is the foundation every later
+chapter assumes.
+
+In [Chapter 2, Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md), we'll
+stop trusting the browser and start inspecting the process. You'll set a breakpoint on the
+exact line where the web layer hands off to the service, step through the call, and watch
+the repository assign an id — then check the app's health and memory while it is still
+running.
+
+## Learn more
+
+- [Java in Visual Studio Code](https://code.visualstudio.com/docs/languages/java) — the product-level guide to the surfaces used here.
+- [Extension Pack for Java on the Marketplace](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) — what the pack installs and why.
+- [Spring Boot reference documentation](https://docs.spring.io/spring-boot/) — starters, auto-configuration, and the application lifecycle.
+- [Maven build lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html) — what `package` actually runs.
+- [Demo source on GitHub](https://github.com/microsoft/github-copilot-java-mcp-demo) — the sample used in every chapter.
+
+---
+
+Chapter 1 of 4 · Next: [Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md)

--- a/learn/java-spring-boot/2-debug-and-inspect.md
+++ b/learn/java-spring-boot/2-debug-and-inspect.md
@@ -5,7 +5,7 @@ MetaDescription: Debug a Spring Boot request and inspect application health and 
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 ---
 
-# Debug and Inspect a Spring Boot Request in Visual Studio Code
+# Debug and inspect a Spring Boot request in Visual Studio Code
 
 A web app that works is not the same as a web app you understand. The page says the item
 was added. It does not say which method received the title, where the id came from, or
@@ -102,10 +102,10 @@ appear while a live process is attached, which is a useful signal in itself.
 
 Let's stop the application in the middle of an add.
 
-1. Open `TodoController.java`, find the `addForm` method, and click the gutter to set a breakpoint on its `service.add(title)` line.
+1. Open `TodoController.java`, find the `addForm` method, and select the gutter to set a breakpoint on its `service.add(title)` line.
 2. Select the **Spring Boot Dashboard** icon in the Activity Bar, select the app's **Debug** action, and wait for the debugger to connect.
 3. Confirm the running debug state in the Dashboard, and find the **Endpoint Mappings** and **Memory** sections listed below **Apps**.
-4. Return to the controller and click the root URL hint. In the page that opens, enter **`Trace this request`** and select **Add**.
+4. Return to the controller and select the root URL hint. In the page that opens, enter **`Trace this request`** and select **Add**.
 5. Wait for Visual Studio Code to stop at the breakpoint.
 
 The request is now frozen immediately before the controller calls the service, which

--- a/learn/java-spring-boot/2-debug-and-inspect.md
+++ b/learn/java-spring-boot/2-debug-and-inspect.md
@@ -1,0 +1,239 @@
+---
+ContentId: 3481fe44-98b0-4590-8e36-12fe0c0ff067
+DateApproved: 08/18/2026
+MetaDescription: Debug a Spring Boot request and inspect application health and memory with Java tools in Visual Studio Code.
+MetaSocialImage: ../images/shared/agent-first-development-social.png
+---
+
+# Debug and Inspect a Spring Boot Request in Visual Studio Code
+
+A web app that works is not the same as a web app you understand. The page says the item
+was added. It does not say which method received the title, where the id came from, or
+whether the process is healthy while it does all that.
+
+Print statements can answer some of that. They also change the code, get committed by
+accident, and tell you nothing about memory.
+
+In this chapter, we'll do it properly: pause the running application on the exact line
+where the web layer hands off to the service, walk the call in and back out, and watch a
+value appear that no log line would have shown.
+
+Then, with the debugger still attached, we'll ask the process how it is doing.
+
+## What You Will Learn
+
+Debugging is easy to demonstrate and easy to get wrong, so this chapter sticks to one
+request and follows it all the way through.
+
+In this chapter, you will learn to:
+
+- **Set a meaningful breakpoint:** Stop on the hand-off between the controller and the service, not somewhere arbitrary.
+- **Launch under the debugger:** Start the app in Debug mode from the Spring Boot Dashboard and confirm the debugger attached.
+- **Step through a real request:** Use **Step Into**, **Step Over**, and **Step Out** to follow one add operation across two classes.
+- **Read the Variables panel:** Find the incoming title, see an unsaved `Todo` with a null id, and resolve the id the repository assigned.
+- **Inspect a live process:** Use **Endpoint Mappings** and **Memory** to check health and heap while the app runs.
+- **Shut down cleanly:** End the process so port 8080 is genuinely free for the next run.
+
+Here is the path the request takes, and where we interrupt it.
+
+```mermaid
+flowchart LR
+    A["Browser form<br/>POST /todos"] --> B["TodoController<br/>addForm"]
+    B -->|breakpoint| C["TodoService<br/>add"]
+    C --> D["TodoRepository<br/>save → assigns id"]
+    D --> E["redirect:/<br/>list re-rendered"]
+    E --> F["Actuator health<br/>+ live memory"]
+```
+
+Fig 1: Chapter 2 journey — one add request, paused at the hand-off, then inspected.
+
+## Problem Framing: Runtime Truth Beats Reading Code
+
+Reading source tells you what should happen. A debugger tells you what did. Those two
+diverge more often than anyone likes to admit — a trimmed string, a null that was
+supposed to be filled in later, an id assigned somewhere you did not expect.
+
+The useful habit is not "debug when something breaks". It is "step through a working path
+once, so you know what normal looks like".
+
+### Try this
+
+Pick any request in your own project and stop on the line where your web layer calls your
+business layer. Step in, step out, and read the return value. If anything surprises you,
+that surprise is a bug waiting for a bad day.
+
+## Prerequisites
+
+This chapter runs the finished sample, so it needs a working Java and Spring Boot setup
+and nothing left running from a previous session.
+
+- **A cloned copy of the sample:** Clone [microsoft/github-copilot-java-mcp-demo](https://github.com/microsoft/github-copilot-java-mcp-demo) and open it in Visual Studio Code.
+- **JDK 25 and both extension packs:** The **Extension Pack for Java** and the **Spring Boot Extension Pack**, installed and working.
+- **A clean starting state:** The app stopped, port 8080 free, no breakpoints set, and the Dashboard's **Endpoint Mappings** section on **Show Defined Endpoints**.
+
+> **Shutdown note:** On Debugger for Java 0.59.0, neither the Dashboard's **Stop** action
+> nor the debug toolbar's stop button ends a **Debug**-launched process. This is an open
+> regression — [vscode-java-debug#1585](https://github.com/microsoft/vscode-java-debug/issues/1585).
+> Shut the app down from its terminal instead, as the final exercise step does. A process
+> left behind holds port 8080 *and* the JMX port the Dashboard uses for **Properties** and
+> **Memory**, so the next launch fails with a `Port already in use` agent error that names
+> the JMX port rather than 8080.
+
+## What Spring Boot Tools Adds to the Editor
+
+Before the debugger enters the picture, the **Spring Boot Tools** extension makes a
+running application visible inside the source file. Whenever the app is up, it renders a
+gray inline hint above every mapped method carrying that mapping's live URL, plus request
+counts and timings once traffic has flowed through it.
+
+Those hints are not decoration. They are a clickable link to the exact endpoint the
+method serves, which is how we will trigger the breakpoint without hunting for a browser
+tab.
+
+![Inline URL hints above the controller mappings](images/ch2-url-hints.png)
+
+Fig 2: Spring Boot Tools renders live URL hints above `@GetMapping` and `@PostMapping`. Requests that have already run add a count and timing to the hint.
+
+The **Spring Boot Dashboard** contributes the other half. Alongside **Apps** it lists
+**Beans**, **Endpoint Mappings**, **Properties**, and **Memory** — and the last two only
+appear while a live process is attached, which is a useful signal in itself.
+
+## Exercise - pause a real request
+
+Let's stop the application in the middle of an add.
+
+1. Open `TodoController.java`, find the `addForm` method, and click the gutter to set a breakpoint on its `service.add(title)` line.
+2. Select the **Spring Boot Dashboard** icon in the Activity Bar, select the app's **Debug** action, and wait for the debugger to connect.
+3. Confirm the running debug state in the Dashboard, and find the **Endpoint Mappings** and **Memory** sections listed below **Apps**.
+4. Return to the controller and click the root URL hint. In the page that opens, enter **`Trace this request`** and select **Add**.
+5. Wait for Visual Studio Code to stop at the breakpoint.
+
+The request is now frozen immediately before the controller calls the service, which
+means the Variables panel holds exactly what the web layer received and nothing it has
+produced yet.
+
+![Visual Studio Code paused at the breakpoint, with the Variables panel showing the incoming title](images/ch2-breakpoint-paused.png)
+
+Fig 3: The paused request. **Local** holds the `title` the form sent, the debug toolbar offers the stepping actions, and the editor annotates the stopped line with its live values.
+
+## Walking the Call
+
+The Variables panel scope is labelled **Local**. Expand it if it is not already open, and
+the incoming `title` reads `Trace this request` — the value that travelled from the form
+field, through Spring's parameter binding, into the method.
+
+From there, three toolbar actions do all the work.
+
+### Step Into
+
+**Step Into** moves from the controller into `TodoService.add`, the shared method behind
+this operation. This is the boundary worth crossing manually, because it is where the web
+layer stops and the application logic starts.
+
+### Step Over
+
+**Step Over** executes the line that creates the `Todo`. Expand the new `todo` entry and
+its `id` is `null`. Nothing has assigned one yet — the repository does that during
+`save`, which is exactly the kind of detail that is invisible from the outside.
+
+### Step Out
+
+**Step Out** finishes the service method and returns to `addForm`. **Local** now includes
+a step-result entry, `→add()`, carrying the same title. Its `id` reads `Long@` and a
+number until you select the **Click to expand** control beside it, which resolves the
+boxed value — `1` on a fresh start, because the in-memory repository resets with the
+process.
+
+That id is not trivia. It is the value the re-rendered page uses in the toggle and delete
+URLs for this row, so the number you just resolved is the number the next click will use.
+
+Select **Continue** to let the rest of the request run. The controller redirects,
+Thymeleaf — the app's server-side template engine — renders the refreshed list, and
+**Trace this request** appears in the browser. Leave the debug session attached; the next
+two checks need a live process.
+
+## Inspecting the Live Process
+
+A completed request tells you the code path works. It does not tell you whether the
+application is healthy, or what it is doing to memory. Two Dashboard sections answer
+that.
+
+### Endpoint Mappings
+
+**Endpoint Mappings** starts out listing only the endpoints this project defines.
+Selecting **Show All Endpoints** in that section's toolbar brings in everything else the
+running app serves. That includes the endpoints contributed by Spring Boot Actuator — the
+dependency that exposes health and monitoring endpoints — and the protocol-level routes
+Chapter 3 relies on. Endpoints the project itself declares are marked `(defined)`.
+
+![Endpoint Mappings showing all endpoints for the running app](images/ch2-endpoint-mappings.png)
+
+Fig 4: With **Show All Endpoints** selected, the section lists every route the live process serves, under a node carrying the app's process id.
+
+Find `/actuator/health` — not the `/actuator/health/**` entry beside it — and select its
+**Open** action. The response's `status` field reads `UP`, and may also include a
+`groups` field. That is a point-in-time answer: healthy, right now.
+
+![Actuator health response showing status UP](images/02-actuator-health.png)
+
+Fig 5: `/actuator/health` from the running sample. A single snapshot, served by the Actuator starter.
+
+### Memory
+
+For something that keeps answering, open **Memory**. It renders the application's live
+heap — size, used, and maximum — and keeps updating while the app runs under the
+debugger.
+
+![Spring Boot Dashboard Memory view with live heap information](images/ch2-memory-view.png)
+
+Fig 6: The Memory section tracks heap usage continuously, which is why it only appears when a live process is attached.
+
+## Exercise - shut down cleanly
+
+Because of the debugger regression noted in the prerequisites, ending the process takes
+one deliberate step rather than a **Stop** click.
+
+1. Open the **Terminal** panel and select the app's terminal.
+2. Select its **Kill Terminal** trash icon. The Java process goes down with the shell and gives up port 8080.
+3. Confirm the Dashboard no longer reports the app as running, and that port 8080 is free.
+
+Leaving that check out is the single most common way to lose ten minutes at the start of
+the next session, because the failure it causes names the wrong port.
+
+## Quick Question
+
+The Dashboard's **Properties** and **Memory** sections appear only while a live process is
+attached. Why can they not simply read the app the way **Endpoint Mappings** appears to?
+
+## Answer
+
+Because they are reading a live JMX connection into the running JVM, not static project
+metadata. When Visual Studio Code launches a Spring Boot project, Spring Boot Tools
+injects JMX and Spring admin options into the launch, and the Dashboard connects to that
+port to stream properties and heap statistics. An application started from a plain
+terminal has no such connection, so those sections stay hidden. It also explains the
+shutdown trap: a process left alive after a failed stop keeps that JMX port bound, which
+is why the next launch complains about a port you never configured.
+
+## What's Next
+
+You can now stop a Spring Boot request mid-flight, follow it across a class boundary,
+read the values it produces, and check the health and memory of the process that produced
+them.
+
+In [Chapter 3, Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md),
+the same `TodoService` gets a second caller. Instead of a browser form, GitHub Copilot
+calls it — the app publishes its operations as Model Context Protocol tools, and a todo
+created from a chat prompt shows up on the very page you have been debugging.
+
+## Learn more
+
+- [Java debugging in Visual Studio Code](https://code.visualstudio.com/docs/java/java-debugging) — launch configurations, stepping, and the Variables panel.
+- [Spring Boot Actuator](https://docs.spring.io/spring-boot/reference/actuator/index.html) — what the health endpoint reports and how to configure it.
+- [Spring Boot Tools extension](https://marketplace.visualstudio.com/items?itemName=vmware.vscode-spring-boot) — the source of the inline URL hints and live data.
+- [vscode-java-debug#1585](https://github.com/microsoft/vscode-java-debug/issues/1585) — the open shutdown regression referenced above.
+- [Demo source on GitHub](https://github.com/microsoft/github-copilot-java-mcp-demo) — the sample used in every chapter.
+
+---
+
+Chapter 2 of 4 · Previous: [Build and Run Your First Spring Boot App](1-build-and-run.md) · Next: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)

--- a/learn/java-spring-boot/3-expose-tools-with-mcp.md
+++ b/learn/java-spring-boot/3-expose-tools-with-mcp.md
@@ -5,7 +5,7 @@ MetaDescription: Expose Spring Boot operations as MCP tools and call them from G
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 ---
 
-# Expose Your Java Operations to GitHub Copilot with MCP
+# Expose your Java operations to GitHub Copilot with MCP
 
 GitHub Copilot is very good at writing Java. It is far less good at knowing what is
 currently in *your* running application, because it cannot see it.
@@ -168,7 +168,7 @@ wait for **Running** rather than treating the count as proof of a live connectio
 2. Select **Configure Tools...** in the chat input, find `todo-mcp`, enable its five tools, and close the picker.
 3. Enter the following prompt and select **Send**:
 
-   ```text
+   ```prompt
    Use the todo-mcp tools to add a todo called 'Email the stakeholders', then list all todos.
    ```
 

--- a/learn/java-spring-boot/3-expose-tools-with-mcp.md
+++ b/learn/java-spring-boot/3-expose-tools-with-mcp.md
@@ -1,0 +1,240 @@
+---
+ContentId: a0c8df3a-3079-4396-8eff-c8afe4c97683
+DateApproved: 08/18/2026
+MetaDescription: Expose Spring Boot operations as MCP tools and call them from GitHub Copilot in Visual Studio Code.
+MetaSocialImage: ../images/shared/agent-first-development-social.png
+---
+
+# Expose Your Java Operations to GitHub Copilot with MCP
+
+GitHub Copilot is very good at writing Java. It is far less good at knowing what is
+currently in *your* running application, because it cannot see it.
+
+That gap is not a model problem. It is a plumbing problem, and it has a standard fix.
+
+In this chapter, we'll take the `TodoService` behind this sample's Todo page — the one
+the web form already calls — and publish its operations as Model Context Protocol tools.
+Then we'll ask Copilot to create a todo, and watch it appear on that page as if a human
+had typed it.
+
+One service. Two callers. No duplicated logic.
+
+## What You Will Learn
+
+The interesting part of this chapter is not the chat prompt. It is how little code it
+takes to get there.
+
+In this chapter, you will learn to:
+
+- **Add an MCP server to a Spring Boot app:** One starter dependency turns the application into an MCP server.
+- **Publish Java methods as tools:** Annotate ordinary Spring bean methods so a client can discover and call them.
+- **Choose the right transport:** Understand the one property that decides whether the `/mcp` endpoint exists at all.
+- **Connect Visual Studio Code:** Register the server in `.vscode/mcp.json` and confirm the tools were discovered.
+- **Drive it from Copilot Chat:** Enable the tools in Agent mode and give Copilot a task that needs two of them in sequence.
+- **Verify the result independently:** Confirm in the browser that Copilot changed real application state.
+
+Here is how the pieces connect.
+
+```mermaid
+flowchart LR
+    subgraph app["Spring Boot application"]
+        TT["TodoTools<br/>@McpTool x5"] --> SVC["TodoService"]
+        CTRL["TodoController<br/>web UI"] --> SVC
+        SVC --> REPO["TodoRepository<br/>in-memory"]
+    end
+    MCPEP["/mcp<br/>Streamable HTTP"] --- TT
+    VSC["Visual Studio Code<br/>MCP client"] --> MCPEP
+    CHAT["Copilot Chat<br/>Agent mode"] --> VSC
+    BROWSER["Browser"] --> CTRL
+```
+
+Fig 1: The MCP tools and the web page are two front doors onto one service and one repository.
+
+## Problem Framing: Tools Beat Instructions
+
+You can describe your API to an assistant in a prompt. It will then guess at URLs,
+invent parameters, and confidently report success it cannot verify.
+
+A tool is different. It has a name, a description, a typed parameter list, and a real
+implementation on your side of the wire. The assistant does not guess — it picks a tool
+and passes arguments, and your code decides what actually happens.
+
+### Try this
+
+Look at any operation in your own service layer that you would be comfortable letting an
+assistant call. If you can name it and describe one required parameter in a sentence, it
+is already most of the way to being an MCP tool.
+
+## Prerequisites
+
+This chapter runs the finished sample rather than building it up, so the setup is short.
+
+- **A cloned copy of the sample:** Clone [microsoft/github-copilot-java-mcp-demo](https://github.com/microsoft/github-copilot-java-mcp-demo) and open it in Visual Studio Code.
+- **JDK 25 and both extension packs:** The **Extension Pack for Java** and the **Spring Boot Extension Pack**.
+- **GitHub Copilot:** Installed and signed in, with Agent mode available in Chat.
+- **A clean starting state:** The app stopped and port 8080 free.
+- **Permission to run tools:** Allow MCP tool use when Visual Studio Code prompts for trust or confirmation.
+
+> **Expected warnings:** Startup prints three `BeanPostProcessorChecker` warnings about
+> the MCP annotation scanner, immediately above the `Registered tools: 5` line. They are
+> normal.
+
+## What Is the Model Context Protocol?
+
+The Model Context Protocol (MCP) is an open standard for connecting AI assistants to
+external systems. A **server** publishes capabilities; a **client** — here, Visual Studio
+Code — discovers them and offers them to the model.
+
+The capability type this chapter uses is a **tool**: a named, described, typed operation
+the assistant can invoke.
+
+- **Name:** What the model asks for, such as `add_todo`.
+- **Description:** Plain-English guidance the model uses to decide when the tool applies.
+- **Parameters:** Typed inputs, each with its own description and whether it is required.
+- **Implementation:** Your Java method. The model never sees it — only its result.
+
+Spring AI's MCP server starter supplies all of the protocol handling. Your job reduces to
+annotating methods that already exist.
+
+### The dependency
+
+In `pom.xml`, `spring-ai-starter-mcp-server-webmvc` is the single dependency that lets
+the application act as an MCP server over HTTP. There is no separate server to deploy and
+no second process to manage — the MCP endpoint is served by the same embedded web server
+that serves the Todo page.
+
+### The tools
+
+Open `src/main/java/com/example/tododemo/mcp/TodoTools.java`. It is an ordinary
+`@Component`, which is what lets the MCP annotation scanner discover it. It holds five
+`@McpTool` methods, in source order:
+
+| Tool | What it does |
+| ------ | -------------- |
+| `list_todos` | Lists all todo items with id, title, and completion status. |
+| `get_todo` | Fetches a single item by id. |
+| `add_todo` | Creates an item from a title. |
+| `complete_todo` | Marks an item complete. |
+| `delete_todo` | Deletes an item. |
+
+Each annotation supplies the tool name and the description the model reads.
+`@McpToolParam` describes each input and marks it required, so `add_todo` advertises that
+it needs a title and `get_todo` that it needs an id.
+
+```java
+@McpTool(name = "add_todo", description = "Create a new todo item with the given title.")
+public Todo addTodo(
+        @McpToolParam(description = "The title of the new todo", required = true) String title) {
+    return service.add(title);
+}
+```
+
+Note what the body does *not* do. It contains no validation, no id generation, and no
+storage — it delegates to the same `TodoService` the web controller uses. That is the
+whole point: the MCP surface adds a caller, not a second implementation.
+
+### The transport
+
+Tools are useless without a transport the client can reach. In `application.properties`,
+one line decides it:
+
+```properties
+spring.ai.mcp.server.protocol=STREAMABLE
+```
+
+That publishes the modern Streamable HTTP endpoint at `/mcp`. Without it, this starter
+falls back to its older Server-Sent Events transport and `POST /mcp` returns **404** —
+which is a genuinely confusing failure, because the dependency, the annotations, and the
+startup log all look correct.
+
+## Exercise - start the server and connect Visual Studio Code
+
+1. Select the **Spring Boot Dashboard** icon in the Activity Bar, find **springboot-mcp-demo**, and select **Run**.
+2. When startup finishes, find **`Registered tools: 5`** in the app's log in the **Terminal** panel. That message confirms Spring discovered every annotated method. Leave the app running.
+3. Open `.vscode/mcp.json` and check the `todo-mcp` server's `type` and `url`.
+4. Select the **Start** code-lens above the server entry, and wait until the code-lens reads **Running** with **5 tools**.
+
+![The mcp.json code lens reporting the todo-mcp server as running with five tools](images/ch3-mcp-json-running.png)
+
+Fig 2: The workspace configuration points Visual Studio Code at `http://localhost:8080/mcp`, and the code-lens reports the connection state and the number of discovered tools.
+
+The **Start** action connects an MCP *client*. It does not launch the Java process — that
+is why the app has to be running first. The tool count is cached between sessions, so
+wait for **Running** rather than treating the count as proof of a live connection.
+
+## Exercise - let Copilot use the tools
+
+1. Open Copilot Chat and select **Agent** mode.
+2. Select **Configure Tools...** in the chat input, find `todo-mcp`, enable its five tools, and close the picker.
+3. Enter the following prompt and select **Send**:
+
+   ```text
+   Use the todo-mcp tools to add a todo called 'Email the stakeholders', then list all todos.
+   ```
+
+4. If prompted, review the tool name and arguments before choosing **Allow Once**. Wait for the final response.
+5. In Chat, find **Email the stakeholders** in the structured `list_todos` result.
+6. Open <http://localhost:8080> in a browser. The same title appears in the Todo list.
+
+![Copilot Chat calling the todo-mcp tools](images/06-copilot-mcp-chat.png)
+
+Fig 3: Copilot picks `add_todo` and passes the title as an argument, and the tool returns a structured result. The frame is scrolled to that first call — the `list_todos` call the prompt also asked for follows below it. The `id` reads `4` because this run already held items; on a clean start the first todo is `1`.
+
+The prompt deliberately needs two tools in sequence, because that is where tool use gets
+interesting: the assistant chooses the order, and the structured result of the second
+call is evidence rather than a claim.
+
+![The todo created through MCP rendered on the web page](images/03-mcp-added-todo.png)
+
+Fig 4: Proof the call was real — the item created from Chat is rendered by the web controller, from the same in-memory repository.
+
+That last check matters more than it looks. The browser knows nothing about MCP. It
+rendered that row because `TodoController` asked `TodoService` for the list, and the list
+contains an item that a chat prompt created.
+
+## Exercise - shut down
+
+1. Select **Stop** for `todo-mcp` in `.vscode/mcp.json`, while the server is still running.
+2. Select **Stop** for **springboot-mcp-demo** in the Spring Boot Dashboard.
+3. Confirm it is no longer running, and that port 8080 is free.
+
+Because the repository is in memory, stopping the process clears the todo created during
+this chapter.
+
+## Quick Question
+
+The MCP tools and the web page produce the same result. If you were adding a sixth
+operation to this application, where would you implement it, and what would you have to
+change in `TodoTools`?
+
+## Answer
+
+Implement it in `TodoService`, once. `TodoTools` then needs a method that delegates to it,
+annotated with `@McpTool` and a description written for a model rather than a developer —
+plus `@McpToolParam` on each input. Nothing else changes: no transport configuration, no
+registration list, no client-side edit, because the annotation scanner discovers the
+method at startup and the log's tool count goes from five to six. The reason this stays so
+cheap is that the tool layer holds no logic of its own; the moment it starts validating or
+storing anything, you have two implementations to keep in step.
+
+## What's Next
+
+Your Java application can now be called by an assistant, and you have verified that the
+calls change real state rather than producing plausible text.
+
+In [Chapter 4, Let Copilot Test Your App with Playwright](4-test-with-playwright.md), we
+point Copilot at the other side of the app. Instead of calling your service directly, it
+drives a real browser against the running page — filling the form, clicking the checkbox,
+deleting the row, and asserting each result along the way.
+
+## Learn more
+
+- [Model Context Protocol](https://modelcontextprotocol.io) — the specification and its core concepts.
+- [MCP servers in Visual Studio Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) — configuration, trust, and tool management.
+- [Spring AI reference documentation](https://docs.spring.io/spring-ai/reference/) — the MCP server starter and its annotations.
+- [Use agent mode in Visual Studio Code](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) — how tool selection and confirmation work.
+- [Demo source on GitHub](https://github.com/microsoft/github-copilot-java-mcp-demo) — the sample used in every chapter.
+
+---
+
+Chapter 3 of 4 · Previous: [Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md) · Next: [Let Copilot Test Your App with Playwright](4-test-with-playwright.md)

--- a/learn/java-spring-boot/4-test-with-playwright.md
+++ b/learn/java-spring-boot/4-test-with-playwright.md
@@ -1,0 +1,214 @@
+---
+ContentId: aad66383-6454-4291-b989-377abba471c5
+DateApproved: 08/18/2026
+MetaDescription: Use GitHub Copilot and Playwright MCP tools to test a Spring Boot web application in Visual Studio Code.
+MetaSocialImage: ../images/shared/agent-first-development-social.png
+---
+
+# Let GitHub Copilot Test Your Spring Boot App with Playwright
+
+Your unit tests pass. Your integration tests pass. And you still open the browser
+afterwards to check that the page actually works, because a green build has never proved
+that a checkbox ticks.
+
+That last manual check is the one nobody automates, because writing browser tests feels
+like a project of its own.
+
+In this chapter, we'll hand it to GitHub Copilot. Copilot gets browser-control tools,
+you describe the journey in one sentence, and a real Chrome window drives your running
+Spring Boot app while you watch.
+
+Then — and this is the part that matters — you read the assertions it actually ran.
+
+## What You Will Learn
+
+Letting an assistant click around your app is a party trick. Letting it *prove* each step
+is a test. This chapter is about the difference.
+
+In this chapter, you will learn to:
+
+- **Install an MCP server from the gallery:** Find the Playwright MCP server in the Extensions view and install it with trust confirmed.
+- **Write markup that is testable:** Recognise the stable hooks that let a tool target one exact control.
+- **Establish a baseline:** Run the existing Java tests so a browser failure means something.
+- **Prompt for actions *and* assertions:** Phrase a request so Copilot verifies each state instead of just performing clicks.
+- **Read the evidence:** Review the completed tool calls rather than trusting what you saw on screen.
+
+Here is the journey Copilot will run.
+
+```mermaid
+flowchart LR
+    A["Open localhost:8080<br/>assert page title"] --> B["Fill input<br/>click Add"]
+    B --> C["Find that exact row"]
+    C --> D["Click checkbox<br/>assert checked"]
+    D --> E["Click Delete<br/>assert row gone"]
+```
+
+Fig 1: Chapter 4 journey — five steps, each with an assertion attached.
+
+## Problem Framing: The Layer Your Tests Do Not Cover
+
+The sample already has unit tests for `TodoService` and an integration test for the Spring
+web flow. Both are valuable, and neither clicks anything. They exercise the code beneath
+the page, so a broken form attribute, a mislabelled control, or a row that renders but
+cannot be selected passes every one of them.
+
+Browser tests close that gap. Historically they cost enough to write that teams skipped
+them, which is exactly the kind of cost an assistant with the right tools can absorb.
+
+### Try this
+
+Look at your own most recent UI change and ask what would have failed if the button had
+rendered with the wrong handler. If the answer is "nothing until someone noticed", that is
+the layer this chapter covers.
+
+## Prerequisites
+
+- **A cloned copy of the sample:** Clone [microsoft/github-copilot-java-mcp-demo](https://github.com/microsoft/github-copilot-java-mcp-demo) and open it in a current version of Visual Studio Code.
+- **JDK 25 and both extension packs:** The **Extension Pack for Java** and the **Spring Boot Extension Pack**.
+- **GitHub Copilot:** Installed and signed in, with Agent mode available in Copilot Chat.
+- **A clean starting state:** The app stopped, port 8080 free, and the Playwright MCP server not yet installed, so the **Install** action is available.
+- **Permission to install and run:** Allow MCP server installation and tool use when prompted.
+
+> **If the gallery result is missing:** when `@mcp playwright` returns nothing in the
+> Extensions view, add the server to `.vscode/mcp.json` and start it from there instead.
+>
+> **Browser warning:** Playwright opens a real Chrome window that shows an **unsupported
+> command-line flag: --no-sandbox** infobar. Dismiss it with its **×**; it does not affect
+> the run.
+
+## What Is the Playwright MCP Server?
+
+Playwright is Microsoft's browser automation library. The Playwright MCP server wraps it
+as Model Context Protocol tools, so an assistant can navigate, inspect, and interact with
+a page without you writing any test code.
+
+It is worth being precise about what it gives the model:
+
+- **Navigation:** Open a URL and wait for the page to settle.
+- **Inspection:** Take an accessibility snapshot of the page, which is how it locates controls by role, label, and text rather than by pixel position.
+- **Interaction:** Click, type, select, and press keys against a specific element.
+- **Evaluation:** Run a snippet against the page to read state, such as whether a checkbox is checked.
+
+Unlike an MCP server you build into your own application, this one is not part of your
+project. It installs into your Visual Studio Code user profile and runs as a local
+process, so it stays available in every workspace once installed.
+
+### Markup that a tool can target
+
+Automation is only as reliable as the hooks it aims at. `templates/index.html` carries
+stable test ids on every control that matters:
+
+| Hook | Control |
+| ------ | --------- |
+| `data-testid="new-todo-input"` | The title field |
+| `data-testid="add-todo"` | The **Add** button |
+| `data-testid="todo-item"` | Each row in the list |
+| `data-testid="delete-todo"` | That row's **Delete** button |
+
+The checkbox is handled differently, and deliberately so. It builds an accessible label
+from the item's own title:
+
+```html
+<input type="checkbox" th:checked="${todo.completed}"
+       th:attr="aria-label='Toggle ' + ${todo.title}"
+       onchange="this.form.submit()" />
+```
+
+Every row's delete button shares one test id, but every row's checkbox has a *unique*
+accessible name — `Toggle Verify the browser flow`, for instance. That is what lets the
+assistant tick the row it just created rather than whichever row happens to be first, and
+it improves the page for screen reader users at the same time.
+
+## Exercise - install the tools and establish a baseline
+
+1. Select the **Extensions** button in the Activity Bar and search **`@mcp playwright`**.
+2. Open the Playwright MCP server result and review its publisher and command configuration before installing.
+3. Select **Install**, confirm trust for the server, and wait for its running status.
+4. Open `templates/index.html` and find the four `data-testid` values and the checkbox's `th:attr` label.
+5. Select the **Testing** button in the Activity Bar, select **Run All Tests**, and wait until every Java test passes.
+
+![The Testing view reporting all Java tests passing](images/ch4-testing-view.png)
+
+Fig 2: The Testing view aggregates the unit and integration tests across the project. A green baseline here means a later browser failure is a UI failure.
+
+Reviewing the publisher and command before installing is not ceremony. An MCP server runs
+a local process with your permissions, so it deserves the same scrutiny as any other
+executable you choose to run.
+
+## Exercise - let Copilot drive the browser
+
+1. Select the **Spring Boot Dashboard** icon in the Activity Bar, find **springboot-mcp-demo**, select **Run**, and wait until the Dashboard shows it running on port 8080.
+2. Open Copilot Chat, select **Agent** mode, select **Configure Tools...** in the chat input, confirm the Playwright tools are listed and enabled, and close the picker.
+3. Enter the following prompt and select **Send**:
+
+   ```text
+   Use the Playwright tools to open http://localhost:8080 and verify the page title is 'Java TODO Demo'. Add a todo called 'Verify the browser flow', find that todo's row, complete it and verify it is checked, then delete it and verify it is gone.
+   ```
+
+4. If prompted, review the tool name and arguments before choosing **Allow Once**.
+5. As Copilot works, watch the page at <http://localhost:8080>: the input filled with **Verify the browser flow**, the new row after **Add**, the checked checkbox after completion, and the row disappearing after deletion.
+
+![The Playwright-controlled browser running against the app](images/ch4-playwright-run.png)
+
+Fig 3: Playwright drives a real Chrome window against the running Spring Boot app. Here it has added the row and ticked its checkbox — the state the prompt asked it to verify before deleting.
+
+The prompt is doing more work than it looks. Every action is paired with a check —
+*verify the page title*, *verify it is checked*, *verify it is gone* — and it names the
+exact title to add, so the assistant has something unambiguous to search for. Drop those
+and you get a demo. Keep them and you get a test.
+
+## Reading the Evidence
+
+Watching the browser is satisfying and proves very little; a page can flash through a
+state too quickly to see, and a human eye is a poor assertion engine.
+
+Return to Chat and review the completed tool calls. The trace shows the page title that
+was read, the exact text that was typed, the row that was located, the checked state that
+was observed after the toggle, and the absence check that ran after the delete. Each of
+those is a value the tool returned, not a claim in the summary.
+
+That is the habit worth taking away: the final response is a summary, and the tool calls
+are the test report.
+
+## Exercise - shut down
+
+1. Close the Playwright browser window.
+2. Return to the Spring Boot Dashboard, select **Stop** for **springboot-mcp-demo**, and confirm it is no longer running.
+3. Leave the Playwright MCP server installed in the Visual Studio Code user profile — it stays available for future Chat sessions in any workspace.
+
+## Quick Question
+
+The prompt names the todo `Verify the browser flow` rather than something short like
+`test`. Why does the specific title matter to the reliability of this run?
+
+## Answer
+
+Because it is what makes the row uniquely addressable. The delete buttons all share one
+test id, so "the delete button" is ambiguous the moment the list has more than one row.
+The checkbox, by contrast, gets an accessible label built from the title — so a distinctive
+title produces a distinctive label, and the assistant can target exactly the row it
+created. A generic title risks colliding with existing data and turning a passing run into
+a false positive, which is the worst outcome a test can have.
+
+## What's Next
+
+You have taken this sample from an unopened folder to a Spring Boot application that
+Copilot can both call and test — a web UI, a debugger session, an MCP tool surface, and a
+browser-driven test, all from Visual Studio Code.
+
+The natural next step is your own project. The pattern transfers directly: put the logic
+in a service, expose the operations you trust as MCP tools, keep stable hooks and
+accessible labels in your markup, and describe journeys with assertions attached rather
+than clicks.
+
+## Learn more
+
+- [Playwright MCP server](https://github.com/microsoft/playwright-mcp) — the server installed in this chapter, and its tool list.
+- [Playwright documentation](https://playwright.dev/docs/intro) — locators, assertions, and the accessibility snapshot model.
+- [MCP servers in Visual Studio Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) — installing from the gallery and managing trust.
+- [Testing Java in Visual Studio Code](https://code.visualstudio.com/docs/java/java-testing) — the Testing view and test discovery.
+- [Demo source on GitHub](https://github.com/microsoft/github-copilot-java-mcp-demo) — the sample used in every chapter.
+
+---
+
+Chapter 4 of 4 · Previous: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)

--- a/learn/java-spring-boot/4-test-with-playwright.md
+++ b/learn/java-spring-boot/4-test-with-playwright.md
@@ -5,7 +5,7 @@ MetaDescription: Use GitHub Copilot and Playwright MCP tools to test a Spring Bo
 MetaSocialImage: ../images/shared/agent-first-development-social.png
 ---
 
-# Let GitHub Copilot Test Your Spring Boot App with Playwright
+# Let GitHub Copilot test your Spring Boot app with Playwright
 
 Your unit tests pass. Your integration tests pass. And you still open the browser
 afterwards to check that the page actually works, because a green build has never proved
@@ -18,7 +18,7 @@ In this chapter, we'll hand it to GitHub Copilot. Copilot gets browser-control t
 you describe the journey in one sentence, and a real Chrome window drives your running
 Spring Boot app while you watch.
 
-Then — and this is the part that matters — you read the assertions it actually ran.
+Then you read the assertions it actually ran, which is the part that matters.
 
 ## What You Will Learn
 
@@ -141,7 +141,7 @@ executable you choose to run.
 2. Open Copilot Chat, select **Agent** mode, select **Configure Tools...** in the chat input, confirm the Playwright tools are listed and enabled, and close the picker.
 3. Enter the following prompt and select **Send**:
 
-   ```text
+   ```prompt
    Use the Playwright tools to open http://localhost:8080 and verify the page title is 'Java TODO Demo'. Add a todo called 'Verify the browser flow', find that todo's row, complete it and verify it is checked, then delete it and verify it is gone.
    ```
 

--- a/learn/java-spring-boot/images/02-actuator-health.png
+++ b/learn/java-spring-boot/images/02-actuator-health.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d784ac605099ce7338c56d99193d21011124e94782fe8845541d2c124f58a937
+size 5389

--- a/learn/java-spring-boot/images/03-mcp-added-todo.png
+++ b/learn/java-spring-boot/images/03-mcp-added-todo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f834df8716df9820d594ab078816ad7726d1b4321f722e539102140709163478
+size 17709

--- a/learn/java-spring-boot/images/06-copilot-mcp-chat.png
+++ b/learn/java-spring-boot/images/06-copilot-mcp-chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75840cc38f6851b4c409b2316832ef0182292e63eadc4adca94ee6be83a2c7a4
+size 119730

--- a/learn/java-spring-boot/images/ch1-dashboard-running.png
+++ b/learn/java-spring-boot/images/ch1-dashboard-running.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b3f5a7857a5c0e4ba963e70f257702cbd0530282553d45c531127294b46002b
+size 25771

--- a/learn/java-spring-boot/images/ch1-extensions-java-pack.png
+++ b/learn/java-spring-boot/images/ch1-extensions-java-pack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc587011894f8d64bdd7aa74c85c16c59c88ad00981560c2091bed97ae4b8cec
+size 267191

--- a/learn/java-spring-boot/images/ch1-web-app.png
+++ b/learn/java-spring-boot/images/ch1-web-app.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0a42342c83f3cd7ec8af25348d7cdbab51fdcfb2637a08a8cd12eb7ba393f02
+size 5951

--- a/learn/java-spring-boot/images/ch2-breakpoint-paused.png
+++ b/learn/java-spring-boot/images/ch2-breakpoint-paused.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaff36369b06dd07300780cce35d001894bcadc8ace40c30929b237b5d0d12e1
+size 121480

--- a/learn/java-spring-boot/images/ch2-endpoint-mappings.png
+++ b/learn/java-spring-boot/images/ch2-endpoint-mappings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f6f8b5af659951fa6c7e381d08ae7b55033700bc63538e499b9047b6ccdd1a0
+size 25585

--- a/learn/java-spring-boot/images/ch2-memory-view.png
+++ b/learn/java-spring-boot/images/ch2-memory-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a00dbed6f9644de86e63f48c8deda64bfd716275b4ccdb1ba7e4edbdb9ddfca9
+size 39178

--- a/learn/java-spring-boot/images/ch2-url-hints.png
+++ b/learn/java-spring-boot/images/ch2-url-hints.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd03e3c0be40cab50a813c897cb8eaf6b9d6221b559d74db2db689affc58de3c
+size 86808

--- a/learn/java-spring-boot/images/ch3-mcp-json-running.png
+++ b/learn/java-spring-boot/images/ch3-mcp-json-running.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8089893506ceeb959a045670503b95b0b3a1e1db042b21ae58ca44ef21a6687b
+size 64869

--- a/learn/java-spring-boot/images/ch4-playwright-run.png
+++ b/learn/java-spring-boot/images/ch4-playwright-run.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6949877a5f247c8be159a95450fc4ba6b091621b0ca6757205de314a726d019f
+size 6217

--- a/learn/java-spring-boot/images/ch4-testing-view.png
+++ b/learn/java-spring-boot/images/ch4-testing-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f806f10d6f5875a4b5a7f5e1cb59496970ddfe6f90a7b4e3f466e2c3a810cce1
+size 11417

--- a/learn/toc.json
+++ b/learn/toc.json
@@ -53,5 +53,17 @@
       ["Building a social media content agent with Agent Builder", "/learn/foundry-toolkit-extension/3-building-social-media-agent"],
       ["Building a hosted agent with GitHub Copilot and Microsoft Foundry", "/learn/foundry-toolkit-extension/4-building-hosted-agent"]
     ]
+  },
+  {
+    "name": "Java, Spring Boot, and GitHub Copilot",
+    "area": "java-spring-boot",
+    "description": "Learn how to build, debug, extend, and test a Spring Boot application with Java tools and GitHub Copilot in VS Code.",
+    "image": "/assets/learn/java-spring-boot/ch1-web-app.png",
+    "topics": [
+      ["Build and Run Your First Spring Boot App", "/learn/java-spring-boot/1-build-and-run"],
+      ["Debug and Inspect a Spring Boot Request", "/learn/java-spring-boot/2-debug-and-inspect"],
+      ["Expose Your Java Operations to GitHub Copilot with MCP", "/learn/java-spring-boot/3-expose-tools-with-mcp"],
+      ["Let GitHub Copilot Test Your Spring Boot App with Playwright", "/learn/java-spring-boot/4-test-with-playwright"]
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Add a four-part Learn course for building and running a Spring Boot app in Visual Studio Code.
- Cover Java debugging, exposing operations as MCP tools, and browser testing with GitHub Copilot and Playwright.
- Register the course in the Learn navigation and add the supporting screenshots.

## Validation

- Ran `npm run check-lfs`.
- Verified all four course routes in the local Docsify preview.
- Verified all 13 article images load successfully.
- Verified the Learn TOC, metadata, local links, and Markdown diagnostics.