### PR TITLE
release notes: add 1.137 Voice Mode updates

### DIFF
--- a/release-notes/images/1_137/voice-mode-demo.mp4
+++ b/release-notes/images/1_137/voice-mode-demo.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bf58e8332872df3e840e289ac5370b65b0b8e21e99e08617368869b7b865f2e
+size 833321

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -1,41 +1,35 @@
 ---
 Order: 147
-TOCTitle: "1.137"
-PageTitle: Visual Studio Code 1.137
-MetaDescription: Learn what is new in Visual Studio Code 1.137
+TOCTitle: Insiders
+PageTitle: "Visual Studio Code 1.137 (Insiders)"
+MetaDescription: Learn what's new in Visual Studio Code 1.137 (Insiders)
 MetaSocialImage: 1_137/release-highlights.webp
 Date: 2026-09-09
 DownloadVersion: 1.137.0
 Milestone: 1.137.0
-ProductEdition: Stable
+ProductEdition: Insiders
 ---
-# Visual Studio Code 1.137
+# Visual Studio Code 1.137 <!-- %IF INSIDERS % (Insiders) %ENDIF % -->
 
 Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://go.microsoft.com/fwlink/?LinkID=533687), [Bluesky](https://bsky.app/profile/vscode.dev), [Instagram](https://www.instagram.com/vscode.ig) <!-- %IF INSIDERS % | Follow Insiders Changelog on [X](https://x.com/VSCodeChangelog) or [Bluesky](https://bsky.app/profile/vscodechangelog.bsky.social) %ENDIF % --> <!-- %IF IN_PRODUCT % | [View online](https://code.visualstudio.com/updates)%ENDIF % -->
 
 ---
 
-_Release date: September 9, 2026_
+_Last updated: August 25, 2026_
 
-<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+Welcome to the 1.137 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
----
+<!-- %IF INSIDERS %
+These release notes cover the Insiders build of VS Code and continue to evolve as new features are added.
 
