### PR TITLE
docs: fix 'allows to' grammar in virtual documents guide

### DIFF
--- a/api/extension-guides/virtual-documents.md
+++ b/api/extension-guides/virtual-documents.md
@@ -122,7 +122,7 @@ Document providers are first class citizens in VS Code, their contents appears i
 
 # File System API
 
-If you need more flexibility and power take a look at the [`FileSystemProvider`](/api/references/vscode-api#FileSystemProvider) API. It allows to implement a full file system, having files, folders, binary data, file-deletion, creation and more.
+If you need more flexibility and power take a look at the [`FileSystemProvider`](/api/references/vscode-api#FileSystemProvider) API. It allows you to implement a full file system, having files, folders, binary data, file-deletion, creation and more.
 
 You can find a sample extension with source code at: [https://github.com/microsoft/vscode-extension-samples/tree/main/fsprovider-sample/README.md](https://github.com/microsoft/vscode-extension-samples/tree/main/fsprovider-sample/README.md).
 


### PR DESCRIPTION
Tiny docs grammar fix.