### PR TITLE
Clarify managed permissions support

### DIFF
--- a/docs/agents/run/approvals.md
+++ b/docs/agents/run/approvals.md
@@ -56,8 +56,6 @@ The permission level applies to the current chat session, and can be changed at 
 
 The permission level determines whether your finer-grained settings apply. **Default Approvals** respects the per-tool, URL, terminal, and sandbox settings you configure in the following sections. **Assisted permissions** delegates individual approval decisions to an LLM judge. **Bypass Approvals** and **Autopilot** override those settings and approve everything automatically.
 
-Your organization can configure [fine-grained managed permissions](/docs/enterprise/ai-settings.md#enforce-fine-grained-permissions) for shell commands, file operations, and domains. Managed rules take precedence over the session permission level. A managed rule can still require approval or block an operation when you use **Bypass Approvals** or **Autopilot**.
-
 > [!IMPORTANT]
 > The **Assisted permissions** level reduces approval interruptions but does not replace your judgment. A model-based risk assessment can make mistakes. The first time you select this level, a warning dialog asks you to confirm. Use [agent sandboxing](/docs/agents/concepts/trust-and-safety.md#agent-sandboxing) to limit file system and network access, and review any tool calls that still require your approval.
 

--- a/docs/enterprise/ai-settings.md
+++ b/docs/enterprise/ai-settings.md
@@ -100,7 +100,6 @@ The following managed settings are available. Most keys map to a {% data variabl
 
 | Managed setting key | {% data variables.product.prodname_vscode_shortname %} policy | Setting | Description |
 |---------------------|----------------|---------|-------------|
-| `permissions.allow`, `permissions.ask`, `permissions.deny` | Not applicable | Not applicable | Fine-grained rules for shell commands, file operations, and domains. See [Enforce fine-grained permissions](#enforce-fine-grained-permissions). |
 | `permissions.disableBypassPermissionsMode` | `ChatToolsAutoApprove` | `setting(chat.tools.global.autoApprove)` | Set to `disable` to turn off global auto-approval ("YOLO mode") and hide the bypass and Autopilot options. |
 | `model` | `ChatDefaultModel` | `setting(chat.defaultModel)` | Default chat model for new conversations. See [Set a default chat model](#set-a-default-chat-model). |
 | `enabledPlugins` | `ChatEnabledPlugins` | `setting(chat.plugins.enabledPlugins)` | Allowlist of plugin IDs, with each plugin explicitly enabled or disabled. |
@@ -263,62 +262,8 @@ Agent tools can perform actions that modify files, run commands, or access exter
 
 Learn more about [tool approval](/docs/agents/run/approvals.md#tool-approval) in {% data variables.product.prodname_vscode_shortname %}.
 
-### Enforce fine-grained permissions
-
-Use the `permissions` managed setting to control which shell commands, file operations, and domains an agent can access. The same rules apply in {% data variables.product.prodname_vscode_shortname %} and {% data variables.copilot.copilot_cli %}.
-
-Define rules in the `allow`, `ask`, and `deny` arrays. Each rule consists of a selector and a pattern:
-
-| Selector | Controls | Example |
-|----------|----------|---------|
-| `Shell` | Shell commands | `Shell(echo allowed *)` |
-| `Read` | File reads | `Read(~/.ssh/**)` |
-| `Edit` | File edits | `Edit(/generated/**)` |
-| `Domain` | Network domains | `Domain(api.github.com)` |
-
-The following `managed-settings.json` example allows selected operations, requires approval for others, and blocks access to sensitive resources:
-
-```json
-{
-    "permissions": {
-        "allow": [
-            "Shell(echo allowed *)",
-            "Read(/docs/**)",
-            "Edit(/generated/**)",
-            "Domain(api.github.com)"
-        ],
-        "ask": [
-            "Shell(git push *)",
-            "Edit(/src/**)",
-            "Domain(github.com)"
-        ],
-        "deny": [
-            "Shell(rm -rf *)",
-            "Read(~/.ssh/**)",
-            "Edit(//etc/**)",
-            "Domain(raw.githubusercontent.com)"
-        ]
-    }
-}
-```
-
-When multiple rules match, the Copilot runtime applies them in the following order:
-
-1. `deny`
-1. `ask`
-1. `allow`
-1. Default to `ask` when no rule matches.
-
-A `deny` rule blocks the operation without presenting an approval option. An `ask` rule requires a human decision for every invocation and presents only **Allow Once** and **Skip**. Developers can't override these rules by selecting **Bypass Approvals** or **Autopilot**. An `allow` rule permits the operation at the managed permissions layer, but does not override stricter client-side approval settings in {% data variables.product.prodname_vscode_shortname %}.
-
-For `Read` and `Edit` rules, the path prefix determines how the pattern is resolved:
-
-| Prefix | Resolution | Example |
-|--------|------------|---------|
-| `/` | Workspace root | `Read(/src/**)` |
-| `./` | Current working directory | `Edit(./generated/**)` |
-| `~/` | Current user's home directory | `Read(~/.ssh/**)` |
-| `//` | File system root | `Edit(//etc/**)` |
+> [!WARNING]
+> Fine-grained `permissions.allow`, `permissions.ask`, and `permissions.deny` managed settings are supported only in GitHub Copilot CLI. Support in {% data variables.product.prodname_vscode_shortname %} is coming soon. For configuration details, see [Enterprise managed settings for GitHub Copilot](https://docs.github.com/en/copilot/reference/enterprise-administrators/enterprise-managed-settings#permissions).
 
 ### Disable global auto-approval
 


### PR DESCRIPTION
Correct the managed permissions documentation to match current product availability.\n\n## Changes\n\n* Remove claims that `permissions.allow`, `permissions.ask`, and `permissions.deny` are supported in VS Code.\n* Remove the related VS Code approvals-page cross-reference.\n* Add a warning that fine-grained managed permissions are currently Copilot CLI-only and link to the GitHub Docs permissions reference.\n\nBackport of `c88b8df66` from `vnext`.\n\n_🤖 Posted by GitHub Copilot on Harald's behalf._