### PR TITLE
docs: Update 1.136 Insiders release notes

### DIFF
--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: August 26, 2026_
+_Last updated: August 28, 2026_
 
 Welcome to the 1.136 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,12 +40,32 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#august-28-2026">August 28, 2026</a></li>
+      <li><a href="#august-27-2026">August 27, 2026</a></li>
       <li><a href="#august-26-2026">August 26, 2026</a></li>
       <li><a href="#august-25-2026">August 25, 2026</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
+
+## August 28, 2026
+
+* Add support for tuning rename detection with `setting(git.similarityThreshold)` (0-100, default 50) so Git treats added and deleted file pairs as renames in `git status`, `git diff`, and `git diff-tree`. _[#282454: Git - Support git.similarityThreshold setting](https://github.com/microsoft/vscode/issues/282454)_
+
+* Remove the chat pet's peeking animation to reduce distracting motion above the chat input. _[#331393: Disable the pet’s peeking animation](https://github.com/microsoft/vscode/issues/331393)_
+
+## August 27, 2026
+
+* Add support for `reasoning-effort` in custom `.agent.md` files so you can tune each agent's reasoning depth, speed, and token usage. Supported values are `low`, `medium`, `high`, `xhigh`, and `max`. _[#313546: Support reasoning effort configuration in custom .agent.md files](https://github.com/microsoft/vscode/issues/313546)_
+
+* Add enterprise policies for `setting(dictation.model)` and `setting(dictation.experimental.llmCleanup)`, enabling administrators to standardize on-device transcription and control whether developers can use LLM-based transcript cleanup. _[#331845: Add enterprise policies for dictation model and LLM cleanup](https://github.com/microsoft/vscode/issues/331845)_
+
+* Add support for `gpt-5.4-nano` in `setting(dictation.experimental.llmCleanupModel)` so dictation can use a low-latency cleanup model and fall back to `copilot-utility-small` when Nano is unavailable. _[#332969: Add GPT-5.4 Nano as a dictation LLM cleanup backend option](https://github.com/microsoft/vscode/issues/332969)_
+
+* Add an **Open Pull Request on GitHub** action to pull request tabs, giving you a fallback when the in-product viewer remains loading. _[#332009: In-product PR viewer stuck. No way to open in external web browser](https://github.com/microsoft/vscode/issues/332009)_
+
+* Add support for attaching folders, repositories, issues, and pull requests to a new chat session while keeping the primary workspace as the main execution context. _[#332805: Redesign new session chat input](https://github.com/microsoft/vscode/issues/332805)_
 
 ## August 26, 2026
 
@@ -56,6 +76,10 @@ Navigation End -->
 * Completed `create_session`, `create_chat`, and targeted `send_message` tool calls show linked session or chat titles, making delegated work easier to identify and open. _[#332741: `create_session` link/artifact is ugly](https://github.com/microsoft/vscode/issues/332741)_
 
 * Add VS Code support for session-aware Voice mode so compatible voice backends can report active and recent session status, navigate between sessions, and direct later voice turns to the selected session. _[#329488: Voice mode: add session awareness and session navigation](https://github.com/microsoft/vscode/issues/329488)_
+
+* Add support for expanding the changed-files summary on completed agent turns so you can inspect the individual changed files from the chat summary. _[#257986: "files changed" does not clear in Copilot chat](https://github.com/microsoft/vscode/issues/257986)_
+
+* Add support for exporting chats as JSON, Markdown, or ZIP with repository context so you can keep conversations after deleting the local workspace. _[#260769: Export chats](https://github.com/microsoft/vscode/issues/260769)_
 
 ## August 25, 2026
 


### PR DESCRIPTION
## Summary

* add nine newly closed feature requests to the 1.136 Insiders release notes
* group entries by their August 26-28 close dates
* update the last-updated date and table of contents

## Validation

* verified every eligible `feature-request` issue closed since the previous update is included
* verified date headings, TOC anchors, and issue-link formatting
* ran `git diff --check`