### PR TITLE
release notes: crop Voice Mode demo

### DIFF
--- a/release-notes/images/1_136/voice-mode-demo.mp4
+++ b/release-notes/images/1_136/voice-mode-demo.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f09c346c5c3dd69230c700ac52fd54dcba83c80062f9dc8c4c1e76b0e891c3b
-size 1056301
+oid sha256:fe86edc20eb71570e9f62f7f5a206b273987a34c8e0edc65e70a91f31cd7a575
+size 871186


### PR DESCRIPTION
Crops the Voice Mode demo to focus on the Chat panel and Voice Mode controls.

The video duration and release-note embed are unchanged. The replacement remains an H.264 MP4 tracked through Git LFS.

Validation:
- decoded the complete MP4 with `ffmpeg -v error`
- verified 366x734 dimensions, 30 fps, and `yuv420p` pixel format
- verified the remote LFS asset is available