### PR TITLE
release notes: expand Voice Mode configuration guidance

### DIFF
--- a/release-notes/images/1_136/voice-mode-context-menu.png
+++ b/release-notes/images/1_136/voice-mode-context-menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ed081a7fea7cca807a1addf92790cd59105402bfb12a3c3d0577f7591c99564
+size 27471

--- a/release-notes/images/1_136/voice-mode-demo.mp4
+++ b/release-notes/images/1_136/voice-mode-demo.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f09c346c5c3dd69230c700ac52fd54dcba83c80062f9dc8c4c1e76b0e891c3b
+size 1056301

--- a/release-notes/images/1_136/voice-mode-introduction.png
+++ b/release-notes/images/1_136/voice-mode-introduction.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8ab16bbabce0a1068457643e372e82999be720773cd35212fb1289aabd32142
+size 28106

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -100,13 +100,15 @@ This iteration, we expanded access to the experimental Voice Mode, making it ava
 
 To try it, enable the `setting(agents.voice.enabled)` setting and select the Voice Mode button in the chat input.
 
+While the agent is speaking, start speaking or use the push-to-talk shortcut to interrupt the response and continue the conversation.
+
 ![Screenshot of the Voice Mode introduction with microphone and agent voice controls.](images/1_136/voice-mode-introduction.png)
 
 <video src="images/1_136/voice-mode-demo.mp4" title="Video showing a spoken conversation with Voice Mode." autoplay loop controls muted></video>
 
 You can customize Voice Mode in the following ways:
 
-* Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active.
+* Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active. Use the Voice Mode controls to show or hide the transcript and mute or unmute your microphone without ending the voice session.
 * Run **Chat: Dictate: Select Microphone** from the Command Palette to choose the input device used by both dictation and Voice Mode.
 * Use `setting(agents.voice.voice)` to select the voice that reads responses aloud.
 * Run **Voice Mode: Show Introduction** from the Command Palette to reopen the introduction, where you can select a microphone and preview the available voices.
@@ -114,16 +116,6 @@ You can customize Voice Mode in the following ways:
 You can also right-click the Voice Mode button in the chat input to quickly access its configuration, instructions, introduction, microphone selection, and transcript controls.
 
 ![Screenshot of the Voice Mode button context menu with configuration, instructions, introduction, microphone, and transcript options.](images/1_136/voice-mode-context-menu.png)
-
-We also made several improvements to Voice Mode:
-
-* **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.
-
-* **Barge in while the agent is speaking**: start speaking or use the push-to-talk shortcut to interrupt the current response and continue the conversation.
-
-* **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one.
-
-* **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running.
 
 ### Enterprise controls for dictation data
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -113,6 +113,8 @@ We also made several improvements to Voice Mode:
 
 * **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.
 
+* **Barge in while the agent is speaking**: start speaking or use the push-to-talk shortcut to interrupt the current response and continue the conversation.
+
 * **Session-aware conversations**: Voice Mode can use information about your active and recent sessions to answer questions such as which session is running, whether an agent is still working, and which model or attachments are selected. You can also ask Voice Mode to switch to another session or start a new one.
 
 * **Smarter request routing**: lightweight questions and application actions can be handled directly by Voice Mode, while requests that need workspace context or coding tools are sent to the coding agent. This lets you ask a quick question or manage sessions without interrupting work that is already running.

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -102,6 +102,8 @@ To try it, enable the `setting(agents.voice.enabled)` setting and select the Voi
 
 ![Screenshot of the Voice Mode introduction with microphone and agent voice controls.](images/1_136/voice-mode-introduction.png)
 
+<video src="images/1_136/voice-mode-demo.mp4" title="Video showing a spoken conversation with Voice Mode." autoplay loop controls muted></video>
+
 You can customize Voice Mode in the following ways:
 
 * Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active.

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -100,6 +100,15 @@ This iteration, we expanded access to the experimental Voice Mode, making it ava
 
 To try it, enable the `setting(agents.voice.enabled)` setting and select the Voice Mode button in the chat input.
 
+![Screenshot of the Voice Mode introduction with microphone and agent voice controls.](images/1_136/voice-mode-introduction.png)
+
+You can customize Voice Mode in the following ways:
+
+* Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active.
+* Run **Chat: Dictate: Select Microphone** from the Command Palette to choose the input device used by both dictation and Voice Mode.
+* Use `setting(agents.voice.voice)` to select the voice that reads responses aloud.
+* Run **Voice Mode: Show Introduction** from the Command Palette to reopen the introduction, where you can select a microphone and preview the available voices.
+
 We also made several improvements to Voice Mode:
 
 * **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -109,6 +109,10 @@ You can customize Voice Mode in the following ways:
 * Use `setting(agents.voice.voice)` to select the voice that reads responses aloud.
 * Run **Voice Mode: Show Introduction** from the Command Palette to reopen the introduction, where you can select a microphone and preview the available voices.
 
+You can also right-click the Voice Mode button in the chat input to quickly access its configuration, instructions, introduction, microphone selection, and transcript controls.
+
+![Screenshot of the Voice Mode button context menu with configuration, instructions, introduction, microphone, and transcript options.](images/1_136/voice-mode-context-menu.png)
+
 We also made several improvements to Voice Mode:
 
 * **More control over your microphone and transcripts**: mute or unmute your microphone without ending the voice session, and quickly show or hide the transcript from the Voice Mode controls.


### PR DESCRIPTION
Expands the 1.136 experimental Voice Mode section with configuration guidance.

- documents transcript visibility, microphone selection, agent voice settings, and barge-in
- documents the command for reopening the Voice Mode introduction
- explains that Voice Mode configuration is available from the button context menu
- adds renamed introduction and context-menu screenshots, plus a Voice Mode demo video, with descriptive accessibility text and Git LFS tracking

Validation:
- `git diff --check`
- verified the copied images match their attachment checksums
- verified the images and video are tracked by Git LFS
