### PR TITLE
Update Java Playwright chapter video

### DIFF
--- a/learn/java-spring-boot/4-test-with-playwright.md
+++ b/learn/java-spring-boot/4-test-with-playwright.md
@@ -7,7 +7,7 @@ MetaSocialImage: ../images/shared/agent-first-development-social.png
 
 # Let GitHub Copilot test your Spring Boot app with Playwright
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YGUwr6UhmUI?si=WZMWMFHq-o7Or7fu" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NR4YHj_9WFw?si=UBOLCtYL2T5gHIqA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Your unit tests pass. Your integration tests pass. And you still open the browser
 afterwards to check that the page actually works, because a green build has never proved


### PR DESCRIPTION
## Summary

- Replace the video in the Java Spring Boot Playwright chapter.
- Preserve the privacy-enhanced `youtube-nocookie.com` embed domain.
- Keep the existing iframe attributes unchanged.

## Validation

- Verified the new video ID is `NR4YHj_9WFw`.
- Verified the embed uses `youtube-nocookie.com`.
- Verified the branch changes only the Chapter 4 Java article.
- Verified no whitespace errors.