### PR TITLE
release notes: add Megan's 1.138 features

### DIFF
--- a/release-notes/images/1_138/configure-automatic-session-cleanup.png
+++ b/release-notes/images/1_138/configure-automatic-session-cleanup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fe56ab40355df42ed0f72f0384afa24406d0997830d8ca274e1db84711b44cb
+size 26287

--- a/release-notes/images/1_138/dev-container-workspace-picker.png
+++ b/release-notes/images/1_138/dev-container-workspace-picker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:637466b87fd56ad4b762afae2f937db52205a2acafaa67953ff53bd237744c74
+size 30032

--- a/release-notes/images/1_138/mark-as-done-confetti.mp4
+++ b/release-notes/images/1_138/mark-as-done-confetti.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca86a819f02b164b65b3880ba57f8a0703ff52d0f7c8cd28d6e8ea39d8da8012
+size 33814

--- a/release-notes/images/1_138/unified-workspace-picker.png
+++ b/release-notes/images/1_138/unified-workspace-picker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4dc2fed047bd31739d6702ab42cd4a8ea3c20c972e2814a08af948f86a8a4ee
+size 42865

--- a/release-notes/images/1_138/voice-mode-session-navigation.mp4
+++ b/release-notes/images/1_138/voice-mode-session-navigation.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eecf37211951f877063e4846725a8e4eb90b8279749ea72d674a96aa04ea15cc
+size 212815

--- a/release-notes/v1_138.md
+++ b/release-notes/v1_138.md
@@ -70,9 +70,45 @@ Navigation End -->
 
 ## Agents
 
+### Automatic cleanup for merged agent sessions (Preview)
+
+**Settings**: `setting(chat.agentSessions.autoMarkAsDoneMergedSessionsAfterDays)`, `setting(chat.agentSessions.autoDeleteArchivedMergedSessionsAfterDays)`
+
+Automatically mark inactive sessions as done after their pull requests merge, and optionally delete them after a separate grace period. Both settings are disabled by default.
+
+When all pull requests for a session are merged, select **Configure Automatic Cleanup** in the **Mark as Done** suggestion to open both settings without enabling them.
+
+![Screenshot showing the Mark as Done suggestion with the Configure Automatic Cleanup action.](images/1_138/configure-automatic-session-cleanup.png)
+
+### Celebrate marking sessions as done (Preview)
+
+**Setting**: `setting(sessions.markAsDoneSessionConfetti)`
+
+Enable this setting to show a confetti animation when you mark a session as done. The animation respects your reduced-motion preference.
+
+<video src="images/1_138/mark-as-done-confetti.mp4" title="Video showing confetti when a session is marked as done." autoplay loop controls muted></video>
+
+### Unified workspace and repository picker (Experimental)
+
+**Setting**: `setting(sessions.chat.unifiedWorkspacePicker.enabled)`
+
+Start agent work from one searchable list of local folders, GitHub repositories, Cloud repositories, and remote targets. Remote connection actions remain available from the **Remote** entry.
+
+![Screenshot showing the unified workspace picker with local folders, repositories, and remote options.](images/1_138/unified-workspace-picker.png)
+
+When `setting(chat.agentHost.devContainer.enabled)` is enabled, local folders with a supported Dev Container configuration automatically show a folder menu with a **Use Dev Container** action. Select the action to run the agent session in the folder's Dev Container.
+
+![Screenshot showing the Use Dev Container action for a folder in the workspace picker.](images/1_138/dev-container-workspace-picker.png)
+
+Selecting **Work in Repository** uses a cloud-first workflow. A GitHub repository that is not already local is selected immediately with the Cloud harness, without a clone prompt. If you later choose a local harness, VS Code prompts you to clone the repository and preserves the cloud selection if you cancel.
 
 ## Chat
 
+### Improved Voice Mode session awareness (Experimental)
+
+Voice Mode can more reliably find recent Agent sessions, switch between sessions by label, and report current session status. This makes it easier to navigate and monitor parallel agent work without leaving the spoken conversation.
+
+<video src="images/1_138/voice-mode-session-navigation.mp4" title="Video showing Voice Mode switching between Agent sessions." autoplay loop controls muted></video>
 
 ## MCP
 


### PR DESCRIPTION
## Summary

* document Megan's public user-facing work closed for milestone 1.138
* cover Agents window repository and Dev Container workflows
* cover merged-session cleanup and Voice Mode session awareness
* exclude rejected, superseded, internal-only, minor-polish, and pure bug-fix items

## Validation

* `npm run lint` (passes with 58 existing warnings)
* `npm run check-release-note-toc -- release-notes/v1_138.md`
* `git diff --check`
