### PR TITLE
release notes: add agent and voice mode updates

### DIFF
--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -86,10 +86,6 @@ VS Code can now notify you when an agent session needs your input or finishes it
 
 Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention.
 
-### Clearer links to delegated sessions
-
-Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation.
-
 ## Chat
 
 ### Voice Mode (Experimental)

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -74,9 +74,11 @@ Navigation End -->
 
 The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout.
 
-### Clearer links to delegated sessions
+### Improved workspace resolution
 
-Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation.
+Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.
+
+As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well.
 
 ### Agent session notifications
 
@@ -84,11 +86,9 @@ VS Code can now notify you when an agent session needs your input or finishes it
 
 Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention.
 
-### Improved workspace resolution
+### Clearer links to delegated sessions
 
-Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.
-
-As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well.
+Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation.
 
 ## Chat
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -119,6 +119,10 @@ The new controls make it possible to require on-device transcription and disable
 
 ## Accessibility
 
+### Screen Reader Optimized badge in the Agents window
+
+When Screen Reader Optimized mode is enabled, the Agents window now shows a **Screen Reader Optimized** badge in the title bar. The badge makes the active accessibility mode easier to identify. Select the badge to disable Screen Reader Optimized mode.
+
 ## Editor Experience
 
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -90,10 +90,6 @@ We also made several improvements to Voice Mode:
 
 The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout.
 
-### Start a session from a GitHub issue or pull request
-
-When you start a session from an issue or pull request, you can now paste a GitHub URL directly into the picker. This makes it faster to hand an existing issue or pull request to an agent without first searching for it by name.
-
 ### Clearer links to delegated sessions
 
 Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation.

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -108,16 +108,16 @@ As a result, you can make requests such as "run this in the vscode workspace" wi
 
 ## Chat
 
-## MCP
-
-
-## Accessibility
-
 ### Enterprise controls for dictation data
 
 Administrators can now manage the dictation model and language-model transcript cleanup through enterprise policies.
 
 The new controls make it possible to require on-device transcription and disable language-model cleanup, so dictation remains available while preventing dictation data from being sent to cloud transcription or a Copilot model.
+
+## MCP
+
+
+## Accessibility
 
 ## Editor Experience
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -70,15 +70,62 @@ Navigation End -->
 
 ## Agents
 
