### PR TITLE
Remove reference to git.similarityThreshold in v1.136

### DIFF
--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -51,8 +51,6 @@ Navigation End -->
 
 ## August 28, 2026
 
-* Add support for tuning rename detection with `setting(git.similarityThreshold)` (0-100, default 50) so Git treats added and deleted file pairs as renames in `git status`, `git diff`, and `git diff-tree`. _[#282454: Git - Support git.similarityThreshold setting](https://github.com/microsoft/vscode/issues/282454)_
-
 * Remove the chat pet's peeking animation to reduce distracting motion above the chat input. _[#331393: Disable the pet’s peeking animation](https://github.com/microsoft/vscode/issues/331393)_
 
 ## August 27, 2026


### PR DESCRIPTION
It was introduced in v1.79 and has no place here.

The issue requesting the feature was closed as "completed", but

> This setting already exists — git.similarityThreshold was added in VS Code 1.79

- https://github.com/microsoft/vscode/issues/282454#issuecomment-5449661126