### PR TITLE
Add Java Spring Boot course card and fix navigation links

### DIFF
--- a/learn/images/java-spring-boot/java-spring-boot-stack-card.png
+++ b/learn/images/java-spring-boot/java-spring-boot-stack-card.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65be7d5683657feffdef1f448dff53e785b3edf0aed447cfe154bdbc77538dc5
+size 116429

--- a/learn/java-spring-boot/1-build-and-run.md
+++ b/learn/java-spring-boot/1-build-and-run.md
@@ -203,7 +203,7 @@ You now have a working Java and Spring Boot setup, a project you can navigate, a
 application you can start and stop from the editor. That is the foundation every later
 chapter assumes.
 
-In [Chapter 2, Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md), we'll
+In [Chapter 2, Debug and Inspect a Spring Boot Request](/learn/java-spring-boot/2-debug-and-inspect), we'll
 stop trusting the browser and start inspecting the process. You'll set a breakpoint on the
 exact line where the web layer hands off to the service, step through the call, and watch
 the repository assign an id — then check the app's health and memory while it is still
@@ -219,4 +219,4 @@ running.
 
 ---
 
-Chapter 1 of 4 · Next: [Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md)
+Chapter 1 of 4 · Next: [Debug and Inspect a Spring Boot Request](/learn/java-spring-boot/2-debug-and-inspect)

--- a/learn/java-spring-boot/2-debug-and-inspect.md
+++ b/learn/java-spring-boot/2-debug-and-inspect.md
@@ -216,7 +216,7 @@ You can now stop a Spring Boot request mid-flight, follow it across a class boun
 read the values it produces, and check the health and memory of the process that produced
 them.
 
-In [Chapter 3, Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp),
+In [Chapter 3, Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md),
 the same `TodoService` gets a second caller. Instead of a browser form, GitHub Copilot
 calls it — the app publishes its operations as Model Context Protocol tools, and a todo
 created from a chat prompt shows up on the very page you have been debugging.
@@ -231,4 +231,4 @@ created from a chat prompt shows up on the very page you have been debugging.
 
 ---
 
-Chapter 2 of 4 · Previous: [Build and Run Your First Spring Boot App](/learn/java-spring-boot/1-build-and-run) · Next: [Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp)
+Chapter 2 of 4 · Previous: [Build and Run Your First Spring Boot App](1-build-and-run.md) · Next: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)

--- a/learn/java-spring-boot/2-debug-and-inspect.md
+++ b/learn/java-spring-boot/2-debug-and-inspect.md
@@ -216,7 +216,7 @@ You can now stop a Spring Boot request mid-flight, follow it across a class boun
 read the values it produces, and check the health and memory of the process that produced
 them.
 
-In [Chapter 3, Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md),
+In [Chapter 3, Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp),
 the same `TodoService` gets a second caller. Instead of a browser form, GitHub Copilot
 calls it — the app publishes its operations as Model Context Protocol tools, and a todo
 created from a chat prompt shows up on the very page you have been debugging.
@@ -231,4 +231,4 @@ created from a chat prompt shows up on the very page you have been debugging.
 
 ---
 
-Chapter 2 of 4 · Previous: [Build and Run Your First Spring Boot App](1-build-and-run.md) · Next: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)
+Chapter 2 of 4 · Previous: [Build and Run Your First Spring Boot App](/learn/java-spring-boot/1-build-and-run) · Next: [Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp)

--- a/learn/java-spring-boot/3-expose-tools-with-mcp.md
+++ b/learn/java-spring-boot/3-expose-tools-with-mcp.md
@@ -213,7 +213,7 @@ storing anything, you have two implementations to keep in step.
 Your Java application can now be called by an assistant, and you have verified that the
 calls change real state rather than producing plausible text.
 
-In [Chapter 4, Let Copilot Test Your App with Playwright](/learn/java-spring-boot/4-test-with-playwright), we
+In [Chapter 4, Let Copilot Test Your App with Playwright](4-test-with-playwright.md), we
 point Copilot at the other side of the app. Instead of calling your service directly, it
 drives a real browser against the running page — filling the form, clicking the checkbox,
 deleting the row, and asserting each result along the way.