+### Voice Mode (Experimental)
+
+**Setting**: `setting(agents.voice.enabled)`
+
+This iteration, we expanded access to the experimental Voice Mode, making it available to external users for the first time. Voice Mode enables you to have a natural, spoken conversation with an agent while it works on your code.
+
+To try it, enable the `setting(agents.voice.enabled)` setting and select the Voice Mode button in the chat input.
+
+We also made several improvements to Voice Mode:
+
+* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls. [Issue #331367](https://github.com/microsoft/vscode/issues/331367)
+
+* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one. [Issue #329488](https://github.com/microsoft/vscode/issues/329488)
+
+* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running. [Issue #329490](https://github.com/microsoft/vscode/issues/329490)
+
+### Redesigned new-session input
+
+The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout. [Issue #332805](https://github.com/microsoft/vscode/issues/332805)
+
+### Start a session from a GitHub issue or pull request
+
+When you start a session from an issue or pull request, you can now paste a GitHub URL directly into the picker. This makes it faster to hand an existing issue or pull request to an agent without first searching for it by name. [Issue #333149](https://github.com/microsoft/vscode/issues/333149)
+
+### Clearer links to delegated sessions
+
+Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation. [Issue #332741](https://github.com/microsoft/vscode/issues/332741)
+
+### Agent session notifications
+
+VS Code can now notify you when an agent session needs your input or finishes its work. This is especially useful when you delegate work across multiple sessions, workspaces, or VS Code windows.
+
+Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention. [Issue #317195](https://github.com/microsoft/vscode/issues/317195)
+
+### Improved workspace resolution
+
+Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.
+
+As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well. [Issue #330948](https://github.com/microsoft/vscode/issues/330948)
 
 ## Chat
 
+### Start dictation from context menus
+
+You can now start dictation from the context menu in the editor or integrated terminal. These new entry points make speech-to-text easier to discover without adding persistent controls to the editor or terminal toolbars. [Issue #331368](https://github.com/microsoft/vscode/issues/331368)
 
 ## MCP
 
 
 ## Accessibility
 
+### Enterprise controls for dictation data
+
+Administrators can now manage the dictation model and language-model transcript cleanup through enterprise policies.
+
+The new controls make it possible to require on-device transcription and disable language-model cleanup, so dictation remains available while preventing dictation data from being sent to cloud transcription or a Copilot model. [Issue #331845](https://github.com/microsoft/vscode/issues/331845)
 
 ## Editor Experience
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -70,22 +70,6 @@ Navigation End -->
 
 ## Agents
 
-### Voice Mode (Experimental)
-
-**Setting**: `setting(agents.voice.enabled)`
-
-This iteration, we expanded access to the experimental Voice Mode, making it available to external users for the first time. Voice Mode enables you to have a natural, spoken conversation with an agent while it works on your code.
-
-To try it, enable the `setting(agents.voice.enabled)` setting and select the Voice Mode button in the chat input.
-
-We also made several improvements to Voice Mode:
-
-* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.
-
-* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one.
-
-* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running.
-
 ### Redesigned new-session input
 
 The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout.
@@ -107,6 +91,22 @@ Agents can now resolve workspaces by project name in addition to absolute paths 
 As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well.
 
 ## Chat
+
+### Voice Mode (Experimental)
+
+**Setting**: `setting(agents.voice.enabled)`
+
+This iteration, we expanded access to the experimental Voice Mode, making it available to external users for the first time. Voice Mode enables you to have a natural, spoken conversation with an agent while it works on your code.
+
+To try it, enable the `setting(agents.voice.enabled)` setting and select the Voice Mode button in the chat input.
+
+We also made several improvements to Voice Mode:
+
+* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.
+
+* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one.
+
+* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running.
 
 ### Enterprise controls for dictation data
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -80,41 +80,41 @@ To try it, enable the `setting(agents.voice.enabled)` setting and select the Voi
 
 We also made several improvements to Voice Mode:
 
-* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls. [Issue #331367](https://github.com/microsoft/vscode/issues/331367)
+* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.
 
-* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one. [Issue #329488](https://github.com/microsoft/vscode/issues/329488)
+* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one.
 
-* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running. [Issue #329490](https://github.com/microsoft/vscode/issues/329490)
+* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running.
 
 ### Redesigned new-session input
 
-The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout. [Issue #332805](https://github.com/microsoft/vscode/issues/332805)
+The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout.
 
 ### Start a session from a GitHub issue or pull request
 
-When you start a session from an issue or pull request, you can now paste a GitHub URL directly into the picker. This makes it faster to hand an existing issue or pull request to an agent without first searching for it by name. [Issue #333149](https://github.com/microsoft/vscode/issues/333149)
+When you start a session from an issue or pull request, you can now paste a GitHub URL directly into the picker. This makes it faster to hand an existing issue or pull request to an agent without first searching for it by name.
 
 ### Clearer links to delegated sessions
 
-Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation. [Issue #332741](https://github.com/microsoft/vscode/issues/332741)
+Links created when work is delegated to another session now use a compact, consistent presentation. You can more easily identify and open the session without a long raw link interrupting the conversation.
 
 ### Agent session notifications
 
 VS Code can now notify you when an agent session needs your input or finishes its work. This is especially useful when you delegate work across multiple sessions, workspaces, or VS Code windows.
 
-Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention. [Issue #317195](https://github.com/microsoft/vscode/issues/317195)
+Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention.
 
 ### Improved workspace resolution
 
 Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.
 
-As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well. [Issue #330948](https://github.com/microsoft/vscode/issues/330948)
+As a result, you can make requests such as "run this in the vscode workspace" without providing a full path. If more than one workspace has the same name, the agent reports the possible matches instead of silently choosing one. Remote workspace URIs are supported as well.
 
 ## Chat
 
 ### Start dictation from context menus
 
-You can now start dictation from the context menu in the editor or integrated terminal. These new entry points make speech-to-text easier to discover without adding persistent controls to the editor or terminal toolbars. [Issue #331368](https://github.com/microsoft/vscode/issues/331368)
+You can now start dictation from the context menu in the editor or integrated terminal. These new entry points make speech-to-text easier to discover without adding persistent controls to the editor or terminal toolbars.
 
 ## MCP
 
@@ -125,7 +125,7 @@ You can now start dictation from the context menu in the editor or integrated te
 
 Administrators can now manage the dictation model and language-model transcript cleanup through enterprise policies.
 
-The new controls make it possible to require on-device transcription and disable language-model cleanup, so dictation remains available while preventing dictation data from being sent to cloud transcription or a Copilot model. [Issue #331845](https://github.com/microsoft/vscode/issues/331845)
+The new controls make it possible to require on-device transcription and disable language-model cleanup, so dictation remains available while preventing dictation data from being sent to cloud transcription or a Copilot model.
 
 ## Editor Experience
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -108,10 +108,6 @@ As a result, you can make requests such as "run this in the vscode workspace" wi
 
 ## Chat
 
-### Start dictation from context menus
-
-You can now start dictation from the context menu in the editor or integrated terminal. These new entry points make speech-to-text easier to discover without adding persistent controls to the editor or terminal toolbars.
-
 ## MCP
 
 


### PR DESCRIPTION
Adds the 1.136 release-note drafts for completed feature work from the current and previous milestones.

- introduces experimental Voice Mode availability for external users
- documents Voice Mode controls, session awareness, and request routing
- covers Agents window and orchestration improvements
- documents dictation entry points and enterprise controls

Validation:
- `git diff --check`
- Repository lint could not run because dependency restore is blocked by the private Azure package registry (HTTP 500/Forbidden); lint only targets JavaScript, and this PR changes Markdown only.