### PR TITLE
docs: fix 'allow to override' grammar in file icon theme guide

### DIFF
--- a/api/extension-guides/file-icon-theme.md
+++ b/api/extension-guides/file-icon-theme.md
@@ -136,7 +136,7 @@ A file extension match is preferred over a language match, but is weaker than a 
 
 `file name match with parent > file name match > file extension match with parent > file extension match > language match ...`
 
-The `light` and the `highContrast` section have the same file association properties as just listed. They allow to override icons for the corresponding themes.
+The `light` and the `highContrast` section have the same file association properties as just listed. They allow overriding icons for the corresponding themes.
 
 ### Font definitions
 


### PR DESCRIPTION
Tiny docs grammar fix: `allow to override` → `allow overriding` in the file icon theme guide.