@@ -228,4 +228,4 @@ deleting the row, and asserting each result along the way.
 
 ---
 
-Chapter 3 of 4 · Previous: [Debug and Inspect a Spring Boot Request](/learn/java-spring-boot/2-debug-and-inspect) · Next: [Let Copilot Test Your App with Playwright](/learn/java-spring-boot/4-test-with-playwright)
+Chapter 3 of 4 · Previous: [Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md) · Next: [Let Copilot Test Your App with Playwright](4-test-with-playwright.md)

--- a/learn/java-spring-boot/3-expose-tools-with-mcp.md
+++ b/learn/java-spring-boot/3-expose-tools-with-mcp.md
@@ -213,7 +213,7 @@ storing anything, you have two implementations to keep in step.
 Your Java application can now be called by an assistant, and you have verified that the
 calls change real state rather than producing plausible text.
 
-In [Chapter 4, Let Copilot Test Your App with Playwright](4-test-with-playwright.md), we
+In [Chapter 4, Let Copilot Test Your App with Playwright](/learn/java-spring-boot/4-test-with-playwright), we
 point Copilot at the other side of the app. Instead of calling your service directly, it
 drives a real browser against the running page — filling the form, clicking the checkbox,
 deleting the row, and asserting each result along the way.
@@ -228,4 +228,4 @@ deleting the row, and asserting each result along the way.
 
 ---
 
-Chapter 3 of 4 · Previous: [Debug and Inspect a Spring Boot Request](2-debug-and-inspect.md) · Next: [Let Copilot Test Your App with Playwright](4-test-with-playwright.md)
+Chapter 3 of 4 · Previous: [Debug and Inspect a Spring Boot Request](/learn/java-spring-boot/2-debug-and-inspect) · Next: [Let Copilot Test Your App with Playwright](/learn/java-spring-boot/4-test-with-playwright)

--- a/learn/java-spring-boot/4-test-with-playwright.md
+++ b/learn/java-spring-boot/4-test-with-playwright.md
@@ -207,4 +207,4 @@ than clicks.
 
 ---
 
-Chapter 4 of 4 · Previous: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)
+Chapter 4 of 4 · Previous: [Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp)

--- a/learn/java-spring-boot/4-test-with-playwright.md
+++ b/learn/java-spring-boot/4-test-with-playwright.md
@@ -207,4 +207,4 @@ than clicks.
 
 ---
 
-Chapter 4 of 4 · Previous: [Expose Your Java Operations to Copilot with MCP](/learn/java-spring-boot/3-expose-tools-with-mcp)
+Chapter 4 of 4 · Previous: [Expose Your Java Operations to Copilot with MCP](3-expose-tools-with-mcp.md)

--- a/learn/toc.json
+++ b/learn/toc.json
@@ -58,7 +58,7 @@
     "name": "Java, Spring Boot, and GitHub Copilot",
     "area": "java-spring-boot",
     "description": "Learn how to build, debug, extend, and test a Spring Boot application with Java tools and GitHub Copilot in VS Code.",
-    "image": "/assets/learn/java-spring-boot/ch1-web-app.png",
+    "image": "/assets/learn/java-spring-boot/java-spring-boot-stack-card.png",
     "topics": [
       ["Build and Run Your First Spring Boot App", "/learn/java-spring-boot/1-build-and-run"],
       ["Debug and Inspect a Spring Boot Request", "/learn/java-spring-boot/2-debug-and-inspect"],


### PR DESCRIPTION
## Summary

Follow-up to #10157.

- Add a dedicated card image for the Java, Spring Boot, and GitHub Copilot Learn course.
- Update the Java course entry in `learn/toc.json` to use the new card.
- Fix broken Previous, Next, and What's Next links across all four Java chapters.
- Replace links that generated `.md` production URLs with extensionless Learn routes.

## Validation

- Verified all nine Java course navigation links match routes registered in `learn/toc.json`.
- Verified the working production URL format directly on `code.visualstudio.com`.
- Verified no `.md` navigation links remain in the Java course.
- Verified the new card image is managed by Git LFS.
- Verified no whitespace errors.
- Verified no other course content was changed.