### PR TITLE
Document the Search subagent semantic search setting

### DIFF
--- a/docs/agents/reference/ai-settings.md
+++ b/docs/agents/reference/ai-settings.md
@@ -120,6 +120,7 @@ Use the following links to jump to the settings for a specific area:
 | `setting(github.copilot.chat.agent.autoFix)`<br/>Automatically diagnose and fix issues in the generated code changes. | `true` |
 | `setting(chat.subagents.allowInvocationsFromSubagents)`<br/>Enable subagents to invoke other subagents, up to a maximum nesting depth of five. | `false` |
 | `setting(chat.subagents.useRichRendering)`<br/>Open each subagent in its own editor instead of showing its full activity inline in the parent chat. | `true` |
+| `setting(github.copilot.chat.searchSubagent.subagentSemanticSearchEnabled)` _(Experimental)_<br/>Enable the semantic search tool for the Search subagent. This only affects the Search subagent and does not disable semantic search elsewhere. | `true` |
 | `setting(chat.agent.thinking.collapsedTools)` _(Experimental)_<br/>Configure how tool calls are grouped with thinking content: `off` keeps tool calls separate, `withThinking` groups them only when thinking is present, and `always` always groups tool calls in collapsible sections. | `always` |
 | `setting(chat.agent.thinkingStyle)` _(Experimental)_<br/>Configure how thinking is rendered in chat: `collapsed` collapses thinking by default and can separate reasoning from grouped tool calls, `collapsedPreview` starts expanded and collapses after non-thinking content appears, and `fixedScrolling` shows thinking in a fixed-height auto-scrolling panel that you can expand. | `fixedScrolling` |
 


### PR DESCRIPTION
Adds the advanced experimental setting github.copilot.chat.searchSubagent.subagentSemanticSearchEnabled to the Agent behavior table: default true, scoped to the Search subagent only, no effect on semantic search elsewhere. Wording follows the setting's own description in the merged vscode#333869.

Only the one table row changes.

Closes #10251

## Verification

- Checked the setting name, type, default, and tags against the merged source PR
- Matched the table and tag style of surrounding rows