### PR TITLE
release notes: refine agent session updates

### DIFF
--- a/release-notes/images/1_136/agents-new-session-input.png
+++ b/release-notes/images/1_136/agents-new-session-input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7c48e3c231b72ff95c83d570b8d54dd2a611404541342b7a39f9abd11de6fe
+size 25270

--- a/release-notes/images/1_136/agents-screen-reader-optimized-badge.png
+++ b/release-notes/images/1_136/agents-screen-reader-optimized-badge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28529e94a580cd75db39dbe0d36988688b4d301ba3db33b2945a2f28eadc28b5
+size 27556

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -74,6 +74,8 @@ Navigation End -->
 
 The new-session input in the Agents window has been redesigned to make it clearer and easier to start delegated work. The updated experience brings the prompt, model selection, workspace selection, and other session controls together in a more streamlined layout.
 
+![Screenshot of the redesigned new-session input in the Agents window with context, permission, worktree, and branch controls.](images/1_136/agents-new-session-input.png)
+
 ### Improved workspace resolution
 
 Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -84,9 +84,11 @@ As a result, you can make requests such as "run this in the vscode workspace" wi
 
 ### Agent session notifications
 
+**Settings**: `setting(chat.notifyWindowOnConfirmation)`, `setting(chat.notifyWindowOnResponseReceived)`
+
 VS Code can now notify you when an agent session needs your input or finishes its work. This is especially useful when you delegate work across multiple sessions, workspaces, or VS Code windows.
 
-Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention.
+By default, notifications only appear when the VS Code window is not focused. You can configure notifications separately for sessions that need input and sessions that have received a response. Notifications include a direct link back to the relevant session, so selecting one focuses the correct window and opens the session that needs attention.
 
 ## Chat
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -123,6 +123,8 @@ The new controls make it possible to require on-device transcription and disable
 
 When Screen Reader Optimized mode is enabled, the Agents window now shows a **Screen Reader Optimized** badge in the title bar. The badge makes the active accessibility mode easier to identify. Select the badge to disable Screen Reader Optimized mode.
 
+![Screenshot of the Screen Reader Optimized badge in the Agents window title bar.](images/1_136/agents-screen-reader-optimized-badge.png)
+
 ## Editor Experience
 
 


### PR DESCRIPTION
Refines the agent-session content in the 1.136 release notes.

- adds renamed screenshots for the redesigned new-session input and Screen Reader Optimized badge
- includes descriptive alt text and tracks both PNGs with Git LFS
- documents the confirmation and response notification settings
- clarifies that notifications only appear when the VS Code window is not focused by default

Validation:
- `git diff --check`
- verified both copied images match their attachment checksums
- verified both images are tracked by Git LFS