-Welcome to the 1.137 release of Visual Studio Code. This release makes it easier to start and track agent sessions, and introduces natural spoken conversations with agents.
-
-* [Voice Mode (Experimental)](#voice-mode-experimental): Have natural spoken conversations with agents as they work on your code.
-
-* [Unified workspace picker](#start-a-session-without-a-workspace): Start a session without selecting a workspace, or find a GitHub or remote workspace from one picker.
-
-* [Session titles across windows](#identify-agent-sessions-across-windows): Identify the originating agent session when you open a separate Agents window.
+You can still track our progress in the [Commit log](https://github.com/Microsoft/vscode/commits/main) and our list of [Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3A1.137.0).
+%ENDIF % -->
 
 Happy Coding!
 
 ---
 
 <!-- %IF STABLE %
-VS Code is rolling out gradually to all users. Use **Check for Updates** in VS Code to get the latest version immediately.
-
 To try new features as soon as possible, [**download the nightly Insiders build**](https://code.visualstudio.com/insiders), which includes the latest updates as soon as they are available.
 
 ---
@@ -93,8 +87,6 @@ Administrators can disable Voice Mode by turning off Copilot preview features fo
 ---
 
 We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
-
->If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -78,7 +78,6 @@ Add a GitHub issue or pull request as context from the **Add Context...** menu i
 
 You can also paste a GitHub issue or pull request URL into the new-session input. The URL remains in your prompt and a context attachment is added automatically. 
 
-When a workspace contains multiple Git-backed folders, first select the workspace folder to use. Each folder remains a distinct choice, even when multiple folders point to the same GitHub repository.
 
 ## Agents
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -59,6 +59,8 @@ To try it, enable `setting(agents.voice.enabled)` and select the **Voice Mode** 
 
 While the agent is speaking, start speaking or use the push-to-talk shortcut to interrupt the response and continue the conversation.
 
+Voice Mode is aware of your active session and can answer questions about running sessions, the selected model, and attached files. You can also ask Voice Mode to start a new session. When a request is routed, Voice Mode announces whether it is sending the request to an existing session or starting a new one.
+
 You can customize Voice Mode in the following ways:
 
 * Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active. Use the Voice Mode controls to show or hide the transcript and mute or unmute your microphone without ending the voice session.
@@ -74,17 +76,25 @@ Administrators can disable Voice Mode by turning off Copilot preview features fo
 
 Add a GitHub issue or pull request as context from the **Add Context...** menu in any chat input, including the Chat view, Chat editor, and Agents window. This makes the issue description, comments, or pull request changes available to the agent without copying them into your prompt.
 
+You can also paste a GitHub issue or pull request URL into the new-session input. The URL remains in your prompt and a context attachment is added automatically. If you remove the URL, the corresponding input-derived attachment is removed without affecting context that you attached explicitly.
+
 When a workspace contains multiple Git-backed folders, first select the workspace folder to use. Each folder remains a distinct choice, even when multiple folders point to the same GitHub repository.
 
 ## Agents
 
-### Unified workspace picker improvements (Experimental)
+### New session experience improvements (Experimental)
 
 **Setting**: `setting(sessions.chat.unifiedWorkspacePicker.enabled)`
 
-We continued improving the unified workspace picker for new agent sessions. You can now search for workspaces and browse consolidated GitHub and remote workspace sources from one picker.
+We continued improving the new-session experience in the Agents window. The workspace picker, harness picker, and context controls are brought together in one layout, with the workspace first because it determines which harnesses are available.
 
-When supported, select **No workspace** to start a session without choosing a folder or workspace. This is useful when you want to ask a general question or decide on a project later.
+Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to search for workspaces and browse consolidated GitHub and remote workspace sources from one picker. When supported, select **No workspace** to ask a general question or decide on a project later.
+
+### Agent Merge for draft pull requests (Preview)
+
+Agent Merge monitors a pull request and works through failed checks and actionable review feedback until it is ready to merge.
+
+You can create a draft pull request and start Agent Merge in one step. Agent Merge addresses CI failures and review feedback while the pull request remains a draft, but does not merge it automatically. When the checks and feedback are clear, mark the pull request as ready for review.
 
 ---
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -42,7 +42,6 @@ To try new features as soon as possible, [**download the nightly Insiders build*
     <ul>
       <li><a href="#chat">Chat</a></li>
       <li><a href="#agents">Agents</a></li>
-      <li><a href="#engineering">Engineering</a></li>
     </ul>
   </nav>
   <div class="notes-main">
@@ -71,6 +70,12 @@ You can also right-click the **Voice Mode** button in the chat input to quickly 
 
 Administrators can disable Voice Mode by turning off Copilot preview features for their organization.
 
+### Attach GitHub issues and pull requests in any chat
+
+Add a GitHub issue or pull request as context from the **Add Context...** menu in any chat input, including the Chat view, Chat editor, and Agents window. This makes the issue description, comments, or pull request changes available to the agent without copying them into your prompt.
+
+When a workspace contains multiple Git-backed folders, first select the workspace folder to use. Each folder remains a distinct choice, even when multiple folders point to the same GitHub repository.
+
 ## Agents
 
 ### Unified workspace picker improvements (Experimental)
@@ -80,12 +85,6 @@ Administrators can disable Voice Mode by turning off Copilot preview features fo
 We continued improving the unified workspace picker for new agent sessions. You can now search for workspaces and browse consolidated GitHub and remote workspace sources from one picker.
 
 When supported, select **No workspace** to start a session without choosing a folder or workspace. This is useful when you want to ask a general question or decide on a project later.
-
-## Engineering
-
-### Identify OSS agent sessions across windows
-
-When you launch an OSS Agents window from an agent session, the Command Center now shows the originating session title instead of a generic label. This helps VS Code contributors identify which session launched each window when working across multiple OSS windows.
 
 ---
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -90,11 +90,6 @@ We continued improving the new-session experience in the Agents window. The work
 
 Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to search for workspaces and browse consolidated GitHub and remote workspace sources from one picker. When supported, select **No workspace** to ask a general question or decide on a project later.
 
-### Agent Merge for draft pull requests (Preview)
-
-Agent Merge monitors a pull request and works through failed checks and actionable review feedback until it is ready to merge.
-
-You can create a draft pull request and start Agent Merge in one step. Agent Merge addresses CI failures and review feedback while the pull request remains a draft, but does not merge it automatically. When the checks and feedback are clear, mark the pull request as ready for review.
 
 ---
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -15,7 +15,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://
 
 ---
 
-_Last updated: August 25, 2026_
+_Last updated: September 4, 2026_
 
 Welcome to the 1.137 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
 
@@ -40,15 +40,22 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
+      <li><a href="#september-3-2026">September 3, 2026</a></li>
       <li><a href="#september-1-2026">September 1, 2026</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
+## September 3, 2026
+
+* Start a new session in the Agents window without selecting a folder or workspace. Choose **No workspace** when you want to ask a general question or decide on a project later. _[#334345: Add `No workspace` option to agents window new session chat input](https://github.com/microsoft/vscode/issues/334345)_
+
+* Keep track of agent sessions across windows. When you open a separate Agents window from a session, the Command Center shows the originating session title instead of a generic label. _[#334288: Show originating session title in the OSS Agents Command Center](https://github.com/microsoft/vscode/issues/334288)_
+
 ## September 1, 2026
 
-* Feature description with link to issue. _[#issue-number](https://github.com/microsoft/vscode/issues/issue-number)_
+* Have natural spoken conversations with an agent through **Voice Mode** (Experimental). Enable `setting(agents.voice.enabled)` and select **Voice Mode** in the chat input. You can interrupt the agent by speaking or using push-to-talk, show the conversation transcript, choose your microphone, and select the voice that reads responses aloud. Enterprise preview-feature policies control whether Voice Mode is available. _[#333790: Gate `agents.voice.enabled` behind the Copilot preview features policy](https://github.com/microsoft/vscode/issues/333790)_
 
 ---
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -76,7 +76,7 @@ Administrators can disable Voice Mode by turning off Copilot preview features fo
 
 Add a GitHub issue or pull request as context from the **Add Context...** menu in any chat input, including the Chat view, Chat editor, and Agents window. This makes the issue description, comments, or pull request changes available to the agent without copying them into your prompt.
 
-You can also paste a GitHub issue or pull request URL into the new-session input. The URL remains in your prompt and a context attachment is added automatically. If you remove the URL, the corresponding input-derived attachment is removed without affecting context that you attached explicitly.
+You can also paste a GitHub issue or pull request URL into the new-session input. The URL remains in your prompt and a context attachment is added automatically. 
 
 When a workspace contains multiple Git-backed folders, first select the workspace folder to use. Each folder remains a distinct choice, even when multiple folders point to the same GitHub repository.
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -61,6 +61,8 @@ While the agent is speaking, start speaking or use the push-to-talk shortcut to 
 
 Voice Mode is aware of your active session and can answer questions about running sessions, the selected model, and attached files. You can also ask Voice Mode to start a new session. When a request is routed, Voice Mode announces whether it is sending the request to an existing session or starting a new one.
 
+<video src="images/1_137/voice-mode-demo.mp4" title="Video showing a spoken conversation with Voice Mode." autoplay loop controls muted></video>
+
 You can customize Voice Mode in the following ways:
 
 * Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active. Use the Voice Mode controls to show or hide the transcript and mute or unmute your microphone without ending the voice session.

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -1,35 +1,41 @@
 ---
 Order: 147
-TOCTitle: Insiders
-PageTitle: "Visual Studio Code 1.137 (Insiders)"
-MetaDescription: Learn what's new in Visual Studio Code 1.137 (Insiders)
+TOCTitle: "1.137"
+PageTitle: Visual Studio Code 1.137
+MetaDescription: Learn what is new in Visual Studio Code 1.137
 MetaSocialImage: 1_137/release-highlights.webp
 Date: 2026-09-09
 DownloadVersion: 1.137.0
 Milestone: 1.137.0
-ProductEdition: Insiders
+ProductEdition: Stable
 ---
-# Visual Studio Code 1.137 <!-- %IF INSIDERS % (Insiders) %ENDIF % -->
+# Visual Studio Code 1.137
 
 Follow us on [LinkedIn](https://www.linkedin.com/showcase/vs-code), [X](https://go.microsoft.com/fwlink/?LinkID=533687), [Bluesky](https://bsky.app/profile/vscode.dev), [Instagram](https://www.instagram.com/vscode.ig) <!-- %IF INSIDERS % | Follow Insiders Changelog on [X](https://x.com/VSCodeChangelog) or [Bluesky](https://bsky.app/profile/vscodechangelog.bsky.social) %ENDIF % --> <!-- %IF IN_PRODUCT % | [View online](https://code.visualstudio.com/updates)%ENDIF % -->
 
 ---
 
-_Last updated: September 4, 2026_
+_Release date: September 9, 2026_
 
-Welcome to the 1.137 <!-- %IF INSIDERS % Insiders %ENDIF % --> release of Visual Studio Code.
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
-<!-- %IF INSIDERS %
-These release notes cover the Insiders build of VS Code and continue to evolve as new features are added.
+---
 
-You can still track our progress in the [Commit log](https://github.com/Microsoft/vscode/commits/main) and our list of [Closed issues](https://github.com/Microsoft/vscode/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3A1.137.0).
-%ENDIF % -->
+Welcome to the 1.137 release of Visual Studio Code. This release makes it easier to start and track agent sessions, and introduces natural spoken conversations with agents.
+
+* [Voice Mode (Experimental)](#voice-mode-experimental): Have natural spoken conversations with agents as they work on your code.
+
+* [Unified workspace picker](#start-a-session-without-a-workspace): Start a session without selecting a workspace, or find a GitHub or remote workspace from one picker.
+
+* [Session titles across windows](#identify-agent-sessions-across-windows): Identify the originating agent session when you open a separate Agents window.
 
 Happy Coding!
 
 ---
 
 <!-- %IF STABLE %
+VS Code is rolling out gradually to all users. Use **Check for Updates** in VS Code to get the latest version immediately.
+
 To try new features as soon as possible, [**download the nightly Insiders build**](https://code.visualstudio.com/insiders), which includes the latest updates as soon as they are available.
 
 ---
@@ -40,26 +46,55 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
-      <li><a href="#september-3-2026">September 3, 2026</a></li>
-      <li><a href="#september-1-2026">September 1, 2026</a></li>
+      <li><a href="#agents">Agents</a></li>
+      <li><a href="#chat">Chat</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## September 3, 2026
+## Agents
 
-* Start a new session in the Agents window without selecting a folder or workspace. Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to use the unified workspace picker, including workspace search, consolidated GitHub and remote workspace sources, and the **No workspace** option when supported. _[#334345: Add `No workspace` option to agents window new session chat input](https://github.com/microsoft/vscode/issues/334345)_
+### Start a session without a workspace
 
-* Keep track of agent sessions across windows. When you open a separate Agents window from a session, the Command Center shows the originating session title instead of a generic label. _[#334288: Show originating session title in the OSS Agents Command Center](https://github.com/microsoft/vscode/issues/334288)_
+**Setting**: `setting(sessions.chat.unifiedWorkspacePicker.enabled)`
 
-## September 1, 2026
+Start a new session in the Agents window without selecting a folder or workspace. This is useful when you want to ask a general question or decide on a project later.
 
-* Have natural spoken conversations with an agent through **Voice Mode** (Experimental). Enable `setting(agents.voice.enabled)` and select **Voice Mode** in the chat input. You can interrupt the agent by speaking or using push-to-talk, show the conversation transcript, choose your microphone, and select the voice that reads responses aloud. Enterprise preview-feature policies control whether Voice Mode is available. _[#333790: Gate `agents.voice.enabled` behind the Copilot preview features policy](https://github.com/microsoft/vscode/issues/333790)_
+Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to use the unified workspace picker. The picker includes workspace search, consolidated GitHub and remote workspace sources, and the **No workspace** option when supported.
+
+### Identify agent sessions across windows
+
+Keep track of agent sessions when you work across multiple windows. When you open a separate Agents window from a session, the Command Center shows the originating session title instead of a generic label.
+
+## Chat
+
+### Voice Mode (Experimental)
+
+**Settings**: `setting(agents.voice.enabled)`, `setting(agents.voice.showTranscript)`, `setting(agents.voice.voice)`
+
+Voice Mode enables you to have a natural, spoken conversation with an agent while it works on your code.
+
+To try it, enable `setting(agents.voice.enabled)` and select the **Voice Mode** button in the chat input.
+
+While the agent is speaking, start speaking or use the push-to-talk shortcut to interrupt the response and continue the conversation.
+
+You can customize Voice Mode in the following ways:
+
+* Enable `setting(agents.voice.showTranscript)` to show the conversation transcript in the chat input while Voice Mode is active. Use the Voice Mode controls to show or hide the transcript and mute or unmute your microphone without ending the voice session.
+* Run **Chat: Dictate: Select Microphone** from the Command Palette to choose the input device used by both dictation and Voice Mode.
+* Use `setting(agents.voice.voice)` to select the voice that reads responses aloud.
+* Run **Voice Mode: Show Introduction** from the Command Palette to reopen the introduction, where you can select a microphone and preview the available voices.
+
+You can also right-click the **Voice Mode** button in the chat input to quickly access its configuration, instructions, introduction, microphone selection, and transcript controls. Learn more about [using Voice Mode](https://code.visualstudio.com/docs/configure/accessibility/voice#use-voice-mode).
+
+Administrators can disable Voice Mode by turning off Copilot preview features for their organization.
 
 ---
 
 We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -40,26 +40,13 @@ To try new features as soon as possible, [**download the nightly Insiders build*
   <nav id="toc-nav">
     <div>In this update</div>
     <ul>
-      <li><a href="#agents">Agents</a></li>
       <li><a href="#chat">Chat</a></li>
+      <li><a href="#agents">Agents</a></li>
+      <li><a href="#engineering">Engineering</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
-
-## Agents
-
-### Start a session without a workspace
-
-**Setting**: `setting(sessions.chat.unifiedWorkspacePicker.enabled)`
-
-Start a new session in the Agents window without selecting a folder or workspace. This is useful when you want to ask a general question or decide on a project later.
-
-Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to use the unified workspace picker. The picker includes workspace search, consolidated GitHub and remote workspace sources, and the **No workspace** option when supported.
-
-### Identify agent sessions across windows
-
-Keep track of agent sessions when you work across multiple windows. When you open a separate Agents window from a session, the Command Center shows the originating session title instead of a generic label.
 
 ## Chat
 
@@ -83,6 +70,22 @@ You can customize Voice Mode in the following ways:
 You can also right-click the **Voice Mode** button in the chat input to quickly access its configuration, instructions, introduction, microphone selection, and transcript controls. Learn more about [using Voice Mode](https://code.visualstudio.com/docs/configure/accessibility/voice#use-voice-mode).
 
 Administrators can disable Voice Mode by turning off Copilot preview features for their organization.
+
+## Agents
+
+### Unified workspace picker improvements (Experimental)
+
+**Setting**: `setting(sessions.chat.unifiedWorkspacePicker.enabled)`
+
+We continued improving the unified workspace picker for new agent sessions. You can now search for workspaces and browse consolidated GitHub and remote workspace sources from one picker.
+
+When supported, select **No workspace** to start a session without choosing a folder or workspace. This is useful when you want to ask a general question or decide on a project later.
+
+## Engineering
+
+### Identify OSS agent sessions across windows
+
+When you launch an OSS Agents window from an agent session, the Command Center now shows the originating session title instead of a generic label. This helps VS Code contributors identify which session launched each window when working across multiple OSS windows.
 
 ---
 

--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -49,7 +49,7 @@ Navigation End -->
 
 ## September 3, 2026
 
-* Start a new session in the Agents window without selecting a folder or workspace. Choose **No workspace** when you want to ask a general question or decide on a project later. _[#334345: Add `No workspace` option to agents window new session chat input](https://github.com/microsoft/vscode/issues/334345)_
+* Start a new session in the Agents window without selecting a folder or workspace. Enable `setting(sessions.chat.unifiedWorkspacePicker.enabled)` to use the unified workspace picker, including workspace search, consolidated GitHub and remote workspace sources, and the **No workspace** option when supported. _[#334345: Add `No workspace` option to agents window new session chat input](https://github.com/microsoft/vscode/issues/334345)_
 
 * Keep track of agent sessions across windows. When you open a separate Agents window from a session, the Command Center shows the originating session title instead of a generic label. _[#334288: Show originating session title in the OSS Agents Command Center](https://github.com/microsoft/vscode/issues/334288)_
 


### PR DESCRIPTION
## Summary

- preserve the existing 1.137 Insiders frontmatter and introductory boilerplate
- add Voice Mode and its confirmed session-aware improvements without animated media
- document GitHub issue and pull request attachments across all chat inputs, pasted-link synchronization, and multi-root folder selection
- describe the Experimental new-session experience, including control ordering, workspace search, remote sources, and the No workspace option
- document Agent Merge support for draft pull requests and automatic CI and review-feedback follow-up
- remove issue links from feature entries

## Feature coverage audit

Reviewed all 15 closed 1.137.0 feature requests assigned to or authored by me, plus all 27 closed milestone items for mislabeled user-facing capabilities. Related issues are consolidated into four user-focused sections.

Not included in the public notes:

- compact pasted GitHub references, superseded before Stable by restored context attachments
- inferred workspace changes from pasted GitHub links, whose implementation PR closed without merging
- unverified portions of Voice Mode navigation and failure handling
- OSS-only session-title behavior, documented in microsoft/vscode-internalbacklog#9086

## Validation

- `npm run check-release-note-toc -- release-notes/v1_137.md`
- `git diff --check origin/vnext...HEAD`