### PR TITLE
Fix 1.135 release notes TOC: remove entries with no matching section

### DIFF
--- a/release-notes/v1_135.md
+++ b/release-notes/v1_135.md
@@ -50,9 +50,6 @@ To try new features as soon as possible, [**download the nightly Insiders build*
     <ul>
       <li><a href="#agents">Agents</a></li>
       <li><a href="#chat">Chat</a></li>
-      <li><a href="#accessibility">Accessibility</a></li>
-      <li><a href="#editor-experience">Editor Experience</a></li>
-      <li><a href="#code-editing">Code Editing</a></li>
       <li><a href="#deprecated-features-and-settings">Deprecated features and settings</a></li>
       <li><a href="#thank-you">Thank you</a></li>
     </ul>


### PR DESCRIPTION
Fixes #333728

The in-product release notes nav block for 1.135 lists Accessibility, Editor Experience, and Code Editing, but this release's markdown only has `## Agents`, `## Chat`, `## Deprecated features and settings`, and `## Thank you` as actual sections. Removed the 3 stale entries from the hand-maintained `<nav>` list in `release-notes/v1_135.md` so the in-product nav matches the content.