### PR TITLE
Add a VS Code pet tidbit to the 1.137 release notes

### DIFF
--- a/release-notes/v1_137.md
+++ b/release-notes/v1_137.md
@@ -120,6 +120,12 @@ You can also paste a GitHub issue or pull request URL into the new-session input
 
 ![Screenshot showing pasted GitHub issue and pull request URLs with context attachments in chat.](images/1_137/paste-github-issue-pull-request.png)
 
+### VS Code pet (Experimental)
+
+Add a little company while you code with the VS Code pet. Type `/vscode-pet` in Chat to show or hide it above the input in the active editor or Agents window.
+
+Drag the pet around, try a few bounces, or right-click it to change its size and colors and open **Achievements** to discover unlockable accessories.
+
 
 ## MCP
 


### PR DESCRIPTION
## Summary

Add a short **VS Code pet (Experimental)** entry under Chat in the 1.137 release notes for Wednesday, September 9, 2026.

The entry covers the `/vscode-pet` toggle, a few playful interactions, and the Achievements menu for discovering accessories.

## Verification

- Confirmed the release draft date and version on `vnext`.
- Verified the public slash-command registration and described interactions against `microsoft/vscode` release/1.137.
- Documentation-only change: six added lines; `git diff --check` passes.

Kept separate from the subagent-rendering code PR.