### PR TITLE
release notes: add Agents chat backgrounds for 1.136

### DIFF
--- a/release-notes/images/1_136/agents-chat-background-codicons.png
+++ b/release-notes/images/1_136/agents-chat-background-codicons.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:880d40f2cd29cbee6469e487d2c5fe9461f9de5908a263d6ed5b1a458f02708b
+size 94766

--- a/release-notes/images/1_136/agents-chat-background-readability.png
+++ b/release-notes/images/1_136/agents-chat-background-readability.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8300249f698d280868b329956f6e4b38de73b95b11b02df28b705621bcb2a329
+size 124119

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -88,6 +88,24 @@ The new-session input in the Agents window has been redesigned to make it cleare
 
 ![Screenshot of the redesigned new-session input in the Agents window with context, permission, worktree, and branch controls.](images/1_136/agents-new-session-input.png)
 
+### Chat backgrounds in the Agents window (Experimental)
+
+**Settings**: `setting(chat.agentSessions.preferredDarkBackgroundImage)`, `setting(chat.agentSessions.preferredLightBackgroundImage)`, `setting(chat.agentSessions.backgroundImageLayout)`
+
+The Agents window is a place you might leave open all day, so it no longer has to be a flat panel color. Chat can sit on a decorative background: either a theme-aware pattern of built-in VS Code icons, or an image of your own.
+
+Run **Chat: Set Background...** to choose between the **Codicons** pattern and an image from your machine. The five images you used most recently are offered under **recently used**, and that list is kept on this machine only.
+
+![Screenshot showing the Codicons pattern behind the new session input in the Agents window.](images/1_136/agents-chat-background-codicons.png)
+
+When you bring your own image, run **Chat: Change Background Layout...** to place it. Eleven layouts are available: **Repeat**, **Stretch**, **Center**, and each edge and corner. Moving through the list previews each layout in place, so you can judge the result before committing to it. **Chat: Clear Background** returns to the plain surface.
+
+Dark and light themes keep separate backgrounds. Every dark theme shares `setting(chat.agentSessions.preferredDarkBackgroundImage)` and every light theme shares `setting(chat.agentSessions.preferredLightBackgroundImage)`, so switching between a dark and a light theme swaps the background along with it. High contrast themes suppress backgrounds entirely, and the three commands are unavailable there.
+
+Chat content carries its own fill so that it stays readable over whatever sits behind it. Your request remains fully opaque, agent responses fade out through the padding on either side, and wide content such as markdown tables and terminal output stays fully backed.
+
+![Screenshot showing an agent response and a markdown table remaining readable over the Codicons background.](images/1_136/agents-chat-background-readability.png)
+
 ### Improved workspace resolution
 
 Agents can now resolve workspaces by project name in addition to absolute paths and workspace URIs. Session tools also preserve project URIs and all working directories for multi-root workspaces.


### PR DESCRIPTION
Adds the 1.136 release note for customizable chat backgrounds in the Agents window, under `## Agents`.

The feature lets Agents-window chat sit on a decorative background instead of a flat panel color — either the built-in Codicons pattern or an image of your own, with separate choices for dark and light themes.

Shipped across #332435, #332462, #332569, #332660, #332762, #332875, and #333061. There was no feature issue, so the test plan item microsoft/vscode#333232 is the best reference.

### Verified against source

Setting names and `experimental` tags, the three command titles and IDs, the eleven layout values, the five-image recent list and its profile-scoped storage, and the high contrast suppression were all checked in `microsoft/vscode` rather than taken from the issue text.

### Notes for review

* Two screenshots added under `release-notes/images/1_136/` (LFS).
* I placed this under **Agents** since it is scoped to the Agents window. Happy to move it if another section fits better.