### PR TITLE
docs: fix 'allow to enhance' grammar in theming guide

### DIFF
--- a/api/extension-capabilities/theming.md
+++ b/api/extension-capabilities/theming.md
@@ -23,7 +23,7 @@ As you can see in the illustration, Color Theme defines colors for UI components
 
 - The `colors` mapping that controls colors for UI Components.
 - The `tokenColors` define the color and styles for highlighting in the editor. The [Syntax Highlight guide](/api/language-extensions/syntax-highlight-guide) has more information on that topic.
-- The `semanticTokenColors` mappings as well as the `semanticHighlighting` setting allow to enhance the highlighting in the editor. The [Semantic Highlight guide](/api/language-extensions/semantic-highlight-guide) explains the APIs related to that.
+- The `semanticTokenColors` mappings as well as the `semanticHighlighting` setting allow enhancing the highlighting in the editor. The [Semantic Highlight guide](/api/language-extensions/semantic-highlight-guide) explains the APIs related to that.
 
 We have a [Color Theme guide](/api/extension-guides/color-theme) and a [Color Theme sample](https://github.com/microsoft/vscode-extension-samples/tree/main/theme-sample) that illustrates how to create a theme.
 


### PR DESCRIPTION
Tiny docs grammar fix: `allow to enhance` → `allow enhancing` in the Color Theme overview.