### PR TITLE
docs: add 1.136.1 release notes

### DIFF
--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -17,7 +17,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 _Release date: September 2, 2026_
 
-**Update 1.136.1**: The update adds a [new model](https://github.com/microsoft/vscode/pull/334117).
+**Update 1.136.1**: The update addresses these [issues](https://github.com/microsoft/vscode/pulls?q=is%3Apr+milestone%3A1.136.1+is%3Aclosed+label%3Acandidate).
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -5,7 +5,7 @@ PageTitle: Visual Studio Code 1.136
 MetaDescription: Learn what is new in Visual Studio Code 1.136
 MetaSocialImage: 1_136/release-highlights.webp
 Date: 2026-09-02
-DownloadVersion: 1.136.0
+DownloadVersion: 1.136.1
 Milestone: 1.136.0
 ProductEdition: Stable
 ---

--- a/release-notes/v1_136.md
+++ b/release-notes/v1_136.md
@@ -17,6 +17,8 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 _Release date: September 2, 2026_
 
+**Update 1.136.1**: The update adds a [new model](https://github.com/microsoft/vscode/pull/334117).
+
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---


### PR DESCRIPTION
We might change the wording after a day or so, but the recovery release really is just for this change for now.